### PR TITLE
fix: harden sqlite migrations and recovery

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -23,7 +23,7 @@ from .db_bootstrap import (
     ExternalContentFtsSpec,
     configure_connection,
     ensure_external_content_fts,
-    set_schema_version,
+    run_versioned_migrations,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,17 +83,25 @@ class SummaryDAG:
                 content_table="summary_nodes",
                 content_rowid="node_id",
                 indexed_column="summary",
-                trigger_name="nodes_fts_insert",
-                trigger_sql="""
+                trigger_sqls=(
+                    """
                     CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
                         AFTER INSERT ON summary_nodes BEGIN
                         INSERT INTO nodes_fts(rowid, summary)
                             VALUES (new.node_id, new.summary);
                     END;
-                """,
+                    """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS nodes_fts_delete
+                        AFTER DELETE ON summary_nodes BEGIN
+                        INSERT INTO nodes_fts(nodes_fts, rowid, summary)
+                            VALUES('delete', old.node_id, old.summary);
+                    END;
+                    """,
+                ),
             ),
         )
-        set_schema_version(self._conn)
+        run_versioned_migrations(self._conn)
         self._conn.commit()
 
     # -- Write --------------------------------------------------------------
@@ -225,23 +233,41 @@ class SummaryDAG:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20) -> List[SummaryNode]:
         """FTS5 search across all summary nodes."""
-        if session_id:
-            rows = self._conn.execute(
-                """SELECT n.* FROM nodes_fts fts
-                   JOIN summary_nodes n ON n.node_id = fts.rowid
-                   WHERE nodes_fts MATCH ? AND n.session_id = ?
-                   ORDER BY rank LIMIT ?""",
-                (query, session_id, limit),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                """SELECT n.* FROM nodes_fts fts
-                   JOIN summary_nodes n ON n.node_id = fts.rowid
-                   WHERE nodes_fts MATCH ?
-                   ORDER BY rank LIMIT ?""",
-                (query, limit),
-            ).fetchall()
-        return [self._row_to_node(r) for r in rows]
+        try:
+            if session_id:
+                rows = self._conn.execute(
+                    """SELECT n.* FROM nodes_fts fts
+                       JOIN summary_nodes n ON n.node_id = fts.rowid
+                       WHERE nodes_fts MATCH ? AND n.session_id = ?
+                       ORDER BY rank LIMIT ?""",
+                    (query, session_id, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT n.* FROM nodes_fts fts
+                       JOIN summary_nodes n ON n.node_id = fts.rowid
+                       WHERE nodes_fts MATCH ?
+                       ORDER BY rank LIMIT ?""",
+                    (query, limit),
+                ).fetchall()
+            return [self._row_to_node(r) for r in rows]
+        except sqlite3.DatabaseError:
+            like = f"%{query.strip().lower()}%"
+            if session_id:
+                rows = self._conn.execute(
+                    """SELECT * FROM summary_nodes
+                       WHERE session_id = ? AND LOWER(COALESCE(summary, '')) LIKE ?
+                       ORDER BY created_at LIMIT ?""",
+                    (session_id, like, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT * FROM summary_nodes
+                       WHERE LOWER(COALESCE(summary, '')) LIKE ?
+                       ORDER BY created_at LIMIT ?""",
+                    (like, limit),
+                ).fetchall()
+            return [self._row_to_node(r) for r in rows]
 
     # -- DAG traversal ------------------------------------------------------
 

--- a/dag.py
+++ b/dag.py
@@ -19,6 +19,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .db_bootstrap import (
+    ExternalContentFtsSpec,
+    configure_connection,
+    ensure_external_content_fts,
+    set_schema_version,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,7 +54,7 @@ class SummaryDAG:
 
     def _init_db(self):
         self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        configure_connection(self._conn)
         self._conn.executescript("""
             CREATE TABLE IF NOT EXISTS summary_nodes (
                 node_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -64,18 +71,29 @@ class SummaryDAG:
             CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
                 ON summary_nodes(session_id, depth, created_at);
 
-            CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
-                summary,
-                content=summary_nodes,
-                content_rowid=node_id
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
             );
-
-            CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
-                AFTER INSERT ON summary_nodes BEGIN
-                INSERT INTO nodes_fts(rowid, summary)
-                    VALUES (new.node_id, new.summary);
-            END;
         """)
+        ensure_external_content_fts(
+            self._conn,
+            ExternalContentFtsSpec(
+                table_name="nodes_fts",
+                content_table="summary_nodes",
+                content_rowid="node_id",
+                indexed_column="summary",
+                trigger_name="nodes_fts_insert",
+                trigger_sql="""
+                    CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
+                        AFTER INSERT ON summary_nodes BEGIN
+                        INSERT INTO nodes_fts(rowid, summary)
+                            VALUES (new.node_id, new.summary);
+                    END;
+                """,
+            ),
+        )
+        set_schema_version(self._conn)
         self._conn.commit()
 
     # -- Write --------------------------------------------------------------

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -10,7 +10,7 @@ import sqlite3
 from typing import Iterable, Sequence
 
 SCHEMA_VERSION = 2
-SQLITE_BUSY_TIMEOUT_MS = 5_000
+SQLITE_BUSY_TIMEOUT_MS = 30_000
 
 
 class ExternalContentFtsSpec:
@@ -145,6 +145,19 @@ def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -
         column_names = {row[1] for row in columns if len(row) > 1}
         if spec.indexed_column not in column_names:
             return True
+
+        content_count = conn.execute(
+            f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.content_table)}"
+        ).fetchone()[0]
+        fts_count = conn.execute(
+            f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.table_name)}"
+        ).fetchone()[0]
+        if int(content_count or 0) != int(fts_count or 0):
+            return True
+
+        conn.execute(
+            f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}, rank) VALUES('integrity-check', 1)"
+        )
     except sqlite3.DatabaseError:
         return True
 

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -7,9 +7,9 @@ same schema-version marker, PRAGMA settings, and FTS repair behavior.
 from __future__ import annotations
 
 import sqlite3
-from typing import Iterable
+from typing import Iterable, Sequence
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 
 
@@ -21,15 +21,13 @@ class ExternalContentFtsSpec:
         content_table: str,
         content_rowid: str,
         indexed_column: str,
-        trigger_name: str,
-        trigger_sql: str,
+        trigger_sqls: Sequence[str],
     ) -> None:
         self.table_name = table_name
         self.content_table = content_table
         self.content_rowid = content_rowid
         self.indexed_column = indexed_column
-        self.trigger_name = trigger_name
-        self.trigger_sql = trigger_sql
+        self.trigger_sqls = tuple(trigger_sqls)
 
 
 def configure_connection(conn: sqlite3.Connection) -> None:
@@ -45,6 +43,42 @@ def ensure_metadata_table(conn: sqlite3.Connection) -> None:
             value TEXT
         )
         """
+    )
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    ensure_metadata_table(conn)
+    row = conn.execute(
+        "SELECT value FROM metadata WHERE key = 'schema_version'"
+    ).fetchone()
+    if not row or row[0] is None:
+        return 0
+    try:
+        return int(str(row[0]))
+    except (TypeError, ValueError):
+        return 0
+
+
+def ensure_migration_state_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_migration_state (
+            step_name TEXT PRIMARY KEY,
+            completed_at REAL NOT NULL
+        )
+        """
+    )
+
+
+def mark_migration_step_complete(conn: sqlite3.Connection, step_name: str) -> None:
+    ensure_migration_state_table(conn)
+    conn.execute(
+        """
+        INSERT INTO lcm_migration_state(step_name, completed_at)
+        VALUES(?, strftime('%s','now'))
+        ON CONFLICT(step_name) DO UPDATE SET completed_at = excluded.completed_at
+        """,
+        (step_name,),
     )
 
 
@@ -139,4 +173,17 @@ def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentF
             f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
         )
 
-    conn.execute(spec.trigger_sql)
+    for trigger_sql in spec.trigger_sqls:
+        conn.execute(trigger_sql)
+
+
+def run_versioned_migrations(conn: sqlite3.Connection) -> None:
+    ensure_metadata_table(conn)
+    ensure_migration_state_table(conn)
+
+    current_version = get_schema_version(conn)
+    if current_version < 2:
+        mark_migration_step_complete(conn, "v2_external_content_fts_triggers")
+        current_version = 2
+
+    set_schema_version(conn, current_version)

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -1,0 +1,142 @@
+"""Shared SQLite bootstrap helpers for hermes-lcm.
+
+This module keeps startup DB initialization in one place so store/DAG use the
+same schema-version marker, PRAGMA settings, and FTS repair behavior.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable
+
+SCHEMA_VERSION = 1
+SQLITE_BUSY_TIMEOUT_MS = 5_000
+
+
+class ExternalContentFtsSpec:
+    def __init__(
+        self,
+        *,
+        table_name: str,
+        content_table: str,
+        content_rowid: str,
+        indexed_column: str,
+        trigger_name: str,
+        trigger_sql: str,
+    ) -> None:
+        self.table_name = table_name
+        self.content_table = content_table
+        self.content_rowid = content_rowid
+        self.indexed_column = indexed_column
+        self.trigger_name = trigger_name
+        self.trigger_sql = trigger_sql
+
+
+def configure_connection(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+
+
+def ensure_metadata_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+
+
+def set_schema_version(conn: sqlite3.Connection, version: int = SCHEMA_VERSION) -> None:
+    ensure_metadata_table(conn)
+    conn.execute(
+        """
+        INSERT INTO metadata(key, value)
+        VALUES('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (str(version),),
+    )
+
+
+def get_existing_table_names(conn: sqlite3.Connection, names: Iterable[str]) -> set[str]:
+    existing: set[str] = set()
+    for name in names:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+            (name,),
+        ).fetchone()
+        if row and row[0]:
+            existing.add(row[0])
+    return existing
+
+
+def get_fts_shadow_table_names(table_name: str) -> list[str]:
+    return [
+        f"{table_name}_data",
+        f"{table_name}_idx",
+        f"{table_name}_docsize",
+        f"{table_name}_config",
+    ]
+
+
+def quote_sql_identifier(identifier: str) -> str:
+    if not identifier or not identifier.replace("_", "a").isalnum() or identifier[0].isdigit():
+        raise ValueError(f"invalid SQL identifier: {identifier}")
+    return f'"{identifier}"'
+
+
+def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    shadow_tables = get_fts_shadow_table_names(spec.table_name)
+    existing_tables = get_existing_table_names(conn, [spec.table_name, *shadow_tables])
+    if spec.table_name not in existing_tables:
+        return True
+    if any(name not in existing_tables for name in shadow_tables):
+        return True
+
+    try:
+        info = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
+            (spec.table_name,),
+        ).fetchone()
+        sql = (info[0] if info else "") or ""
+        normalized = sql.lower()
+        if "virtual table" not in normalized or "using fts5" not in normalized:
+            return True
+
+        columns = conn.execute(
+            f"PRAGMA table_info({quote_sql_identifier(spec.table_name)})"
+        ).fetchall()
+        column_names = {row[1] for row in columns if len(row) > 1}
+        if spec.indexed_column not in column_names:
+            return True
+    except sqlite3.DatabaseError:
+        return True
+
+    return False
+
+
+def _drop_fts_table(conn: sqlite3.Connection, table_name: str) -> None:
+    conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(table_name)}")
+    for shadow_name in get_fts_shadow_table_names(table_name):
+        conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(shadow_name)}")
+
+
+def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
+    if _fts_needs_rebuild(conn, spec):
+        _drop_fts_table(conn, spec.table_name)
+        conn.execute(
+            f"""
+            CREATE VIRTUAL TABLE {quote_sql_identifier(spec.table_name)} USING fts5(
+                {quote_sql_identifier(spec.indexed_column)},
+                content={quote_sql_identifier(spec.content_table)},
+                content_rowid={quote_sql_identifier(spec.content_rowid)}
+            )
+            """
+        )
+        conn.execute(
+            f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
+        )
+
+    conn.execute(spec.trigger_sql)

--- a/store.py
+++ b/store.py
@@ -13,6 +13,13 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .db_bootstrap import (
+    ExternalContentFtsSpec,
+    configure_connection,
+    ensure_external_content_fts,
+    set_schema_version,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -27,8 +34,7 @@ class MessageStore:
 
     def _init_db(self):
         self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA busy_timeout=5000")
+        configure_connection(self._conn)
         self._conn.executescript("""
             CREATE TABLE IF NOT EXISTS messages (
                 store_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -47,23 +53,29 @@ class MessageStore:
             CREATE INDEX IF NOT EXISTS idx_msg_session_ts
                 ON messages(session_id, timestamp);
 
-            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-                content,
-                content=messages,
-                content_rowid=store_id
-            );
-
-            CREATE TRIGGER IF NOT EXISTS msg_fts_insert
-                AFTER INSERT ON messages BEGIN
-                INSERT INTO messages_fts(rowid, content)
-                    VALUES (new.store_id, new.content);
-            END;
-
             CREATE TABLE IF NOT EXISTS metadata (
                 key TEXT PRIMARY KEY,
                 value TEXT
             );
         """)
+        ensure_external_content_fts(
+            self._conn,
+            ExternalContentFtsSpec(
+                table_name="messages_fts",
+                content_table="messages",
+                content_rowid="store_id",
+                indexed_column="content",
+                trigger_name="msg_fts_insert",
+                trigger_sql="""
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_insert
+                        AFTER INSERT ON messages BEGIN
+                        INSERT INTO messages_fts(rowid, content)
+                            VALUES (new.store_id, new.content);
+                    END;
+                """,
+            ),
+        )
+        set_schema_version(self._conn)
         self._conn.commit()
 
     # -- Write operations ---------------------------------------------------

--- a/store.py
+++ b/store.py
@@ -17,7 +17,7 @@ from .db_bootstrap import (
     ExternalContentFtsSpec,
     configure_connection,
     ensure_external_content_fts,
-    set_schema_version,
+    run_versioned_migrations,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,17 +65,25 @@ class MessageStore:
                 content_table="messages",
                 content_rowid="store_id",
                 indexed_column="content",
-                trigger_name="msg_fts_insert",
-                trigger_sql="""
+                trigger_sqls=(
+                    """
                     CREATE TRIGGER IF NOT EXISTS msg_fts_insert
                         AFTER INSERT ON messages BEGIN
                         INSERT INTO messages_fts(rowid, content)
                             VALUES (new.store_id, new.content);
                     END;
-                """,
+                    """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_delete
+                        AFTER DELETE ON messages BEGIN
+                        INSERT INTO messages_fts(messages_fts, rowid, content)
+                            VALUES('delete', old.store_id, old.content);
+                    END;
+                    """,
+                ),
             ),
         )
-        set_schema_version(self._conn)
+        run_versioned_migrations(self._conn)
         self._conn.commit()
 
     # -- Write operations ---------------------------------------------------
@@ -213,31 +221,54 @@ class MessageStore:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20) -> List[Dict[str, Any]]:
         """FTS5 search across messages. Returns matches with snippets."""
-        if session_id:
-            rows = self._conn.execute(
-                """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                   FROM messages_fts fts
-                   JOIN messages m ON m.store_id = fts.rowid
-                   WHERE messages_fts MATCH ? AND m.session_id = ?
-                   ORDER BY rank LIMIT ?""",
-                (query, session_id, limit),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                   FROM messages_fts fts
-                   JOIN messages m ON m.store_id = fts.rowid
-                   WHERE messages_fts MATCH ?
-                   ORDER BY rank LIMIT ?""",
-                (query, limit),
-            ).fetchall()
-        results = []
-        for r in rows:
-            d = self._row_to_dict(r)
-            # snippet is the extra column
-            d["snippet"] = r[-1] if len(r) > 10 else ""
-            results.append(d)
-        return results
+        try:
+            if session_id:
+                rows = self._conn.execute(
+                    """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                       FROM messages_fts fts
+                       JOIN messages m ON m.store_id = fts.rowid
+                       WHERE messages_fts MATCH ? AND m.session_id = ?
+                       ORDER BY rank LIMIT ?""",
+                    (query, session_id, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                       FROM messages_fts fts
+                       JOIN messages m ON m.store_id = fts.rowid
+                       WHERE messages_fts MATCH ?
+                       ORDER BY rank LIMIT ?""",
+                    (query, limit),
+                ).fetchall()
+            results = []
+            for r in rows:
+                d = self._row_to_dict(r)
+                # snippet is the extra column
+                d["snippet"] = r[-1] if len(r) > 10 else ""
+                results.append(d)
+            return results
+        except sqlite3.DatabaseError:
+            like = f"%{query.strip().lower()}%"
+            if session_id:
+                rows = self._conn.execute(
+                    """SELECT * FROM messages
+                       WHERE session_id = ? AND LOWER(COALESCE(content, '')) LIKE ?
+                       ORDER BY store_id LIMIT ?""",
+                    (session_id, like, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT * FROM messages
+                       WHERE LOWER(COALESCE(content, '')) LIKE ?
+                       ORDER BY store_id LIMIT ?""",
+                    (like, limit),
+                ).fetchall()
+            results = []
+            for r in rows:
+                d = self._row_to_dict(r)
+                d["snippet"] = d.get("content") or ""
+                results.append(d)
+            return results
 
     # -- Helpers ------------------------------------------------------------
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2,6 +2,8 @@
 
 import json
 import sqlite3
+import threading
+import time
 
 import pytest
 
@@ -259,6 +261,87 @@ class TestMessageStore:
         assert results[0]["content"] == "docker fallback search still works"
         assert "fallback" in results[0]["snippet"].lower()
 
+    def test_init_repairs_message_fts_drifted_row_count(self, tmp_path):
+        db_path = tmp_path / "message-fts-drift.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE VIRTUAL TABLE messages_fts USING fts5(
+                content,
+                content=messages,
+                content_rowid=store_id
+            );
+            CREATE TRIGGER msg_fts_insert
+                AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content)
+                    VALUES (new.store_id, new.content);
+            END;
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '2');
+            INSERT INTO messages(session_id, role, content, timestamp, token_estimate, pinned)
+            VALUES ('sess1', 'user', 'drifted search row', 1.0, 3, 0);
+            DELETE FROM messages_fts;
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        store = MessageStore(db_path)
+        results = store.search("drifted", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "drifted search row"
+
+        fts_count = store._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+        assert fts_count == 1
+        store.close()
+
+    def test_store_waits_out_long_write_lock_with_extended_busy_timeout(self, tmp_path):
+        db_path = tmp_path / "busy-timeout.db"
+        store = MessageStore(db_path)
+
+        lock_conn = sqlite3.connect(db_path, timeout=1.0, check_same_thread=False)
+        lock_conn.execute("PRAGMA journal_mode=WAL")
+        lock_conn.execute("BEGIN IMMEDIATE")
+        lock_conn.execute(
+            "INSERT INTO messages(session_id, role, content, timestamp, token_estimate, pinned) VALUES (?, ?, ?, ?, ?, ?)",
+            ("hold", "user", "holding write lock", 1.0, 1, 0),
+        )
+
+        def release_lock():
+            time.sleep(6.2)
+            lock_conn.commit()
+            lock_conn.close()
+
+        releaser = threading.Thread(target=release_lock, daemon=True)
+        releaser.start()
+
+        start = time.monotonic()
+        store.append("sess1", {"role": "user", "content": "writer survives lock"})
+        elapsed = time.monotonic() - start
+        releaser.join(timeout=1.0)
+
+        assert elapsed >= 6.0
+        assert store.get_session_count("sess1") == 1
+        assert store._conn.execute("PRAGMA busy_timeout").fetchone()[0] >= 30000
+
+        store.close()
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -453,6 +536,61 @@ class TestSummaryDAG:
 
         assert len(results) == 1
         assert results[0].summary == "dag fallback search still works"
+
+    def test_init_repairs_nodes_fts_drifted_row_count(self, tmp_path):
+        db_path = tmp_path / "nodes-fts-drift.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE VIRTUAL TABLE nodes_fts USING fts5(
+                summary,
+                content=summary_nodes,
+                content_rowid=node_id
+            );
+            CREATE TRIGGER nodes_fts_insert
+                AFTER INSERT ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(rowid, summary)
+                    VALUES (new.node_id, new.summary);
+            END;
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '2');
+            INSERT INTO summary_nodes(
+                session_id, depth, summary, token_count, source_token_count,
+                source_ids, source_type, created_at, expand_hint
+            ) VALUES (
+                's1', 0, 'drifted dag row', 5, 10,
+                '[1]', 'messages', 1.0, ''
+            );
+            DELETE FROM nodes_fts;
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        dag = SummaryDAG(db_path)
+        results = dag.search("drifted", session_id="s1")
+
+        assert len(results) == 1
+        assert results[0].summary == "drifted dag row"
+
+        fts_count = dag._conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0]
+        assert fts_count == 1
+        dag.close()
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1,6 +1,8 @@
 """Tests for LCM core components: store, DAG, tokens, config, escalation."""
 
 import json
+import sqlite3
+
 import pytest
 
 from hermes_lcm.config import LCMConfig
@@ -143,6 +145,98 @@ class TestMessageStore:
         results = store.search("docker", session_id="sess1")
         assert len(results) >= 1
 
+    def test_init_repairs_malformed_message_fts_and_sets_schema_version(self, tmp_path):
+        db_path = tmp_path / "legacy-store.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE TABLE messages_fts (
+                rowid INTEGER PRIMARY KEY,
+                content TEXT
+            );
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO messages (session_id, role, content, timestamp, token_estimate, pinned)
+            VALUES ('sess1', 'user', 'legacy docker migration note', 1.0, 7, 0);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        store = MessageStore(db_path)
+
+        version = store._conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        assert version == ("1",)
+
+        results = store.search("docker", session_id="sess1")
+        assert len(results) == 1
+        assert results[0]["content"] == "legacy docker migration note"
+
+        store.close()
+
+    def test_init_recreates_missing_message_fts_trigger(self, tmp_path):
+        db_path = tmp_path / "legacy-trigger.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE VIRTUAL TABLE messages_fts USING fts5(
+                content,
+                content=messages,
+                content_rowid=store_id
+            );
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        store = MessageStore(db_path)
+        store.append("sess1", {"role": "user", "content": "fresh searchable message"})
+
+        results = store.search("searchable", session_id="sess1")
+        assert len(results) == 1
+
+        trigger_names = {
+            row[0]
+            for row in store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND name='msg_fts_insert'"
+            ).fetchall()
+        }
+        assert trigger_names == {"msg_fts_insert"}
+
+        store.close()
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -212,6 +306,106 @@ class TestSummaryDAG:
         ))
         results = dag.search("Docker", session_id="s1")
         assert len(results) >= 1
+
+    def test_init_repairs_malformed_nodes_fts_and_sets_schema_version(self, tmp_path):
+        db_path = tmp_path / "legacy-dag.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE TABLE nodes_fts (
+                rowid INTEGER PRIMARY KEY,
+                summary TEXT
+            );
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO summary_nodes (
+                session_id, depth, summary, token_count, source_token_count,
+                source_ids, source_type, created_at, expand_hint
+            ) VALUES (
+                's1', 0, 'legacy summary about docker recovery', 9, 18,
+                '[1]', 'messages', 1.0, ''
+            );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        dag = SummaryDAG(db_path)
+
+        version = dag._conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        assert version == ("1",)
+
+        results = dag.search("docker", session_id="s1")
+        assert len(results) == 1
+        assert results[0].summary == "legacy summary about docker recovery"
+
+        dag.close()
+
+    def test_init_recreates_missing_nodes_fts_trigger(self, tmp_path):
+        db_path = tmp_path / "legacy-nodes-trigger.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE VIRTUAL TABLE nodes_fts USING fts5(
+                summary,
+                content=summary_nodes,
+                content_rowid=node_id
+            );
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        dag = SummaryDAG(db_path)
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0, summary="fresh dag search result",
+            token_count=5, source_ids=[1], source_type="messages",
+        ))
+
+        results = dag.search("fresh", session_id="s1")
+        assert len(results) == 1
+
+        trigger_names = {
+            row[0]
+            for row in dag._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND name='nodes_fts_insert'"
+            ).fetchall()
+        }
+        assert trigger_names == {"nodes_fts_insert"}
+
+        dag.close()
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -182,7 +182,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("1",)
+        assert version == ("2",)
 
         results = store.search("docker", session_id="sess1")
         assert len(results) == 1
@@ -216,6 +216,7 @@ class TestMessageStore:
                 key TEXT PRIMARY KEY,
                 value TEXT
             );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '1');
             """
         )
         conn.commit()
@@ -227,15 +228,36 @@ class TestMessageStore:
         results = store.search("searchable", session_id="sess1")
         assert len(results) == 1
 
+        version = store._conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        assert version == ("2",)
+
+        migration_state = store._conn.execute(
+            "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
+        ).fetchall()
+        assert ("v2_external_content_fts_triggers",) in migration_state
+
         trigger_names = {
             row[0]
             for row in store._conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='trigger' AND name='msg_fts_insert'"
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('msg_fts_insert', 'msg_fts_delete')"
             ).fetchall()
         }
-        assert trigger_names == {"msg_fts_insert"}
+        assert trigger_names == {"msg_fts_insert", "msg_fts_delete"}
 
         store.close()
+
+    def test_search_falls_back_to_like_when_message_fts_breaks(self, store):
+        store.append("sess1", {"role": "user", "content": "docker fallback search still works"})
+        store._conn.execute("DROP TABLE messages_fts")
+        store._conn.commit()
+
+        results = store.search("fallback", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "docker fallback search still works"
+        assert "fallback" in results[0]["snippet"].lower()
 
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
@@ -349,7 +371,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("1",)
+        assert version == ("2",)
 
         results = dag.search("docker", session_id="s1")
         assert len(results) == 1
@@ -383,6 +405,7 @@ class TestSummaryDAG:
                 key TEXT PRIMARY KEY,
                 value TEXT
             );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '1');
             """
         )
         conn.commit()
@@ -397,15 +420,39 @@ class TestSummaryDAG:
         results = dag.search("fresh", session_id="s1")
         assert len(results) == 1
 
+        version = dag._conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        assert version == ("2",)
+
+        migration_state = dag._conn.execute(
+            "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
+        ).fetchall()
+        assert ("v2_external_content_fts_triggers",) in migration_state
+
         trigger_names = {
             row[0]
             for row in dag._conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='trigger' AND name='nodes_fts_insert'"
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('nodes_fts_insert', 'nodes_fts_delete')"
             ).fetchall()
         }
-        assert trigger_names == {"nodes_fts_insert"}
+        assert trigger_names == {"nodes_fts_insert", "nodes_fts_delete"}
 
         dag.close()
+
+    def test_search_falls_back_to_like_when_nodes_fts_breaks(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="dag fallback search still works",
+            token_count=10, source_ids=[1], source_type="messages",
+        ))
+        dag._conn.execute("DROP TABLE nodes_fts")
+        dag._conn.commit()
+
+        results = dag.search("fallback", session_id="s1")
+
+        assert len(results) == 1
+        assert results[0].summary == "dag fallback search still works"
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(


### PR DESCRIPTION
## Summary
- add a shared SQLite bootstrap path for store/DAG setup
- introduce a small versioned migration baseline (`schema_version = 2` + `lcm_migration_state`)
- repair malformed or drifted external-content FTS tables on startup
- fall back to `LIKE` search if FTS is unavailable at runtime
- raise SQLite `busy_timeout` to 30s and cover longer write-lock waits with regression tests

## Why
Existing `CREATE TABLE IF NOT EXISTS` bootstrap was fine for fresh DBs, but too weak for real upgrades and messy legacy state. This tightens the plugin-side DB layer so old or damaged local state is less likely to stay broken or fail under normal write contention.

## Notes
- this stays fully inside `hermes-lcm`; no Hermes Agent/core changes are involved
- startup repair and runtime fallback are both included, so degraded FTS state is less likely to crash search outright

## Test Plan
- `python3 -m pytest tests/test_lcm_core.py -q`
- `python3 -m pytest tests/ -q`
