### PR TITLE
feat: polish retrieval search ranking

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -26,10 +26,16 @@ from .db_bootstrap import (
     run_versioned_migrations,
 )
 from .search_query import (
+    compute_directness_rank_bonus_upper_bound,
+    compute_directness_score,
+    compute_search_fetch_limit,
+    contains_risky_fts_ascii,
     count_term_matches,
     escape_like,
+    extract_quoted_phrases,
     extract_search_terms,
     requires_like_fallback,
+    should_apply_directness_rank_adjustment,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,24 +54,55 @@ def _build_search_order_by(sort: str | None, recency_expr: str) -> str:
         return f"rank ASC, {recency_expr} DESC"
     if normalized == "hybrid":
         return (
-            f"(rank / (1 + (((strftime('%s','now') - {recency_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC, "
+            f"(rank / (1 + (MAX(0.0, ((strftime('%s','now') - {recency_expr}) / 3600.0)) * {AGE_DECAY_RATE}))) ASC, "
             f"{recency_expr} DESC"
         )
     return f"{recency_expr} DESC"
 
 
-def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float]:
+def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
     normalized = _normalize_search_sort(sort)
     score = float(node.search_rank or 0.0) * -1.0
     recency = float(node.latest_at or node.created_at or 0.0)
+    directness = float(node.search_directness or 0.0)
 
     if normalized == "relevance":
-        return (-score, -recency)
+        return (-score, -directness, -recency)
     if normalized == "hybrid":
         age_hours = max(0.0, (time.time() - recency) / 3600.0)
         blended = score / (1 + (age_hours * AGE_DECAY_RATE))
-        return (-blended, -recency)
-    return (-recency, -score)
+        return (-blended, -directness, -recency)
+    return (-recency, -score, -directness)
+
+
+def _fts_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
+    normalized = _normalize_search_sort(sort)
+    rank = node.search_rank
+    rank_value = float(rank) if rank is not None else float("inf")
+    recency = float(node.latest_at or node.created_at or 0.0)
+    directness = float(node.search_directness or 0.0)
+
+    if normalized == "relevance":
+        return (rank_value, -directness, -recency)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        strength = (-rank_value) if rank is not None else float("-inf")
+        blended_strength = strength / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("-inf")
+        return (-blended_strength, -directness, -recency)
+    return (-recency, rank_value, 0.0)
+
+
+def _fts_primary_value(node: "SummaryNode", sort: str | None) -> float:
+    normalized = _normalize_search_sort(sort)
+    rank = node.search_rank
+    rank_value = float(rank) if rank is not None else float("inf")
+    if normalized == "hybrid":
+        recency = float(node.latest_at or node.created_at or 0.0)
+        age_hours = max(0.0, (time.time() - recency) / 3600.0)
+        strength = (-rank_value) if rank is not None else float("-inf")
+        blended_strength = strength / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("-inf")
+        return -blended_strength
+    return rank_value
 
 
 @dataclass
@@ -84,6 +121,7 @@ class SummaryNode:
     latest_at: float | None = None
     expand_hint: str = ""  # "Expand for details about: ..."
     search_rank: float | None = None
+    search_directness: float = 0.0
 
 
 class SummaryDAG:
@@ -292,34 +330,65 @@ class SummaryDAG:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
         """FTS5 search across all summary nodes."""
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
 
         order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
-        try:
-            if session_id:
-                rows = self._conn.execute(
-                    f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
-                       JOIN summary_nodes n ON n.node_id = fts.rowid
-                       WHERE nodes_fts MATCH ? AND n.session_id = ?
-                       ORDER BY {order_by} LIMIT ?""",
-                    (query, session_id, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
-                       JOIN summary_nodes n ON n.node_id = fts.rowid
-                       WHERE nodes_fts MATCH ?
-                       ORDER BY {order_by} LIMIT ?""",
-                    (query, limit),
-                ).fetchall()
-        except sqlite3.Error:
-            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
-        return [self._row_to_node(r) for r in rows]
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
+        max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 2e-7
+        offset = 0
+        results: list[SummaryNode] = []
+        while True:
+            try:
+                if session_id:
+                    rows = self._conn.execute(
+                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                           JOIN summary_nodes n ON n.node_id = fts.rowid
+                           WHERE nodes_fts MATCH ? AND n.session_id = ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, session_id, fetch_limit, offset),
+                    ).fetchall()
+                else:
+                    rows = self._conn.execute(
+                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                           JOIN summary_nodes n ON n.node_id = fts.rowid
+                           WHERE nodes_fts MATCH ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, fetch_limit, offset),
+                    ).fetchall()
+            except sqlite3.Error:
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+
+            raw_nodes = [self._row_to_node(r) for r in rows]
+            raw_primary_values: list[float] = []
+            for node in raw_nodes:
+                node.search_directness = compute_directness_score(node.summary, terms, phrases)
+                if apply_directness_adjustment and node.search_rank is not None:
+                    rank_adjustment = max(float(node.search_directness), 0.0)
+                    node.search_rank = float(node.search_rank) - (rank_adjustment * 2e-7)
+                raw_primary_values.append(_fts_primary_value(node, sort))
+                results.append(node)
+            results.sort(key=lambda node: _fts_result_sort_key(node, sort))
+
+            if not apply_directness_adjustment or len(rows) < fetch_limit or len(results) <= limit:
+                return results[:limit]
+
+            worst_visible_primary = _fts_primary_value(results[min(limit, len(results)) - 1], sort)
+            last_fetched_primary = raw_primary_values[-1]
+            best_unseen_primary = last_fetched_primary - max_rank_bonus
+            if best_unseen_primary > worst_visible_primary:
+                return results[:limit]
+
+            offset += len(rows)
+            fetch_limit *= 2
 
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
         terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
         if not terms:
             return []
 
@@ -338,13 +407,18 @@ class SummaryDAG:
             f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)}",
             args,
         ).fetchall()
+        collapse_risky_repeats = contains_risky_fts_ascii(query)
         nodes: list[SummaryNode] = []
         for row in rows:
             node = self._row_to_node(row)
-            score = sum(count_term_matches(node.summary, term) for term in terms)
+            score = sum(
+                min(count_term_matches(node.summary, term), 1) if collapse_risky_repeats else count_term_matches(node.summary, term)
+                for term in terms
+            )
             if score <= 0:
                 continue
             node.search_rank = -float(score)
+            node.search_directness = compute_directness_score(node.summary, terms, phrases)
             nodes.append(node)
 
         nodes.sort(key=lambda node: _fallback_result_sort_key(node, sort))

--- a/search_query.py
+++ b/search_query.py
@@ -25,7 +25,10 @@ _QUOTED_PHRASE_RE = re.compile(r'"([^"]+)"')
 _BOOLEAN_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
 _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
-_STRIP_EDGE_PUNCT = "()[]{}.,;"
+_STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
+
+
+_WORD_RE = re.compile(r"[\w-]+", re.UNICODE)
 
 
 def contains_cjk(text: str) -> bool:
@@ -101,6 +104,10 @@ def extract_search_terms(query: str) -> List[str]:
     return deduped
 
 
+def extract_quoted_phrases(query: str) -> List[str]:
+    return [phrase.strip() for phrase in _QUOTED_PHRASE_RE.findall(query or "") if phrase.strip()]
+
+
 def escape_like(term: str) -> str:
     return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
@@ -111,6 +118,92 @@ def count_term_matches(text: str, term: str) -> int:
     if not haystack or not needle:
         return 0
     return haystack.lower().count(needle.lower())
+
+
+def compute_directness_score(text: str, terms: List[str], phrases: List[str] | None = None) -> float:
+    content = text or ""
+    if not content:
+        return 0.0
+
+    unique_hits = 0
+    total_hits = 0
+    non_phrase_unique_hits = 0
+    non_phrase_total_hits = 0
+    normalized_phrases = {(phrase or "").strip().lower() for phrase in (phrases or []) if (phrase or "").strip()}
+    for term in terms:
+        matches = count_term_matches(content, term)
+        if matches > 0:
+            unique_hits += 1
+            total_hits += matches
+            if term.strip().lower() not in normalized_phrases:
+                non_phrase_unique_hits += 1
+                non_phrase_total_hits += matches
+
+    phrase_hits = 0
+    lowered = content.lower()
+    for phrase in phrases or []:
+        if phrase and phrase.lower() in lowered:
+            phrase_hits += 1
+
+    repetition_penalty = max(0, total_hits - unique_hits)
+    non_phrase_repetition_penalty = max(0, non_phrase_total_hits - non_phrase_unique_hits)
+    score = float((unique_hits * 5) + (phrase_hits * 8))
+    if not phrases:
+        score -= min(repetition_penalty, 6)
+    else:
+        score -= min(non_phrase_repetition_penalty, 6)
+
+    if phrases:
+        for phrase in phrases:
+            normalized_phrase = (phrase or "").strip().lower()
+            if not normalized_phrase:
+                continue
+            phrase_occurrences = lowered.count(normalized_phrase)
+            if phrase_occurrences <= 1:
+                continue
+            segments = re.split(re.escape(normalized_phrase), lowered)
+            gap_unique_counts = []
+            for segment in segments:
+                segment_tokens = [
+                    token.lower()
+                    for token in _WORD_RE.findall(segment)
+                    if any(char.isalpha() for char in token)
+                ]
+                gap_unique_counts.append(len(set(segment_tokens)))
+            interior_gap_counts = gap_unique_counts[1:-1]
+            tail_gap_count = gap_unique_counts[-1] if gap_unique_counts else 0
+            extra_occurrences = phrase_occurrences - 1
+            score -= extra_occurrences * 0.5
+            score -= sum(1.5 for count in interior_gap_counts if 0 < count <= 4)
+            if all(count == 0 for count in interior_gap_counts) and tail_gap_count <= 2:
+                score -= min(extra_occurrences, 3) * 1.0
+
+    return score
+
+
+def _is_precise_query_shape(terms: List[str], phrases: List[str] | None = None) -> bool:
+    if len(terms) == 1:
+        return True
+    return len(phrases or []) == 1 and len(terms) <= 2
+
+
+def should_widen_candidate_fetch(terms: List[str], phrases: List[str] | None = None) -> bool:
+    return _is_precise_query_shape(terms, phrases)
+
+
+def should_apply_directness_rank_adjustment(terms: List[str], phrases: List[str] | None = None) -> bool:
+    return _is_precise_query_shape(terms, phrases)
+
+
+def compute_directness_rank_bonus_upper_bound(terms: List[str], phrases: List[str] | None = None) -> float:
+    return float((len(terms) * 5) + (len(phrases or []) * 8))
+
+
+def compute_search_fetch_limit(limit: int, terms: List[str], phrases: List[str] | None = None) -> int:
+    base = max(limit * 5, limit, 20)
+    if should_widen_candidate_fetch(terms, phrases):
+        return max(base, limit * 10, 50)
+    return base
 
 
 def build_snippet(text: str, terms: List[str], width: int = 80) -> str:

--- a/store.py
+++ b/store.py
@@ -21,15 +21,43 @@ from .db_bootstrap import (
 )
 from .search_query import (
     build_snippet,
+    compute_directness_rank_bonus_upper_bound,
+    compute_directness_score,
+    compute_search_fetch_limit,
+    contains_risky_fts_ascii,
     count_term_matches,
     escape_like,
+    extract_quoted_phrases,
     extract_search_terms,
     requires_like_fallback,
+    should_apply_directness_rank_adjustment,
 )
 
 logger = logging.getLogger(__name__)
 
 AGE_DECAY_RATE = 0.001
+
+
+_MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
+
+
+def _message_role_bias(role: str | None) -> float:
+    if role == "user":
+        return 0.0
+    if role == "assistant":
+        return 1.0
+    if role == "tool":
+        return 2.0
+    return 1.0
+
+
+def _message_directness_score(role: str | None, content: str | None, terms: List[str], phrases: List[str] | None = None) -> float:
+    score = compute_directness_score(content or "", terms, phrases)
+    if role == "tool":
+        stripped = (content or "").lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            score -= 4.0
+    return score
 
 
 def _normalize_search_sort(sort: str | None) -> str:
@@ -44,34 +72,68 @@ def _build_search_order_by(
 ) -> str:
     normalized = _normalize_search_sort(sort)
     order_parts: list[str] = []
-    if role_penalty_expr:
-        order_parts.append(f"{role_penalty_expr} ASC")
     if normalized == "relevance":
-        order_parts.extend(["rank ASC", f"{timestamp_expr} DESC"])
+        if role_penalty_expr:
+            order_parts.extend(["rank ASC", f"{role_penalty_expr} ASC", f"{timestamp_expr} DESC"])
+        else:
+            order_parts.extend(["rank ASC", f"{timestamp_expr} DESC"])
         return ", ".join(order_parts)
     if normalized == "hybrid":
-        order_parts.extend([
-            f"(rank / (1 + (((strftime('%s','now') - {timestamp_expr}) / 3600.0) * {AGE_DECAY_RATE}))) ASC",
-            f"{timestamp_expr} DESC",
-        ])
+        blended = f"(rank / (1 + (MAX(0.0, ((strftime('%s','now') - {timestamp_expr}) / 3600.0)) * {AGE_DECAY_RATE})))"
+        if role_penalty_expr:
+            order_parts.extend([f"{blended} ASC", f"{role_penalty_expr} ASC", f"{timestamp_expr} DESC"])
+        else:
+            order_parts.extend([f"{blended} ASC", f"{timestamp_expr} DESC"])
         return ", ".join(order_parts)
-    order_parts.extend([f"{timestamp_expr} DESC", "rank ASC"])
+    order_parts.append(f"{timestamp_expr} DESC")
+    if role_penalty_expr:
+        order_parts.append(f"{role_penalty_expr} ASC")
+    order_parts.append("rank ASC")
     return ", ".join(order_parts)
 
 
-def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float]:
+def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
     normalized = _normalize_search_sort(sort)
     score = float(result.get("_fallback_score") or 0.0)
+    directness = float(result.get("_directness_score") or 0.0)
     timestamp = float(result.get("timestamp") or 0.0)
-    role_bias = 1.0 if result.get("role") == "tool" else 0.0
+    role_bias = _message_role_bias(result.get("role"))
 
     if normalized == "relevance":
-        return (role_bias, -score, -timestamp)
+        return (-score, -directness, role_bias, -timestamp)
     if normalized == "hybrid":
         age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
         blended = score / (1 + (age_hours * AGE_DECAY_RATE))
-        return (role_bias, -blended, -timestamp)
-    return (role_bias, -timestamp, -score)
+        return (-blended, -directness, role_bias, -timestamp)
+    return (-timestamp, role_bias, -score, -directness)
+
+
+def _fts_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
+    normalized = _normalize_search_sort(sort)
+    rank = result.get("search_rank")
+    rank_value = float(rank) if rank is not None else float("inf")
+    directness = float(result.get("_directness_score") or 0.0)
+    timestamp = float(result.get("timestamp") or 0.0)
+    role_bias = _message_role_bias(result.get("role"))
+
+    if normalized == "relevance":
+        return (rank_value, -directness, role_bias, -timestamp)
+    if normalized == "hybrid":
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        blended = rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
+        return (blended, -directness, role_bias, -timestamp)
+    return (-timestamp, role_bias, rank_value, 0.0)
+
+
+def _fts_primary_value(result: Dict[str, Any], sort: str | None) -> float:
+    normalized = _normalize_search_sort(sort)
+    rank = result.get("search_rank")
+    rank_value = float(rank) if rank is not None else float("inf")
+    if normalized == "hybrid":
+        timestamp = float(result.get("timestamp") or 0.0)
+        age_hours = max(0.0, (time.time() - timestamp) / 3600.0)
+        return rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
+    return rank_value
 
 
 class MessageStore:
@@ -284,48 +346,75 @@ class MessageStore:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
         """FTS5 search across messages. Returns matches with snippets."""
+        terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
 
         order_by = _build_search_order_by(
             sort,
             "m.timestamp",
-            "CASE WHEN m.role = 'tool' THEN 1 ELSE 0 END",
+            _MESSAGE_ROLE_BIAS_SQL,
         )
-        try:
-            if session_id:
-                rows = self._conn.execute(
-                    f"""SELECT m.*, rank as search_rank,
-                              snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                       FROM messages_fts fts
-                       JOIN messages m ON m.store_id = fts.rowid
-                       WHERE messages_fts MATCH ? AND m.session_id = ?
-                       ORDER BY {order_by} LIMIT ?""",
-                    (query, session_id, limit),
-                ).fetchall()
-            else:
-                rows = self._conn.execute(
-                    f"""SELECT m.*, rank as search_rank,
-                              snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                       FROM messages_fts fts
-                       JOIN messages m ON m.store_id = fts.rowid
-                       WHERE messages_fts MATCH ?
-                       ORDER BY {order_by} LIMIT ?""",
-                    (query, limit),
-                ).fetchall()
-        except sqlite3.Error:
-            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
-        results = []
-        for r in rows:
-            d = self._row_to_dict(r)
-            d["search_rank"] = r[10] if len(r) > 10 else None
-            d["snippet"] = r[11] if len(r) > 11 else ""
-            results.append(d)
-        return results
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
+        max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 3e-7
+        offset = 0
+        results: list[Dict[str, Any]] = []
+        while True:
+            try:
+                if session_id:
+                    rows = self._conn.execute(
+                        f"""SELECT m.*, rank as search_rank,
+                                  snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                           FROM messages_fts fts
+                           JOIN messages m ON m.store_id = fts.rowid
+                           WHERE messages_fts MATCH ? AND m.session_id = ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, session_id, fetch_limit, offset),
+                    ).fetchall()
+                else:
+                    rows = self._conn.execute(
+                        f"""SELECT m.*, rank as search_rank,
+                                  snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                           FROM messages_fts fts
+                           JOIN messages m ON m.store_id = fts.rowid
+                           WHERE messages_fts MATCH ?
+                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                        (query, fetch_limit, offset),
+                    ).fetchall()
+            except sqlite3.Error:
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+
+            raw_primary_values: list[float] = []
+            for r in rows:
+                d = self._row_to_dict(r)
+                d["search_rank"] = r[10] if len(r) > 10 else None
+                d["snippet"] = r[11] if len(r) > 11 else ""
+                d["_directness_score"] = _message_directness_score(d.get("role"), d.get("content"), terms, phrases)
+                if apply_directness_adjustment and d["search_rank"] is not None:
+                    rank_adjustment = max(float(d["_directness_score"]), 0.0)
+                    d["search_rank"] = float(d["search_rank"]) - (rank_adjustment * 3e-7)
+                raw_primary_values.append(_fts_primary_value(d, sort))
+                results.append(d)
+            results.sort(key=lambda result: _fts_result_sort_key(result, sort))
+
+            if not apply_directness_adjustment or len(rows) < fetch_limit or len(results) <= limit:
+                return results[:limit]
+
+            worst_visible_primary = _fts_primary_value(results[min(limit, len(results)) - 1], sort)
+            last_fetched_primary = raw_primary_values[-1]
+            best_unseen_primary = last_fetched_primary - max_rank_bonus
+            if best_unseen_primary > worst_visible_primary:
+                return results[:limit]
+
+            offset += len(rows)
+            fetch_limit *= 2
 
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
         terms = extract_search_terms(query)
+        phrases = extract_quoted_phrases(query)
         if not terms:
             return []
 
@@ -341,20 +430,24 @@ class MessageStore:
         where.append("(" + " OR ".join(like_clauses) + ")")
 
         rows = self._conn.execute(
-            f"SELECT * FROM messages WHERE {' AND '.join(where)}"
-            , args,
+            f"SELECT * FROM messages WHERE {' AND '.join(where)}",
+            args,
         ).fetchall()
-
-        results: list[Dict[str, Any]] = []
+        results: List[Dict[str, Any]] = []
+        collapse_risky_repeats = contains_risky_fts_ascii(query)
         for row in rows:
             result = self._row_to_dict(row)
             content = result.get("content") or ""
-            score = sum(count_term_matches(content, term) for term in terms)
+            score = sum(
+                min(count_term_matches(content, term), 1) if collapse_risky_repeats else count_term_matches(content, term)
+                for term in terms
+            )
             if score <= 0:
                 continue
             result["search_rank"] = -float(score)
             result["snippet"] = build_snippet(content, terms)
             result["_fallback_score"] = float(score)
+            result["_directness_score"] = _message_directness_score(result.get("role"), content, terms, phrases)
             results.append(result)
 
         results.sort(key=lambda result: _fallback_result_sort_key(result, sort))

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -523,6 +523,319 @@ class TestMessageStore:
         assert fallback_results[0]["store_id"] == fallback_user_id
         assert fallback_results[1]["store_id"] == fallback_tool_id
 
+    def test_search_relevance_prefers_user_over_newer_assistant_on_similar_match(self, store):
+        user_id = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "vendoring should stay external plugin host support only",
+            },
+        )
+        assistant_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "vendoring should stay external plugin host support only",
+            },
+        )
+
+        results = store.search("vendoring", session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == user_id
+        assert results[1]["store_id"] == assistant_id
+
+    def test_search_relevance_does_not_let_weaker_user_hit_beat_stronger_assistant_hit(self, store):
+        weaker_user_id = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "vendoring blah blah external blah host",
+            },
+        )
+        stronger_assistant_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "vendoring external host",
+            },
+        )
+
+        results = store.search("vendoring external host", session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == stronger_assistant_id
+        assert results[1]["store_id"] == weaker_user_id
+
+    def test_search_relevance_still_surfaces_preferred_user_hit_from_large_same_rank_pool(self, store):
+        preferred_user_id = store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "vendoring",
+            },
+        )
+        for _ in range(150):
+            store.append(
+                "sess1",
+                {
+                    "role": "assistant",
+                    "content": "vendoring",
+                },
+            )
+
+        results = store.search("vendoring", session_id="sess1", limit=5, sort="relevance")
+
+        assert results[0]["store_id"] == preferred_user_id
+        assert results[0]["role"] == "user"
+
+    def test_search_relevance_top_results_do_not_change_when_limit_increases_on_large_single_term_pool(self, store):
+        store.append(
+            "sess1",
+            {
+                "role": "user",
+                "content": "vendoring",
+            },
+        )
+        for idx in range(250):
+            content = (
+                '{"vendoring":"vendoring vendoring vendoring"}'
+                if idx % 5 == 0
+                else "vendoring vendoring vendoring vendoring vendoring spam"
+            )
+            store.append(
+                "sess1",
+                {
+                    "role": "tool" if idx % 5 == 0 else "assistant",
+                    "content": content,
+                },
+            )
+        top_5 = [result["store_id"] for result in store.search("vendoring", session_id="sess1", limit=5, sort="relevance")]
+        top_50 = [result["store_id"] for result in store.search("vendoring", session_id="sess1", limit=50, sort="relevance")[:5]]
+
+        assert top_5 == top_50
+
+    def test_search_relevance_prefers_assistant_over_tool_on_similar_match(self, store):
+        assistant_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "plugin-only support should stay external and generic",
+            },
+        )
+        tool_id = store.append(
+            "sess1",
+            {
+                "role": "tool",
+                "content": "plugin-only support should stay external and generic",
+            },
+        )
+
+        results = store.search("plugin-only", session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == assistant_id
+        assert results[1]["store_id"] == tool_id
+
+    def test_search_relevance_still_returns_tool_when_it_is_only_real_hit(self, store):
+        tool_id = store.append(
+            "sess1",
+            {
+                "role": "tool",
+                "content": '{"verdict":"tool-only hit about vendoring boundaries"}',
+            },
+        )
+
+        results = store.search("tool-only", session_id="sess1", limit=2, sort="relevance")
+
+        assert len(results) == 1
+        assert results[0]["store_id"] == tool_id
+
+    def test_search_relevance_prefers_direct_hit_over_repetition_spam_for_single_term_query(self, store):
+        spam_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "query audit notes: vendoring vendoring vendoring vendoring vendoring",
+            },
+        )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring out of hermes-agent.",
+            },
+        )
+
+        results = store.search("vendoring", session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == direct_id
+        assert results[1]["store_id"] == spam_id
+
+    def test_search_relevance_still_surfaces_direct_phrase_hit_when_phrase_matches_many_spammy_candidates(self, store):
+        for _ in range(150):
+            store.append(
+                "sess1",
+                {
+                    "role": "assistant",
+                    "content": 'vendoring external vendoring external vendoring external spam note',
+                },
+            )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring external support plugin-only.",
+            },
+        )
+
+        results = store.search('"vendoring external"', session_id="sess1", limit=5, sort="relevance")
+
+        assert direct_id in [result["store_id"] for result in results]
+
+    def test_search_relevance_prefers_direct_phrase_hit_over_repeated_phrase_with_varied_filler(self, store):
+        spam_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "vendoring external rollout checklist vendoring external support matrix vendoring external adapter notes",
+            },
+        )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring external support plugin-only.",
+            },
+        )
+
+        results = store.search('"vendoring external"', session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == direct_id
+        assert results[1]["store_id"] == spam_id
+
+    def test_search_relevance_prefers_direct_phrase_hit_over_repeated_phrase_with_richer_filler(self, store):
+        spam_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "vendoring external rollout checklist vendoring external support matrix vendoring external adapter integration notes",
+            },
+        )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring external support plugin-only.",
+            },
+        )
+
+        results = store.search('"vendoring external"', session_id="sess1", limit=2, sort="relevance")
+
+        assert results[0]["store_id"] == direct_id
+        assert results[1]["store_id"] == spam_id
+
+    def test_search_relevance_still_surfaces_direct_phrase_hit_when_phrase_plus_extra_term_matches_many_spammy_candidates(self, store):
+        for idx in range(25):
+            store.append(
+                "sess1",
+                {
+                    "role": "assistant",
+                    "content": f"vendoring external plugin rollout {idx} vendoring external plugin support {idx}",
+                },
+            )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring external plugin support simple.",
+            },
+        )
+
+        results = store.search('"vendoring external" plugin', session_id="sess1", limit=5, sort="relevance")
+
+        assert direct_id in [result["store_id"] for result in results]
+        assert results[0]["store_id"] == direct_id
+
+    def test_search_relevance_prefers_direct_phrase_hit_over_repeated_non_phrase_term_spam(self, store):
+        for idx in range(30):
+            store.append(
+                "sess1",
+                {
+                    "role": "assistant",
+                    "content": f"vendoring external plugin plugin plugin plugin {idx}",
+                },
+            )
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring external plugin support simple.",
+            },
+        )
+
+        results = store.search('"vendoring external" plugin', session_id="sess1", limit=5, sort="relevance")
+
+        assert direct_id in [result["store_id"] for result in results]
+        assert results[0]["store_id"] == direct_id
+
+    def test_search_like_fallback_strips_unmatched_quote_characters(self, store):
+        direct_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "Keep vendoring out of hermes-agent.",
+            },
+        )
+
+        results = store.search('"vendoring', session_id="sess1", limit=5, sort="relevance")
+
+        assert [result["store_id"] for result in results] == [direct_id]
+
+    def test_search_recency_same_timestamp_pool_is_limit_stable(self, store):
+        ids = store.append_batch(
+            "sess1",
+            [
+                {
+                    "role": "assistant",
+                    "content": f"alpha alpha alpha beta beta gamma gamma gamma spam {idx}",
+                }
+                for idx in range(120)
+            ] + [
+                {
+                    "role": "assistant",
+                    "content": "keep alpha beta gamma concise",
+                }
+            ],
+        )
+        timestamp = store.get(ids[0])["timestamp"]
+
+        short_results = store.search("alpha beta gamma", session_id="sess1", limit=5, sort="recency")
+        long_results = store.search("alpha beta gamma", session_id="sess1", limit=200, sort="recency")
+
+        assert [result["timestamp"] for result in short_results] == [timestamp] * len(short_results)
+        assert [result["store_id"] for result in short_results] == [result["store_id"] for result in long_results[:5]]
+
+    def test_search_hybrid_clamps_future_timestamps_consistently(self, store):
+        now = time.time()
+        future = now + (60 * 24 * 3600)
+        current_ids = [
+            store.append(
+                "sess1",
+                {"role": "assistant", "content": "vendoring external"},
+            )
+            for _ in range(20)
+        ]
+        future_id = store.append(
+            "sess1",
+            {"role": "assistant", "content": "vendoring external"},
+        )
+        for current_id in current_ids:
+            store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (now, current_id))
+        store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (future, future_id))
+        store._conn.commit()
+
+        results = store.search("vendoring external", session_id="sess1", limit=1, sort="hybrid")
+
+        assert [result["store_id"] for result in results] == [future_id]
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)
@@ -834,7 +1147,7 @@ class TestSummaryDAG:
             session_id="s1", depth=0,
             summary="error handling checklist error handling checklist error handling checklist with confirmed fixes",
             token_count=18, source_ids=[1], source_type="messages",
-            created_at=1_900_000_000,
+            created_at=1_700_000_000,
             earliest_at=1_700_000_000,
             latest_at=1_700_000_000,
         ))
@@ -842,9 +1155,9 @@ class TestSummaryDAG:
             session_id="s1", depth=0,
             summary="recent note mentioning the error handling checklist",
             token_count=9, source_ids=[2], source_type="messages",
-            created_at=1_800_000_000,
-            earliest_at=1_800_000_000,
-            latest_at=1_800_000_000,
+            created_at=1_700_086_400,
+            earliest_at=1_700_086_400,
+            latest_at=1_700_086_400,
         ))
 
         recency_results = dag.search(
@@ -934,6 +1247,231 @@ class TestSummaryDAG:
 
         assert len(results) == 1
         assert results[0].node_id == target
+
+    def test_search_hybrid_clamps_future_timestamps_consistently(self, dag):
+        now = time.time()
+        future = now + (60 * 24 * 3600)
+        future_node = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring",
+            token_count=10, source_ids=[3001], source_type="messages",
+            created_at=future,
+            earliest_at=future,
+            latest_at=future,
+        ))
+        current_node = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring",
+            token_count=10, source_ids=[3002], source_type="messages",
+            created_at=now,
+            earliest_at=now,
+            latest_at=now,
+        ))
+
+        results = dag.search("vendoring", session_id="s1", limit=2, sort="hybrid")
+
+        assert [node.node_id for node in results] == [future_node, current_node]
+
+    def test_search_relevance_prefers_direct_summary_hit_over_repetition_spam_for_single_term_query(self, dag):
+        spammy = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Summary notes: vendoring vendoring vendoring vendoring vendoring",
+            token_count=10, source_ids=[1], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring out of hermes-agent.",
+            token_count=10, source_ids=[2], source_type="messages",
+            created_at=1_699_999_000,
+            earliest_at=1_699_999_000,
+            latest_at=1_699_999_000,
+        ))
+
+        results = dag.search("vendoring", session_id="s1", limit=2, sort="relevance")
+
+        assert results[0].node_id == direct
+        assert results[1].node_id == spammy
+
+    def test_search_relevance_still_surfaces_direct_summary_when_single_term_matches_many_spammy_candidates(self, dag):
+        for idx in range(150):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"Summary spam {idx}: vendoring vendoring vendoring vendoring vendoring",
+                token_count=10, source_ids=[idx + 1], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring out of hermes-agent.",
+            token_count=10, source_ids=[999], source_type="messages",
+            created_at=1_699_999_000,
+            earliest_at=1_699_999_000,
+            latest_at=1_699_999_000,
+        ))
+
+        results = dag.search("vendoring", session_id="s1", limit=5, sort="relevance")
+
+        assert [node.node_id for node in results[:1]] == [direct]
+        assert direct in [node.node_id for node in results]
+
+    def test_search_relevance_prefers_direct_summary_over_risky_ascii_repetition_spam_in_like_fallback(self, dag):
+        spammy = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="plugin-only plugin-only plugin-only plugin-only status dump",
+            token_count=10, source_ids=[1001], source_type="messages",
+            created_at=1_700_000_100,
+            earliest_at=1_700_000_100,
+            latest_at=1_700_000_100,
+        ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep plugin-only support external.",
+            token_count=10, source_ids=[1002], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+
+        results = dag.search("plugin-only", session_id="s1", limit=2, sort="relevance")
+
+        assert results[0].node_id == direct
+        assert results[1].node_id == spammy
+
+    def test_search_relevance_still_surfaces_direct_phrase_summary_when_phrase_matches_many_spammy_candidates(self, dag):
+        for idx in range(150):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"Summary spam {idx}: vendoring external vendoring external vendoring external status",
+                token_count=10, source_ids=[2000 + idx], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring external support plugin-only.",
+            token_count=10, source_ids=[9999], source_type="messages",
+            created_at=1_699_999_000,
+            earliest_at=1_699_999_000,
+            latest_at=1_699_999_000,
+        ))
+
+        results = dag.search('"vendoring external"', session_id="s1", limit=5, sort="relevance")
+
+        assert direct in [node.node_id for node in results]
+
+    def test_search_relevance_prefers_direct_phrase_summary_over_repeated_phrase_with_varied_filler(self, dag):
+        spammy = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring external rollout checklist vendoring external support matrix vendoring external adapter notes",
+            token_count=10, source_ids=[4001], source_type="messages",
+            created_at=1_700_000_100,
+            earliest_at=1_700_000_100,
+            latest_at=1_700_000_100,
+        ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring external support plugin-only.",
+            token_count=10, source_ids=[4002], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+
+        results = dag.search('"vendoring external"', session_id="s1", limit=2, sort="relevance")
+
+        assert results[0].node_id == direct
+        assert results[1].node_id == spammy
+
+    def test_search_relevance_prefers_direct_phrase_summary_over_repeated_phrase_with_richer_filler(self, dag):
+        spammy = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring external rollout checklist vendoring external support matrix vendoring external adapter integration notes",
+            token_count=10, source_ids=[4011], source_type="messages",
+            created_at=1_700_000_100,
+            earliest_at=1_700_000_100,
+            latest_at=1_700_000_100,
+        ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring external support plugin-only.",
+            token_count=10, source_ids=[4012], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+
+        results = dag.search('"vendoring external"', session_id="s1", limit=2, sort="relevance")
+
+        assert results[0].node_id == direct
+        assert results[1].node_id == spammy
+
+    def test_search_relevance_still_surfaces_direct_phrase_summary_when_phrase_plus_extra_term_matches_many_spammy_candidates(self, dag):
+        for idx in range(25):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"vendoring external plugin rollout {idx} vendoring external plugin support {idx}",
+                token_count=10, source_ids=[5000 + idx], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring external plugin support simple.",
+            token_count=10, source_ids=[5999], source_type="messages",
+            created_at=1_699_999_000,
+            earliest_at=1_699_999_000,
+            latest_at=1_699_999_000,
+        ))
+
+        results = dag.search('"vendoring external" plugin', session_id="s1", limit=5, sort="relevance")
+
+        assert direct in [node.node_id for node in results]
+        assert results[0].node_id == direct
+
+    def test_search_relevance_prefers_direct_phrase_summary_over_repeated_non_phrase_term_spam(self, dag):
+        for idx in range(30):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"vendoring external plugin plugin plugin plugin {idx}",
+                token_count=10, source_ids=[6100 + idx], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring external plugin support simple.",
+            token_count=10, source_ids=[6999], source_type="messages",
+            created_at=1_699_999_000,
+            earliest_at=1_699_999_000,
+            latest_at=1_699_999_000,
+        ))
+
+        results = dag.search('"vendoring external" plugin', session_id="s1", limit=5, sort="relevance")
+
+        assert direct in [node.node_id for node in results]
+        assert results[0].node_id == direct
+
+    def test_search_like_fallback_strips_unmatched_quote_characters_for_summaries(self, dag):
+        direct = dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Keep vendoring out of hermes-agent.",
+            token_count=10, source_ids=[7100], source_type="messages",
+            created_at=1_700_000_000,
+            earliest_at=1_700_000_000,
+            latest_at=1_700_000_000,
+        ))
+
+        results = dag.search('"vendoring', session_id="s1", limit=5, sort="relevance")
+
+        assert [node.node_id for node in results] == [direct]
 
     def test_describe_subtree(self, dag):
         c1 = dag.add_node(SummaryNode(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1602,6 +1602,586 @@ class TestEngineTools:
         assert result["results"][0]["role"] == "user"
         assert result["results"][1]["role"] == "tool"
 
+    def test_handle_grep_relevance_prefers_user_over_newer_assistant_on_similar_match(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "external plugin host support should stay generic"},
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "external plugin host support should stay generic"},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "external plugin host support", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["role"] == "user"
+        assert result["results"][1]["role"] == "assistant"
+
+    def test_handle_grep_relevance_does_not_let_weaker_user_hit_beat_stronger_assistant_hit(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "vendoring blah blah external blah host"},
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "vendoring external host"},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring external host", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "message"
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][1]["type"] == "message"
+        assert result["results"][1]["role"] == "user"
+
+    def test_handle_grep_relevance_still_surfaces_preferred_user_hit_from_large_same_rank_pool(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "vendoring"},
+        )
+        for _ in range(150):
+            engine._store.append(
+                "test-session",
+                {"role": "assistant", "content": "vendoring"},
+            )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 5, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "message"
+        assert result["results"][0]["role"] == "user"
+
+    def test_handle_grep_relevance_prefers_assistant_over_tool_on_similar_match(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "plugin-only support should stay external and generic"},
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "tool", "content": "plugin-only support should stay external and generic"},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "plugin-only", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][1]["role"] == "tool"
+
+    def test_handle_grep_relevance_prefers_direct_hit_over_repetition_spam_for_single_term_query(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "query audit notes: vendoring vendoring vendoring vendoring vendoring"},
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "Keep vendoring out of hermes-agent."},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["snippet"].startswith("Keep >>>vendoring<<< out")
+
+    def test_handle_grep_relevance_prefers_direct_summary_hit_over_repetition_spam_summary(self, engine):
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Summary notes: vendoring vendoring vendoring vendoring vendoring",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Keep vendoring out of hermes-agent.",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[2],
+                source_type="messages",
+                created_at=1_699_999_000,
+                earliest_at=1_699_999_000,
+                latest_at=1_699_999_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Keep vendoring out of hermes-agent")
+
+    def test_handle_grep_relevance_still_surfaces_direct_summary_when_single_term_matches_many_spammy_candidates(self, engine):
+        for idx in range(150):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"Summary spam {idx}: vendoring vendoring vendoring vendoring vendoring",
+                    token_count=10,
+                    source_token_count=20,
+                    source_ids=[idx + 1],
+                    source_type="messages",
+                    created_at=1_700_000_000 + idx,
+                    earliest_at=1_700_000_000 + idx,
+                    latest_at=1_700_000_000 + idx,
+                )
+            )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Keep vendoring out of hermes-agent.",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[999],
+                source_type="messages",
+                created_at=1_699_999_000,
+                earliest_at=1_699_999_000,
+                latest_at=1_699_999_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 5, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Keep vendoring out of hermes-agent")
+
+    def test_handle_grep_relevance_still_surfaces_direct_phrase_summary_when_phrase_matches_many_spammy_candidates(self, engine):
+        for idx in range(150):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"Summary spam {idx}: vendoring external vendoring external vendoring external status",
+                    token_count=10,
+                    source_token_count=20,
+                    source_ids=[3000 + idx],
+                    source_type="messages",
+                    created_at=1_700_000_000 + idx,
+                    earliest_at=1_700_000_000 + idx,
+                    latest_at=1_700_000_000 + idx,
+                )
+            )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Keep vendoring external support plugin-only.",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[9999],
+                source_type="messages",
+                created_at=1_699_999_000,
+                earliest_at=1_699_999_000,
+                latest_at=1_699_999_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": '"vendoring external"', "limit": 5, "sort": "relevance"},
+            )
+        )
+
+        assert any(
+            item["type"] == "summary" and item["snippet"].startswith("Keep vendoring external support")
+            for item in result["results"]
+        )
+
+    def test_handle_grep_relevance_prefers_direct_phrase_summary_over_repeated_phrase_with_varied_filler(self, engine):
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring external rollout checklist vendoring external support matrix vendoring external adapter notes",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[4100],
+                source_type="messages",
+                created_at=1_700_000_100,
+                earliest_at=1_700_000_100,
+                latest_at=1_700_000_100,
+            )
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Keep vendoring external support plugin-only.",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[4101],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": '"vendoring external"', "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Keep vendoring external support")
+
+    def test_handle_grep_relevance_prefers_direct_phrase_summary_over_repeated_phrase_with_richer_filler(self, engine):
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring external rollout checklist vendoring external support matrix vendoring external adapter integration notes",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[4110],
+                source_type="messages",
+                created_at=1_700_000_100,
+                earliest_at=1_700_000_100,
+                latest_at=1_700_000_100,
+            )
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Keep vendoring external support plugin-only.",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[4111],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": '"vendoring external"', "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Keep vendoring external support")
+
+    def test_handle_grep_relevance_unmatched_quote_still_finds_results(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "Keep vendoring out of hermes-agent."},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": '"vendoring', "limit": 5, "sort": "relevance"},
+            )
+        )
+
+        assert result["total_results"] == 1
+        assert result["results"][0]["type"] == "message"
+        assert result["results"][0]["snippet"].startswith("Keep vendoring out")
+
+    def test_handle_grep_recency_same_timestamp_pool_matches_store_ordering(self, engine):
+        ids = engine._store.append_batch(
+            "test-session",
+            [
+                {
+                    "role": "assistant",
+                    "content": f"alpha alpha alpha beta beta gamma gamma gamma spam {idx}",
+                }
+                for idx in range(120)
+            ] + [
+                {
+                    "role": "assistant",
+                    "content": "keep alpha beta gamma concise",
+                }
+            ],
+        )
+
+        store_results = engine._store.search("alpha beta gamma", session_id="test-session", limit=5, sort="recency")
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "alpha beta gamma", "limit": 5, "sort": "recency"},
+            )
+        )
+
+        assert [item["type"] for item in result["results"]] == ["message"] * len(result["results"])
+        assert [item["store_id"] for item in result["results"]] == [hit["store_id"] for hit in store_results]
+
+    def test_handle_grep_hybrid_summary_only_matches_dag_order_for_future_timestamps(self, engine):
+        now = time.time()
+        future = now + (60 * 24 * 3600)
+        future_node = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[8001],
+                source_type="messages",
+                created_at=future,
+                earliest_at=future,
+                latest_at=future,
+            )
+        )
+        current_node = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[8002],
+                source_type="messages",
+                created_at=now,
+                earliest_at=now,
+                latest_at=now,
+            )
+        )
+
+        dag_results = engine._dag.search("vendoring", session_id="test-session", limit=2, sort="hybrid")
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "hybrid"},
+            )
+        )
+
+        assert [node.node_id for node in dag_results] == [future_node, current_node]
+        assert [item["node_id"] for item in result["results"]] == [future_node, current_node]
+
+    def test_handle_grep_hybrid_message_only_clamps_future_timestamps_consistently(self, engine):
+        now = time.time()
+        future = now + (60 * 24 * 3600)
+        current_ids = [
+            engine._store.append(
+                "test-session",
+                {"role": "assistant", "content": "vendoring external"},
+            )
+            for _ in range(20)
+        ]
+        future_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "vendoring external"},
+        )
+        for current_id in current_ids:
+            engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (now, current_id))
+        engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (future, future_id))
+        engine._store._conn.commit()
+
+        store_results = engine._store.search("vendoring external", session_id="test-session", limit=1, sort="hybrid")
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring external", "limit": 1, "sort": "hybrid"},
+            )
+        )
+
+        assert [hit["store_id"] for hit in store_results] == [future_id]
+        assert [item["store_id"] for item in result["results"]] == [future_id]
+
+    def test_handle_grep_relevance_prefers_much_better_summary_over_vague_user_hit(self, engine):
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "vendoring? maybe?"},
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="Summary: keep hermes-lcm external and never vendor it into hermes-agent. generic host support only.",
+                token_count=20,
+                source_token_count=40,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "never vendor hermes-agent", "limit": 2, "sort": "relevance"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Summary: keep hermes-lcm external")
+        assert result["results"][1]["type"] == "message"
+        assert result["results"][1]["role"] == "user"
+
+    def test_handle_grep_hybrid_prefers_much_better_summary_over_vague_recent_user_hit(self, engine):
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "vendoring? maybe?"},
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="Summary: keep hermes-lcm external and never vendor it into hermes-agent. generic host support only.",
+                token_count=20,
+                source_token_count=40,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "never vendor hermes-agent", "limit": 2, "sort": "hybrid"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "summary"
+        assert result["results"][0]["snippet"].startswith("Summary: keep hermes-lcm external")
+        assert result["results"][1]["type"] == "message"
+        assert result["results"][1]["role"] == "user"
+
+    def test_handle_grep_hybrid_does_not_let_weak_summary_beat_stronger_message_hit(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "Keep vendoring out of hermes-agent."},
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring vendoring vendoring vendoring vendoring",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "hybrid"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "message"
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][1]["type"] == "summary"
+
+    def test_handle_grep_recency_preserves_message_ordering_for_same_timestamp_hits(self, engine):
+        ids = engine._store.append_batch(
+            "test-session",
+            [
+                {"role": "user", "content": "vendoring"},
+                {"role": "assistant", "content": "vendoring vendoring vendoring vendoring vendoring"},
+            ],
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id IN (?, ?)",
+            (1_700_000_000, ids[0], ids[1]),
+        )
+        engine._store._conn.commit()
+
+        store_hits = engine._store.search("vendoring", session_id="test-session", limit=2, sort="recency")
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "recency"},
+            )
+        )
+
+        assert [hit["role"] for hit in store_hits] == ["user", "assistant"]
+        assert [item["role"] for item in result["results"]] == ["user", "assistant"]
+
+    def test_handle_grep_recency_prefers_message_over_weaker_summary_at_same_timestamp(self, engine):
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "Keep vendoring external support clean."},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_700_000_000, store_id),
+        )
+        engine._store._conn.commit()
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="vendoring vendoring vendoring",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                earliest_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "vendoring", "limit": 2, "sort": "recency"},
+            )
+        )
+
+        assert result["results"][0]["type"] == "message"
+        assert result["results"][0]["role"] == "user"
+        assert result["results"][1]["type"] == "summary"
+
     def test_handle_describe_overview(self, engine):
         result = json.loads(engine.handle_tool_call("lcm_describe", {}))
         assert "session_id" in result

--- a/tools.py
+++ b/tools.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, TYPE_CHECKING
 if TYPE_CHECKING:
     from .engine import LCMEngine
 
+
 logger = logging.getLogger(__name__)
 
 AGE_DECAY_RATE = 0.001
@@ -20,22 +21,36 @@ def _normalize_search_sort(sort: str | None) -> str:
     return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
 
 
-def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple[float, float, int, int]:
+def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple:
     sort_timestamp = float(result.get("_sort_ts") or 0.0)
     rank = result.get("_sort_rank")
     rank_value = float(rank) if rank is not None else float("inf")
+    directness = float(result.get("_sort_directness") or 0.0)
     type_bias = 0 if result.get("type") == "message" else 1
-    role_bias = 1 if result.get("role") == "tool" else 0
+    role = result.get("role")
+    if role == "user":
+        role_bias = 0
+    elif role == "assistant":
+        role_bias = 1
+    elif role == "tool":
+        role_bias = 2
+    else:
+        role_bias = 1
+
+    effective_directness = directness if result.get("type") == "message" else (directness * 0.8)
 
     if sort == "relevance":
-        return (role_bias, rank_value, -sort_timestamp, type_bias)
+        return (rank_value, -effective_directness, role_bias, -sort_timestamp, type_bias)
 
     if sort == "hybrid":
         age_hours = max(0.0, (time.time() - sort_timestamp) / 3600.0)
         blended = rank_value / (1 + (age_hours * AGE_DECAY_RATE)) if rank is not None else float("inf")
-        return (role_bias, blended, -sort_timestamp, type_bias)
+        summary_override = int(result.get("_hybrid_summary_override") or 0)
+        return (-summary_override, blended, -effective_directness, role_bias, -sort_timestamp, type_bias)
 
-    return (role_bias, -sort_timestamp, rank_value, type_bias)
+    if result.get("type") == "message":
+        return (-sort_timestamp, type_bias, role_bias, rank_value, 0.0, float("inf"))
+    return (-sort_timestamp, type_bias, 0, rank_value, 0.0, role_bias)
 
 
 def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
@@ -179,11 +194,12 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
 
     limit = args.get("limit", 10)
     sort = _normalize_search_sort(args.get("sort"))
+    source_limit = max(limit * 4, limit, 20)
     session_id = engine._session_id
     results = []
 
     try:
-        msg_hits = engine._store.search(query, session_id=session_id, limit=limit, sort=sort)
+        msg_hits = engine._store.search(query, session_id=session_id, limit=source_limit, sort=sort)
         for hit in msg_hits:
             results.append(
                 {
@@ -194,13 +210,14 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
                     "_sort_ts": hit.get("timestamp", 0),
                     "_sort_rank": hit.get("search_rank"),
+                    "_sort_directness": hit.get("_directness_score") or 0.0,
                 }
             )
     except Exception as exc:
         logger.debug("Message search failed: %s", exc)
 
     try:
-        node_hits = engine._dag.search(query, session_id=session_id, limit=limit, sort=sort)
+        node_hits = engine._dag.search(query, session_id=session_id, limit=source_limit, sort=sort)
         for node in node_hits:
             results.append(
                 {
@@ -214,15 +231,27 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "latest_at": node.latest_at,
                     "_sort_ts": node.latest_at or node.created_at,
                     "_sort_rank": node.search_rank,
+                    "_sort_directness": node.search_directness or 0.0,
                 }
             )
     except Exception as exc:
         logger.debug("Node search failed: %s", exc)
 
+    if sort == "hybrid":
+        max_message_directness = max(
+            (float(result.get("_sort_directness") or 0.0) for result in results if result.get("type") == "message"),
+            default=0.0,
+        )
+        for result in results:
+            if result.get("type") == "summary":
+                result["_hybrid_summary_override"] = 1 if float(result.get("_sort_directness") or 0.0) >= (max_message_directness + 8.0) else 0
+
     results.sort(key=lambda result: _combined_result_sort_key(result, sort))
     for result in results:
         result.pop("_sort_ts", None)
         result.pop("_sort_rank", None)
+        result.pop("_sort_directness", None)
+        result.pop("_hybrid_summary_override", None)
     return json.dumps({"query": query, "sort": sort, "total_results": len(results), "results": results[:limit]})
 
 


### PR DESCRIPTION
## Summary
- refine retrieval ranking across raw messages, summaries, and `lcm_grep`
- improve exact-phrase handling, quote fallback behavior, and precise-query candidate widening
- make recency ordering stable/predictable and align hybrid future-timestamp handling across store/dag/tool paths

## What changed
- added directness-based reranking for precise single-term / exact-phrase retrieval without letting repetition spam dominate
- penalized repeated non-phrase filler inside phrase queries
- fixed unmatched-quote fallback so malformed quoted queries still find sensible LIKE matches
- widened precise-query candidate fetching so better direct hits are not truncated out of the first result page
- kept recency ordering boring and consistent instead of letting hidden reranks change top-k behavior
- aligned hybrid future-timestamp handling between message search, summary search, and `lcm_grep`
- expanded regression coverage for phrase spam, mixed message/summary ordering, fallback edge cases, recency stability, and future-timestamp hybrid behavior

## Validation
- `python3 -m pytest tests/ -q`
- `git diff --check`
- `python3 -m compileall -q .`
