### PR TITLE
feat: add /lcm command surface and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
 
+## Gateway Slash Commands
+
+When Hermes host support for plugin slash commands is available, `hermes-lcm` also exposes a `/lcm` operator surface for quick read-only diagnostics from chat:
+
+- `/lcm` or `/lcm status` — current session/runtime status
+- `/lcm doctor` — SQLite + FTS health checks and store/node totals
+- `/lcm doctor clean` — best-effort read-only scan for obvious junk/noise sessions matched from stored session keys
+- `/lcm backup` — create a timestamped SQLite backup before any future cleanup workflow
+
+`/lcm doctor clean apply` is intentionally not implemented yet. This slice is diagnostics-first and backup-first.
+
 ## How It Works
 
 1. **Ingest** — every message persisted verbatim in an immutable SQLite store
@@ -195,10 +206,11 @@ hermes-lcm/
 ├── dag.py           # summary DAG with depth-aware nodes (FTS5)
 ├── escalation.py    # L1 → L2 → L3 guaranteed convergence
 ├── config.py        # LCMConfig + env var overrides
+├── command.py       # /lcm slash command handlers for gateway diagnostics
 ├── tokens.py        # tiktoken with char-based fallback
 ├── schemas.py       # tool schemas (what the LLM sees)
 ├── tools.py         # tool handlers (lcm_grep, lcm_describe, lcm_expand, lcm_expand_query)
-└── tests/           # 72 tests
+└── tests/           # standalone pytest coverage
 ```
 
 **Running tests:**

--- a/__init__.py
+++ b/__init__.py
@@ -32,4 +32,16 @@ def register(ctx):
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
 
+    register_command = getattr(ctx, "register_command", None)
+    if callable(register_command):
+        from .command import handle_lcm_command
+
+        register_command(
+            "lcm",
+            lambda raw_args: handle_lcm_command(raw_args, engine),
+            description="LCM status and diagnostics",
+        )
+    else:
+        logger.info("LCM slash command registration unavailable on this Hermes host; continuing without /lcm")
+
     logger.info("LCM plugin loaded — lossless context management active")

--- a/command.py
+++ b/command.py
@@ -1,0 +1,320 @@
+"""Slash-style /lcm command helpers for Hermes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sqlite3
+from typing import Any
+
+from .session_patterns import build_session_match_keys, matches_session_pattern
+
+
+def _fmt_bool(value: Any) -> str:
+    return "yes" if bool(value) else "no"
+
+
+def _fmt_size(num_bytes: int) -> str:
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    value = float(num_bytes)
+    unit = 0
+    while value >= 1024 and unit < len(units) - 1:
+        value /= 1024
+        unit += 1
+    precision = 0 if value >= 100 else 1 if value >= 10 else 2
+    return f"{value:.{precision}f} {units[unit]}"
+
+
+def _help_text(error: str | None = None) -> str:
+    lines = []
+    if error:
+        lines.append(error)
+        lines.append("")
+    lines.extend([
+        "LCM command help",
+        "- /lcm or /lcm status: show current LCM runtime/session status",
+        "- /lcm doctor: run read-only LCM health checks",
+        "- /lcm doctor clean: best-effort scan of obvious junk/noise session candidates without deleting anything",
+        "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
+        "- /lcm help: show this help",
+    ])
+    return "\n".join(lines)
+
+
+def _status_text(engine) -> str:
+    status = engine.get_status()
+    db_path = Path(engine._store.db_path)
+    db_exists = db_path.exists()
+    db_size = db_path.stat().st_size if db_exists else 0
+    lines = [
+        "LCM status",
+        f"engine: {status.get('engine', engine.name)}",
+        f"session_id: {engine._session_id or '(none)'}",
+        f"session_platform: {status.get('session_platform') or '(unknown)'}",
+        f"database_path: {db_path}",
+        f"database_exists: {_fmt_bool(db_exists)}",
+        f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
+        f"store_messages: {status.get('store_messages', 0)}",
+        f"dag_nodes: {status.get('dag_nodes', 0)}",
+        f"compression_count: {engine.compression_count}",
+        f"threshold_tokens: {engine.threshold_tokens}",
+        f"session_ignored: {_fmt_bool(status.get('session_ignored'))}",
+        f"session_stateless: {_fmt_bool(status.get('session_stateless'))}",
+    ]
+    if "ignore_session_patterns_source" in status:
+        lines.append(
+            f"ignore_session_patterns_source: {status.get('ignore_session_patterns_source')}"
+        )
+    if "stateless_session_patterns_source" in status:
+        lines.append(
+            f"stateless_session_patterns_source: {status.get('stateless_session_patterns_source')}"
+        )
+    return "\n".join(lines)
+
+
+def _doctor_text(engine) -> str:
+    db_path = Path(engine._store.db_path)
+    store_conn = engine._store._conn
+    dag_conn = engine._dag._conn
+
+    issues: list[str] = []
+
+    def _safe_count(conn, query: str, issue_key: str) -> int | str:
+        try:
+            return int(conn.execute(query).fetchone()[0])
+        except Exception as exc:  # pragma: no cover - defensive
+            issues.append(issue_key)
+            return f"error: {exc}"
+
+    try:
+        integrity_row = store_conn.execute("PRAGMA integrity_check").fetchone()
+        integrity = str(integrity_row[0]) if integrity_row else "unknown"
+    except Exception as exc:  # pragma: no cover - defensive
+        integrity = f"error: {exc}"
+        issues.append("sqlite_integrity")
+
+    try:
+        store_fts_count = int(store_conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+        store_fts = "ok"
+    except Exception as exc:  # pragma: no cover - defensive
+        store_fts_count = f"error: {exc}"
+        store_fts = f"error: {exc}"
+        issues.append("messages_fts")
+
+    try:
+        node_fts_count = int(dag_conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0])
+        node_fts = "ok"
+    except Exception as exc:  # pragma: no cover - defensive
+        node_fts_count = f"error: {exc}"
+        node_fts = f"error: {exc}"
+        issues.append("nodes_fts")
+
+    total_messages = _safe_count(store_conn, "SELECT COUNT(*) FROM messages", "messages_total")
+    total_message_sessions = _safe_count(
+        store_conn,
+        "SELECT COUNT(DISTINCT session_id) FROM messages",
+        "message_sessions_total",
+    )
+    total_nodes = _safe_count(dag_conn, "SELECT COUNT(*) FROM summary_nodes", "summary_nodes_total")
+    total_node_sessions = _safe_count(
+        dag_conn,
+        "SELECT COUNT(DISTINCT session_id) FROM summary_nodes",
+        "summary_node_sessions_total",
+    )
+
+    db_exists = db_path.exists()
+    db_size = db_path.stat().st_size if db_exists else 0
+
+    doctor_status = "ok" if integrity == "ok" and not issues else "issues-found"
+    lines = [
+        "LCM doctor",
+        f"status: {doctor_status}",
+        f"database_path: {db_path}",
+        f"database_exists: {_fmt_bool(db_exists)}",
+        f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
+        f"sqlite_integrity: {integrity}",
+        f"messages_total: {total_messages}",
+        f"message_sessions_total: {total_message_sessions}",
+        f"summary_nodes_total: {total_nodes}",
+        f"summary_node_sessions_total: {total_node_sessions}",
+        f"messages_fts: {store_fts}",
+        f"messages_fts_rows: {store_fts_count}",
+        f"nodes_fts: {node_fts}",
+        f"nodes_fts_rows: {node_fts_count}",
+    ]
+    if issues:
+        lines.append(f"issues: {', '.join(issues)}")
+    else:
+        lines.append("issues: none")
+    return "\n".join(lines)
+
+
+def _doctor_clean_text(engine) -> str:
+    conn = engine._store._conn
+    try:
+        rows = conn.execute(
+            """
+            WITH session_ids AS (
+                SELECT session_id FROM messages
+                UNION
+                SELECT session_id FROM summary_nodes
+            ),
+            message_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS message_count,
+                       COALESCE(SUM(token_estimate), 0) AS token_total
+                FROM messages
+                GROUP BY session_id
+            ),
+            node_stats AS (
+                SELECT session_id, COUNT(*) AS node_count
+                FROM summary_nodes
+                GROUP BY session_id
+            )
+            SELECT s.session_id,
+                   COALESCE(m.message_count, 0) AS message_count,
+                   COALESCE(m.token_total, 0) AS token_total,
+                   COALESCE(n.node_count, 0) AS node_count
+            FROM session_ids s
+            LEFT JOIN message_stats m ON m.session_id = s.session_id
+            LEFT JOIN node_stats n ON n.session_id = s.session_id
+            ORDER BY s.session_id
+            """
+        ).fetchall()
+    except Exception as exc:  # pragma: no cover - defensive
+        return "\n".join([
+            "LCM doctor clean",
+            "status: error",
+            f"error: {exc}",
+            "note: read-only scan only — no rows were deleted",
+        ])
+
+    candidates = []
+    ignored_count = 0
+    stateless_count = 0
+
+    for session_id, message_count, token_total, node_count in rows:
+        keys = build_session_match_keys(session_id)
+        matched_classes = []
+        if matches_session_pattern(keys, engine._compiled_ignore_session_patterns):
+            matched_classes.append("ignored-pattern")
+            ignored_count += 1
+        elif matches_session_pattern(keys, engine._compiled_stateless_session_patterns):
+            matched_classes.append("stateless-pattern")
+            stateless_count += 1
+        if not matched_classes:
+            continue
+        candidates.append(
+            {
+                "session_id": session_id,
+                "classes": matched_classes,
+                "message_count": int(message_count),
+                "node_count": int(node_count),
+                "token_total": int(token_total),
+            }
+        )
+
+    lines = [
+        "LCM doctor clean",
+        f"status: {'candidates-found' if candidates else 'ok'}",
+        f"candidate_sessions: {len(candidates)}",
+        f"ignored_pattern_matches: {ignored_count}",
+        f"stateless_pattern_matches: {stateless_count}",
+    ]
+
+    if not candidates:
+        lines.append("result: no obvious junk/noise session candidates detected")
+        return "\n".join(lines)
+
+    lines.append("candidates:")
+    for item in candidates[:20]:
+        classes = ", ".join(item["classes"])
+        lines.append(
+            "- "
+            f"{item['session_id']} | class={classes} | messages={item['message_count']} | "
+            f"nodes={item['node_count']} | tokens={item['token_total']}"
+        )
+    if len(candidates) > 20:
+        lines.append(f"... {len(candidates) - 20} more candidate session(s) omitted")
+    lines.append("note: best-effort stored-session scan only — platform-only matches may not be reconstructable from the SQLite state")
+    lines.append("note: read-only scan only — no rows were deleted")
+    return "\n".join(lines)
+
+
+def _backup_text(engine) -> str:
+    db_path = Path(engine._store.db_path)
+    if not db_path.exists():
+        return "\n".join([
+            "LCM backup",
+            "status: error",
+            f"database_path: {db_path}",
+            "error: database file does not exist",
+        ])
+
+    backup_root = Path(engine._hermes_home).expanduser() if getattr(engine, "_hermes_home", "") else db_path.parent
+    backup_dir = backup_root / "backups" / "lcm"
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = backup_dir / f"{db_path.stem}-{timestamp}.sqlite3"
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        engine._store._conn.commit()
+        engine._dag._conn.commit()
+
+        dest = sqlite3.connect(str(backup_path))
+        try:
+            engine._store._conn.backup(dest)
+        finally:
+            dest.close()
+    except (OSError, sqlite3.Error) as exc:
+        return "\n".join([
+            "LCM backup",
+            "status: error",
+            f"database_path: {db_path}",
+            f"error: {exc}",
+        ])
+
+    backup_size = backup_path.stat().st_size if backup_path.exists() else 0
+    return "\n".join([
+        "LCM backup",
+        "status: ok",
+        f"database_path: {db_path}",
+        f"backup_path: {backup_path}",
+        f"backup_size: {_fmt_size(backup_size)}",
+        "note: backup created before any future cleanup/apply workflow",
+    ])
+
+
+def handle_lcm_command(raw_args: str | None, engine) -> str:
+    tokens = [part.strip() for part in (raw_args or "").strip().split() if part.strip()]
+    if not tokens:
+        return _status_text(engine)
+
+    head = tokens[0].lower()
+    rest = tokens[1:]
+
+    if head == "status":
+        if rest:
+            return _help_text("`/lcm status` does not accept extra arguments.")
+        return _status_text(engine)
+
+    if head == "doctor":
+        if not rest:
+            return _doctor_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "clean":
+            return _doctor_clean_text(engine)
+        if len(rest) == 2 and rest[0].lower() == "clean" and rest[1].lower() == "apply":
+            return _help_text("`/lcm doctor clean apply` is not implemented yet. This slice is read-only diagnostics only.")
+        return _help_text("`/lcm doctor` currently supports only `clean` as an extra subcommand.")
+
+    if head == "backup":
+        if rest:
+            return _help_text("`/lcm backup` does not accept extra arguments.")
+        return _backup_text(engine)
+
+    if head == "help":
+        return _help_text()
+
+    return _help_text(f"Unknown subcommand: {tokens[0]}")

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1,0 +1,187 @@
+"""Tests for /lcm command surface and diagnostics."""
+
+from pathlib import Path
+import importlib.util
+import sqlite3
+import sys
+
+import pytest
+
+import hermes_lcm.command as command_mod
+from hermes_lcm.command import _fmt_size, handle_lcm_command
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_test.db")
+    hermes_home = tmp_path / "hermes_home"
+    e = LCMEngine(config=config, hermes_home=str(hermes_home))
+    e._session_id = "test-session"
+    e._session_platform = "telegram"
+    e.context_length = 200000
+    e.threshold_tokens = int(200000 * config.context_threshold)
+    return e
+
+
+def test_lcm_status_default_reports_current_session(engine):
+    result = handle_lcm_command("", engine)
+
+    assert "LCM status" in result
+    assert "engine: lcm" in result
+    assert "session_id: test-session" in result
+    assert "store_messages: 0" in result
+    assert "dag_nodes: 0" in result
+
+
+def test_lcm_doctor_reports_health_checks(engine):
+    result = handle_lcm_command("doctor", engine)
+
+    assert "LCM doctor" in result
+    assert "sqlite_integrity: ok" in result
+    assert "messages_fts: ok" in result
+    assert "nodes_fts: ok" in result
+
+
+def test_lcm_help_on_unknown_subcommand(engine):
+    result = handle_lcm_command("wat", engine)
+
+    assert "Unknown subcommand: wat" in result
+    assert "/lcm status" in result
+    assert "/lcm doctor" in result
+
+
+def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
+    result = handle_lcm_command("doctor clean foo", engine)
+
+    assert "currently supports only `clean`" in result
+    assert "clean apply" not in result
+
+
+def test_lcm_doctor_clean_reports_pattern_matched_junk_candidates(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_clean.db"),
+        ignore_session_patterns=["cron*"],
+        ignore_session_patterns_source="env",
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+    engine._store.append("normal_session", {"role": "user", "content": "real conversation"}, token_estimate=20)
+
+    result = handle_lcm_command("doctor clean", engine)
+
+    assert "LCM doctor clean" in result
+    assert "status: candidates-found" in result
+    assert "ignored_pattern_matches: 1" in result
+    assert "cron_20260414" in result
+    assert "normal_session" not in result
+
+
+def test_lcm_doctor_clean_prefers_ignore_over_stateless_when_both_match(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_overlap.db"),
+        ignore_session_patterns=["cron*"],
+        stateless_session_patterns=["cron*"],
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+
+    result = handle_lcm_command("doctor clean", engine)
+
+    assert "ignored_pattern_matches: 1" in result
+    assert "stateless_pattern_matches: 0" in result
+    assert "class=ignored-pattern" in result
+
+
+def test_lcm_doctor_clean_returns_error_on_schema_problem(engine):
+    engine._store._conn = _FakeConn()
+
+    result = handle_lcm_command("doctor clean", engine)
+
+    assert "LCM doctor clean" in result
+    assert "status: error" in result
+    assert "malformed schema" in result
+
+
+def test_lcm_backup_creates_sqlite_snapshot(engine):
+    engine._store.append(engine._session_id, {"role": "user", "content": "hello backup"}, token_estimate=11)
+
+    result = handle_lcm_command("backup", engine)
+
+    assert "LCM backup" in result
+    backup_line = next(line for line in result.splitlines() if line.startswith("backup_path: "))
+    backup_path = Path(backup_line.split(": ", 1)[1])
+    assert backup_path.exists()
+    assert backup_path.stat().st_size > 0
+
+
+def test_lcm_backup_returns_error_when_sqlite_backup_fails(engine, monkeypatch):
+    def boom(_path):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(command_mod.sqlite3, "connect", boom)
+
+    result = handle_lcm_command("backup", engine)
+
+    assert "LCM backup" in result
+    assert "status: error" in result
+    assert "disk I/O error" in result
+
+
+class _FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeConn:
+    def execute(self, query):
+        if "PRAGMA integrity_check" in query:
+            return _FakeCursor(("ok",))
+        raise sqlite3.OperationalError("malformed schema")
+
+
+def test_lcm_doctor_reports_issues_instead_of_raising_on_schema_errors(engine):
+    engine._store._conn = _FakeConn()
+    engine._dag._conn = _FakeConn()
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "LCM doctor" in result
+    assert "status: issues-found" in result
+    assert "malformed schema" in result
+    assert "issues:" in result
+
+
+def test_fmt_size_reports_megabytes_correctly():
+    assert _fmt_size(15_360_000) == "14.6 MB"
+
+
+def test_register_skips_slash_command_when_host_context_has_no_register_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_lcm_init_runtime",
+        str(Path(__file__).resolve().parent.parent / "__init__.py"),
+        submodule_search_locations=[str(Path(__file__).resolve().parent.parent)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _Ctx()
+    module.register(ctx)
+
+    assert ctx.engine is not None


### PR DESCRIPTION
## Summary
- add a `/lcm` slash command surface for Hermes hosts that support plugin slash commands
- expose:
  - `/lcm` and `/lcm status`
  - `/lcm doctor`
  - `/lcm doctor clean`
  - `/lcm backup`
- return diagnostic error output instead of crashing on backup/schema failure paths
- degrade cleanly on older Hermes hosts that expose the context-engine slot but do not yet expose `register_command`
- document the operator surface in the README

## Why
The plugin already had agent tools like `lcm_status` and `lcm_doctor`, but there was no quick operator-facing command surface for checking LCM state from chat. This adds a first diagnostics-first slice without introducing destructive cleanup.

## Notes
- `/lcm doctor clean apply` is intentionally not implemented in this slice yet
- `/lcm doctor clean` is best-effort and read-only; it reports candidates from stored session keys without deleting anything
- `/lcm backup` is backup-first support for any future cleanup/restructure workflow

## Test plan
- `python3 -m pytest tests/test_lcm_command.py -q`
- `python3 -m pytest tests/test_lcm_engine.py tests/test_lcm_command.py -q`
