### PR TITLE
fix: accept api_mode in update_model

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -330,7 +330,7 @@ class LCMEngine(ContextEngine):
 
     def update_model(self, model: str, context_length: int,
                      base_url: str = "", api_key: str = "",
-                     provider: str = "") -> None:
+                     provider: str = "", api_mode: str = "", **kwargs) -> None:
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self._config.context_threshold)
 


### PR DESCRIPTION
## Summary
- accept api_mode in update_model
- preserve compatibility for callers that pass api_mode during model updates

## Notes
- opened as a draft to verify the fork/push/create-PR flow with the refreshed GitHub token