### PR TITLE
fix: add overflow recovery for assembly guardrails

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,26 @@ def _parse_pattern_list(raw: str) -> list[str]:
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
+def _parse_int_env(key: str, default: int) -> int:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_float_env(key: str, default: float) -> float:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass
 class LCMConfig:
     """All tunables for the LCM engine."""
@@ -65,8 +85,8 @@ class LCMConfig:
     def from_env(cls) -> "LCMConfig":
         """Build config from environment variables (LCM_ prefix)."""
         c = cls()
-        _int = lambda key, default: int(os.environ.get(key, default))
-        _float = lambda key, default: float(os.environ.get(key, default))
+        _int = _parse_int_env
+        _float = _parse_float_env
         _str = lambda key, default: os.environ.get(key, default)
 
         c.fresh_tail_count = _int("LCM_FRESH_TAIL_COUNT", c.fresh_tail_count)

--- a/engine.py
+++ b/engine.py
@@ -6,6 +6,7 @@ with a DAG-based summarization system that preserves every message.
 
 import json
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -99,6 +100,7 @@ class LCMEngine(ContextEngine):
         self._context_probe_persistable = False
         self.quiet_mode = False
         self.summary_model = self._config.summary_model
+        self._last_overflow_recovery_failed = False
 
     @property
     def name(self) -> str:
@@ -115,6 +117,8 @@ class LCMEngine(ContextEngine):
         if self._session_ignored or self._session_stateless:
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if self._should_force_overflow_recovery(observed_tokens=tokens):
+            return True
         if self.threshold_tokens <= 0:
             return False
         return tokens >= self.threshold_tokens
@@ -130,6 +134,8 @@ class LCMEngine(ContextEngine):
                 logger.debug("Ingest during preflight: %s", e)
         from .tokens import count_messages_tokens
         rough = count_messages_tokens(messages)
+        if self._should_force_overflow_recovery(observed_tokens=rough):
+            return True
         return rough >= self.threshold_tokens
 
     def compress(self, messages: List[Dict[str, Any]],
@@ -154,7 +160,19 @@ class LCMEngine(ContextEngine):
             )
             return messages
 
-        prompt_tokens = current_tokens or self.last_prompt_tokens
+        observed_prompt_tokens = current_tokens if current_tokens is not None else None
+        force_overflow = self._should_force_overflow_recovery(
+            observed_tokens=observed_prompt_tokens,
+            messages=messages,
+        )
+        recovery_assembly_cap = (
+            self._overflow_recovery_assembly_cap(
+                observed_tokens=observed_prompt_tokens,
+                messages=messages,
+            )
+            if force_overflow
+            else None
+        )
 
         # Step 1: Ingest new messages into the immutable store
         self._ingest_messages(messages)
@@ -166,6 +184,17 @@ class LCMEngine(ContextEngine):
         # Protect system prompt (always index 0)
         if fresh_tail_start <= 1:
             # Not enough messages to compact
+            if force_overflow and len(messages) >= 1:
+                compressed = self._assemble_overflow_recovery_context(
+                    messages[0],
+                    messages[1:],
+                    assembly_cap_override=recovery_assembly_cap,
+                )
+                return self._finalize_forced_overflow_result(
+                    messages,
+                    compressed,
+                    assembly_cap_override=recovery_assembly_cap,
+                )
             return messages
 
         # Step 3: Identify messages to compact (between system prompt and fresh tail)
@@ -173,11 +202,22 @@ class LCMEngine(ContextEngine):
         to_compact = messages[1:fresh_tail_start]
 
         if not to_compact:
+            if force_overflow and len(messages) >= 1:
+                compressed = self._assemble_overflow_recovery_context(
+                    messages[0],
+                    messages[1:],
+                    assembly_cap_override=recovery_assembly_cap,
+                )
+                return self._finalize_forced_overflow_result(
+                    messages,
+                    compressed,
+                    assembly_cap_override=recovery_assembly_cap,
+                )
             return messages
 
         # Calculate source tokens
         source_tokens = count_messages_tokens(to_compact)
-        if source_tokens < self._config.leaf_chunk_tokens:
+        if source_tokens < self._config.leaf_chunk_tokens and not force_overflow:
             # Not enough to justify compaction
             return messages
 
@@ -220,17 +260,32 @@ class LCMEngine(ContextEngine):
         self._maybe_condense(focus_topic=focus_topic)
 
         # Step 7: Assemble new active context
-        compressed = self._assemble_context(messages[0], messages[fresh_tail_start:])
+        compressed = self._assemble_context(
+            messages[0],
+            messages[fresh_tail_start:],
+            assembly_cap_override=recovery_assembly_cap,
+        )
         self.compression_count += 1
+        if recovery_assembly_cap is None:
+            self._last_overflow_recovery_failed = False
+        else:
+            self._last_overflow_recovery_failed = count_messages_tokens(compressed) > recovery_assembly_cap
+            if self._last_overflow_recovery_failed:
+                logger.warning(
+                    "LCM overflow recovery could not get under cap=%d after compaction; returning best-effort context (%d tokens)",
+                    recovery_assembly_cap,
+                    count_messages_tokens(compressed),
+                )
         # Reset cursor to the length of the compressed context so that
         # only messages appended *after* this point get ingested next time.
         self._ingest_cursor = len(compressed)
 
         logger.info(
-            "LCM compaction #%d: %d messages → %d (L%d, %d→%d tokens, %d DAG nodes)",
+            "LCM compaction #%d: %d messages → %d (L%d, %d→%d tokens, %d DAG nodes%s)",
             self.compression_count, n, len(compressed), level,
             source_tokens, count_tokens(summary_text),
             len(self._dag.get_session_nodes(self._session_id)),
+            ", forced overflow recovery" if force_overflow else "",
         )
 
         return compressed
@@ -242,6 +297,7 @@ class LCMEngine(ContextEngine):
         self._session_platform = str(kwargs.get("platform") or "")
         self._ingest_cursor = 0
         self._last_compacted_store_id = 0
+        self._last_overflow_recovery_failed = False
         self._refresh_session_filters()
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
@@ -263,6 +319,7 @@ class LCMEngine(ContextEngine):
         self._ingest_cursor = 0
         self._context_probed = False
         self._context_probe_persistable = False
+        self._last_overflow_recovery_failed = False
 
         # Retain DAG nodes across sessions based on config.
         #   -1  → keep all nodes
@@ -326,6 +383,7 @@ class LCMEngine(ContextEngine):
             status["stateless_session_patterns"] = list(self._config.stateless_session_patterns)
             status["ignore_session_patterns_source"] = self._config.ignore_session_patterns_source
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
+            status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
         return status
 
     def update_model(self, model: str, context_length: int,
@@ -549,8 +607,13 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: context assembly ----------------------------------------
 
-    def _assemble_context(self, system_msg: Dict[str, Any],
-                          tail_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _assemble_context(
+        self,
+        system_msg: Dict[str, Any],
+        tail_messages: List[Dict[str, Any]],
+        assembly_cap_override: Optional[int] = None,
+        include_lcm_note: bool = True,
+    ) -> List[Dict[str, Any]]:
         """Build the active context from DAG summaries + fresh tail.
 
         Structure:
@@ -562,7 +625,7 @@ class LCMEngine(ContextEngine):
 
         # System prompt with LCM annotation
         sys_msg = system_msg.copy()
-        if self.compression_count == 0:
+        if self.compression_count == 0 and include_lcm_note:
             sys_content = sys_msg.get("content", "")
             sys_msg["content"] = (
                 sys_content
@@ -573,7 +636,11 @@ class LCMEngine(ContextEngine):
             )
         result.append(sys_msg)
 
-        assembly_cap = self._effective_assembly_token_cap()
+        assembly_cap = (
+            assembly_cap_override
+            if assembly_cap_override is not None
+            else self._effective_assembly_token_cap()
+        )
 
         tail_selected = tail_messages
         summary_budget = None
@@ -634,6 +701,83 @@ class LCMEngine(ContextEngine):
 
         return result
 
+    def _finalize_forced_overflow_result(
+        self,
+        original_messages: List[Dict[str, Any]],
+        compressed: List[Dict[str, Any]],
+        assembly_cap_override: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        if compressed != original_messages:
+            self._ingest_cursor = len(compressed)
+            logger.info(
+                "LCM assembly guardrail recovery: %d messages → %d (no new summary node)",
+                len(original_messages),
+                len(compressed),
+            )
+
+        effective_cap = (
+            assembly_cap_override
+            if assembly_cap_override is not None
+            else self._effective_assembly_token_cap()
+        )
+        if effective_cap is None:
+            self._last_overflow_recovery_failed = False
+        else:
+            self._last_overflow_recovery_failed = count_messages_tokens(compressed) > effective_cap
+            if self._last_overflow_recovery_failed:
+                logger.warning(
+                    "LCM overflow recovery could not get under cap=%d; returning best-effort context (%d tokens)",
+                    effective_cap,
+                    count_messages_tokens(compressed),
+                )
+        return compressed
+
+    def _should_force_overflow_recovery(
+        self,
+        observed_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        assembly_cap = self._effective_assembly_token_cap()
+        if assembly_cap is None:
+            return False
+
+        tokens = self._overflow_recovery_signal_tokens(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
+        if tokens is None:
+            return False
+        return tokens >= assembly_cap
+
+    def _overflow_recovery_signal_tokens(
+        self,
+        observed_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[int]:
+        candidates: list[int] = []
+        if observed_tokens is not None and observed_tokens > 0:
+            candidates.append(observed_tokens)
+        if messages is not None:
+            candidates.append(count_messages_tokens(messages))
+        if not candidates:
+            return None
+        return max(candidates)
+
+    def _overflow_recovery_assembly_cap(
+        self,
+        observed_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[int]:
+        assembly_cap = self._effective_assembly_token_cap()
+        if assembly_cap is None:
+            return None
+        if messages is None or observed_tokens is None or observed_tokens <= 0:
+            return assembly_cap
+
+        message_tokens = count_messages_tokens(messages)
+        overhead_tokens = max(0, observed_tokens - message_tokens)
+        return max(1, assembly_cap - overhead_tokens)
+
     def _effective_assembly_token_cap(self) -> Optional[int]:
         """Return the active assembly cap, if any.
 
@@ -663,6 +807,48 @@ class LCMEngine(ContextEngine):
         return max(1, min(caps))
 
     # -- Internal: helpers -------------------------------------------------
+
+    def _assemble_overflow_recovery_context(
+        self,
+        system_msg: Dict[str, Any],
+        tail_messages: List[Dict[str, Any]],
+        assembly_cap_override: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        if tail_messages:
+            first = tail_messages[0]
+            content = first.get("content") or ""
+            role = first.get("role") or ""
+            if role == "assistant" and self._looks_like_active_summary_blob(content):
+                candidate = self._assemble_context(
+                    system_msg,
+                    tail_messages[1:],
+                    assembly_cap_override=assembly_cap_override,
+                    include_lcm_note=False,
+                )
+                if any(
+                    (msg.get("content") or "") == content
+                    for msg in candidate[1:]
+                ):
+                    return candidate
+
+        return self._assemble_context(
+            system_msg,
+            tail_messages,
+            assembly_cap_override=assembly_cap_override,
+            include_lcm_note=False,
+        )
+
+    @staticmethod
+    def _looks_like_active_summary_blob(content: str) -> bool:
+        if not isinstance(content, str) or not content:
+            return False
+        block = (
+            r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary \(d\d+, node \d+\)\]\n"
+            r".*?\n"
+            r"\[Expand for details: .*?\]"
+        )
+        pattern = rf"^{block}(?:\n\n---\n\n{block})*$"
+        return re.fullmatch(pattern, content, flags=re.DOTALL) is not None
 
     @staticmethod
     def _extract_expand_hint(summary: str) -> str:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -51,6 +51,21 @@ class TestConfig:
         assert c.summary_timeout_ms == 45_000
         assert c.expansion_timeout_ms == 90_000
 
+    def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")
+        monkeypatch.setenv("LCM_LEAF_CHUNK_TOKENS", "")
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "bad-float")
+        monkeypatch.setenv("LCM_MAX_ASSEMBLY_TOKENS", "nope")
+        monkeypatch.setenv("LCM_RESERVE_TOKENS_FLOOR", "still-nope")
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 64
+        assert c.leaf_chunk_tokens == 20_000
+        assert c.context_threshold == 0.75
+        assert c.max_assembly_tokens == 0
+        assert c.reserve_tokens_floor == 0
+
 
 class TestSessionPatterns:
     def test_compile_pattern_wildcards(self):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -45,6 +45,17 @@ class TestEngineABC:
         assert not engine.should_compress(1000)
         assert engine.should_compress(engine.threshold_tokens)
 
+    def test_should_compress_when_explicit_assembly_cap_is_hit(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_should_compress_cap.db"),
+            max_assembly_tokens=90,
+        )
+        instance = LCMEngine(config=config)
+        instance.context_length = 200000
+        instance.threshold_tokens = int(200000 * config.context_threshold)
+
+        assert instance.should_compress(90)
+
     def test_update_from_response(self, engine):
         engine.update_from_response({
             "prompt_tokens": 5000,
@@ -720,6 +731,298 @@ class TestAssemblyGuardrails:
             assert instance._effective_assembly_token_cap() is None
 
         assert "reserve_tokens_floor=100 disables reserve-based assembly cap" in caplog.text
+
+    def test_compress_forces_overflow_recovery_when_context_hits_assembly_cap(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=100,
+            database_path=str(tmp_path / "lcm_guardrail_forced.db"),
+            max_assembly_tokens=90,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+        monkeypatch.setattr(lcm_engine_module, "count_tokens", lambda text: len(text))
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "summarize_with_escalation",
+            lambda **kwargs: ("summary", 1),
+        )
+
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 20},
+            {"role": "assistant", "content": "b" * 20},
+            {"role": "user", "content": "c" * 20},
+            {"role": "assistant", "content": "d" * 20},
+        ]
+
+        result = instance.compress(messages, current_tokens=90)
+
+        assert len(result) < len(messages)
+        assert result[-2:] == messages[-2:]
+        assert lcm_engine_module.count_messages_tokens(result) < 90
+        assert instance._dag.get_session_nodes("guardrail-session")
+
+    def test_forced_overflow_tail_capping_updates_bookkeeping_without_middle_compaction(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_tail_only.db"),
+            max_assembly_tokens=70,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 40},
+            {"role": "assistant", "content": "b" * 40},
+        ]
+
+        result = instance.compress(messages, current_tokens=90)
+
+        assert result == [messages[0], messages[-1]]
+        assert instance.compression_count == 1
+        assert instance._ingest_cursor == len(result)
+        assert not instance.get_status()["overflow_recovery_failed"]
+
+    def test_forced_overflow_recovery_reserves_provider_overhead(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_overhead.db"),
+            max_assembly_tokens=90,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 30},
+            {"role": "assistant", "content": "b" * 40},
+        ]
+
+        result = instance.compress(messages, current_tokens=100)
+
+        assert result == [messages[0], messages[-1]]
+        assert lcm_engine_module.count_messages_tokens(result) < 70
+
+    def test_forced_overflow_recovery_does_not_duplicate_existing_summary_message(self, tmp_path, monkeypatch):
+        import importlib
+        from hermes_lcm.dag import SummaryNode
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_summary_dup.db"),
+            max_assembly_tokens=90,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+
+        node = SummaryNode(
+            session_id="guardrail-session",
+            depth=0,
+            summary="sum",
+            token_count=3,
+            source_token_count=50,
+            source_ids=[],
+            source_type="messages",
+            created_at=time.time(),
+            expand_hint="x",
+        )
+        node_id = instance._dag.add_node(node)
+        summary_blob = (
+            f"[Recent Summary (d0, node {node_id})]\n"
+            f"sum\n"
+            f"[Expand for details: x]"
+        )
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "assistant", "content": summary_blob},
+            {"role": "user", "content": "tail" * 2},
+        ]
+
+        result = instance.compress(messages, current_tokens=90)
+
+        joined = "\n\n".join(msg.get("content", "") for msg in result)
+        assert joined.count("[Expand for details:") == 1
+        assert not instance.get_status()["overflow_recovery_failed"]
+
+    def test_forced_overflow_recovery_flags_irreducible_single_tail_overflow(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_irreducible.db"),
+            max_assembly_tokens=70,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 20},
+            {"role": "assistant", "content": "b" * 80},
+        ]
+
+        result = instance.compress(messages, current_tokens=110)
+
+        assert result == [messages[0], messages[-1]]
+        assert instance.get_status()["overflow_recovery_failed"]
+
+    def test_overflow_recovery_failure_flag_resets_after_successful_compression(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=100,
+            database_path=str(tmp_path / "lcm_guardrail_flag_reset.db"),
+            max_assembly_tokens=70,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+        monkeypatch.setattr(lcm_engine_module, "count_tokens", lambda text: len(text))
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "summarize_with_escalation",
+            lambda **kwargs: ("summary", 1),
+        )
+
+        failed_messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 20},
+            {"role": "assistant", "content": "b" * 80},
+        ]
+        instance.compress(failed_messages, current_tokens=110)
+        assert instance.get_status()["overflow_recovery_failed"]
+
+        success_messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 20},
+            {"role": "assistant", "content": "b" * 20},
+            {"role": "user", "content": "c" * 20},
+            {"role": "assistant", "content": "d" * 20},
+        ]
+        instance.compress(success_messages, current_tokens=90)
+
+        assert not instance.get_status()["overflow_recovery_failed"]
+
+    def test_compress_ignores_stale_last_prompt_tokens_for_overflow_recovery(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_stale_prompt.db"),
+            max_assembly_tokens=70,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+        instance.last_prompt_tokens = 200
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "a" * 20},
+            {"role": "assistant", "content": "b" * 20},
+        ]
+
+        result = instance.compress(messages)
+
+        assert result == messages
 
 
 class TestEngineTools:


### PR DESCRIPTION
## Summary
- add forced overflow recovery when assembly-cap pressure is hit instead of effectively no-oping below the normal leaf threshold
- reserve observed provider overhead when deciding the effective recovery cap
- surface `overflow_recovery_failed` in engine status for irreducible cases and add regression coverage for guardrail edge cases

## Why
We already had hard assembly budget controls, but that only capped context assembly. This slice adds the actual recovery path for cases where live context pressure hits the cap and normal compaction thresholds would otherwise fail to respond usefully.

That closes the practical gap between “we know the budget is blown” and “we actively recover under budget when possible, and say so explicitly when not”.

## Validation
Local plugin validation:
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `python3 -m pytest tests/ -q`

Local host/runtime dogfood:
- confirmed Hermes loads the external plugin from `~/.hermes/plugins/hermes-lcm/engine.py`
- confirmed the active status surface includes `overflow_recovery_failed`
