### PR TITLE
fix: clarify /lcm status before first session bind

### DIFF
--- a/command.py
+++ b/command.py
@@ -48,21 +48,42 @@ def _status_text(engine) -> str:
     db_path = Path(engine._store.db_path)
     db_exists = db_path.exists()
     db_size = db_path.stat().st_size if db_exists else 0
+    session_bound = bool(engine._session_id)
+
+    def _safe_scalar(conn, query: str) -> int | str:
+        try:
+            return int(conn.execute(query).fetchone()[0])
+        except Exception as exc:  # pragma: no cover - defensive
+            return f"error: {exc}"
+
     lines = [
         "LCM status",
         f"engine: {status.get('engine', engine.name)}",
-        f"session_id: {engine._session_id or '(none)'}",
-        f"session_platform: {status.get('session_platform') or '(unknown)'}",
+        f"session_id: {engine._session_id or '(unbound)'}",
+        f"session_platform: {status.get('session_platform') or ('(unbound)' if not session_bound else '(unknown)')}",
         f"database_path: {db_path}",
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
-        f"store_messages: {status.get('store_messages', 0)}",
-        f"dag_nodes: {status.get('dag_nodes', 0)}",
         f"compression_count: {engine.compression_count}",
-        f"threshold_tokens: {engine.threshold_tokens}",
+        f"threshold_tokens: {engine.threshold_tokens if session_bound else '(uninitialized)'}",
         f"session_ignored: {_fmt_bool(status.get('session_ignored'))}",
         f"session_stateless: {_fmt_bool(status.get('session_stateless'))}",
     ]
+
+    if session_bound:
+        lines.extend([
+            f"store_messages: {status.get('store_messages', 0)}",
+            f"dag_nodes: {status.get('dag_nodes', 0)}",
+        ])
+    else:
+        lines.extend([
+            f"messages_total: {_safe_scalar(engine._store._conn, 'SELECT COUNT(*) FROM messages')}",
+            f"message_sessions_total: {_safe_scalar(engine._store._conn, 'SELECT COUNT(DISTINCT session_id) FROM messages')}",
+            f"summary_nodes_total: {_safe_scalar(engine._dag._conn, 'SELECT COUNT(*) FROM summary_nodes')}",
+            f"summary_node_sessions_total: {_safe_scalar(engine._dag._conn, 'SELECT COUNT(DISTINCT session_id) FROM summary_nodes')}",
+            "note: no active Hermes session has initialized LCM in this process yet — after a fresh restart, send one normal message first if you want live per-session runtime details",
+        ])
+
     if "ignore_session_patterns_source" in status:
         lines.append(
             f"ignore_session_patterns_source: {status.get('ignore_session_patterns_source')}"

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -36,6 +36,22 @@ def test_lcm_status_default_reports_current_session(engine):
     assert "dag_nodes: 0" in result
 
 
+def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_unbound.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._store.append("telegram:chat-1", {"role": "user", "content": "hello"}, token_estimate=7)
+
+    result = handle_lcm_command("status", engine)
+
+    assert "LCM status" in result
+    assert "session_id: (unbound)" in result
+    assert "session_platform: (unbound)" in result
+    assert "threshold_tokens: (uninitialized)" in result
+    assert "message_sessions_total: 1" in result
+    assert "messages_total: 1" in result
+    assert "note: no active Hermes session has initialized LCM in this process yet" in result
+
+
 def test_lcm_doctor_reports_health_checks(engine):
     result = handle_lcm_command("doctor", engine)
 


### PR DESCRIPTION
## Summary
- make `/lcm status` explicitly report an unbound runtime before the first session bind
- show useful database totals in that unbound state instead of misleading per-session zeros
- add a regression test covering the fresh-restart / pre-first-turn case

## Why
Right after a fresh Hermes restart, `/lcm` can run before any normal agent turn has called `on_session_start()`. In that state the command was showing `session_id: (none)`, `session_platform: (unknown)`, and `threshold_tokens: 0`, which looks broken even though the real issue is simply that no live session has bound the engine yet.

This change makes that state explicit and useful:
- `session_id: (unbound)`
- `session_platform: (unbound)`
- `threshold_tokens: (uninitialized)`
- global DB totals plus a note explaining that one normal message will populate live per-session runtime details

## Test Plan
- `python3 -m pytest tests/test_lcm_command.py -q`
- `python3 -m pytest tests/ -q`
