### PR TITLE
✨ feat: make lcm_grep recall much sharper

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -28,6 +28,25 @@ from .db_bootstrap import (
 
 logger = logging.getLogger(__name__)
 
+AGE_DECAY_RATE = 0.001
+
+
+def _normalize_search_sort(sort: str | None) -> str:
+    normalized = (sort or "recency").strip().lower()
+    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
+
+
+def _build_search_order_by(sort: str | None, created_at_expr: str) -> str:
+    normalized = _normalize_search_sort(sort)
+    if normalized == "relevance":
+        return f"rank ASC, {created_at_expr} DESC"
+    if normalized == "hybrid":
+        return (
+            f"(rank / (1 + (((strftime('%s','now') - {created_at_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
+            f"{created_at_expr} DESC"
+        )
+    return f"{created_at_expr} DESC"
+
 
 @dataclass
 class SummaryNode:
@@ -42,6 +61,7 @@ class SummaryNode:
     source_type: str = "messages"  # "messages" or "nodes"
     created_at: float = 0.0
     expand_hint: str = ""  # "Expand for details about: ..."
+    search_rank: float | None = None
 
 
 class SummaryDAG:
@@ -231,23 +251,24 @@ class SummaryDAG:
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,
-               limit: int = 20) -> List[SummaryNode]:
+               limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
         """FTS5 search across all summary nodes."""
+        order_by = _build_search_order_by(sort, "n.created_at")
         try:
             if session_id:
                 rows = self._conn.execute(
-                    """SELECT n.* FROM nodes_fts fts
+                    f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                        JOIN summary_nodes n ON n.node_id = fts.rowid
                        WHERE nodes_fts MATCH ? AND n.session_id = ?
-                       ORDER BY rank LIMIT ?""",
+                       ORDER BY {order_by} LIMIT ?""",
                     (query, session_id, limit),
                 ).fetchall()
             else:
                 rows = self._conn.execute(
-                    """SELECT n.* FROM nodes_fts fts
+                    f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                        JOIN summary_nodes n ON n.node_id = fts.rowid
                        WHERE nodes_fts MATCH ?
-                       ORDER BY rank LIMIT ?""",
+                       ORDER BY {order_by} LIMIT ?""",
                     (query, limit),
                 ).fetchall()
             return [self._row_to_node(r) for r in rows]
@@ -257,14 +278,14 @@ class SummaryDAG:
                 rows = self._conn.execute(
                     """SELECT * FROM summary_nodes
                        WHERE session_id = ? AND LOWER(COALESCE(summary, '')) LIKE ?
-                       ORDER BY created_at LIMIT ?""",
+                       ORDER BY created_at DESC LIMIT ?""",
                     (session_id, like, limit),
                 ).fetchall()
             else:
                 rows = self._conn.execute(
                     """SELECT * FROM summary_nodes
                        WHERE LOWER(COALESCE(summary, '')) LIKE ?
-                       ORDER BY created_at LIMIT ?""",
+                       ORDER BY created_at DESC LIMIT ?""",
                     (like, limit),
                 ).fetchall()
             return [self._row_to_node(r) for r in rows]
@@ -326,6 +347,7 @@ class SummaryDAG:
             source_type=row[7],
             created_at=row[8],
             expand_hint=row[9] or "",
+            search_rank=row[10] if len(row) > 10 else None,
         )
 
     def close(self):

--- a/dag.py
+++ b/dag.py
@@ -25,6 +25,12 @@ from .db_bootstrap import (
     ensure_external_content_fts,
     run_versioned_migrations,
 )
+from .search_query import (
+    count_term_matches,
+    escape_like,
+    extract_search_terms,
+    requires_like_fallback,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +42,30 @@ def _normalize_search_sort(sort: str | None) -> str:
     return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
 
 
-def _build_search_order_by(sort: str | None, created_at_expr: str) -> str:
+def _build_search_order_by(sort: str | None, recency_expr: str) -> str:
     normalized = _normalize_search_sort(sort)
     if normalized == "relevance":
-        return f"rank ASC, {created_at_expr} DESC"
+        return f"rank ASC, {recency_expr} DESC"
     if normalized == "hybrid":
         return (
-            f"(rank / (1 + (((strftime('%s','now') - {created_at_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
-            f"{created_at_expr} DESC"
+            f"(rank / (1 + (((strftime('%s','now') - {recency_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
+            f"{recency_expr} DESC"
         )
-    return f"{created_at_expr} DESC"
+    return f"{recency_expr} DESC"
+
+
+def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float]:
+    normalized = _normalize_search_sort(sort)
+    score = float(node.search_rank or 0.0) * -1.0
+    recency = float(node.latest_at or node.created_at or 0.0)
+
+    if normalized == "relevance":
+        return (-score, -recency)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        blended = score / (1 + (age_hours * AGE_DECAY_RATE))
+        return (-blended, -recency)
+    return (-recency, -score)
 
 
 @dataclass
@@ -60,6 +80,8 @@ class SummaryNode:
     source_ids: List[int] = field(default_factory=list)  # store_ids or node_ids
     source_type: str = "messages"  # "messages" or "nodes"
     created_at: float = 0.0
+    earliest_at: float | None = None
+    latest_at: float | None = None
     expand_hint: str = ""  # "Expand for details about: ..."
     search_rank: float | None = None
 
@@ -86,6 +108,8 @@ class SummaryDAG:
                 source_ids TEXT NOT NULL DEFAULT '[]',
                 source_type TEXT NOT NULL DEFAULT 'messages',
                 created_at REAL NOT NULL,
+                earliest_at REAL,
+                latest_at REAL,
                 expand_hint TEXT DEFAULT ''
             );
             CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
@@ -122,7 +146,20 @@ class SummaryDAG:
             ),
         )
         run_versioned_migrations(self._conn)
+        self._ensure_source_window_columns()
         self._conn.commit()
+
+    def _ensure_source_window_columns(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(summary_nodes)").fetchall()
+        }
+        if "earliest_at" not in columns:
+            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL")
+        if "latest_at" not in columns:
+            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN latest_at REAL")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
+        )
 
     # -- Write --------------------------------------------------------------
 
@@ -131,8 +168,8 @@ class SummaryDAG:
         cur = self._conn.execute(
             """INSERT INTO summary_nodes
                (session_id, depth, summary, token_count, source_token_count,
-                source_ids, source_type, created_at, expand_hint)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 node.session_id,
                 node.depth,
@@ -142,6 +179,8 @@ class SummaryDAG:
                 json.dumps(node.source_ids),
                 node.source_type,
                 node.created_at or time.time(),
+                node.earliest_at,
+                node.latest_at,
                 node.expand_hint,
             ),
         )
@@ -253,7 +292,10 @@ class SummaryDAG:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
         """FTS5 search across all summary nodes."""
-        order_by = _build_search_order_by(sort, "n.created_at")
+        if requires_like_fallback(query):
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+
+        order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
         try:
             if session_id:
                 rows = self._conn.execute(
@@ -271,24 +313,42 @@ class SummaryDAG:
                        ORDER BY {order_by} LIMIT ?""",
                     (query, limit),
                 ).fetchall()
-            return [self._row_to_node(r) for r in rows]
-        except sqlite3.DatabaseError:
-            like = f"%{query.strip().lower()}%"
-            if session_id:
-                rows = self._conn.execute(
-                    """SELECT * FROM summary_nodes
-                       WHERE session_id = ? AND LOWER(COALESCE(summary, '')) LIKE ?
-                       ORDER BY created_at DESC LIMIT ?""",
-                    (session_id, like, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    """SELECT * FROM summary_nodes
-                       WHERE LOWER(COALESCE(summary, '')) LIKE ?
-                       ORDER BY created_at DESC LIMIT ?""",
-                    (like, limit),
-                ).fetchall()
-            return [self._row_to_node(r) for r in rows]
+        except sqlite3.Error:
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+        return [self._row_to_node(r) for r in rows]
+
+    def _search_like(self, query: str, session_id: str | None = None,
+                     limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
+        terms = extract_search_terms(query)
+        if not terms:
+            return []
+
+        where: list[str] = ["summary IS NOT NULL"]
+        args: list[Any] = []
+        if session_id:
+            where.append("session_id = ?")
+            args.append(session_id)
+        like_clauses = []
+        for term in terms:
+            like_clauses.append("summary LIKE ? ESCAPE '\\'")
+            args.append(f"%{escape_like(term)}%")
+        where.append("(" + " OR ".join(like_clauses) + ")")
+
+        rows = self._conn.execute(
+            f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)}",
+            args,
+        ).fetchall()
+        nodes: list[SummaryNode] = []
+        for row in rows:
+            node = self._row_to_node(row)
+            score = sum(count_term_matches(node.summary, term) for term in terms)
+            if score <= 0:
+                continue
+            node.search_rank = -float(score)
+            nodes.append(node)
+
+        nodes.sort(key=lambda node: _fallback_result_sort_key(node, sort))
+        return nodes[:limit]
 
     # -- DAG traversal ------------------------------------------------------
 
@@ -304,6 +364,22 @@ class SummaryDAG:
             node.source_ids,
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
+
+    def get_source_time_window(self, node_ids: List[int]) -> tuple[float | None, float | None]:
+        if not node_ids:
+            return None, None
+        placeholders = ",".join("?" * len(node_ids))
+        row = self._conn.execute(
+            f"""SELECT
+                    MIN(COALESCE(earliest_at, created_at)),
+                    MAX(COALESCE(latest_at, created_at))
+                FROM summary_nodes
+                WHERE node_id IN ({placeholders})""",
+            node_ids,
+        ).fetchone()
+        if not row:
+            return None, None
+        return row[0], row[1]
 
     def describe_subtree(self, node_id: int) -> Dict[str, Any]:
         """Return metadata about a node's subtree without loading content."""
@@ -329,6 +405,8 @@ class SummaryDAG:
             "source_token_count": node.source_token_count,
             "source_type": node.source_type,
             "num_sources": len(node.source_ids),
+            "earliest_at": node.earliest_at,
+            "latest_at": node.latest_at,
             "expand_hint": node.expand_hint,
             "children": children,
         }
@@ -346,8 +424,10 @@ class SummaryDAG:
             source_ids=json.loads(row[6]) if row[6] else [],
             source_type=row[7],
             created_at=row[8],
-            expand_hint=row[9] or "",
-            search_rank=row[10] if len(row) > 10 else None,
+            earliest_at=row[9],
+            latest_at=row[10],
+            expand_hint=row[11] or "",
+            search_rank=row[12] if len(row) > 12 else None,
         )
 
     def close(self):

--- a/engine.py
+++ b/engine.py
@@ -241,6 +241,7 @@ class LCMEngine(ContextEngine):
         # Step 5: Create DAG node
         # Collect store_ids for source tracking
         source_store_ids = self._get_store_ids_for_messages(to_compact)
+        earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
 
         node = SummaryNode(
             session_id=self._session_id,
@@ -251,6 +252,8 @@ class LCMEngine(ContextEngine):
             source_ids=source_store_ids,
             source_type="messages",
             created_at=time.time(),
+            earliest_at=earliest_at,
+            latest_at=latest_at,
             expand_hint=self._extract_expand_hint(summary_text),
         )
         self._dag.add_node(node)
@@ -615,6 +618,7 @@ class LCMEngine(ContextEngine):
                 focus_topic=focus_topic or "",
             )
 
+            earliest_at, latest_at = self._dag.get_source_time_window([n.node_id for n in to_condense])
             node = SummaryNode(
                 session_id=self._session_id,
                 depth=depth + 1,
@@ -624,6 +628,8 @@ class LCMEngine(ContextEngine):
                 source_ids=[n.node_id for n in to_condense],
                 source_type="nodes",
                 created_at=time.time(),
+                earliest_at=earliest_at,
+                latest_at=latest_at,
                 expand_hint=self._extract_expand_hint(summary_text),
             )
             self._dag.add_node(node)

--- a/schemas.py
+++ b/schemas.py
@@ -14,12 +14,24 @@ LCM_GREP = {
         "properties": {
             "query": {
                 "type": "string",
-                "description": "Search query (FTS5 syntax: keywords, phrases, OR/NOT)",
+                "description": (
+                    "Search query (FTS5 syntax: keywords, phrases, OR/NOT). "
+                    "FTS5 defaults to AND matching, so prefer 1-3 distinctive terms or one quoted multi-word phrase."
+                ),
             },
             "limit": {
                 "type": "integer",
                 "description": "Max results to return (default 10)",
                 "default": 10,
+            },
+            "sort": {
+                "type": "string",
+                "enum": ["recency", "relevance", "hybrid"],
+                "description": (
+                    "How to order matches. 'recency' favors newer hits, 'relevance' favors strongest FTS matches, "
+                    "and 'hybrid' keeps strong older matches competitive while still boosting newer context."
+                ),
+                "default": "recency",
             },
         },
         "required": ["query"],

--- a/schemas.py
+++ b/schemas.py
@@ -16,7 +16,8 @@ LCM_GREP = {
                 "type": "string",
                 "description": (
                     "Search query (FTS5 syntax: keywords, phrases, OR/NOT). "
-                    "FTS5 defaults to AND matching, so prefer 1-3 distinctive terms or one quoted multi-word phrase."
+                    "FTS5 defaults to AND matching, so prefer 1-3 distinctive terms or one quoted multi-word phrase. "
+                    "Wrap exact phrases in quotes. Short CJK fragments and emoji-heavy queries may use substring fallback instead of plain FTS token matching."
                 ),
             },
             "limit": {

--- a/search_query.py
+++ b/search_query.py
@@ -1,0 +1,98 @@
+"""Helpers for search query handling across FTS and LIKE fallback paths."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+_CJK_RE = re.compile(
+    r"["
+    r"\u3400-\u4dbf"
+    r"\u4e00-\u9fff"
+    r"\u3000-\u303f"
+    r"\u3040-\u30ff"
+    r"\uac00-\ud7af"
+    r"\uff00-\uffef"
+    r"]"
+)
+_EMOJI_RE = re.compile(
+    r"["
+    r"\u2600-\u27bf"
+    r"\U0001F300-\U0001FAFF"
+    r"]"
+)
+_QUOTED_PHRASE_RE = re.compile(r'"([^"]+)"')
+
+
+def contains_cjk(text: str) -> bool:
+    return bool(_CJK_RE.search(text or ""))
+
+
+def contains_emoji(text: str) -> bool:
+    return bool(_EMOJI_RE.search(text or ""))
+
+
+def requires_like_fallback(query: str) -> bool:
+    return contains_cjk(query) or contains_emoji(query)
+
+
+def extract_search_terms(query: str) -> List[str]:
+    text = (query or "").strip()
+    if not text:
+        return []
+
+    terms: list[str] = []
+    for phrase in _QUOTED_PHRASE_RE.findall(text):
+        cleaned = phrase.strip()
+        if cleaned:
+            terms.append(cleaned)
+
+    text_without_phrases = _QUOTED_PHRASE_RE.sub(" ", text)
+    for token in text_without_phrases.split():
+        cleaned = token.strip()
+        if cleaned:
+            terms.append(cleaned)
+
+    if not terms:
+        terms.append(text)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for term in terms:
+        if term not in seen:
+            deduped.append(term)
+            seen.add(term)
+    return deduped
+
+
+def escape_like(term: str) -> str:
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def count_term_matches(text: str, term: str) -> int:
+    haystack = (text or "")
+    needle = (term or "")
+    if not haystack or not needle:
+        return 0
+    return haystack.lower().count(needle.lower())
+
+
+def build_snippet(text: str, terms: List[str], width: int = 80) -> str:
+    content = (text or "")
+    if not content:
+        return ""
+    lowered = content.lower()
+    for term in terms:
+        if not term:
+            continue
+        idx = lowered.find(term.lower())
+        if idx >= 0:
+            start = max(0, idx - width // 2)
+            end = min(len(content), idx + len(term) + width // 2)
+            snippet = content[start:end]
+            if start > 0:
+                snippet = "..." + snippet
+            if end < len(content):
+                snippet = snippet + "..."
+            return snippet
+    return content[:width] + ("..." if len(content) > width else "")

--- a/store.py
+++ b/store.py
@@ -22,6 +22,25 @@ from .db_bootstrap import (
 
 logger = logging.getLogger(__name__)
 
+AGE_DECAY_RATE = 0.001
+
+
+def _normalize_search_sort(sort: str | None) -> str:
+    normalized = (sort or "recency").strip().lower()
+    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
+
+
+def _build_search_order_by(sort: str | None, timestamp_expr: str) -> str:
+    normalized = _normalize_search_sort(sort)
+    if normalized == "relevance":
+        return f"rank ASC, {timestamp_expr} DESC"
+    if normalized == "hybrid":
+        return (
+            f"(rank / (1 + (((strftime('%s','now') - {timestamp_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
+            f"{timestamp_expr} DESC"
+        )
+    return f"{timestamp_expr} DESC"
+
 
 class MessageStore:
     """SQLite-backed immutable message store."""
@@ -219,32 +238,35 @@ class MessageStore:
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,
-               limit: int = 20) -> List[Dict[str, Any]]:
+               limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
         """FTS5 search across messages. Returns matches with snippets."""
+        order_by = _build_search_order_by(sort, "m.timestamp")
         try:
             if session_id:
                 rows = self._conn.execute(
-                    """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                    f"""SELECT m.*, rank as search_rank,
+                              snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
                        FROM messages_fts fts
                        JOIN messages m ON m.store_id = fts.rowid
                        WHERE messages_fts MATCH ? AND m.session_id = ?
-                       ORDER BY rank LIMIT ?""",
+                       ORDER BY {order_by} LIMIT ?""",
                     (query, session_id, limit),
                 ).fetchall()
             else:
                 rows = self._conn.execute(
-                    """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                    f"""SELECT m.*, rank as search_rank,
+                              snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
                        FROM messages_fts fts
                        JOIN messages m ON m.store_id = fts.rowid
                        WHERE messages_fts MATCH ?
-                       ORDER BY rank LIMIT ?""",
+                       ORDER BY {order_by} LIMIT ?""",
                     (query, limit),
                 ).fetchall()
             results = []
             for r in rows:
                 d = self._row_to_dict(r)
-                # snippet is the extra column
-                d["snippet"] = r[-1] if len(r) > 10 else ""
+                d["search_rank"] = r[10] if len(r) > 10 else None
+                d["snippet"] = r[11] if len(r) > 11 else ""
                 results.append(d)
             return results
         except sqlite3.DatabaseError:
@@ -253,14 +275,14 @@ class MessageStore:
                 rows = self._conn.execute(
                     """SELECT * FROM messages
                        WHERE session_id = ? AND LOWER(COALESCE(content, '')) LIKE ?
-                       ORDER BY store_id LIMIT ?""",
+                       ORDER BY timestamp DESC LIMIT ?""",
                     (session_id, like, limit),
                 ).fetchall()
             else:
                 rows = self._conn.execute(
                     """SELECT * FROM messages
                        WHERE LOWER(COALESCE(content, '')) LIKE ?
-                       ORDER BY store_id LIMIT ?""",
+                       ORDER BY timestamp DESC LIMIT ?""",
                     (like, limit),
                 ).fetchall()
             results = []

--- a/store.py
+++ b/store.py
@@ -19,6 +19,13 @@ from .db_bootstrap import (
     ensure_external_content_fts,
     run_versioned_migrations,
 )
+from .search_query import (
+    build_snippet,
+    count_term_matches,
+    escape_like,
+    extract_search_terms,
+    requires_like_fallback,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +47,20 @@ def _build_search_order_by(sort: str | None, timestamp_expr: str) -> str:
             f"{timestamp_expr} DESC"
         )
     return f"{timestamp_expr} DESC"
+
+
+def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float]:
+    normalized = _normalize_search_sort(sort)
+    score = float(result.get("_fallback_score") or 0.0)
+    timestamp = float(result.get("timestamp") or 0.0)
+
+    if normalized == "relevance":
+        return (-score, -timestamp)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        blended = score / (1 + (age_hours * AGE_DECAY_RATE))
+        return (-blended, -timestamp)
+    return (-timestamp, -score)
 
 
 class MessageStore:
@@ -235,11 +256,26 @@ class MessageStore:
         ).fetchone()
         return row[0] if row else 0
 
+    def get_time_bounds(self, store_ids: List[int]) -> tuple[float | None, float | None]:
+        if not store_ids:
+            return None, None
+        placeholders = ",".join("?" * len(store_ids))
+        row = self._conn.execute(
+            f"SELECT MIN(timestamp), MAX(timestamp) FROM messages WHERE store_id IN ({placeholders})",
+            store_ids,
+        ).fetchone()
+        if not row:
+            return None, None
+        return row[0], row[1]
+
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
         """FTS5 search across messages. Returns matches with snippets."""
+        if requires_like_fallback(query):
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+
         order_by = _build_search_order_by(sort, "m.timestamp")
         try:
             if session_id:
@@ -262,35 +298,54 @@ class MessageStore:
                        ORDER BY {order_by} LIMIT ?""",
                     (query, limit),
                 ).fetchall()
-            results = []
-            for r in rows:
-                d = self._row_to_dict(r)
-                d["search_rank"] = r[10] if len(r) > 10 else None
-                d["snippet"] = r[11] if len(r) > 11 else ""
-                results.append(d)
-            return results
-        except sqlite3.DatabaseError:
-            like = f"%{query.strip().lower()}%"
-            if session_id:
-                rows = self._conn.execute(
-                    """SELECT * FROM messages
-                       WHERE session_id = ? AND LOWER(COALESCE(content, '')) LIKE ?
-                       ORDER BY timestamp DESC LIMIT ?""",
-                    (session_id, like, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    """SELECT * FROM messages
-                       WHERE LOWER(COALESCE(content, '')) LIKE ?
-                       ORDER BY timestamp DESC LIMIT ?""",
-                    (like, limit),
-                ).fetchall()
-            results = []
-            for r in rows:
-                d = self._row_to_dict(r)
-                d["snippet"] = d.get("content") or ""
-                results.append(d)
-            return results
+        except sqlite3.Error:
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+        results = []
+        for r in rows:
+            d = self._row_to_dict(r)
+            d["search_rank"] = r[10] if len(r) > 10 else None
+            d["snippet"] = r[11] if len(r) > 11 else ""
+            results.append(d)
+        return results
+
+    def _search_like(self, query: str, session_id: str | None = None,
+                     limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
+        terms = extract_search_terms(query)
+        if not terms:
+            return []
+
+        where: list[str] = ["content IS NOT NULL"]
+        args: list[Any] = []
+        if session_id:
+            where.append("session_id = ?")
+            args.append(session_id)
+        like_clauses = []
+        for term in terms:
+            like_clauses.append("content LIKE ? ESCAPE '\\'")
+            args.append(f"%{escape_like(term)}%")
+        where.append("(" + " OR ".join(like_clauses) + ")")
+
+        rows = self._conn.execute(
+            f"SELECT * FROM messages WHERE {' AND '.join(where)}"
+            , args,
+        ).fetchall()
+
+        results: list[Dict[str, Any]] = []
+        for row in rows:
+            result = self._row_to_dict(row)
+            content = result.get("content") or ""
+            score = sum(count_term_matches(content, term) for term in terms)
+            if score <= 0:
+                continue
+            result["search_rank"] = -float(score)
+            result["snippet"] = build_snippet(content, terms)
+            result["_fallback_score"] = float(score)
+            results.append(result)
+
+        results.sort(key=lambda result: _fallback_result_sort_key(result, sort))
+        for result in results:
+            result.pop("_fallback_score", None)
+        return results[:limit]
 
     # -- Helpers ------------------------------------------------------------
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -357,6 +357,47 @@ class TestMessageStore:
 
         store.close()
 
+    def test_search_sort_modes_apply_before_limit(self, store):
+        older_strong = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "database migration plan database migration plan database migration plan with rollback notes",
+            },
+        )
+        newer_weak = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "recent status note about the database migration plan",
+            },
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_700_000_000, older_strong),
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_800_000_000, newer_weak),
+        )
+        store._conn.commit()
+
+        recency_results = store.search(
+            '"database migration plan"',
+            session_id="sess1",
+            limit=1,
+            sort="recency",
+        )
+        relevance_results = store.search(
+            '"database migration plan"',
+            session_id="sess1",
+            limit=1,
+            sort="relevance",
+        )
+
+        assert recency_results[0]["store_id"] == newer_weak
+        assert relevance_results[0]["store_id"] == older_strong
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -606,6 +647,36 @@ class TestSummaryDAG:
         fts_count = dag._conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0]
         assert fts_count == 1
         dag.close()
+
+    def test_search_sort_modes_apply_before_limit(self, dag):
+        older_strong = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="error handling checklist error handling checklist error handling checklist with confirmed fixes",
+            token_count=18, source_ids=[1], source_type="messages",
+            created_at=1_700_000_000,
+        ))
+        newer_weak = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="recent note mentioning the error handling checklist",
+            token_count=9, source_ids=[2], source_type="messages",
+            created_at=1_800_000_000,
+        ))
+
+        recency_results = dag.search(
+            '"error handling checklist"',
+            session_id="s1",
+            limit=1,
+            sort="recency",
+        )
+        hybrid_results = dag.search(
+            '"error handling checklist"',
+            session_id="s1",
+            limit=1,
+            sort="hybrid",
+        )
+
+        assert recency_results[0].node_id == newer_weak
+        assert hybrid_results[0].node_id == older_strong
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -398,6 +398,56 @@ class TestMessageStore:
         assert recency_results[0]["store_id"] == newer_weak
         assert relevance_results[0]["store_id"] == older_strong
 
+    def test_search_cjk_queries_fall_back_with_aligned_sort_modes(self, store):
+        older_strong = store.append(
+            "sess1",
+            {"role": "user", "content": "部署 部署 数据库迁移清单"},
+        )
+        newer_weak = store.append(
+            "sess1",
+            {"role": "assistant", "content": "最新部署状态更新"},
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_700_000_000, older_strong),
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_800_000_000, newer_weak),
+        )
+        store._conn.commit()
+
+        recency_results = store.search("部署", session_id="sess1", limit=1, sort="recency")
+        relevance_results = store.search("部署", session_id="sess1", limit=1, sort="relevance")
+
+        assert recency_results[0]["store_id"] == newer_weak
+        assert relevance_results[0]["store_id"] == older_strong
+
+    def test_search_emoji_queries_fall_back_with_aligned_sort_modes(self, store):
+        older_strong = store.append(
+            "sess1",
+            {"role": "user", "content": "🚀 🚀 launch checklist"},
+        )
+        newer_weak = store.append(
+            "sess1",
+            {"role": "assistant", "content": "fresh 🚀 status"},
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_700_000_000, older_strong),
+        )
+        store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_800_000_000, newer_weak),
+        )
+        store._conn.commit()
+
+        recency_results = store.search("🚀", session_id="sess1", limit=1, sort="recency")
+        relevance_results = store.search("🚀", session_id="sess1", limit=1, sort="relevance")
+
+        assert recency_results[0]["store_id"] == newer_weak
+        assert relevance_results[0]["store_id"] == older_strong
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -648,18 +698,78 @@ class TestSummaryDAG:
         assert fts_count == 1
         dag.close()
 
+    def test_add_and_get_preserves_source_window_timestamps(self, dag):
+        node_id = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Planning notes",
+            token_count=10, source_ids=[1], source_type="messages",
+            created_at=1_900_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_800_000_000,
+        ))
+
+        node = dag.get_node(node_id)
+        assert node.earliest_at == 1_700_000_000
+        assert node.latest_at == 1_800_000_000
+
+    def test_existing_db_is_upgraded_with_summary_source_window_columns(self, tmp_path):
+        db_path = tmp_path / "legacy_dag.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE VIRTUAL TABLE nodes_fts USING fts5(
+                summary,
+                content=summary_nodes,
+                content_rowid=node_id
+            );
+            CREATE TRIGGER nodes_fts_insert
+                AFTER INSERT ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(rowid, summary)
+                    VALUES (new.node_id, new.summary);
+            END;
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        dag = SummaryDAG(db_path)
+        columns = {
+            row[1] for row in dag._conn.execute("PRAGMA table_info(summary_nodes)").fetchall()
+        }
+
+        assert "earliest_at" in columns
+        assert "latest_at" in columns
+
+        dag.close()
+
     def test_search_sort_modes_apply_before_limit(self, dag):
         older_strong = dag.add_node(SummaryNode(
             session_id="s1", depth=0,
             summary="error handling checklist error handling checklist error handling checklist with confirmed fixes",
             token_count=18, source_ids=[1], source_type="messages",
-            created_at=1_700_000_000,
+            created_at=1_900_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
         ))
         newer_weak = dag.add_node(SummaryNode(
             session_id="s1", depth=0,
             summary="recent note mentioning the error handling checklist",
             token_count=9, source_ids=[2], source_type="messages",
             created_at=1_800_000_000,
+            earliest_at=1_800_000_000,
+            latest_at=1_800_000_000,
         ))
 
         recency_results = dag.search(
@@ -677,6 +787,54 @@ class TestSummaryDAG:
 
         assert recency_results[0].node_id == newer_weak
         assert hybrid_results[0].node_id == older_strong
+
+    def test_search_cjk_queries_fall_back_with_aligned_sort_modes(self, dag):
+        older_strong = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="部署 部署 数据库迁移清单",
+            token_count=12, source_ids=[1], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+        newer_weak = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="最新部署状态更新",
+            token_count=8, source_ids=[2], source_type="messages",
+            created_at=1_800_000_000,
+            earliest_at=1_800_000_000,
+            latest_at=1_800_000_000,
+        ))
+
+        recency_results = dag.search("部署", session_id="s1", limit=1, sort="recency")
+        relevance_results = dag.search("部署", session_id="s1", limit=1, sort="relevance")
+
+        assert recency_results[0].node_id == newer_weak
+        assert relevance_results[0].node_id == older_strong
+
+    def test_search_emoji_queries_fall_back_with_aligned_sort_modes(self, dag):
+        older_strong = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="🚀 🚀 launch checklist",
+            token_count=12, source_ids=[1], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+        newer_weak = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="fresh 🚀 status",
+            token_count=8, source_ids=[2], source_type="messages",
+            created_at=1_800_000_000,
+            earliest_at=1_800_000_000,
+            latest_at=1_800_000_000,
+        ))
+
+        recency_results = dag.search("🚀", session_id="s1", limit=1, sort="recency")
+        relevance_results = dag.search("🚀", session_id="s1", limit=1, sort="relevance")
+
+        assert recency_results[0].node_id == newer_weak
+        assert relevance_results[0].node_id == older_strong
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1108,6 +1108,19 @@ class TestEngineTools:
         result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
         assert "results" in result
 
+    def test_handle_grep_reports_sort_mode(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "database migration plan database migration plan"},
+        )
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": '"database migration plan"', "limit": 1, "sort": "relevance"},
+            )
+        )
+        assert result["sort"] == "relevance"
+
     def test_handle_describe_overview(self, engine):
         result = json.loads(engine.handle_tool_call("lcm_describe", {}))
         assert "session_id" in result

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -275,6 +275,68 @@ class TestEngineCompress:
         finally:
             esc._call_llm_for_summary = original_fn
 
+    def test_compress_leaf_node_tracks_source_window_from_message_timestamps(self, engine):
+        messages = self._make_long_conversation(20)
+        engine._ingest_messages(messages)
+        all_rows = engine._store.get_session_messages("test-session")
+        expected_store_ids = [row["store_id"] for row in all_rows[1:-engine._config.fresh_tail_count]]
+        for idx, store_id in enumerate(expected_store_ids):
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (1_700_000_000 + idx, store_id),
+            )
+        engine._store._conn.commit()
+
+        import hermes_lcm.engine as engine_module
+        original_fn = engine_module.summarize_with_escalation
+
+        def mock_summary(**kwargs):
+            return "Leaf summary.\nExpand for details about: leaf window", 1
+
+        engine_module.summarize_with_escalation = mock_summary
+        try:
+            engine.compress(messages)
+            node = engine._dag.get_session_nodes("test-session")[0]
+            assert node.source_ids == expected_store_ids
+            assert node.earliest_at == 1_700_000_000
+            assert node.latest_at == 1_700_000_000 + len(expected_store_ids) - 1
+        finally:
+            engine_module.summarize_with_escalation = original_fn
+
+    def test_condensed_parent_node_tracks_child_source_window(self, engine, monkeypatch):
+        child_windows = [
+            (1_700_000_010, 1_700_000_020),
+            (1_700_000_030, 1_700_000_040),
+            (1_700_000_050, 1_700_000_060),
+            (1_700_000_070, 1_700_000_080),
+        ]
+        for idx, (earliest_at, latest_at) in enumerate(child_windows, start=1):
+            engine._dag.add_node(SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary=f"child {idx}",
+                token_count=10,
+                source_ids=[idx],
+                source_type="messages",
+                created_at=1_900_000_000 + idx,
+                earliest_at=earliest_at,
+                latest_at=latest_at,
+            ))
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            return "Parent summary.\nExpand for details about: parent window", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        engine._maybe_condense()
+
+        nodes = engine._dag.get_session_nodes("test-session")
+        parent = next(node for node in nodes if node.depth == 1)
+        assert parent.earliest_at == child_windows[0][0]
+        assert parent.latest_at == child_windows[-1][1]
+
 
 class TestPostCompactionIngestion:
     """Regression tests for issue #1 — messages must be persisted after

--- a/tools.py
+++ b/tools.py
@@ -4,12 +4,37 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from typing import Any, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .engine import LCMEngine
 
 logger = logging.getLogger(__name__)
+
+AGE_DECAY_RATE = 0.001
+
+
+def _normalize_search_sort(sort: str | None) -> str:
+    normalized = (sort or "recency").strip().lower()
+    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
+
+
+def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple[float, float, int]:
+    sort_timestamp = float(result.get("_sort_ts") or 0.0)
+    rank = result.get("_sort_rank")
+    rank_value = float(rank) if rank is not None else float("inf")
+    type_bias = 0 if result.get("type") == "message" else 1
+
+    if sort == "relevance":
+        return (rank_value, -sort_timestamp, type_bias)
+
+    if sort == "hybrid":
+        age_hours = max(0.0, (time.time() - sort_timestamp) / 3600.0)
+        blended = rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
+        return (blended, -sort_timestamp, type_bias)
+
+    return (-sort_timestamp, rank_value, type_bias)
 
 
 def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
@@ -152,11 +177,12 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": "No query provided"})
 
     limit = args.get("limit", 10)
+    sort = _normalize_search_sort(args.get("sort"))
     session_id = engine._session_id
     results = []
 
     try:
-        msg_hits = engine._store.search(query, session_id=session_id, limit=limit)
+        msg_hits = engine._store.search(query, session_id=session_id, limit=limit, sort=sort)
         for hit in msg_hits:
             results.append(
                 {
@@ -165,13 +191,15 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "store_id": hit["store_id"],
                     "role": hit["role"],
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
+                    "_sort_ts": hit.get("timestamp", 0),
+                    "_sort_rank": hit.get("search_rank"),
                 }
             )
     except Exception as exc:
         logger.debug("Message search failed: %s", exc)
 
     try:
-        node_hits = engine._dag.search(query, session_id=session_id, limit=limit)
+        node_hits = engine._dag.search(query, session_id=session_id, limit=limit, sort=sort)
         for node in node_hits:
             results.append(
                 {
@@ -181,13 +209,18 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "snippet": node.summary[:300],
                     "token_count": node.token_count,
                     "expand_hint": node.expand_hint,
+                    "_sort_ts": node.created_at,
+                    "_sort_rank": node.search_rank,
                 }
             )
     except Exception as exc:
         logger.debug("Node search failed: %s", exc)
 
-    results.sort(key=lambda result: (0 if result["type"] == "message" else 1, result.get("depth", "")))
-    return json.dumps({"query": query, "total_results": len(results), "results": results[:limit]})
+    results.sort(key=lambda result: _combined_result_sort_key(result, sort))
+    for result in results:
+        result.pop("_sort_ts", None)
+        result.pop("_sort_rank", None)
+    return json.dumps({"query": query, "sort": sort, "total_results": len(results), "results": results[:limit]})
 
 
 def lcm_describe(args: Dict[str, Any], **kwargs) -> str:

--- a/tools.py
+++ b/tools.py
@@ -209,7 +209,9 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "snippet": node.summary[:300],
                     "token_count": node.token_count,
                     "expand_hint": node.expand_hint,
-                    "_sort_ts": node.created_at,
+                    "earliest_at": node.earliest_at,
+                    "latest_at": node.latest_at,
+                    "_sort_ts": node.latest_at or node.created_at,
                     "_sort_rank": node.search_rank,
                 }
             )


### PR DESCRIPTION
## 🎉 This makes `lcm_grep` feel a lot less like “it found something” and a lot more like “it found the right thing”

This PR is a retrieval-quality pass for `lcm_grep`.

The short version:
- search ordering is now intentional instead of flat
- summary recall uses source-content recency, not just compaction-row time
- short CJK fragments and emoji-heavy queries no longer quietly fall through the cracks

That means `lcm_grep` gets noticeably better at the stuff that actually matters in real use:
- finding the newest relevant thing when you care about recency
- surfacing the strongest older hit when you care about relevance
- staying useful when the query is not nice clean ASCII/Latin text

## What changed

### 1. Explicit search ordering
`lcm_grep`, message search, and summary search now support:
- `recency`
- `relevance`
- `hybrid`

These orderings are applied before `LIMIT`, so the ranking actually affects what survives the cut.

### 2. Summary source-window timestamps
Summary nodes now persist:
- `earliest_at`
- `latest_at`

This lets summary recall rank on when the summarized content happened, instead of only when the summary row was created.

Also included:
- in-place upgrade for older DAG DBs that do not have these columns yet
- leaf summaries derive their source window from source message timestamps
- condensed summaries derive their source window from child-node windows

### 3. CJK / emoji-aware fallback
Short CJK fragments and emoji-heavy queries should not blindly trust plain SQLite FTS tokenization.

This PR routes those queries through substring fallback for both:
- message search
- summary search

And the fallback path keeps the same ordering semantics:
- `recency`
- `relevance`
- `hybrid`

So CJK / emoji queries do not silently collapse into a different search experience.

### 4. Better tool guidance
The `lcm_grep` schema guidance now more clearly nudges:
- short focused FTS queries
- quoted multi-word phrases
- the fact that short CJK / emoji-heavy queries may use substring fallback

## Why this is worth it
Before this, `lcm_grep` was functional, but still had a few rough edges:
- summaries were effectively ranked by compaction timing more than source timing
- CJK / emoji retrieval could be incomplete or brittle
- fallback behavior could feel different from the main FTS path

After this, the retrieval story is a lot cleaner and more honest.

## Validation
Ran locally:
- `python3 -m pytest tests/test_lcm_core.py -k 'sort_modes_apply_before_limit' -q`
- `python3 -m pytest tests/test_lcm_engine.py -k 'grep_reports_sort_mode' -q`
- `python3 -m pytest tests/test_lcm_core.py -k 'source_window or search_sort_modes_apply_before_limit' -q`
- `python3 -m pytest tests/test_lcm_engine.py -k 'source_window' -q`
- `python3 -m pytest tests/test_lcm_core.py -k 'cjk_queries or emoji_queries' -q`
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `python3 -m pytest tests/ -q`

Latest full run:
- `python3 -m pytest tests/ -q` → `95 passed`

## Files
- `store.py`
- `dag.py`
- `engine.py`
- `tools.py`
- `schemas.py`
- `search_query.py`
- `tests/test_lcm_core.py`
- `tests/test_lcm_engine.py`
