### PR TITLE
feat: custom summary instructions and pre-compaction extraction

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,6 +88,18 @@ class LCMConfig:
     ignore_session_patterns_source: str = "default"
     stateless_session_patterns_source: str = "default"
 
+    # -- Summary instructions ---
+    # Custom instructions injected into all summarization prompts
+    custom_instructions: str = ""
+
+    # -- Pre-compaction extraction ---
+    # Extract decisions/commitments to files before compaction
+    extraction_enabled: bool = False
+    # Model for extraction (empty = fall back to summary_model)
+    extraction_model: str = ""
+    # Directory for daily extraction files (empty = auto: ~/.hermes/lcm-extractions/)
+    extraction_output_path: str = ""
+
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
@@ -132,6 +144,10 @@ class LCMConfig:
         c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)
         c.max_assembly_tokens = _int("LCM_MAX_ASSEMBLY_TOKENS", c.max_assembly_tokens)
         c.reserve_tokens_floor = _int("LCM_RESERVE_TOKENS_FLOOR", c.reserve_tokens_floor)
+        c.custom_instructions = _str("LCM_CUSTOM_INSTRUCTIONS", c.custom_instructions)
+        c.extraction_enabled = _parse_bool_env("LCM_EXTRACTION_ENABLED", c.extraction_enabled)
+        c.extraction_model = _str("LCM_EXTRACTION_MODEL", c.extraction_model)
+        c.extraction_output_path = _str("LCM_EXTRACTION_OUTPUT_PATH", c.extraction_output_path)
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
         c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)

--- a/engine.py
+++ b/engine.py
@@ -6,6 +6,7 @@ with a DAG-based summarization system that preserves every message.
 
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path

--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,7 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
+from .extraction import extract_before_compaction
 from .schemas import LCM_DESCRIBE, LCM_DOCTOR, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_GREP, LCM_STATUS
 from .session_patterns import (
     build_session_match_keys,
@@ -236,6 +237,7 @@ class LCMEngine(ContextEngine):
                     l2_budget_ratio=self._config.l2_budget_ratio,
                     l3_truncate_tokens=self._config.l3_truncate_tokens,
                     focus_topic=focus_topic or "",
+                    custom_instructions=self._config.custom_instructions,
                 )
                 return attempt_chunk, source_tokens, summary_text, level, attempt_number
             except Exception as exc:
@@ -334,6 +336,10 @@ class LCMEngine(ContextEngine):
 
             if not to_compact:
                 break
+
+            # Pre-compaction extraction: best-effort, never blocks compaction
+            if self._config.extraction_enabled:
+                self._run_pre_compaction_extraction(to_compact)
 
             compacted_chunk, source_tokens, summary_text, _level, _rescue_attempts = self._summarize_leaf_chunk_with_rescue(
                 to_compact,
@@ -733,6 +739,25 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: summarization -------------------------------------------
 
+    def _run_pre_compaction_extraction(self, messages: List[Dict[str, Any]]) -> None:
+        """Best-effort extraction of decisions before compaction."""
+        try:
+            serialized = self._serialize_messages(messages)
+            output_path = self._config.extraction_output_path
+            if not output_path:
+                base = self._hermes_home or os.path.expanduser("~/.hermes")
+                output_path = os.path.join(base, "lcm-extractions")
+            extraction_model = self._config.extraction_model or self._config.summary_model
+            extract_before_compaction(
+                serialized_messages=serialized,
+                output_path=output_path,
+                session_id=self._session_id or "",
+                model=extraction_model,
+                timeout=self._config.summary_timeout_ms / 1000,
+            )
+        except Exception as e:
+            logger.debug("Pre-compaction extraction failed (non-blocking): %s", e)
+
     def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Serialize messages into labeled text for the summarizer."""
         parts = []
@@ -853,6 +878,7 @@ class LCMEngine(ContextEngine):
                 l2_budget_ratio=self._config.l2_budget_ratio,
                 l3_truncate_tokens=self._config.l3_truncate_tokens,
                 focus_topic=focus_topic or "",
+                custom_instructions=self._config.custom_instructions,
             )
 
             earliest_at, latest_at = self._dag.get_source_time_window([n.node_id for n in to_condense])

--- a/escalation.py
+++ b/escalation.py
@@ -55,7 +55,8 @@ def _invoke_summary_llm(prompt: str, max_tokens: int, model: str = "", timeout: 
     return _call_llm_for_summary(prompt, max_tokens, **kwargs)
 
 
-def _build_l1_prompt(text: str, token_budget: int, depth: int, focus_topic: str = "") -> str:
+def _build_l1_prompt(text: str, token_budget: int, depth: int,
+                     focus_topic: str = "", custom_instructions: str = "") -> str:
     """Level 1: preserve details."""
     depth_guidance = {
         0: "Preserve decisions, rationale, constraints, active tasks, file paths, commands, and specific values.",
@@ -71,11 +72,15 @@ def _build_l1_prompt(text: str, token_budget: int, depth: int, focus_topic: str 
             "Spend roughly 60-70% of the summary budget on that topic when relevant.\n"
         )
 
+    custom_block = ""
+    if custom_instructions:
+        custom_block = f"\nAdditional instructions:\n{custom_instructions}\n"
+
     return f"""Summarize this conversation segment for future turns.
 {guidance}
 Remove repetition and conversational filler.
 End with: "Expand for details about: <what was compressed>"
-{focus_guidance}
+{focus_guidance}{custom_block}
 
 Target ~{token_budget} tokens.
 
@@ -83,7 +88,8 @@ CONTENT:
 {text}"""
 
 
-def _build_l2_prompt(text: str, token_budget: int, focus_topic: str = "") -> str:
+def _build_l2_prompt(text: str, token_budget: int,
+                     focus_topic: str = "", custom_instructions: str = "") -> str:
     """Level 2: aggressive bullet points."""
     focus_guidance = ""
     if focus_topic:
@@ -91,10 +97,14 @@ def _build_l2_prompt(text: str, token_budget: int, focus_topic: str = "") -> str
             f'Prioritize bullets related to: "{focus_topic}" when present.\n'
         )
 
+    custom_block = ""
+    if custom_instructions:
+        custom_block = f"\nAdditional instructions:\n{custom_instructions}\n"
+
     return f"""Compress this into bullet points. Maximum {token_budget} tokens.
 Keep only: decisions made, files changed, errors hit, current state.
 Drop all reasoning, alternatives considered, and process detail.
-{focus_guidance}
+{focus_guidance}{custom_block}
 
 CONTENT:
 {text}"""
@@ -131,6 +141,7 @@ def summarize_with_escalation(
     l2_budget_ratio: float = 0.50,
     l3_truncate_tokens: int = 512,
     focus_topic: str = "",
+    custom_instructions: str = "",
 ) -> tuple[str, int]:
     """Run 3-level escalation. Returns (summary, level_used).
 
@@ -138,7 +149,9 @@ def summarize_with_escalation(
     output shorter than the source.
     """
     # Level 1: detailed summary
-    l1_prompt = _build_l1_prompt(text, token_budget, depth, focus_topic=focus_topic)
+    l1_prompt = _build_l1_prompt(text, token_budget, depth,
+                                 focus_topic=focus_topic,
+                                 custom_instructions=custom_instructions)
     l1_result = _invoke_summary_llm(l1_prompt, token_budget * 2, model=model, timeout=timeout)
 
     if l1_result and count_tokens(l1_result) < source_tokens:
@@ -147,7 +160,9 @@ def summarize_with_escalation(
 
     # Level 2: aggressive bullets at reduced budget
     l2_budget = int(token_budget * l2_budget_ratio)
-    l2_prompt = _build_l2_prompt(text, l2_budget, focus_topic=focus_topic)
+    l2_prompt = _build_l2_prompt(text, l2_budget,
+                                 focus_topic=focus_topic,
+                                 custom_instructions=custom_instructions)
     l2_result = _invoke_summary_llm(l2_prompt, l2_budget * 2, model=model, timeout=timeout)
 
     if l2_result and count_tokens(l2_result) < source_tokens:

--- a/extraction.py
+++ b/extraction.py
@@ -1,0 +1,97 @@
+"""Pre-compaction extraction — extract decisions and commitments before summarization.
+
+Best-effort: failures never block compaction. Extracted content is written to
+daily note files so key decisions survive even if the DAG summary loses nuance.
+"""
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_PROMPT = """Extract decisions, commitments, outcomes, and rules from this conversation segment.
+
+Format as a flat list of bullet points. Each bullet should be self-contained and understandable
+without the surrounding conversation. Include:
+- Decisions made (what was chosen, and why if stated)
+- Commitments (who will do what)
+- Outcomes (what happened as a result of an action)
+- Rules or constraints discovered
+
+Skip: greetings, meta-discussion, reasoning that led nowhere, repeated information.
+If there is nothing worth extracting, respond with exactly: NOTHING_TO_EXTRACT
+
+CONTENT:
+{text}"""
+
+
+def _call_extraction_llm(prompt: str, model: str = "",
+                          timeout: float | None = None) -> Optional[str]:
+    """Call the Hermes auxiliary LLM for extraction."""
+    try:
+        from agent.auxiliary_client import call_llm
+        call_kwargs = {
+            "task": "extraction",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.2,
+            "max_tokens": 2000,
+        }
+        if model:
+            call_kwargs["model"] = model
+        if timeout is not None:
+            call_kwargs["timeout"] = timeout
+        response = call_llm(**call_kwargs)
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return content.strip()
+    except Exception as e:
+        logger.debug("Extraction LLM call failed: %s", e)
+        return None
+
+
+def extract_before_compaction(
+    serialized_messages: str,
+    output_path: str,
+    session_id: str = "",
+    model: str = "",
+    timeout: float | None = None,
+) -> bool:
+    """Extract decisions from messages about to be compacted and write to a daily file.
+
+    Returns True if extraction succeeded, False otherwise.
+    Never raises — failures are logged and swallowed.
+    """
+    try:
+        prompt = EXTRACTION_PROMPT.format(text=serialized_messages)
+        result = _call_extraction_llm(prompt, model=model, timeout=timeout)
+
+        if not result or result.strip() == "NOTHING_TO_EXTRACT":
+            logger.debug("Pre-compaction extraction: nothing to extract")
+            return True
+
+        output_dir = Path(output_path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        file_path = output_dir / f"{date_str}.md"
+
+        header = f"\n\n## Extraction — {datetime.now().strftime('%H:%M')}"
+        if session_id:
+            header += f" ({session_id})"
+        header += "\n\n"
+
+        with open(file_path, "a", encoding="utf-8") as f:
+            f.write(header)
+            f.write(result)
+            f.write("\n")
+
+        logger.info("Pre-compaction extraction written to %s", file_path)
+        return True
+
+    except Exception as e:
+        logger.warning("Pre-compaction extraction failed (non-blocking): %s", e)
+        return False

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -32,6 +33,10 @@ class TestConfig:
         assert c.dynamic_leaf_chunk_max == 40_000
         assert c.cache_friendly_condensation_enabled is False
         assert c.cache_friendly_min_debt_groups == 2
+        assert c.custom_instructions == ""
+        assert c.extraction_enabled is False
+        assert c.extraction_model == ""
+        assert c.extraction_output_path == ""
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
         assert c.ignore_session_patterns_source == "default"
@@ -53,6 +58,10 @@ class TestConfig:
         monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_MAX", "64000")
         monkeypatch.setenv("LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED", "1")
         monkeypatch.setenv("LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS", "3")
+        monkeypatch.setenv("LCM_CUSTOM_INSTRUCTIONS", "Write as a neutral documenter.")
+        monkeypatch.setenv("LCM_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("LCM_EXTRACTION_MODEL", "openai/gpt-5.4-mini")
+        monkeypatch.setenv("LCM_EXTRACTION_OUTPUT_PATH", "/tmp/extractions")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
@@ -67,6 +76,10 @@ class TestConfig:
         assert c.dynamic_leaf_chunk_max == 64_000
         assert c.cache_friendly_condensation_enabled is True
         assert c.cache_friendly_min_debt_groups == 3
+        assert c.custom_instructions == "Write as a neutral documenter."
+        assert c.extraction_enabled is True
+        assert c.extraction_model == "openai/gpt-5.4-mini"
+        assert c.extraction_output_path == "/tmp/extractions"
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")
@@ -1549,3 +1562,127 @@ class TestEscalation:
 
     def test_truncate_short(self):
         assert _deterministic_truncate("hello", 1000) == "hello"
+
+    def test_custom_instructions_injected_into_l1_prompt(self):
+        from hermes_lcm.escalation import _build_l1_prompt
+        prompt = _build_l1_prompt(
+            "test content", 500, depth=0,
+            custom_instructions="Write as a neutral documenter.",
+        )
+        assert "Additional instructions:" in prompt
+        assert "Write as a neutral documenter." in prompt
+
+    def test_custom_instructions_injected_into_l2_prompt(self):
+        from hermes_lcm.escalation import _build_l2_prompt
+        prompt = _build_l2_prompt(
+            "test content", 500,
+            custom_instructions="Use third person only.",
+        )
+        assert "Additional instructions:" in prompt
+        assert "Use third person only." in prompt
+
+    def test_custom_instructions_omitted_when_empty(self):
+        from hermes_lcm.escalation import _build_l1_prompt, _build_l2_prompt
+        l1 = _build_l1_prompt("test", 500, depth=0, custom_instructions="")
+        l2 = _build_l2_prompt("test", 500, custom_instructions="")
+        assert "Additional instructions:" not in l1
+        assert "Additional instructions:" not in l2
+
+
+class TestExtraction:
+    def test_extract_writes_daily_file(self, tmp_path):
+        from hermes_lcm.extraction import extract_before_compaction
+
+        # Mock the LLM call
+        import hermes_lcm.extraction as ext_module
+        original = ext_module._call_extraction_llm
+
+        def mock_llm(prompt, model="", timeout=None):
+            return "- Decided to use PostgreSQL for the user store\n- Stephen will handle the migration by Friday"
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            output_dir = str(tmp_path / "extractions")
+            result = extract_before_compaction(
+                serialized_messages="[USER]: Let's use PostgreSQL\n[ASSISTANT]: Done",
+                output_path=output_dir,
+                session_id="test-session",
+            )
+            assert result is True
+
+            files = list(Path(tmp_path / "extractions").glob("*.md"))
+            assert len(files) == 1
+            content = files[0].read_text()
+            assert "PostgreSQL" in content
+            assert "test-session" in content
+            assert "migration" in content
+        finally:
+            ext_module._call_extraction_llm = original
+
+    def test_extract_skips_when_nothing_to_extract(self, tmp_path):
+        from hermes_lcm.extraction import extract_before_compaction
+        import hermes_lcm.extraction as ext_module
+        original = ext_module._call_extraction_llm
+
+        def mock_llm(prompt, model="", timeout=None):
+            return "NOTHING_TO_EXTRACT"
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            output_dir = str(tmp_path / "extractions")
+            result = extract_before_compaction(
+                serialized_messages="[USER]: hello\n[ASSISTANT]: hi",
+                output_path=output_dir,
+            )
+            assert result is True
+            files = list(Path(tmp_path / "extractions").glob("*.md"))
+            assert len(files) == 0
+        finally:
+            ext_module._call_extraction_llm = original
+
+    def test_extract_never_blocks_on_failure(self, tmp_path):
+        from hermes_lcm.extraction import extract_before_compaction
+        import hermes_lcm.extraction as ext_module
+        original = ext_module._call_extraction_llm
+
+        def mock_llm(prompt, model="", timeout=None):
+            return None
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            result = extract_before_compaction(
+                serialized_messages="test",
+                output_path=str(tmp_path / "extractions"),
+            )
+            # Should return True (nothing to write) not raise
+            assert result is True
+        finally:
+            ext_module._call_extraction_llm = original
+
+    def test_extract_appends_to_existing_daily_file(self, tmp_path):
+        from hermes_lcm.extraction import extract_before_compaction
+        import hermes_lcm.extraction as ext_module
+        original = ext_module._call_extraction_llm
+
+        call_count = 0
+
+        def mock_llm(prompt, model="", timeout=None):
+            nonlocal call_count
+            call_count += 1
+            return f"- Decision {call_count}"
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            output_dir = str(tmp_path / "extractions")
+            extract_before_compaction("first", output_path=output_dir, session_id="s1")
+            extract_before_compaction("second", output_path=output_dir, session_id="s2")
+
+            files = list(Path(tmp_path / "extractions").glob("*.md"))
+            assert len(files) == 1
+            content = files[0].read_text()
+            assert "Decision 1" in content
+            assert "Decision 2" in content
+            assert "s1" in content
+            assert "s2" in content
+        finally:
+            ext_module._call_extraction_llm = original

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1659,6 +1659,37 @@ class TestExtraction:
         finally:
             ext_module._call_extraction_llm = original
 
+    def test_engine_extraction_uses_default_path_when_config_empty(self, tmp_path, monkeypatch):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+        import hermes_lcm.extraction as ext_module
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_extract.db"),
+            extraction_enabled=True,
+            extraction_output_path="",
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        original = ext_module._call_extraction_llm
+
+        def mock_llm(prompt, model="", timeout=None):
+            return "- Decided to use Redis for caching"
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            engine._run_pre_compaction_extraction([
+                {"role": "user", "content": "Let's use Redis"},
+                {"role": "assistant", "content": "Done"},
+            ])
+            extraction_dir = tmp_path / "hermes" / "lcm-extractions"
+            files = list(extraction_dir.glob("*.md"))
+            assert len(files) == 1
+            assert "Redis" in files[0].read_text()
+        finally:
+            ext_module._call_extraction_llm = original
+
     def test_extract_appends_to_existing_daily_file(self, tmp_path):
         from hermes_lcm.extraction import extract_before_compaction
         import hermes_lcm.extraction as ext_module


### PR DESCRIPTION
## Summary

Two features inspired by [lossless-claw-vigil-recall](https://github.com/jamebobob/lossless-claw-vigil-recall), which identified these as the top production pain points with LCM-style context management:

- **Custom summary instructions** — configurable string injected into all summarization prompts (L1 and L2). Controls summary voice and style. e.g. `LCM_CUSTOM_INSTRUCTIONS="Write as a neutral documenter. Use third person. Report facts, not significance."`

- **Pre-compaction extraction** — before messages are summarized into DAG nodes, an optional LLM call extracts decisions, commitments, and outcomes into daily note files (`YYYY-MM-DD.md`). Best-effort: failures never block compaction. Disabled by default.

## New config

| Variable | Default | Description |
|----------|---------|-------------|
| `LCM_CUSTOM_INSTRUCTIONS` | `""` | Instructions injected into all summarization prompts |
| `LCM_EXTRACTION_ENABLED` | `false` | Enable pre-compaction decision extraction |
| `LCM_EXTRACTION_MODEL` | *(summary model)* | Override model for extraction |
| `LCM_EXTRACTION_OUTPUT_PATH` | `~/.hermes/lcm-extractions/` | Directory for daily extraction files |

## Test plan

- [x] Custom instructions appear in L1 and L2 prompts when set
- [x] Custom instructions omitted when empty (no prompt pollution)
- [x] Extraction writes daily files with session ID and timestamp headers
- [x] Extraction skips when LLM returns NOTHING_TO_EXTRACT
- [x] Extraction never blocks on LLM failure
- [x] Multiple extractions append to the same daily file
- [x] Config defaults and env var parsing

7 new tests, all passing. 1 pre-existing failure in `test_dynamic_leaf_chunk_sizing_runs_bounded_catchup_passes_when_pressure_remains_high` (from #20, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)