### PR TITLE
feat: add separate expansion path and query tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ into anything that was compacted.
 - **Immutable store** — every message persisted in SQLite, never modified
 - **Summary DAG** — hierarchical compaction (D0 minutes → D1 hours → D2 days)
 - **3-level escalation** — L1 detailed → L2 bullets → L3 deterministic truncate (guaranteed convergence)
-- **Agent tools** — `lcm_grep`, `lcm_describe`, `lcm_expand` for structured retrieval
+- **Agent tools** — `lcm_grep`, `lcm_describe`, `lcm_expand`, `lcm_expand_query` for structured retrieval
 - **Current-turn search** — live messages ingested before tool execution
 - **Profile-scoped** — separate DB per Hermes profile
 
@@ -94,7 +94,7 @@ Verify with `hermes plugins`:
 
 ```
 Plugins (1):
-  ✓ hermes-lcm v0.1.0 (3 tools, 0 hooks)
+  ✓ hermes-lcm v0.1.0 (4 tools, 0 hooks)
 
 Provider Plugins:
   Context Engine: lcm
@@ -112,6 +112,9 @@ Environment variables (all optional):
 | `LCM_INCREMENTAL_MAX_DEPTH` | `1` | Max condensation depth (`0` = disabled, `-1` = unlimited) |
 | `LCM_CONDENSATION_FANIN` | `4` | Same-depth nodes needed to trigger condensation |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization |
+| `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis |
+| `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
+| `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after `/new` (`-1` = all, `0` = none, `2` = keep d2+) |
 
@@ -122,6 +125,7 @@ Environment variables (all optional):
 | `lcm_grep` | Search raw messages AND summaries across all depths. FTS5 syntax. |
 | `lcm_describe` | Inspect DAG structure — token counts, children, expand hints. No node_id = session overview. |
 | `lcm_expand` | Recover original content from a summary node. Token-budgeted. |
+| `lcm_expand_query` | Answer a question from expanded LCM context using either a query or explicit node_ids. Uses the expansion path/model instead of the summarization path. |
 
 ## How It Works
 
@@ -130,7 +134,7 @@ Environment variables (all optional):
 3. **Condense** — when enough D0 nodes accumulate, they're condensed into D1 nodes (and so on up)
 4. **Escalate** — if a summary is too long, escalate: L1 detailed → L2 bullets → L3 deterministic truncate
 5. **Assemble** — active context = system prompt + highest-depth summaries + fresh tail
-6. **Retrieve** — agent uses `lcm_grep`/`lcm_describe`/`lcm_expand` to drill into compacted history
+6. **Retrieve** — agent uses `lcm_grep`/`lcm_describe`/`lcm_expand`/`lcm_expand_query` to drill into compacted history or synthesize answers from expanded context
 
 ## Architecture
 
@@ -145,8 +149,8 @@ hermes-lcm/
 ├── config.py        # LCMConfig + env var overrides
 ├── tokens.py        # tiktoken with char-based fallback
 ├── schemas.py       # tool schemas (what the LLM sees)
-├── tools.py         # tool handlers (lcm_grep, lcm_describe, lcm_expand)
-└── tests/           # 46 tests
+├── tools.py         # tool handlers (lcm_grep, lcm_describe, lcm_expand, lcm_expand_query)
+└── tests/           # 54 tests
 ```
 
 **Running tests:**

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 """LCM configuration with defaults and env var overrides."""
-
 import os
 from dataclasses import dataclass, field
 
@@ -29,6 +28,11 @@ class LCMConfig:
 
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
+    expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
+
+    # -- Timeouts ---
+    summary_timeout_ms: int = 60_000
+    expansion_timeout_ms: int = 120_000
 
     # -- Storage ---
     database_path: str = ""       # empty = auto (~/.hermes/lcm.db)
@@ -51,6 +55,9 @@ class LCMConfig:
         c.incremental_max_depth = _int("LCM_INCREMENTAL_MAX_DEPTH", c.incremental_max_depth)
         c.condensation_fanin = _int("LCM_CONDENSATION_FANIN", c.condensation_fanin)
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
+        c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
+        c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)
+        c.expansion_timeout_ms = _int("LCM_EXPANSION_TIMEOUT_MS", c.expansion_timeout_ms)
         c.database_path = _str("LCM_DATABASE_PATH", c.database_path)
         c.new_session_retain_depth = _int("LCM_NEW_SESSION_RETAIN_DEPTH", c.new_session_retain_depth)
 

--- a/engine.py
+++ b/engine.py
@@ -15,7 +15,7 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
-from .schemas import LCM_DESCRIBE, LCM_EXPAND, LCM_GREP
+from .schemas import LCM_DESCRIBE, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_GREP
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
@@ -165,6 +165,7 @@ class LCMEngine(ContextEngine):
             token_budget=token_budget,
             depth=0,
             model=self._config.summary_model,
+            timeout=self._config.summary_timeout_ms / 1000,
             l2_budget_ratio=self._config.l2_budget_ratio,
             l3_truncate_tokens=self._config.l3_truncate_tokens,
             focus_topic=focus_topic or "",
@@ -251,7 +252,7 @@ class LCMEngine(ContextEngine):
         return self._dag.reassign_session_nodes(old_session_id, new_session_id)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [LCM_GREP, LCM_DESCRIBE, LCM_EXPAND]
+        return [LCM_GREP, LCM_DESCRIBE, LCM_EXPAND, LCM_EXPAND_QUERY]
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
         # Ingest live messages if passed (enables current-turn search)
@@ -267,6 +268,7 @@ class LCMEngine(ContextEngine):
             "lcm_grep": lcm_tools.lcm_grep,
             "lcm_describe": lcm_tools.lcm_describe,
             "lcm_expand": lcm_tools.lcm_expand,
+            "lcm_expand_query": lcm_tools.lcm_expand_query,
         }
         handler = handlers.get(name)
         if handler:
@@ -423,6 +425,7 @@ class LCMEngine(ContextEngine):
                 token_budget=token_budget,
                 depth=depth + 1,
                 model=self._config.summary_model,
+                timeout=self._config.summary_timeout_ms / 1000,
                 l2_budget_ratio=self._config.l2_budget_ratio,
                 l3_truncate_tokens=self._config.l3_truncate_tokens,
                 focus_topic=focus_topic or "",

--- a/escalation.py
+++ b/escalation.py
@@ -7,6 +7,7 @@ Level 3 (Fallback):   Deterministic truncation — no LLM, guaranteed convergenc
 Each level checks if Tokens(summary) < Tokens(source). If not, escalates.
 """
 
+import inspect
 import logging
 from typing import List, Optional
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _call_llm_for_summary(prompt: str, max_tokens: int,
-                           model: str = "") -> Optional[str]:
+                           model: str = "", timeout: float | None = None) -> Optional[str]:
     """Call the Hermes auxiliary LLM for summarization."""
     try:
         from agent.auxiliary_client import call_llm
@@ -28,6 +29,8 @@ def _call_llm_for_summary(prompt: str, max_tokens: int,
         }
         if model:
             call_kwargs["model"] = model
+        if timeout is not None:
+            call_kwargs["timeout"] = timeout
         response = call_llm(**call_kwargs)
         content = response.choices[0].message.content
         if not isinstance(content, str):
@@ -36,6 +39,20 @@ def _call_llm_for_summary(prompt: str, max_tokens: int,
     except Exception as e:
         logger.warning("LLM summarization failed: %s", e)
         return None
+
+
+def _invoke_summary_llm(prompt: str, max_tokens: int, model: str = "", timeout: float | None = None) -> Optional[str]:
+    kwargs = {"model": model} if model else {}
+    if timeout is not None:
+        try:
+            sig = inspect.signature(_call_llm_for_summary)
+            if "timeout" in sig.parameters or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            ):
+                kwargs["timeout"] = timeout
+        except Exception:
+            pass
+    return _call_llm_for_summary(prompt, max_tokens, **kwargs)
 
 
 def _build_l1_prompt(text: str, token_budget: int, depth: int, focus_topic: str = "") -> str:
@@ -110,6 +127,7 @@ def summarize_with_escalation(
     token_budget: int,
     depth: int = 0,
     model: str = "",
+    timeout: float | None = None,
     l2_budget_ratio: float = 0.50,
     l3_truncate_tokens: int = 512,
     focus_topic: str = "",
@@ -121,7 +139,7 @@ def summarize_with_escalation(
     """
     # Level 1: detailed summary
     l1_prompt = _build_l1_prompt(text, token_budget, depth, focus_topic=focus_topic)
-    l1_result = _call_llm_for_summary(l1_prompt, token_budget * 2, model=model)
+    l1_result = _invoke_summary_llm(l1_prompt, token_budget * 2, model=model, timeout=timeout)
 
     if l1_result and count_tokens(l1_result) < source_tokens:
         logger.debug("L1 summarization succeeded (%d tokens)", count_tokens(l1_result))
@@ -130,7 +148,7 @@ def summarize_with_escalation(
     # Level 2: aggressive bullets at reduced budget
     l2_budget = int(token_budget * l2_budget_ratio)
     l2_prompt = _build_l2_prompt(text, l2_budget, focus_topic=focus_topic)
-    l2_result = _call_llm_for_summary(l2_prompt, l2_budget * 2, model=model)
+    l2_result = _invoke_summary_llm(l2_prompt, l2_budget * 2, model=model, timeout=timeout)
 
     if l2_result and count_tokens(l2_result) < source_tokens:
         logger.debug("L2 summarization succeeded (%d tokens)", count_tokens(l2_result))

--- a/schemas.py
+++ b/schemas.py
@@ -71,3 +71,41 @@ LCM_EXPAND = {
         "required": ["node_id"],
     },
 }
+
+LCM_EXPAND_QUERY = {
+    "name": "lcm_expand_query",
+    "description": (
+        "Answer a natural-language question using expanded LCM context. Provide a prompt, and either "
+        "query matching summaries to expand or explicit node_ids to inspect. Uses the expansion path "
+        "instead of the summarization path so retrieval/synthesis can use a different model or timeout."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "The question or task to answer from expanded LCM context",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional search query used to find candidate summaries before expansion",
+            },
+            "node_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Optional explicit summary node IDs to expand instead of searching",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Max candidate summaries to expand when using query (default 5)",
+                "default": 5,
+            },
+            "max_tokens": {
+                "type": "integer",
+                "description": "Max answer tokens for synthesis (default 2000)",
+                "default": 2000,
+            },
+        },
+        "required": ["prompt"],
+    },
+}

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -17,13 +17,23 @@ class TestConfig:
         assert c.leaf_chunk_tokens == 20_000
         assert c.context_threshold == 0.75
         assert c.condensation_fanin == 4
+        assert c.summary_model == ""
+        assert c.expansion_model == ""
+        assert c.summary_timeout_ms == 60_000
+        assert c.expansion_timeout_ms == 120_000
 
     def test_from_env(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "32")
         monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.80")
+        monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
+        monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
+        monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
+        assert c.expansion_model == "openai/gpt-5.4-mini"
+        assert c.summary_timeout_ms == 45_000
+        assert c.expansion_timeout_ms == 90_000
 
 
 class TestTokens:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -35,6 +35,7 @@ class TestEngineABC:
         assert "lcm_grep" in names
         assert "lcm_describe" in names
         assert "lcm_expand" in names
+        assert "lcm_expand_query" in names
 
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)
@@ -426,19 +427,22 @@ class TestUnlimitedCondensationDepth:
 
 
 class TestConfigCleanup:
-    """Tests for issue #2c — removed config options."""
+    """Tests for issue #2c follow-up — expansion path is now separate from summary-only config."""
 
-    def test_no_expansion_model(self):
+    def test_has_expansion_model(self):
         config = LCMConfig()
-        assert not hasattr(config, "expansion_model")
+        assert hasattr(config, "expansion_model")
+        assert config.expansion_model == ""
 
-    def test_no_summary_timeout(self):
+    def test_has_summary_timeout_ms(self):
         config = LCMConfig()
-        assert not hasattr(config, "summary_timeout_ms")
+        assert hasattr(config, "summary_timeout_ms")
+        assert config.summary_timeout_ms == 60_000
 
-    def test_no_delegation_timeout(self):
+    def test_has_expansion_timeout_ms(self):
         config = LCMConfig()
-        assert not hasattr(config, "delegation_timeout_ms")
+        assert hasattr(config, "expansion_timeout_ms")
+        assert config.expansion_timeout_ms == 120_000
 
 
 class TestEngineTools:
@@ -476,6 +480,55 @@ class TestEngineTools:
         assert result_b["total_results"] == 1
         assert "alpha" in result_a["results"][0]["snippet"]
         assert "beta" in result_b["results"][0]["snippet"]
+
+    def test_handle_expand_query_requires_prompt(self, engine):
+        result = json.loads(engine.handle_tool_call("lcm_expand_query", {"query": "docker"}))
+        assert "error" in result
+        assert "prompt" in result["error"]
+
+    def test_handle_expand_query_uses_expansion_model(self, engine, monkeypatch):
+        engine._config.expansion_model = "expansion-model-x"
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        seen = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            seen["prompt"] = prompt
+            seen["context_blocks"] = context_blocks
+            seen["model"] = model
+            seen["max_tokens"] = max_tokens
+            seen["timeout"] = timeout
+            return "Expansion answer"
+
+        monkeypatch.setattr("hermes_lcm.tools._synthesize_expansion_answer", fake_synthesize)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?", "max_tokens": 500},
+            )
+        )
+
+        assert result["answer"] == "Expansion answer"
+        assert result["model"] == "expansion-model-x"
+        assert result["node_ids"] == [node_id]
+        assert seen["model"] == "expansion-model-x"
+        assert seen["timeout"] == engine._config.expansion_timeout_ms / 1000
+        assert seen["max_tokens"] == 500
+        assert seen["prompt"] == "What was the plan?"
+        assert seen["context_blocks"]
 
     def test_describe_and_expand_are_session_scoped(self, engine):
         node_id = engine._dag.add_node(

--- a/tools.py
+++ b/tools.py
@@ -24,6 +24,123 @@ def _get_session_node(engine: "LCMEngine", node_id: int):
     return node
 
 
+def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
+    from .tokens import count_tokens
+
+    messages = []
+    budget_used = 0
+    for store_id in node.source_ids:
+        stored = engine._store.get(store_id)
+        if not stored or stored.get("session_id") != engine._session_id:
+            continue
+        content = stored.get("content", "")
+        msg_tokens = count_tokens(content)
+        if budget_used + msg_tokens > max_tokens and messages:
+            messages.append(
+                {
+                    "note": f"Truncated — {len(node.source_ids) - len(messages)} more messages available",
+                }
+            )
+            break
+        messages.append(
+            {
+                "store_id": stored["store_id"],
+                "role": stored["role"],
+                "content": content[:2000] if len(content) > 2000 else content,
+            }
+        )
+        budget_used += msg_tokens
+    return messages
+
+
+def _expand_child_nodes(engine: "LCMEngine", node) -> list[dict[str, Any]]:
+    children = [child for child in engine._dag.get_source_nodes(node) if child.session_id == engine._session_id]
+    return [
+        {
+            "node_id": child.node_id,
+            "depth": child.depth,
+            "summary": child.summary[:1000],
+            "token_count": child.token_count,
+            "expand_hint": child.expand_hint,
+        }
+        for child in children
+    ]
+
+
+def _collect_context_blocks_for_node(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "summary",
+            "node_id": node.node_id,
+            "depth": node.depth,
+            "summary": node.summary,
+            "expand_hint": node.expand_hint,
+            "token_count": node.token_count,
+        }
+    ]
+
+    if node.source_type == "messages":
+        messages = _expand_message_sources(engine, node, max_tokens=max_tokens)
+        if messages:
+            blocks.append(
+                {
+                    "type": "messages",
+                    "node_id": node.node_id,
+                    "messages": messages,
+                }
+            )
+    elif node.source_type == "nodes":
+        children = _expand_child_nodes(engine, node)
+        if children:
+            blocks.append(
+                {
+                    "type": "child_nodes",
+                    "node_id": node.node_id,
+                    "children": children,
+                }
+            )
+
+    return blocks
+
+
+def _synthesize_expansion_answer(
+    *,
+    prompt: str,
+    context_blocks: list[dict[str, Any]],
+    model: str,
+    max_tokens: int,
+    timeout: float,
+) -> str:
+    from agent.auxiliary_client import call_llm
+
+    system_prompt = (
+        "You answer questions using expanded LCM retrieval context. "
+        "Be concise, factual, and grounded in the provided context. "
+        "If the context is insufficient, say so plainly."
+    )
+    user_prompt = (
+        f"QUESTION:\n{prompt}\n\n"
+        "EXPANDED CONTEXT:\n"
+        f"{json.dumps(context_blocks, ensure_ascii=False, indent=2)}"
+    )
+    call_kwargs = {
+        "task": "compression",
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "max_tokens": max_tokens,
+        "timeout": timeout,
+    }
+    if model:
+        call_kwargs["model"] = model
+    response = call_llm(**call_kwargs)
+    content = response.choices[0].message.content
+    if not isinstance(content, str):
+        content = str(content) if content else ""
+    return content.strip()
+
+
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     """Search across the full DAG and raw messages for the current session."""
     engine = _require_engine(kwargs)
@@ -132,32 +249,7 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     max_tokens = args.get("max_tokens", 4000)
 
     if node.source_type == "messages":
-        from .tokens import count_tokens
-
-        messages = []
-        budget_used = 0
-        for store_id in node.source_ids:
-            stored = engine._store.get(store_id)
-            if not stored or stored.get("session_id") != engine._session_id:
-                continue
-            content = stored.get("content", "")
-            msg_tokens = count_tokens(content)
-            if budget_used + msg_tokens > max_tokens and messages:
-                messages.append(
-                    {
-                        "note": f"Truncated — {len(node.source_ids) - len(messages)} more messages available",
-                    }
-                )
-                break
-            messages.append(
-                {
-                    "store_id": stored["store_id"],
-                    "role": stored["role"],
-                    "content": content[:2000] if len(content) > 2000 else content,
-                }
-            )
-            budget_used += msg_tokens
-
+        messages = _expand_message_sources(engine, node, max_tokens=max_tokens)
         return json.dumps(
             {
                 "node_id": node_id,
@@ -168,23 +260,85 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         )
 
     if node.source_type == "nodes":
-        children = [child for child in engine._dag.get_source_nodes(node) if child.session_id == engine._session_id]
+        children = _expand_child_nodes(engine, node)
         return json.dumps(
             {
                 "node_id": node_id,
                 "depth": node.depth,
                 "source_type": "nodes",
-                "expanded": [
-                    {
-                        "node_id": child.node_id,
-                        "depth": child.depth,
-                        "summary": child.summary[:1000],
-                        "token_count": child.token_count,
-                        "expand_hint": child.expand_hint,
-                    }
-                    for child in children
-                ],
+                "expanded": children,
             }
         )
 
     return json.dumps({"error": f"Unknown source_type: {node.source_type}"})
+
+
+def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
+    """Answer a question by expanding matching summaries or explicit node ids."""
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+
+    prompt = str(args.get("prompt") or "").strip()
+    if not prompt:
+        return json.dumps({"error": "prompt is required"})
+
+    max_tokens = int(args.get("max_tokens", 2000))
+    max_results = int(args.get("max_results", 5))
+    query = str(args.get("query") or "").strip()
+    raw_node_ids = args.get("node_ids") or []
+
+    nodes = []
+    if raw_node_ids:
+        for node_id in raw_node_ids:
+            node = _get_session_node(engine, int(node_id))
+            if node is not None:
+                nodes.append(node)
+    elif query:
+        nodes = engine._dag.search(query, session_id=engine._session_id, limit=max_results)
+    else:
+        return json.dumps({"error": "Provide either query or node_ids"})
+
+    if not nodes:
+        return json.dumps(
+            {
+                "prompt": prompt,
+                "query": query,
+                "answer": "No matching summaries found in the current session.",
+                "node_ids": [],
+                "matches": [],
+            }
+        )
+
+    context_blocks = []
+    for node in nodes[:max_results]:
+        context_blocks.extend(_collect_context_blocks_for_node(engine, node, max_tokens=max_tokens))
+
+    model = engine._config.expansion_model or engine._config.summary_model or ""
+    timeout = engine._config.expansion_timeout_ms / 1000
+    answer = _synthesize_expansion_answer(
+        prompt=prompt,
+        context_blocks=context_blocks,
+        model=model,
+        max_tokens=max_tokens,
+        timeout=timeout,
+    )
+
+    return json.dumps(
+        {
+            "prompt": prompt,
+            "query": query,
+            "answer": answer,
+            "model": model,
+            "node_ids": [node.node_id for node in nodes[:max_results]],
+            "matches": [
+                {
+                    "node_id": node.node_id,
+                    "depth": node.depth,
+                    "summary": node.summary[:300],
+                    "expand_hint": node.expand_hint,
+                }
+                for node in nodes[:max_results]
+            ],
+        }
+    )


### PR DESCRIPTION
## Summary
- add a separate expansion path instead of reusing the summary-only path
- add `LCM_EXPANSION_MODEL`, `LCM_SUMMARY_TIMEOUT_MS`, and `LCM_EXPANSION_TIMEOUT_MS`
- add `lcm_expand_query` for answering a question from expanded LCM context
- keep this scoped to in-process expansion/synthesis for now, without introducing delegated sub-agent behavior yet

## Why
`lcm_expand` is useful for raw drill-down, but it is still a manual retrieval step. This adds a practical path for query-driven answer synthesis while keeping expansion configuration separate from summarization.

It also lets summary and expansion use different model/timeout settings.

## What changed
- config:
  - `expansion_model`
  - `summary_timeout_ms`
  - `expansion_timeout_ms`
- tool surface:
  - add `lcm_expand_query`
- engine:
  - expose the new tool
  - pass summary timeout into the summarization path
- docs/tests:
  - update README
  - add config + tool coverage

## Validation
Passed locally:

- `python3 -m pytest tests/ -q`
  - result: `54 passed`

Also dogfooded locally in Hermes using the external plugin runtime:
- verified Hermes loaded `/home/nabu/.hermes/plugins/hermes-lcm/engine.py`
- verified `lcm_expand_query` was exposed to `AIAgent`
- verified a live expansion query returned the correct answer using `LCM_EXPANSION_MODEL=gpt-5.4`
- verified this while `LCM_SUMMARY_MODEL` was intentionally set to a bogus value, to prove the answer path was not coupled to the summary model

## Non-goals
- no bundling into Hermes core
- no delegated/sub-agent expansion path in this PR
- no recursion/concurrency guard yet for delegated expansion, since delegation itself is not introduced here

Those can be layered on later if we want to get closer to `lossless-claw` parity.