### PR TITLE
✨ feat: make compaction more adaptive and cache-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,14 @@ Environment variables (all optional):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LCM_FRESH_TAIL_COUNT` | `64` | Recent messages protected from compaction |
-| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Token threshold for leaf compaction |
+| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Token threshold floor for leaf compaction |
+| `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Opt-in dynamic oldest-chunk sizing instead of always compacting the full raw backlog outside the fresh tail |
+| `LCM_DYNAMIC_LEAF_CHUNK_MAX` | `50000` | Upper bound for dynamic leaf chunk sizing |
 | `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of context window triggering compaction |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `1` | Max condensation depth (`0` = disabled, `-1` = unlimited) |
 | `LCM_CONDENSATION_FANIN` | `4` | Same-depth nodes needed to trigger condensation |
+| `LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED` | `false` | Opt-in suppression of low-value follow-on condensation after a leaf pass |
+| `LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS` | `2` | Debt threshold multiplier before cache-friendly gating allows a follow-on condensation pass |
 | `LCM_IGNORE_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions to exclude from LCM storage entirely |
 | `LCM_STATELESS_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions that stay read-only (`platform:session_id` matching supported) |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization |
@@ -152,6 +156,8 @@ Environment variables (all optional):
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after `/new` (`-1` = all, `0` = none, `2` = keep d2+) |
+
+The point-8 compaction knobs are intentionally opt-in. `cache_friendly_*` is a plugin-local prompt-stability heuristic, not a claim that Hermes currently passes true prompt-cache metrics into `hermes-lcm`.
 
 Pattern syntax matches `lossless-claw`:
 - `*` matches within one colon-delimited segment

--- a/config.py
+++ b/config.py
@@ -27,6 +27,18 @@ def _parse_float_env(key: str, default: float) -> float:
         return default
 
 
+def _parse_bool_env(key: str, default: bool) -> bool:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
 @dataclass
 class LCMConfig:
     """All tunables for the LCM engine."""
@@ -43,6 +55,10 @@ class LCMConfig:
     incremental_max_depth: int = 1
     # How many same-depth summaries trigger condensation
     condensation_fanin: int = 4
+    # When enabled, leaf compaction may use a larger working chunk size based on backlog pressure
+    dynamic_leaf_chunk_enabled: bool = False
+    # Upper bound for the working dynamic leaf chunk threshold
+    dynamic_leaf_chunk_max: int = 40_000
 
     # -- Escalation ---
     # L2 bullet budget as fraction of L1
@@ -94,6 +110,10 @@ class LCMConfig:
         c.context_threshold = _float("LCM_CONTEXT_THRESHOLD", c.context_threshold)
         c.incremental_max_depth = _int("LCM_INCREMENTAL_MAX_DEPTH", c.incremental_max_depth)
         c.condensation_fanin = _int("LCM_CONDENSATION_FANIN", c.condensation_fanin)
+        c.dynamic_leaf_chunk_enabled = _parse_bool_env(
+            "LCM_DYNAMIC_LEAF_CHUNK_ENABLED", c.dynamic_leaf_chunk_enabled
+        )
+        c.dynamic_leaf_chunk_max = _int("LCM_DYNAMIC_LEAF_CHUNK_MAX", c.dynamic_leaf_chunk_max)
         c.l2_budget_ratio = _float("LCM_L2_BUDGET_RATIO", c.l2_budget_ratio)
         c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)
         c.max_assembly_tokens = _int("LCM_MAX_ASSEMBLY_TOKENS", c.max_assembly_tokens)

--- a/config.py
+++ b/config.py
@@ -59,6 +59,12 @@ class LCMConfig:
     dynamic_leaf_chunk_enabled: bool = False
     # Upper bound for the working dynamic leaf chunk threshold
     dynamic_leaf_chunk_max: int = 40_000
+    # When enabled, suppress follow-on condensation after a leaf pass unless
+    # debt/pressure says the extra churn is worth it
+    cache_friendly_condensation_enabled: bool = False
+    # Minimum number of same-depth fanin groups before one follow-on
+    # condensation pass is allowed in cache-friendly mode
+    cache_friendly_min_debt_groups: int = 2
 
     # -- Escalation ---
     # L2 bullet budget as fraction of L1
@@ -114,6 +120,14 @@ class LCMConfig:
             "LCM_DYNAMIC_LEAF_CHUNK_ENABLED", c.dynamic_leaf_chunk_enabled
         )
         c.dynamic_leaf_chunk_max = _int("LCM_DYNAMIC_LEAF_CHUNK_MAX", c.dynamic_leaf_chunk_max)
+        c.cache_friendly_condensation_enabled = _parse_bool_env(
+            "LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED",
+            c.cache_friendly_condensation_enabled,
+        )
+        c.cache_friendly_min_debt_groups = _int(
+            "LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS",
+            c.cache_friendly_min_debt_groups,
+        )
         c.l2_budget_ratio = _float("LCM_L2_BUDGET_RATIO", c.l2_budget_ratio)
         c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)
         c.max_assembly_tokens = _int("LCM_MAX_ASSEMBLY_TOKENS", c.max_assembly_tokens)

--- a/engine.py
+++ b/engine.py
@@ -292,86 +292,104 @@ class LCMEngine(ContextEngine):
         # Step 1: Ingest new messages into the immutable store
         self._ingest_messages(messages)
 
-        # Step 2: Identify fresh tail boundary
-        n = len(messages)
-        fresh_tail_start = max(0, n - self._config.fresh_tail_count)
+        working_messages = list(messages)
+        leaf_compacted_this_turn = False
+        leaf_passes = 0
+        max_leaf_passes = 4 if self._config.dynamic_leaf_chunk_enabled else 1
+        estimated_active_tokens = (
+            observed_prompt_tokens
+            if observed_prompt_tokens is not None and observed_prompt_tokens > 0
+            else count_messages_tokens(messages)
+        )
 
-        # Protect system prompt (always index 0)
-        if fresh_tail_start <= 1:
-            # Not enough messages to compact
-            if force_overflow and len(messages) >= 1:
-                compressed = self._assemble_overflow_recovery_context(
-                    messages[0],
-                    messages[1:],
-                    assembly_cap_override=recovery_assembly_cap,
-                )
-                return self._finalize_forced_overflow_result(
-                    messages,
-                    compressed,
-                    assembly_cap_override=recovery_assembly_cap,
-                )
-            return messages
+        while leaf_passes < max_leaf_passes:
+            n = len(working_messages)
+            fresh_tail_start = max(0, n - self._config.fresh_tail_count)
 
-        # Step 3: Identify messages eligible for leaf compaction
-        # Skip system prompt (index 0), candidate raw backlog is indices 1..fresh_tail_start
-        candidate_raw = messages[1:fresh_tail_start]
+            # Protect system prompt (always index 0)
+            if fresh_tail_start <= 1:
+                break
 
-        if not candidate_raw:
-            if force_overflow and len(messages) >= 1:
-                compressed = self._assemble_overflow_recovery_context(
-                    messages[0],
-                    messages[1:],
-                    assembly_cap_override=recovery_assembly_cap,
-                )
-                return self._finalize_forced_overflow_result(
-                    messages,
-                    compressed,
-                    assembly_cap_override=recovery_assembly_cap,
-                )
-            return messages
+            # Skip system prompt (index 0), candidate raw backlog is indices 1..fresh_tail_start
+            candidate_raw = working_messages[1:fresh_tail_start]
+            if not candidate_raw:
+                break
 
-        raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
-        if self._config.dynamic_leaf_chunk_enabled:
-            working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
-            if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
-                return messages
-            if force_overflow:
-                to_compact = candidate_raw
+            raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
+            if self._config.dynamic_leaf_chunk_enabled:
+                working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
+                if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
+                    break
+                if force_overflow:
+                    to_compact = candidate_raw
+                else:
+                    to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
             else:
-                to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
-        else:
-            if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
-                # Not enough to justify compaction
-                return messages
-            to_compact = candidate_raw
+                if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
+                    break
+                to_compact = candidate_raw
 
-        # Step 4: Serialize and summarize, with bounded smaller-chunk rescue for retry-worthy failures
-        compacted_chunk, source_tokens, summary_text, level, rescue_attempts = self._summarize_leaf_chunk_with_rescue(
-            to_compact,
-            focus_topic=focus_topic,
-        )
-        remaining_messages = messages[1 + len(compacted_chunk):]
+            if not to_compact:
+                break
 
-        # Step 5: Create DAG node
-        # Collect store_ids for source tracking
-        source_store_ids = self._get_store_ids_for_messages(compacted_chunk)
-        earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
+            compacted_chunk, source_tokens, summary_text, _level, _rescue_attempts = self._summarize_leaf_chunk_with_rescue(
+                to_compact,
+                focus_topic=focus_topic,
+            )
+            remaining_messages = working_messages[1 + len(compacted_chunk):]
 
-        node = SummaryNode(
-            session_id=self._session_id,
-            depth=0,
-            summary=summary_text,
-            token_count=count_tokens(summary_text),
-            source_token_count=source_tokens,
-            source_ids=source_store_ids,
-            source_type="messages",
-            created_at=time.time(),
-            earliest_at=earliest_at,
-            latest_at=latest_at,
-            expand_hint=self._extract_expand_hint(summary_text),
-        )
-        self._dag.add_node(node)
-        self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
+            source_store_ids = self._get_store_ids_for_messages(compacted_chunk)
+            earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
+            summary_tokens = count_tokens(summary_text)
+
+            node = SummaryNode(
+                session_id=self._session_id,
+                depth=0,
+                summary=summary_text,
+                token_count=summary_tokens,
+                source_token_count=source_tokens,
+                source_ids=source_store_ids,
+                source_type="messages",
+                created_at=time.time(),
+                earliest_at=earliest_at,
+                latest_at=latest_at,
+                expand_hint=self._extract_expand_hint(summary_text),
+            )
+            self._dag.add_node(node)
+            self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
+
+            working_messages = [working_messages[0]] + remaining_messages
+            leaf_compacted_this_turn = True
+            leaf_passes += 1
+            estimated_active_tokens = max(0, estimated_active_tokens - source_tokens + summary_tokens)
+
+            if not self._config.dynamic_leaf_chunk_enabled:
+                break
+
+            if not force_overflow:
+                if self.threshold_tokens > 0 and estimated_active_tokens < self.threshold_tokens:
+                    break
+                remaining_raw = working_messages[1:max(0, len(working_messages) - self._config.fresh_tail_count)]
+                if not remaining_raw:
+                    break
+                remaining_raw_tokens = count_messages_tokens(remaining_raw)
+                remaining_threshold = self._working_leaf_chunk_tokens(remaining_raw_tokens)
+                if remaining_raw_tokens < remaining_threshold:
+                    break
+
+        if not leaf_compacted_this_turn:
+            if force_overflow and len(messages) >= 1:
+                compressed = self._assemble_overflow_recovery_context(
+                    messages[0],
+                    messages[1:],
+                    assembly_cap_override=recovery_assembly_cap,
+                )
+                return self._finalize_forced_overflow_result(
+                    messages,
+                    compressed,
+                    assembly_cap_override=recovery_assembly_cap,
+                )
+            return messages
 
         # Step 6: Check if condensation is needed
         self._maybe_condense(
@@ -382,8 +400,8 @@ class LCMEngine(ContextEngine):
 
         # Step 7: Assemble new active context
         compressed = self._assemble_context(
-            messages[0],
-            remaining_messages,
+            working_messages[0],
+            working_messages[1:],
             assembly_cap_override=recovery_assembly_cap,
         )
         self.compression_count += 1
@@ -402,9 +420,14 @@ class LCMEngine(ContextEngine):
         self._ingest_cursor = len(compressed)
 
         logger.info(
-            "LCM compaction #%d: %d messages → %d (L%d, %d→%d tokens, %d DAG nodes%s)",
-            self.compression_count, n, len(compressed), level,
-            source_tokens, count_tokens(summary_text),
+            "LCM compaction #%d: %d messages → %d (%d leaf pass%s, %d→%d tokens, %d DAG nodes%s)",
+            self.compression_count,
+            len(messages),
+            len(compressed),
+            leaf_passes,
+            "es" if leaf_passes != 1 else "",
+            count_messages_tokens(messages),
+            count_messages_tokens(compressed),
             len(self._dag.get_session_nodes(self._session_id)),
             ", forced overflow recovery" if force_overflow else "",
         )

--- a/engine.py
+++ b/engine.py
@@ -101,6 +101,7 @@ class LCMEngine(ContextEngine):
         self.quiet_mode = False
         self.summary_model = self._config.summary_model
         self._last_overflow_recovery_failed = False
+        self._last_condensation_suppressed_reason = ""
 
     @property
     def name(self) -> str:
@@ -372,7 +373,11 @@ class LCMEngine(ContextEngine):
         self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
 
         # Step 6: Check if condensation is needed
-        self._maybe_condense(focus_topic=focus_topic)
+        self._maybe_condense(
+            focus_topic=focus_topic,
+            leaf_compacted_this_turn=True,
+            force_overflow=force_overflow,
+        )
 
         # Step 7: Assemble new active context
         compressed = self._assemble_context(
@@ -413,6 +418,7 @@ class LCMEngine(ContextEngine):
         self._ingest_cursor = 0
         self._last_compacted_store_id = 0
         self._last_overflow_recovery_failed = False
+        self._last_condensation_suppressed_reason = ""
         self._refresh_session_filters()
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
@@ -435,6 +441,7 @@ class LCMEngine(ContextEngine):
         self._context_probed = False
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False
+        self._last_condensation_suppressed_reason = ""
 
         # Retain DAG nodes across sessions based on config.
         #   -1  → keep all nodes
@@ -528,6 +535,7 @@ class LCMEngine(ContextEngine):
             status["ignore_session_patterns_source"] = self._config.ignore_session_patterns_source
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
+            status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
         return status
 
     def update_model(self, model: str, context_length: int,
@@ -690,8 +698,38 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: condensation --------------------------------------------
 
-    def _maybe_condense(self, focus_topic: Optional[str] = None) -> None:
+    def _should_allow_follow_on_condensation(
+        self,
+        *,
+        uncondensed_count: int,
+        leaf_compacted_this_turn: bool,
+        force_overflow: bool,
+    ) -> tuple[bool, str]:
+        if not leaf_compacted_this_turn:
+            return True, ""
+        if not self._config.cache_friendly_condensation_enabled:
+            return True, ""
+        if force_overflow:
+            return True, ""
+
+        fanin = max(1, self._config.condensation_fanin)
+        debt_threshold = fanin * max(1, self._config.cache_friendly_min_debt_groups)
+        if uncondensed_count >= debt_threshold:
+            return True, ""
+        if uncondensed_count == fanin:
+            return False, "cache_friendly_single_group"
+        return False, "cache_friendly_low_debt"
+
+    def _maybe_condense(
+        self,
+        focus_topic: Optional[str] = None,
+        *,
+        leaf_compacted_this_turn: bool = False,
+        force_overflow: bool = False,
+    ) -> None:
         """Check if any depth level has enough nodes for condensation."""
+        self._last_condensation_suppressed_reason = ""
+
         max_depth = self._config.incremental_max_depth
         if max_depth == 0:
             return  # condensation disabled
@@ -705,11 +743,23 @@ class LCMEngine(ContextEngine):
         else:
             upper = max_depth
 
+        condensed_any = False
+        suppression_reason = ""
+
         for depth in range(upper):
             uncondensed = self._dag.get_uncondensed_at_depth(
                 self._session_id, depth
             )
             if len(uncondensed) < self._config.condensation_fanin:
+                continue
+
+            allow_condense, reason = self._should_allow_follow_on_condensation(
+                uncondensed_count=len(uncondensed),
+                leaf_compacted_this_turn=leaf_compacted_this_turn,
+                force_overflow=force_overflow,
+            )
+            if not allow_condense:
+                suppression_reason = reason or suppression_reason
                 continue
 
             # Take the first fanin nodes and condense
@@ -745,12 +795,19 @@ class LCMEngine(ContextEngine):
                 expand_hint=self._extract_expand_hint(summary_text),
             )
             self._dag.add_node(node)
+            condensed_any = True
 
             logger.info(
                 "LCM condensation: d%d × %d → d%d (L%d, %d→%d tokens)",
                 depth, len(to_condense), depth + 1, level,
                 source_tokens, count_tokens(summary_text),
             )
+
+            if leaf_compacted_this_turn and self._config.cache_friendly_condensation_enabled:
+                break
+
+        if not condensed_any and leaf_compacted_this_turn and self._config.cache_friendly_condensation_enabled:
+            self._last_condensation_suppressed_reason = suppression_reason
 
     # -- Internal: context assembly ----------------------------------------
 

--- a/engine.py
+++ b/engine.py
@@ -138,6 +138,31 @@ class LCMEngine(ContextEngine):
             return True
         return rough >= self.threshold_tokens
 
+    def _working_leaf_chunk_tokens(self, raw_tokens_outside_tail: int) -> int:
+        base = max(1, self._config.leaf_chunk_tokens)
+        if not self._config.dynamic_leaf_chunk_enabled:
+            return base
+        ceiling = max(base, self._config.dynamic_leaf_chunk_max)
+        working = base
+        while working < ceiling and raw_tokens_outside_tail > working * 2:
+            working = min(ceiling, working * 2)
+        return working
+
+    def _select_oldest_leaf_chunk(
+        self,
+        candidate_raw: List[Dict[str, Any]],
+        working_leaf_chunk_tokens: int,
+    ) -> List[Dict[str, Any]]:
+        selected: list[Dict[str, Any]] = []
+        used = 0
+        for msg in candidate_raw:
+            msg_tokens = count_message_tokens(msg)
+            if used + msg_tokens > working_leaf_chunk_tokens and selected:
+                break
+            selected.append(msg)
+            used += msg_tokens
+        return selected
+
     def compress(self, messages: List[Dict[str, Any]],
                  current_tokens: int = None,
                  focus_topic: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -197,11 +222,11 @@ class LCMEngine(ContextEngine):
                 )
             return messages
 
-        # Step 3: Identify messages to compact (between system prompt and fresh tail)
-        # Skip system prompt (index 0), compact indices 1..fresh_tail_start
-        to_compact = messages[1:fresh_tail_start]
+        # Step 3: Identify messages eligible for leaf compaction
+        # Skip system prompt (index 0), candidate raw backlog is indices 1..fresh_tail_start
+        candidate_raw = messages[1:fresh_tail_start]
 
-        if not to_compact:
+        if not candidate_raw:
             if force_overflow and len(messages) >= 1:
                 compressed = self._assemble_overflow_recovery_context(
                     messages[0],
@@ -215,11 +240,26 @@ class LCMEngine(ContextEngine):
                 )
             return messages
 
+        raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
+        if self._config.dynamic_leaf_chunk_enabled:
+            working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
+            if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
+                return messages
+            if force_overflow:
+                to_compact = candidate_raw
+                remaining_messages = messages[fresh_tail_start:]
+            else:
+                to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
+                remaining_messages = messages[1 + len(to_compact):]
+        else:
+            if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
+                # Not enough to justify compaction
+                return messages
+            to_compact = candidate_raw
+            remaining_messages = messages[fresh_tail_start:]
+
         # Calculate source tokens
         source_tokens = count_messages_tokens(to_compact)
-        if source_tokens < self._config.leaf_chunk_tokens and not force_overflow:
-            # Not enough to justify compaction
-            return messages
 
         # Step 4: Serialize and summarize
         serialized = self._serialize_messages(to_compact)
@@ -265,7 +305,7 @@ class LCMEngine(ContextEngine):
         # Step 7: Assemble new active context
         compressed = self._assemble_context(
             messages[0],
-            messages[fresh_tail_start:],
+            remaining_messages,
             assembly_cap_override=recovery_assembly_cap,
         )
         self.compression_count += 1

--- a/engine.py
+++ b/engine.py
@@ -102,6 +102,7 @@ class LCMEngine(ContextEngine):
         self.summary_model = self._config.summary_model
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
+        self._logged_filter_config = False
 
     @property
     def name(self) -> str:
@@ -563,18 +564,20 @@ class LCMEngine(ContextEngine):
         )
 
     def _log_session_filter_diagnostics(self) -> None:
-        if self._config.ignore_session_patterns:
-            logger.info(
-                "LCM ignore_session_patterns from %s: %s",
-                self._config.ignore_session_patterns_source,
-                ", ".join(self._config.ignore_session_patterns),
-            )
-        if self._config.stateless_session_patterns:
-            logger.info(
-                "LCM stateless_session_patterns from %s: %s",
-                self._config.stateless_session_patterns_source,
-                ", ".join(self._config.stateless_session_patterns),
-            )
+        if not self._logged_filter_config:
+            if self._config.ignore_session_patterns:
+                logger.info(
+                    "LCM ignore_session_patterns from %s: %s",
+                    self._config.ignore_session_patterns_source,
+                    ", ".join(self._config.ignore_session_patterns),
+                )
+            if self._config.stateless_session_patterns:
+                logger.info(
+                    "LCM stateless_session_patterns from %s: %s",
+                    self._config.stateless_session_patterns_source,
+                    ", ".join(self._config.stateless_session_patterns),
+                )
+            self._logged_filter_config = True
         if self._session_ignored:
             logger.info(
                 "LCM session %s matched ignore_session_patterns via %s — skipping writes and compaction",

--- a/engine.py
+++ b/engine.py
@@ -163,6 +163,94 @@ class LCMEngine(ContextEngine):
             used += msg_tokens
         return selected
 
+    def _is_retry_worthy_leaf_summary_error(self, exc: Exception) -> bool:
+        if isinstance(exc, TimeoutError):
+            return True
+        message = str(exc).lower()
+        retry_markers = (
+            "context length",
+            "maximum context",
+            "max context",
+            "too many tokens",
+            "token limit",
+            "prompt is too long",
+            "input too long",
+            "request too large",
+            "timed out",
+            "timeout",
+        )
+        return any(marker in message for marker in retry_markers)
+
+    def _next_leaf_rescue_chunk(
+        self,
+        current_chunk: List[Dict[str, Any]],
+        current_source_tokens: int,
+    ) -> List[Dict[str, Any]]:
+        if len(current_chunk) <= 1:
+            return []
+
+        floor_tokens = max(1, self._config.leaf_chunk_tokens)
+        shrink_targets = [
+            max(floor_tokens, int(current_source_tokens * 0.75)),
+            max(floor_tokens, int(current_source_tokens * 0.50)),
+        ]
+
+        for target in shrink_targets:
+            if target >= current_source_tokens:
+                continue
+            smaller = self._select_oldest_leaf_chunk(current_chunk, target)
+            if smaller and len(smaller) < len(current_chunk):
+                return smaller
+
+        return current_chunk[:-1]
+
+    def _summarize_leaf_chunk_with_rescue(
+        self,
+        initial_chunk: List[Dict[str, Any]],
+        focus_topic: Optional[str] = None,
+    ) -> tuple[List[Dict[str, Any]], int, str, int, int]:
+        attempt_chunk = list(initial_chunk)
+        max_attempts = 3
+        attempt_number = 0
+
+        while attempt_chunk and attempt_number < max_attempts:
+            attempt_number += 1
+            source_tokens = count_messages_tokens(attempt_chunk)
+            serialized = self._serialize_messages(attempt_chunk)
+            token_budget = max(2000, int(source_tokens * 0.20))
+            token_budget = min(token_budget, 12000)
+
+            try:
+                summary_text, level = summarize_with_escalation(
+                    text=serialized,
+                    source_tokens=source_tokens,
+                    token_budget=token_budget,
+                    depth=0,
+                    model=self._config.summary_model,
+                    timeout=self._config.summary_timeout_ms / 1000,
+                    l2_budget_ratio=self._config.l2_budget_ratio,
+                    l3_truncate_tokens=self._config.l3_truncate_tokens,
+                    focus_topic=focus_topic or "",
+                )
+                return attempt_chunk, source_tokens, summary_text, level, attempt_number
+            except Exception as exc:
+                if attempt_number >= max_attempts or not self._is_retry_worthy_leaf_summary_error(exc):
+                    raise
+                smaller_chunk = self._next_leaf_rescue_chunk(attempt_chunk, source_tokens)
+                if not smaller_chunk or len(smaller_chunk) >= len(attempt_chunk):
+                    raise
+                logger.warning(
+                    "LCM leaf summarization retrying with smaller oldest chunk after retry-worthy failure: %s (attempt %d/%d, %d→%d messages)",
+                    exc,
+                    attempt_number,
+                    max_attempts,
+                    len(attempt_chunk),
+                    len(smaller_chunk),
+                )
+                attempt_chunk = smaller_chunk
+
+        raise RuntimeError("adaptive leaf rescue exhausted without a valid chunk")
+
     def compress(self, messages: List[Dict[str, Any]],
                  current_tokens: int = None,
                  focus_topic: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -247,40 +335,24 @@ class LCMEngine(ContextEngine):
                 return messages
             if force_overflow:
                 to_compact = candidate_raw
-                remaining_messages = messages[fresh_tail_start:]
             else:
                 to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
-                remaining_messages = messages[1 + len(to_compact):]
         else:
             if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
                 # Not enough to justify compaction
                 return messages
             to_compact = candidate_raw
-            remaining_messages = messages[fresh_tail_start:]
 
-        # Calculate source tokens
-        source_tokens = count_messages_tokens(to_compact)
-
-        # Step 4: Serialize and summarize
-        serialized = self._serialize_messages(to_compact)
-        token_budget = max(2000, int(source_tokens * 0.20))
-        token_budget = min(token_budget, 12000)
-
-        summary_text, level = summarize_with_escalation(
-            text=serialized,
-            source_tokens=source_tokens,
-            token_budget=token_budget,
-            depth=0,
-            model=self._config.summary_model,
-            timeout=self._config.summary_timeout_ms / 1000,
-            l2_budget_ratio=self._config.l2_budget_ratio,
-            l3_truncate_tokens=self._config.l3_truncate_tokens,
-            focus_topic=focus_topic or "",
+        # Step 4: Serialize and summarize, with bounded smaller-chunk rescue for retry-worthy failures
+        compacted_chunk, source_tokens, summary_text, level, rescue_attempts = self._summarize_leaf_chunk_with_rescue(
+            to_compact,
+            focus_topic=focus_topic,
         )
+        remaining_messages = messages[1 + len(compacted_chunk):]
 
         # Step 5: Create DAG node
         # Collect store_ids for source tracking
-        source_store_ids = self._get_store_ids_for_messages(to_compact)
+        source_store_ids = self._get_store_ids_for_messages(compacted_chunk)
         earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
 
         node = SummaryNode(

--- a/search_query.py
+++ b/search_query.py
@@ -22,6 +22,10 @@ _EMOJI_RE = re.compile(
     r"]"
 )
 _QUOTED_PHRASE_RE = re.compile(r'"([^"]+)"')
+_BOOLEAN_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
+_RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
+_SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
+_STRIP_EDGE_PUNCT = "()[]{}.,;"
 
 
 def contains_cjk(text: str) -> bool:
@@ -32,8 +36,40 @@ def contains_emoji(text: str) -> bool:
     return bool(_EMOJI_RE.search(text or ""))
 
 
+def contains_risky_fts_ascii(text: str) -> bool:
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if raw.count('"') % 2:
+        return True
+    text_without_phrases = _QUOTED_PHRASE_RE.sub(" ", raw)
+    return bool(_RISKY_FTS_TOKEN_RE.search(text_without_phrases))
+
+
 def requires_like_fallback(query: str) -> bool:
-    return contains_cjk(query) or contains_emoji(query)
+    return contains_cjk(query) or contains_emoji(query) or contains_risky_fts_ascii(query)
+
+
+def _token_variants(token: str) -> List[str]:
+    cleaned = (token or "").strip().strip(_STRIP_EDGE_PUNCT)
+    if not cleaned:
+        return []
+    if cleaned.upper() in _BOOLEAN_OPERATORS:
+        return []
+
+    variants = [cleaned]
+    if _SPLIT_PUNCT_RE.search(cleaned):
+        parts = [part for part in _SPLIT_PUNCT_RE.split(cleaned) if part]
+        if len(parts) > 1:
+            variants.extend(parts)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for variant in variants:
+        if variant not in seen:
+            deduped.append(variant)
+            seen.add(variant)
+    return deduped
 
 
 def extract_search_terms(query: str) -> List[str]:
@@ -49,12 +85,12 @@ def extract_search_terms(query: str) -> List[str]:
 
     text_without_phrases = _QUOTED_PHRASE_RE.sub(" ", text)
     for token in text_without_phrases.split():
-        cleaned = token.strip()
-        if cleaned:
-            terms.append(cleaned)
+        terms.extend(_token_variants(token))
 
     if not terms:
-        terms.append(text)
+        fallback_text = text.strip().strip(_STRIP_EDGE_PUNCT)
+        if fallback_text:
+            terms.append(fallback_text)
 
     deduped: list[str] = []
     seen: set[str] = set()

--- a/store.py
+++ b/store.py
@@ -37,30 +37,41 @@ def _normalize_search_sort(sort: str | None) -> str:
     return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
 
 
-def _build_search_order_by(sort: str | None, timestamp_expr: str) -> str:
+def _build_search_order_by(
+    sort: str | None,
+    timestamp_expr: str,
+    role_penalty_expr: str | None = None,
+) -> str:
     normalized = _normalize_search_sort(sort)
+    order_parts: list[str] = []
+    if role_penalty_expr:
+        order_parts.append(f"{role_penalty_expr} ASC")
     if normalized == "relevance":
-        return f"rank ASC, {timestamp_expr} DESC"
+        order_parts.extend(["rank ASC", f"{timestamp_expr} DESC"])
+        return ", ".join(order_parts)
     if normalized == "hybrid":
-        return (
-            f"(rank / (1 + (((strftime('%s','now') - {timestamp_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
-            f"{timestamp_expr} DESC"
-        )
-    return f"{timestamp_expr} DESC"
+        order_parts.extend([
+            f"(rank / (1 + (((strftime('%s','now') - {timestamp_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC",
+            f"{timestamp_expr} DESC",
+        ])
+        return ", ".join(order_parts)
+    order_parts.extend([f"{timestamp_expr} DESC", "rank ASC"])
+    return ", ".join(order_parts)
 
 
-def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float]:
+def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float]:
     normalized = _normalize_search_sort(sort)
     score = float(result.get("_fallback_score") or 0.0)
     timestamp = float(result.get("timestamp") or 0.0)
+    role_bias = 1.0 if result.get("role") == "tool" else 0.0
 
     if normalized == "relevance":
-        return (-score, -timestamp)
+        return (role_bias, -score, -timestamp)
     if normalized == "hybrid":
         age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
         blended = score / (1 + (age_hours * AGE_DECAY_RATE))
-        return (-blended, -timestamp)
-    return (-timestamp, -score)
+        return (role_bias, -blended, -timestamp)
+    return (role_bias, -timestamp, -score)
 
 
 class MessageStore:
@@ -276,7 +287,11 @@ class MessageStore:
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
 
-        order_by = _build_search_order_by(sort, "m.timestamp")
+        order_by = _build_search_order_by(
+            sort,
+            "m.timestamp",
+            "CASE WHEN m.role = 'tool' THEN 1 ELSE 0 END",
+        )
         try:
             if session_id:
                 rows = self._conn.execute(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -483,6 +483,46 @@ class TestMessageStore:
         assert results[0]["store_id"] == target
         assert results[0]["snippet"]
 
+    def test_search_prefers_conversational_hits_over_tool_output_noise(self, store):
+        user_id = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "vendoring external plugin support should stay generic host support only",
+            },
+        )
+        tool_id = store.append(
+            "sess1",
+            {
+                "role": "tool",
+                "content": '{"vendoring":"vendoring vendoring vendoring","payload":"external plugin generic host support"}',
+            },
+        )
+
+        relevance_results = store.search("vendoring", session_id="sess1", limit=2, sort="relevance")
+        fallback_results = store.search("hermes-lcm", session_id="sess1", limit=2, sort="relevance")
+
+        assert relevance_results[0]["store_id"] == user_id
+        assert relevance_results[1]["store_id"] == tool_id
+
+        fallback_user_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "hermes-lcm should stay external and plugin-only in practice",
+            },
+        )
+        fallback_tool_id = store.append(
+            "sess1",
+            {
+                "role": "tool",
+                "content": '{"query":"hermes-lcm","matches":["hermes-lcm","hermes-lcm"]}',
+            },
+        )
+        fallback_results = store.search("hermes-lcm", session_id="sess1", limit=2, sort="relevance")
+        assert fallback_results[0]["store_id"] == fallback_user_id
+        assert fallback_results[1]["store_id"] == fallback_tool_id
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -460,6 +460,29 @@ class TestMessageStore:
         assert recency_results[0]["store_id"] == newer_weak
         assert relevance_results[0]["store_id"] == older_strong
 
+    def test_search_hyphenated_operator_queries_fall_back_cleanly(self, store):
+        target = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "hermes-lcm plugin-only external context-engine generic host support no vendoring stays external",
+            },
+        )
+        store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "or or or filler words without the target concepts",
+            },
+        )
+
+        query = "8416 OR vendored OR vendoring OR plugin-only OR external context-engine OR generic host support OR hermes-lcm stays external OR no vendoring"
+        results = store.search(query, session_id="sess1", limit=5, sort="relevance")
+
+        assert len(results) == 1
+        assert results[0]["store_id"] == target
+        assert results[0]["snippet"]
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -847,6 +870,30 @@ class TestSummaryDAG:
 
         assert recency_results[0].node_id == newer_weak
         assert relevance_results[0].node_id == older_strong
+
+    def test_search_hyphenated_operator_queries_fall_back_cleanly(self, dag):
+        target = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="hermes-lcm plugin-only external context-engine generic host support no vendoring stays external",
+            token_count=10, source_ids=[1], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="or or or filler words without the target concepts",
+            token_count=10, source_ids=[2], source_type="messages",
+            created_at=1_800_000_000,
+            earliest_at=1_800_000_000,
+            latest_at=1_800_000_000,
+        ))
+
+        query = "8416 OR vendored OR vendoring OR plugin-only OR external context-engine OR generic host support OR hermes-lcm stays external OR no vendoring"
+        results = dag.search(query, session_id="s1", limit=5, sort="relevance")
+
+        assert len(results) == 1
+        assert results[0].node_id == target
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -27,6 +27,8 @@ class TestConfig:
         assert c.leaf_chunk_tokens == 20_000
         assert c.context_threshold == 0.75
         assert c.condensation_fanin == 4
+        assert c.dynamic_leaf_chunk_enabled is False
+        assert c.dynamic_leaf_chunk_max == 40_000
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
         assert c.ignore_session_patterns_source == "default"
@@ -44,6 +46,8 @@ class TestConfig:
         monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
         monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
         monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
+        monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_ENABLED", "1")
+        monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_MAX", "64000")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
@@ -54,6 +58,8 @@ class TestConfig:
         assert c.expansion_model == "openai/gpt-5.4-mini"
         assert c.summary_timeout_ms == 45_000
         assert c.expansion_timeout_ms == 90_000
+        assert c.dynamic_leaf_chunk_enabled is True
+        assert c.dynamic_leaf_chunk_max == 64_000
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -29,6 +29,8 @@ class TestConfig:
         assert c.condensation_fanin == 4
         assert c.dynamic_leaf_chunk_enabled is False
         assert c.dynamic_leaf_chunk_max == 40_000
+        assert c.cache_friendly_condensation_enabled is False
+        assert c.cache_friendly_min_debt_groups == 2
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
         assert c.ignore_session_patterns_source == "default"
@@ -48,6 +50,8 @@ class TestConfig:
         monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
         monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_ENABLED", "1")
         monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_MAX", "64000")
+        monkeypatch.setenv("LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED", "1")
+        monkeypatch.setenv("LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS", "3")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
@@ -60,6 +64,8 @@ class TestConfig:
         assert c.expansion_timeout_ms == 90_000
         assert c.dynamic_leaf_chunk_enabled is True
         assert c.dynamic_leaf_chunk_max == 64_000
+        assert c.cache_friendly_condensation_enabled is True
+        assert c.cache_friendly_min_debt_groups == 3
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -9,7 +9,7 @@ from agent.context_engine import ContextEngine
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
-from hermes_lcm.tokens import count_message_tokens
+from hermes_lcm.tokens import count_message_tokens, count_messages_tokens
 
 
 @pytest.fixture
@@ -393,6 +393,141 @@ class TestEngineCompress:
         assert candidate_raw[3]["content"] in compressed_contents
         assert messages[-1]["content"] in compressed_contents
         assert len(stored) == len(messages)
+
+    def test_adaptive_leaf_rescue_retries_with_smaller_oldest_chunk(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            database_path=str(tmp_path / "lcm_dynamic_leaf_retry.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        candidate_raw = messages[1:-config.fresh_tail_count]
+        initial_chunk = engine._select_oldest_leaf_chunk(
+            candidate_raw,
+            engine._working_leaf_chunk_tokens(count_messages_tokens(candidate_raw)),
+        )
+        assert len(initial_chunk) == 2
+        first_msg_tokens = count_message_tokens(candidate_raw[0])
+        assert count_messages_tokens(initial_chunk) > first_msg_tokens
+
+        import hermes_lcm.engine as engine_module
+
+        attempts: list[int] = []
+
+        def flaky_summary(**kwargs):
+            attempts.append(kwargs["source_tokens"])
+            if kwargs["source_tokens"] > first_msg_tokens:
+                raise RuntimeError("context length exceeded")
+            return "Recovered smaller leaf summary.\nExpand for details about: oldest raw chunk", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", flaky_summary)
+
+        compressed = engine.compress(messages)
+
+        assert len(attempts) == 2
+        assert attempts[0] > attempts[1]
+
+        nodes = engine._dag.get_session_nodes("test-session")
+        assert len(nodes) == 1
+        node = nodes[0]
+        selected_contents = [engine._store.get(store_id)["content"] for store_id in node.source_ids]
+        assert len(node.source_ids) == 1
+        assert selected_contents == [candidate_raw[0]["content"]]
+
+        compressed_contents = [msg.get("content") for msg in compressed]
+        assert candidate_raw[1]["content"] in compressed_contents
+        assert candidate_raw[2]["content"] in compressed_contents
+        assert candidate_raw[3]["content"] in compressed_contents
+
+    def test_adaptive_leaf_rescue_stops_after_bounded_retry_worthy_failures(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            database_path=str(tmp_path / "lcm_dynamic_leaf_retry_fail.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        attempts: list[int] = []
+
+        def always_fails(**kwargs):
+            attempts.append(kwargs["source_tokens"])
+            raise RuntimeError("context length exceeded")
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", always_fails)
+
+        with pytest.raises(RuntimeError, match="context length exceeded"):
+            engine.compress(messages)
+
+        assert len(attempts) == 2
+        assert attempts[0] > attempts[-1]
+        assert engine._dag.get_session_nodes("test-session") == []
+
+    def test_adaptive_leaf_rescue_does_not_retry_non_retry_worthy_errors(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            database_path=str(tmp_path / "lcm_dynamic_leaf_retry_nonretry.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        call_count = 0
+
+        def bad_template(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("template exploded")
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", bad_template)
+
+        with pytest.raises(RuntimeError, match="template exploded"):
+            engine.compress(messages)
+
+        assert call_count == 1
+        assert engine._dag.get_session_nodes("test-session") == []
 
 
 class TestPostCompactionIngestion:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -9,6 +9,7 @@ from agent.context_engine import ContextEngine
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
+from hermes_lcm.tokens import count_message_tokens
 
 
 @pytest.fixture
@@ -336,6 +337,62 @@ class TestEngineCompress:
         parent = next(node for node in nodes if node.depth == 1)
         assert parent.earliest_at == child_windows[0][0]
         assert parent.latest_at == child_windows[-1][1]
+
+    def test_dynamic_leaf_chunk_sizing_compacts_only_oldest_bounded_raw_chunk(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            database_path=str(tmp_path / "lcm_dynamic_leaf.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        candidate_raw = messages[1:-config.fresh_tail_count]
+        candidate_tokens = [count_message_tokens(msg) for msg in candidate_raw]
+        assert len(candidate_raw) == 4
+        assert sum(candidate_tokens) > config.dynamic_leaf_chunk_max
+        assert sum(candidate_tokens[:2]) <= config.dynamic_leaf_chunk_max
+        assert sum(candidate_tokens[:3]) > config.dynamic_leaf_chunk_max
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            return "Dynamic leaf summary.\nExpand for details about: oldest raw chunk", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        compressed = engine.compress(messages)
+
+        nodes = engine._dag.get_session_nodes("test-session")
+        assert len(nodes) == 1
+        node = nodes[0]
+
+        stored = engine._store.get_session_messages("test-session")
+        selected_contents = [
+            engine._store.get(store_id)["content"]
+            for store_id in node.source_ids
+        ]
+
+        assert len(node.source_ids) == 2
+        assert selected_contents == [msg["content"] for msg in candidate_raw[:2]]
+
+        compressed_contents = [msg.get("content") for msg in compressed]
+        assert candidate_raw[2]["content"] in compressed_contents
+        assert candidate_raw[3]["content"] in compressed_contents
+        assert messages[-1]["content"] in compressed_contents
+        assert len(stored) == len(messages)
 
 
 class TestPostCompactionIngestion:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -120,6 +120,21 @@ class TestSessionFiltering:
         assert "LCM ignore_session_patterns from env: cron:*" in caplog.text
         assert "matched ignore_session_patterns" in caplog.text
 
+    def test_filter_config_diagnostics_log_only_once_per_engine_instance(self, tmp_path, caplog):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_ignore_once.db"),
+            ignore_session_patterns=["cron:*"],
+            ignore_session_patterns_source="env",
+        )
+        instance = LCMEngine(config=config)
+
+        with caplog.at_level("INFO", logger="hermes_lcm.engine"):
+            instance.on_session_start("cron_123", platform="cron", context_length=1000)
+            instance.on_session_start("cron_456", platform="cron", context_length=1000)
+
+        assert caplog.text.count("LCM ignore_session_patterns from env: cron:*") == 1
+        assert caplog.text.count("matched ignore_session_patterns") == 2
+
     def test_on_session_start_marks_stateless_session_and_reports_status(self, tmp_path, caplog):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_stateless.db"),

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -529,6 +529,162 @@ class TestEngineCompress:
         assert call_count == 1
         assert engine._dag.get_session_nodes("test-session") == []
 
+    def test_cache_friendly_gating_suppresses_follow_on_condensation_for_single_fanin_group(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            condensation_fanin=2,
+            database_path=str(tmp_path / "lcm_cache_friendly_suppress.db"),
+        )
+        config.cache_friendly_condensation_enabled = True
+        config.cache_friendly_min_debt_groups = 2
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        engine._dag.add_node(SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary="Earlier leaf",
+            token_count=40,
+            source_token_count=80,
+            source_ids=[1],
+            source_type="messages",
+            created_at=time.time() - 10,
+            expand_hint="earlier leaf",
+        ))
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            if kwargs["depth"] == 0:
+                return "Leaf summary.\nExpand for details about: oldest raw chunk", 1
+            return "Condensed summary.\nExpand for details about: d0 summaries", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        engine.compress(messages)
+
+        depth0 = engine._dag.get_session_nodes("test-session", depth=0)
+        depth1 = engine._dag.get_session_nodes("test-session", depth=1)
+        assert len(depth0) == 2
+        assert depth1 == []
+        assert engine.get_status()["condensation_suppressed_reason"] == "cache_friendly_single_group"
+
+    def test_cache_friendly_gating_allows_condensation_when_debt_reaches_two_groups(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            condensation_fanin=2,
+            database_path=str(tmp_path / "lcm_cache_friendly_debt.db"),
+        )
+        config.cache_friendly_condensation_enabled = True
+        config.cache_friendly_min_debt_groups = 2
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        for i in range(3):
+            engine._dag.add_node(SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary=f"Earlier leaf {i}",
+                token_count=40,
+                source_token_count=80,
+                source_ids=[i + 1],
+                source_type="messages",
+                created_at=time.time() - (10 + i),
+                expand_hint=f"earlier leaf {i}",
+            ))
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            if kwargs["depth"] == 0:
+                return "Leaf summary.\nExpand for details about: oldest raw chunk", 1
+            return "Condensed summary.\nExpand for details about: d0 summaries", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        engine.compress(messages)
+
+        depth1 = engine._dag.get_session_nodes("test-session", depth=1)
+        assert len(depth1) == 1
+        assert engine.get_status()["condensation_suppressed_reason"] == ""
+
+    def test_cache_friendly_gating_does_not_block_forced_overflow_condensation(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            condensation_fanin=2,
+            max_assembly_tokens=90,
+            database_path=str(tmp_path / "lcm_cache_friendly_overflow.db"),
+        )
+        config.cache_friendly_condensation_enabled = True
+        config.cache_friendly_min_debt_groups = 2
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        engine._dag.add_node(SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary="Earlier leaf",
+            token_count=40,
+            source_token_count=80,
+            source_ids=[1],
+            source_type="messages",
+            created_at=time.time() - 10,
+            expand_hint="earlier leaf",
+        ))
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "A " * 40},
+            {"role": "assistant", "content": "B " * 40},
+            {"role": "user", "content": "Tail " * 60},
+        ]
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            if kwargs["depth"] == 0:
+                return "Leaf summary.\nExpand for details about: oldest raw chunk", 1
+            return "Condensed summary.\nExpand for details about: d0 summaries", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        engine.compress(messages, current_tokens=120)
+
+        depth1 = engine._dag.get_session_nodes("test-session", depth=1)
+        assert len(depth1) == 1
+        assert engine.get_status()["condensation_suppressed_reason"] == ""
+
 
 class TestPostCompactionIngestion:
     """Regression tests for issue #1 — messages must be persisted after

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1609,6 +1609,47 @@ class TestEngineTools:
         assert seen["prompt"] == "What was the plan?"
         assert seen["context_blocks"]
 
+    def test_handle_expand_query_hyphenated_operator_query_falls_back_cleanly(self, engine, monkeypatch):
+        engine._store.append(
+            "test-session",
+            {
+                "role": "user",
+                "content": "hermes-lcm plugin-only external context-engine generic host support no vendoring stays external",
+            },
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="hermes-lcm plugin-only external context-engine generic host support no vendoring stays external",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        monkeypatch.setattr(
+            "hermes_lcm.tools._synthesize_expansion_answer",
+            lambda **kwargs: "Recovered through normalized retrieval",
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "query": "8416 OR vendored OR vendoring OR plugin-only OR external context-engine OR generic host support OR hermes-lcm stays external OR no vendoring",
+                    "prompt": "What were the agreements?",
+                    "max_tokens": 500,
+                },
+            )
+        )
+
+        assert result["answer"] == "Recovered through normalized retrieval"
+        assert result["node_ids"] == [node_id]
+        assert result["matches"]
+
     def test_describe_and_expand_are_session_scoped(self, engine):
         node_id = engine._dag.add_node(
             SummaryNode(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -468,6 +468,42 @@ class TestEngineCompress:
         assert candidate_raw[2]["content"] in compressed_contents
         assert candidate_raw[3]["content"] in compressed_contents
 
+    def test_dynamic_leaf_chunk_sizing_runs_bounded_catchup_passes_when_pressure_remains_high(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=180,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=360,
+            database_path=str(tmp_path / "lcm_dynamic_leaf_catchup.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 1200
+        engine.threshold_tokens = 700
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(16):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("dense " * 40),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            return "Catchup summary.\nExpand for details about: oldest raw chunk", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        compressed = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+        nodes = engine._dag.get_session_nodes("test-session")
+        assert len(nodes) >= 2
+        assert count_messages_tokens(compressed) < engine.threshold_tokens
+        compressed_contents = [msg.get("content") for msg in compressed]
+        assert messages[-1]["content"] in compressed_contents
+
     def test_adaptive_leaf_rescue_stops_after_bounded_retry_worthy_failures(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
@@ -1545,6 +1581,26 @@ class TestEngineTools:
             )
         )
         assert result["sort"] == "relevance"
+
+    def test_handle_grep_prefers_conversational_hits_over_tool_output_noise(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "vendoring should stay generic host support only"},
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "tool", "content": '{"vendoring":"vendoring vendoring vendoring","payload":"generic host support"}'},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["role"] == "user"
+        assert result["results"][1]["role"] == "tool"
 
     def test_handle_describe_overview(self, engine):
         result = json.loads(engine.handle_tool_call("lcm_describe", {}))

--- a/tools.py
+++ b/tools.py
@@ -20,21 +20,22 @@ def _normalize_search_sort(sort: str | None) -> str:
     return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
 
 
-def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple[float, float, int]:
+def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple[float, float, int, int]:
     sort_timestamp = float(result.get("_sort_ts") or 0.0)
     rank = result.get("_sort_rank")
     rank_value = float(rank) if rank is not None else float("inf")
     type_bias = 0 if result.get("type") == "message" else 1
+    role_bias = 1 if result.get("role") == "tool" else 0
 
     if sort == "relevance":
-        return (rank_value, -sort_timestamp, type_bias)
+        return (role_bias, rank_value, -sort_timestamp, type_bias)
 
     if sort == "hybrid":
         age_hours = max(0.0, (time.time() - sort_timestamp) / 3600.0)
         blended = rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
-        return (blended, -sort_timestamp, type_bias)
+        return (role_bias, blended, -sort_timestamp, type_bias)
 
-    return (-sort_timestamp, rank_value, type_bias)
+    return (role_bias, -sort_timestamp, rank_value, type_bias)
 
 
 def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":

--- a/tools.py
+++ b/tools.py
@@ -427,6 +427,10 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         "config": {
             "fresh_tail_count": engine._config.fresh_tail_count,
             "leaf_chunk_tokens": engine._config.leaf_chunk_tokens,
+            "dynamic_leaf_chunk_enabled": engine._config.dynamic_leaf_chunk_enabled,
+            "dynamic_leaf_chunk_max": engine._config.dynamic_leaf_chunk_max,
+            "cache_friendly_condensation_enabled": engine._config.cache_friendly_condensation_enabled,
+            "cache_friendly_min_debt_groups": engine._config.cache_friendly_min_debt_groups,
             "context_threshold": engine._config.context_threshold,
             "max_depth": engine._config.incremental_max_depth,
             "condensation_fanin": engine._config.condensation_fanin,


### PR DESCRIPTION
## Summary

This makes the current compaction path more adaptive and more resilient without pretending the plugin has cache metrics it does not actually receive.

The original policy slice is still here:

- dynamic leaf chunk sizing
- adaptive leaf rescue for retry-worthy summarization failures
- cache-friendly follow-on condensation gating

But the branch now also includes the hardening that fell out of local dogfooding and broader maturity review:

- hyphenated / operator-heavy retrieval fallback hardening for `lcm_grep` and `lcm_expand_query`
- ranking changes that demote raw tool-output noise below conversational hits
- bounded dynamic catch-up leaf passes when one leaf pass still leaves the active context under meaningful pressure
- reduced session-filter config log noise

## What changed

- add `dynamic_leaf_chunk_enabled` and `dynamic_leaf_chunk_max`
- compute a working leaf threshold from backlog pressure when dynamic mode is enabled
- compact the oldest bounded raw chunk instead of always taking the entire raw backlog outside the fresh tail
- add bounded adaptive rescue for retry-worthy timeout / context / token-limit style failures
- keep non-retry-worthy failures as hard failures instead of looping
- add `cache_friendly_condensation_enabled` and `cache_friendly_min_debt_groups`
- suppress single-group follow-on condensation after a leaf pass while still allowing one bounded follow-on pass when real debt is present
- add bounded dynamic catch-up leaf passes so dynamic mode can continue compacting when one pass still leaves the context above threshold
- harden retrieval fallback for risky query shapes like `hermes-lcm`, `plugin-only`, and operator-heavy query strings
- demote `tool`-role search hits below conversational hits in both store-level and combined `lcm_grep` relevance ordering
- reduce repeated filter-config diagnostics noise in the engine logs
- document the new point-8 knobs in the README

## Why this helps

The previous path was safe, but still blunt in a few practical ways:

- a large raw backlog could trigger an oversized leaf pass
- retry-worthy provider failures could repeat the same bad chunk choice
- dynamic mode could still stop after one pass even when pressure remained high
- retrieval could fall over on risky query shapes or return noisy tool-output-heavy hits
- repeated filter diagnostics added noise during runtime debugging

This keeps the default behavior intact when the new knobs are off, while making the opt-in path more resilient and more usable in the real runtime.

## Validation

- `python3 -m pytest tests/test_lcm_engine.py -k 'dynamic_leaf_chunk_sizing_runs_bounded_catchup_passes_when_pressure_remains_high or dynamic_leaf_chunk_sizing_compacts_only_oldest_bounded_raw_chunk or adaptive_leaf_rescue_retries_with_smaller_oldest_chunk or cache_friendly_gating' -q`
  - `6 passed`
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
  - `117 passed`
- `python3 -m pytest tests/ -q`
  - `130 passed`

Also rechecked locally against the real `~/.hermes/lcm.db` and the live Hermes runtime after restart:

- risky retrieval queries now return hits instead of surfacing the earlier SQLite parser failure path
- `lcm_expand_query` no longer reproduces the earlier `no such column: lcm` / `no such column: only` failure
- top message hits for `hermes-lcm`, `plugin-only`, and `vendoring` are no longer dominated by raw tool JSON noise
- no fresh post-restart journald hits appeared for `database is locked`, `overflow_recovery_failed`, or the old parser-failure path
