### PR TITLE
Keep source mapping stable across repeated content and carry-over

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -106,7 +106,7 @@ class SummaryDAG:
     def delete_below_depth(self, session_id: str, min_depth: int) -> int:
         """Delete all nodes for a session with depth < min_depth.
 
-        Returns the number of deleted nodes.  Used during session reset
+        Returns the number of deleted nodes. Used during session reset
         to retain only high-level summaries across sessions.
         """
         cur = self._conn.execute(
@@ -129,6 +129,21 @@ class SummaryDAG:
         if deleted:
             self._conn.commit()
         return deleted
+
+    def reassign_session_nodes(self, old_session_id: str, new_session_id: str) -> int:
+        """Move all nodes from one session_id to another.
+
+        Used for /new carry-over where retained summaries should become part of
+        the fresh session while preserving node IDs and node-to-node links.
+        """
+        cur = self._conn.execute(
+            "UPDATE summary_nodes SET session_id = ? WHERE session_id = ?",
+            (new_session_id, old_session_id),
+        )
+        moved = cur.rowcount
+        if moved:
+            self._conn.commit()
+        return moved
 
     # -- Read ---------------------------------------------------------------
 

--- a/engine.py
+++ b/engine.py
@@ -212,6 +212,8 @@ class LCMEngine(ContextEngine):
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         self._session_id = session_id
+        self._ingest_cursor = 0
+        self._last_compacted_store_id = 0
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
         # Pick up context_length from kwargs if provided
@@ -242,6 +244,12 @@ class LCMEngine(ContextEngine):
                 self._dag.delete_session_nodes(self._session_id)
             else:
                 self._dag.delete_below_depth(self._session_id, retain)
+
+    def carry_over_new_session_context(self, old_session_id: str, new_session_id: str) -> int:
+        """Move retained summaries from the old session into the new one."""
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return 0
+        return self._dag.reassign_session_nodes(old_session_id, new_session_id)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [LCM_GREP, LCM_DESCRIBE, LCM_EXPAND]
@@ -313,30 +321,30 @@ class LCMEngine(ContextEngine):
         logger.debug("Ingested %d messages into LCM store", len(new_messages))
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
-        """Map message list back to store_ids via content matching.
+        """Map current raw messages back to store_ids in stable store order.
 
-        Uses (role, content) to match against stored messages.  Robust
-        across compaction cycles — synthetic summary messages that aren't
-        in the store are silently skipped.
+        Matching starts strictly after ``_last_compacted_store_id`` so repeated
+        content from older already-compacted history cannot hijack the mapping.
+        Synthetic summary messages simply fail to match and are skipped.
         """
-        from collections import defaultdict
+        candidates = [
+            stored for stored in self._store.get_session_messages(self._session_id)
+            if stored["store_id"] > self._last_compacted_store_id
+        ]
 
-        all_stored = self._store.get_session_messages(self._session_id)
-        # Build ordered lookup: (role, content) → [store_id, ...]
-        lookup: dict[tuple, list[int]] = defaultdict(list)
-        for s in all_stored:
-            key = (s.get("role", ""), s.get("content") or "")
-            lookup[key].append(s["store_id"])
-
-        ids = []
-        consumed: set[int] = set()
+        ids: list[int] = []
+        store_idx = 0
         for msg in messages:
-            key = (msg.get("role", ""), msg.get("content") or "")
-            for sid in lookup.get(key, []):
-                if sid not in consumed:
-                    ids.append(sid)
-                    consumed.add(sid)
+            role = msg.get("role", "")
+            content = msg.get("content") or ""
+            probe_idx = store_idx
+            while probe_idx < len(candidates):
+                stored = candidates[probe_idx]
+                if stored.get("role", "") == role and (stored.get("content") or "") == content:
+                    ids.append(stored["store_id"])
+                    store_idx = probe_idx + 1
                     break
+                probe_idx += 1
 
         return ids
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5,6 +5,7 @@ import pytest
 
 from agent.context_engine import ContextEngine
 from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
 
 
@@ -268,6 +269,32 @@ class TestStoreIdMapping:
         finally:
             esc._call_llm_for_summary = original_fn
 
+    def test_repeated_content_maps_to_later_store_rows(self, engine):
+        import hermes_lcm.escalation as esc
+        original_fn = esc._call_llm_for_summary
+        esc._call_llm_for_summary = self._mock_summarize
+        try:
+            messages = [{"role": "system", "content": "You are a helpful assistant."}]
+            for _ in range(20):
+                messages.append({"role": "user", "content": "repeat"})
+                messages.append({"role": "assistant", "content": "same"})
+
+            compressed = engine.compress(messages)
+            first_node = engine._dag.get_session_nodes("test-session")[0]
+            first_max = max(first_node.source_ids)
+
+            for _ in range(15):
+                compressed.append({"role": "user", "content": "repeat"})
+                compressed.append({"role": "assistant", "content": "same"})
+
+            engine.compress(compressed)
+            nodes = engine._dag.get_session_nodes("test-session")
+            second_node = nodes[1]
+            assert second_node.source_ids
+            assert all(store_id > first_max for store_id in second_node.source_ids)
+        finally:
+            esc._call_llm_for_summary = original_fn
+
 
 class TestSessionRetainDepth:
     """Tests for issue #2a — new_session_retain_depth wiring."""
@@ -319,6 +346,27 @@ class TestSessionRetainDepth:
             ))
         engine.on_session_reset()
         assert len(engine._dag.get_session_nodes("test-session")) == 3
+
+    def test_carry_over_moves_retained_nodes_into_new_session(self, engine):
+        engine._config.new_session_retain_depth = 2
+        import time
+        for depth in range(4):
+            engine._dag.add_node(SummaryNode(
+                session_id="old-session", depth=depth,
+                summary=f"d{depth} summary", token_count=100,
+                source_token_count=500, source_ids=[],
+                source_type="messages", created_at=time.time(),
+            ))
+
+        engine._session_id = "old-session"
+        engine.on_session_reset()
+        moved = engine.carry_over_new_session_context("old-session", "new-session")
+
+        assert moved == 2
+        assert engine._dag.get_session_nodes("old-session") == []
+        new_nodes = engine._dag.get_session_nodes("new-session")
+        assert len(new_nodes) == 2
+        assert all(node.depth >= 2 for node in new_nodes)
 
 
 class TestUnlimitedCondensationDepth:


### PR DESCRIPTION
This tightens source-id mapping during compaction and adds a helper for moving retained summaries into a new session.

What changed:
- source-id matching now walks forward in store order instead of matching against any earlier duplicate content
- matching starts after the last compacted store id, so repeated content from older history can't hijack newer source rows
- added `reassign_session_nodes()` in the DAG
- added `carry_over_new_session_context()` on the engine for retained-summary handoff
- reset startup now clears the ingest/mapping cursors again

Why this matters:
- repeated content can otherwise point a later summary back at older rows
- retained summaries are a lot more useful if they can be moved into the new session cleanly

Tests:
- added repeated-content coverage for later-row mapping
- added carry-over coverage for retained nodes moving into a new session
- `python3 -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py -q`

This should make multi-compaction and session-reset flows much more predictable in Hermes-style runtimes.