### PR TITLE
Add session filtering and stateless session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ into anything that was compacted.
 - **3-level escalation** — L1 detailed → L2 bullets → L3 deterministic truncate (guaranteed convergence)
 - **Agent tools** — `lcm_grep`, `lcm_describe`, `lcm_expand`, `lcm_expand_query` for structured retrieval
 - **Current-turn search** — live messages ingested before tool execution
+- **Session filtering** — exclude noisy sessions entirely or mark them read-only with glob patterns
 - **Profile-scoped** — separate DB per Hermes profile
 
 ## Requirements
@@ -111,12 +112,25 @@ Environment variables (all optional):
 | `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of context window triggering compaction |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `1` | Max condensation depth (`0` = disabled, `-1` = unlimited) |
 | `LCM_CONDENSATION_FANIN` | `4` | Same-depth nodes needed to trigger condensation |
+| `LCM_IGNORE_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions to exclude from LCM storage entirely |
+| `LCM_STATELESS_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions that stay read-only (`platform:session_id` matching supported) |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization |
 | `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after `/new` (`-1` = all, `0` = none, `2` = keep d2+) |
+
+Pattern syntax matches `lossless-claw`:
+- `*` matches within one colon-delimited segment
+- `**` can span across colons
+
+Hermes currently matches each pattern against multiple candidate keys for flexibility:
+- raw `session_id`
+- `platform`
+- `platform:session_id`
+
+That means patterns like `cron:*` can catch Hermes cron sessions today, while plain raw session-id matching still works if you know the exact IDs you want to target.
 
 ## Agent Tools
 
@@ -150,7 +164,7 @@ hermes-lcm/
 ├── tokens.py        # tiktoken with char-based fallback
 ├── schemas.py       # tool schemas (what the LLM sees)
 ├── tools.py         # tool handlers (lcm_grep, lcm_describe, lcm_expand, lcm_expand_query)
-└── tests/           # 54 tests
+└── tests/           # 59 tests
 ```
 
 **Running tests:**

--- a/config.py
+++ b/config.py
@@ -3,6 +3,10 @@ import os
 from dataclasses import dataclass, field
 
 
+def _parse_pattern_list(raw: str) -> list[str]:
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
 @dataclass
 class LCMConfig:
     """All tunables for the LCM engine."""
@@ -32,6 +36,15 @@ class LCMConfig:
     # Reserve this many tokens from the model context window before assembly
     # (0 = disabled). Effective cap becomes context_length - reserve_tokens_floor.
     reserve_tokens_floor: int = 0
+
+    # -- Session filtering ---
+    # Sessions to exclude from LCM storage entirely.
+    ignore_session_patterns: list[str] = field(default_factory=list)
+    # Sessions that may read carried-over LCM state but never write new data.
+    stateless_session_patterns: list[str] = field(default_factory=list)
+    # Diagnostics: where each pattern list came from.
+    ignore_session_patterns_source: str = "default"
+    stateless_session_patterns_source: str = "default"
 
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
@@ -71,5 +84,15 @@ class LCMConfig:
         c.expansion_timeout_ms = _int("LCM_EXPANSION_TIMEOUT_MS", c.expansion_timeout_ms)
         c.database_path = _str("LCM_DATABASE_PATH", c.database_path)
         c.new_session_retain_depth = _int("LCM_NEW_SESSION_RETAIN_DEPTH", c.new_session_retain_depth)
+
+        raw_ignore = os.environ.get("LCM_IGNORE_SESSION_PATTERNS")
+        if raw_ignore is not None:
+            c.ignore_session_patterns = _parse_pattern_list(raw_ignore)
+            c.ignore_session_patterns_source = "env"
+
+        raw_stateless = os.environ.get("LCM_STATELESS_SESSION_PATTERNS")
+        if raw_stateless is not None:
+            c.stateless_session_patterns = _parse_pattern_list(raw_stateless)
+            c.stateless_session_patterns_source = "env"
 
         return c

--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,11 @@ from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
 from .schemas import LCM_DESCRIBE, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_GREP
+from .session_patterns import (
+    build_session_match_keys,
+    compile_session_patterns,
+    matches_session_pattern,
+)
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
@@ -54,6 +59,16 @@ class LCMEngine(ContextEngine):
         self._dag = SummaryDAG(db_path)
 
         self._session_id: str = ""
+        self._session_platform: str = ""
+        self._session_match_keys: list[str] = []
+        self._session_ignored = False
+        self._session_stateless = False
+        self._compiled_ignore_session_patterns = compile_session_patterns(
+            self._config.ignore_session_patterns
+        )
+        self._compiled_stateless_session_patterns = compile_session_patterns(
+            self._config.stateless_session_patterns
+        )
 
         # Track which store_ids have been ingested into the DAG
         self._last_compacted_store_id: int = 0
@@ -97,6 +112,8 @@ class LCMEngine(ContextEngine):
         self.last_total_tokens = usage.get("total_tokens", 0)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
+        if self._session_ignored or self._session_stateless:
+            return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if self.threshold_tokens <= 0:
             return False
@@ -104,6 +121,8 @@ class LCMEngine(ContextEngine):
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
+        if self._session_ignored or self._session_stateless:
+            return False
         if self._session_id and messages:
             try:
                 self._ingest_messages(messages)
@@ -125,6 +144,14 @@ class LCMEngine(ContextEngine):
         5. Assemble new active context: summaries + fresh tail
         """
         if not messages:
+            return messages
+
+        if self._session_ignored or self._session_stateless:
+            logger.debug(
+                "LCM compress bypassed for %s session %s",
+                "ignored" if self._session_ignored else "stateless",
+                self._session_id or "(unknown)",
+            )
             return messages
 
         prompt_tokens = current_tokens or self.last_prompt_tokens
@@ -212,8 +239,10 @@ class LCMEngine(ContextEngine):
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         self._session_id = session_id
+        self._session_platform = str(kwargs.get("platform") or "")
         self._ingest_cursor = 0
         self._last_compacted_store_id = 0
+        self._refresh_session_filters()
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
         # Pick up context_length from kwargs if provided
@@ -222,6 +251,7 @@ class LCMEngine(ContextEngine):
             self.threshold_tokens = int(
                 self.context_length * self._config.context_threshold
             )
+        self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         # Ensure all messages are persisted
@@ -249,6 +279,12 @@ class LCMEngine(ContextEngine):
         """Move retained summaries from the old session into the new one."""
         if not old_session_id or not new_session_id or old_session_id == new_session_id:
             return 0
+        if self._session_ignored and new_session_id == self._session_id:
+            logger.debug(
+                "LCM carry-over skipped for ignored session %s",
+                new_session_id,
+            )
+            return 0
         return self._dag.reassign_session_nodes(old_session_id, new_session_id)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -257,8 +293,8 @@ class LCMEngine(ContextEngine):
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
         # Ingest live messages if passed (enables current-turn search)
         messages = kwargs.get("messages")
-        
-        if messages and self._session_id:
+
+        if messages and self._session_id and not (self._session_ignored or self._session_stateless):
             try:
                 self._ingest_messages(messages)
             except Exception as e:
@@ -281,6 +317,13 @@ class LCMEngine(ContextEngine):
             status["engine"] = "lcm"
             status["store_messages"] = self._store.get_session_count(self._session_id)
             status["dag_nodes"] = len(self._dag.get_session_nodes(self._session_id))
+            status["session_platform"] = self._session_platform
+            status["session_ignored"] = self._session_ignored
+            status["session_stateless"] = self._session_stateless
+            status["ignore_session_patterns"] = list(self._config.ignore_session_patterns)
+            status["stateless_session_patterns"] = list(self._config.stateless_session_patterns)
+            status["ignore_session_patterns_source"] = self._config.ignore_session_patterns_source
+            status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
         return status
 
     def update_model(self, model: str, context_length: int,
@@ -288,6 +331,49 @@ class LCMEngine(ContextEngine):
                      provider: str = "") -> None:
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self._config.context_threshold)
+
+    def _refresh_session_filters(self) -> None:
+        self._session_match_keys = build_session_match_keys(
+            self._session_id,
+            platform=self._session_platform,
+        )
+        self._session_ignored = matches_session_pattern(
+            self._session_match_keys,
+            self._compiled_ignore_session_patterns,
+        )
+        self._session_stateless = (
+            not self._session_ignored
+            and matches_session_pattern(
+                self._session_match_keys,
+                self._compiled_stateless_session_patterns,
+            )
+        )
+
+    def _log_session_filter_diagnostics(self) -> None:
+        if self._config.ignore_session_patterns:
+            logger.info(
+                "LCM ignore_session_patterns from %s: %s",
+                self._config.ignore_session_patterns_source,
+                ", ".join(self._config.ignore_session_patterns),
+            )
+        if self._config.stateless_session_patterns:
+            logger.info(
+                "LCM stateless_session_patterns from %s: %s",
+                self._config.stateless_session_patterns_source,
+                ", ".join(self._config.stateless_session_patterns),
+            )
+        if self._session_ignored:
+            logger.info(
+                "LCM session %s matched ignore_session_patterns via %s — skipping writes and compaction",
+                self._session_id,
+                ", ".join(self._session_match_keys),
+            )
+        elif self._session_stateless:
+            logger.info(
+                "LCM session %s matched stateless_session_patterns via %s — read-only mode (no LCM writes)",
+                self._session_id,
+                ", ".join(self._session_match_keys),
+            )
 
     # -- Internal: message ingestion ---------------------------------------
 
@@ -302,6 +388,14 @@ class LCMEngine(ContextEngine):
         """
         if not self._session_id:
             logger.debug("Ingest skipped: no session_id")
+            return
+
+        if self._session_ignored or self._session_stateless:
+            logger.debug(
+                "Ingest skipped for %s session %s",
+                "ignored" if self._session_ignored else "stateless",
+                self._session_id,
+            )
             return
 
         n = len(messages)

--- a/session_patterns.py
+++ b/session_patterns.py
@@ -1,0 +1,52 @@
+"""Session-pattern helpers for LCM session filtering.
+
+`*` matches within a single colon-delimited segment.
+`**` can span across colons.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+def compile_session_pattern(pattern: str) -> re.Pattern[str]:
+    """Compile a session glob into a regex.
+
+    `*` matches any non-colon characters, while `**` can span colons.
+    """
+    escaped = re.escape(pattern)
+    escaped = escaped.replace(r"\*\*", "\x00")
+    escaped = escaped.replace(r"\*", "[^:]*")
+    escaped = escaped.replace("\x00", ".*")
+    return re.compile(rf"^{escaped}$")
+
+
+def compile_session_patterns(patterns: Iterable[str]) -> List[re.Pattern[str]]:
+    """Compile configured session patterns once at startup."""
+    return [compile_session_pattern(pattern) for pattern in patterns]
+
+
+def build_session_match_keys(session_id: str, platform: str = "") -> list[str]:
+    """Build candidate keys that session filters may match against.
+
+    Hermes currently gives the engine a random-ish session_id plus some session
+    metadata like platform. Matching against multiple shapes keeps the filter
+    useful now while leaving room for richer host-provided keys later.
+    """
+    keys: list[str] = []
+    if session_id:
+        keys.append(session_id)
+    if platform:
+        keys.append(platform)
+    if session_id and platform:
+        keys.append(f"{platform}:{session_id}")
+    return keys
+
+
+def matches_session_pattern(session_keys: Iterable[str], patterns: Iterable[re.Pattern[str]]) -> bool:
+    """Check whether any session key matches any compiled pattern."""
+    keys = [key for key in session_keys if key]
+    if not keys:
+        return False
+    return any(pattern.match(key) for pattern in patterns for key in keys)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -8,6 +8,12 @@ from hermes_lcm.tokens import count_tokens, count_message_tokens, count_messages
 from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG, SummaryNode
 from hermes_lcm.escalation import _deterministic_truncate
+from hermes_lcm.session_patterns import (
+    build_session_match_keys,
+    compile_session_pattern,
+    compile_session_patterns,
+    matches_session_pattern,
+)
 
 
 class TestConfig:
@@ -17,6 +23,10 @@ class TestConfig:
         assert c.leaf_chunk_tokens == 20_000
         assert c.context_threshold == 0.75
         assert c.condensation_fanin == 4
+        assert c.ignore_session_patterns == []
+        assert c.stateless_session_patterns == []
+        assert c.ignore_session_patterns_source == "default"
+        assert c.stateless_session_patterns_source == "default"
         assert c.summary_model == ""
         assert c.expansion_model == ""
         assert c.summary_timeout_ms == 60_000
@@ -25,15 +35,53 @@ class TestConfig:
     def test_from_env(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "32")
         monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.80")
+        monkeypatch.setenv("LCM_IGNORE_SESSION_PATTERNS", "cron:*,subagent:**")
+        monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "telegram:*, cli:debug")
         monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
         monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
         monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
+        assert c.ignore_session_patterns == ["cron:*", "subagent:**"]
+        assert c.stateless_session_patterns == ["telegram:*", "cli:debug"]
+        assert c.ignore_session_patterns_source == "env"
+        assert c.stateless_session_patterns_source == "env"
         assert c.expansion_model == "openai/gpt-5.4-mini"
         assert c.summary_timeout_ms == 45_000
         assert c.expansion_timeout_ms == 90_000
+
+
+class TestSessionPatterns:
+    def test_compile_pattern_wildcards(self):
+        base_cron = compile_session_pattern("cron:*")
+        deep_cron = compile_session_pattern("cron:**")
+
+        assert base_cron.match("cron:job-123")
+        assert not base_cron.match("cron:nightly:run-1")
+        assert deep_cron.match("cron:nightly:run-1")
+
+    def test_build_session_match_keys(self):
+        assert build_session_match_keys("sess-123", platform="cron") == [
+            "sess-123",
+            "cron",
+            "cron:sess-123",
+        ]
+
+    def test_matches_any_compiled_pattern(self):
+        patterns = compile_session_patterns(["cron:**", "telegram:*"])
+        assert matches_session_pattern(
+            build_session_match_keys("cron_123", platform="cron"),
+            patterns,
+        )
+        assert matches_session_pattern(
+            build_session_match_keys("debug", platform="telegram"),
+            patterns,
+        )
+        assert not matches_session_pattern(
+            build_session_match_keys("sess-123", platform="cli"),
+            patterns,
+        )
 
 
 class TestTokens:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -81,9 +81,97 @@ class TestEngineABC:
             messages.append({"role": "user", "content": f"Question {i}: " + "x" * 200})
             messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
 
-        engine.compress(messages, focus_topic="database schema")
+        engine.compress(messages, focus_topic="database migrations")
 
-        assert captured["focus_topic"] == "database schema"
+        assert captured["focus_topic"] == "database migrations"
+
+
+class TestSessionFiltering:
+    def test_on_session_start_marks_ignored_session_and_reports_status(self, tmp_path, caplog):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_ignore.db"),
+            ignore_session_patterns=["cron:*"],
+            ignore_session_patterns_source="env",
+        )
+        instance = LCMEngine(config=config)
+
+        with caplog.at_level("INFO", logger="hermes_lcm.engine"):
+            instance.on_session_start("cron_123", platform="cron", context_length=1000)
+
+        status = instance.get_status()
+        assert status["session_ignored"] is True
+        assert status["session_stateless"] is False
+        assert status["ignore_session_patterns"] == ["cron:*"]
+        assert status["ignore_session_patterns_source"] == "env"
+        assert "LCM ignore_session_patterns from env: cron:*" in caplog.text
+        assert "matched ignore_session_patterns" in caplog.text
+
+    def test_on_session_start_marks_stateless_session_and_reports_status(self, tmp_path, caplog):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_stateless.db"),
+            stateless_session_patterns=["telegram:*"],
+            stateless_session_patterns_source="env",
+        )
+        instance = LCMEngine(config=config)
+
+        with caplog.at_level("INFO", logger="hermes_lcm.engine"):
+            instance.on_session_start("debug", platform="telegram", context_length=1000)
+
+        status = instance.get_status()
+        assert status["session_ignored"] is False
+        assert status["session_stateless"] is True
+        assert status["stateless_session_patterns"] == ["telegram:*"]
+        assert status["stateless_session_patterns_source"] == "env"
+        assert "LCM stateless_session_patterns from env: telegram:*" in caplog.text
+        assert "matched stateless_session_patterns" in caplog.text
+
+    def test_ignored_session_does_not_write_to_store_or_compact(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_ignore_behavior.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("cron_123", platform="cron", context_length=1000)
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "again"},
+        ]
+
+        result = instance.compress(messages)
+
+        assert result == messages
+        assert instance._store.get_session_count("cron_123") == 0
+        assert instance._dag.get_session_nodes("cron_123") == []
+        assert instance.compression_count == 0
+
+    def test_stateless_session_does_not_write_to_store_or_compact(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_stateless_behavior.db"),
+            stateless_session_patterns=["telegram:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("debug", platform="telegram", context_length=1000)
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "again"},
+        ]
+
+        result = instance.compress(messages)
+
+        assert result == messages
+        assert instance._store.get_session_count("debug") == 0
+        assert instance._dag.get_session_nodes("debug") == []
+        assert instance.compression_count == 0
 
 
 class TestEngineIngest:


### PR DESCRIPTION
## Summary
- add lossless-claw-style session pattern matching with `*` and `**`
- add `LCM_IGNORE_SESSION_PATTERNS` and `LCM_STATELESS_SESSION_PATTERNS`
- skip LCM writes/compaction for ignored and stateless sessions
- surface pattern-source diagnostics in engine status and startup logs
- add regression coverage for config parsing, pattern matching, and engine behavior

## Why
A lot of noisy sessions should never pollute long-term LCM state in the first place.

This adds two buckets:
- ignored sessions: fully excluded from LCM writes
- stateless sessions: read-only from the LCM point of view, so they don't add new state

That gives us a clean path for things like cron-style runs and other transient sessions.

## Test Plan
- `python3 -m pytest tests/ -q`
- `59 passed`
