### PR TITLE
fix: add api_mode param to update_model() for Hermes compatibility

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -330,7 +330,8 @@ class LCMEngine(ContextEngine):
 
     def update_model(self, model: str, context_length: int,
                      base_url: str = "", api_key: str = "",
-                     provider: str = "") -> None:
+                     provider: str = "",
+                     api_mode: str = "") -> None:
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self._config.context_threshold)
 


### PR DESCRIPTION
## Problem

Hermes run_agent.py:1600 passes api_mode=self.api_mode to update_model(), but LCMEngine.update_model() does not accept it:

```
TypeError: update_model() got an unexpected keyword argument 'api_mode'
```

## Fix

Add api_mode: str = "" as an explicit parameter. Accepted and ignored — consistent with model/base_url/api_key/provider which are also accepted but unused in the method body.

Note: compress() already correctly accepts focus_topic as an explicit param.

## Companion

A companion PR has been submitted to hermes-agent to add api_mode to the ContextEngine ABC itself.