### PR TITLE
feat: add lifecycle checkpoint substrate

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, Sequence
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 SQLITE_BUSY_TIMEOUT_MS = 30_000
 
 
@@ -67,6 +67,31 @@ def ensure_migration_state_table(conn: sqlite3.Connection) -> None:
             completed_at REAL NOT NULL
         )
         """
+    )
+
+
+def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_lifecycle_state (
+            conversation_id TEXT PRIMARY KEY,
+            current_session_id TEXT,
+            last_finalized_session_id TEXT,
+            current_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+            last_finalized_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+            current_bound_at REAL,
+            last_finalized_at REAL,
+            last_rollover_at REAL,
+            last_reset_at REAL,
+            updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lcm_lifecycle_current_session ON lcm_lifecycle_state(current_session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lcm_lifecycle_last_finalized_session ON lcm_lifecycle_state(last_finalized_session_id)"
     )
 
 
@@ -198,5 +223,12 @@ def run_versioned_migrations(conn: sqlite3.Connection) -> None:
     if current_version < 2:
         mark_migration_step_complete(conn, "v2_external_content_fts_triggers")
         current_version = 2
+
+    if current_version < 3:
+        ensure_lifecycle_state_table(conn)
+        mark_migration_step_complete(conn, "v3_lifecycle_state")
+        current_version = 3
+    else:
+        ensure_lifecycle_state_table(conn)
 
     set_schema_version(conn, current_version)

--- a/engine.py
+++ b/engine.py
@@ -22,6 +22,7 @@ from .session_patterns import (
     compile_session_patterns,
     matches_session_pattern,
 )
+from .lifecycle_state import LifecycleStateStore
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
@@ -58,9 +59,11 @@ class LCMEngine(ContextEngine):
 
         self._store = MessageStore(db_path)
         self._dag = SummaryDAG(db_path)
+        self._lifecycle = LifecycleStateStore(db_path)
 
         self._session_id: str = ""
         self._session_platform: str = ""
+        self._conversation_id: str = ""
         self._session_match_keys: list[str] = []
         self._session_ignored = False
         self._session_stateless = False
@@ -357,6 +360,7 @@ class LCMEngine(ContextEngine):
             )
             self._dag.add_node(node)
             self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
+            self._persist_frontier_marker()
 
             working_messages = [working_messages[0]] + remaining_messages
             leaf_compacted_this_turn = True
@@ -436,6 +440,25 @@ class LCMEngine(ContextEngine):
 
     # -- ContextEngine optional methods ------------------------------------
 
+    def _bind_lifecycle_state(
+        self,
+        session_id: str,
+        *,
+        conversation_id: str | None = None,
+    ) -> None:
+        state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
+        self._conversation_id = state.conversation_id
+        self._last_compacted_store_id = state.current_frontier_store_id
+
+    def _persist_frontier_marker(self) -> None:
+        if not self._session_id or not self._conversation_id:
+            return
+        self._lifecycle.advance_frontier(
+            self._conversation_id,
+            self._session_id,
+            self._last_compacted_store_id,
+        )
+
     def on_session_start(self, session_id: str, **kwargs) -> None:
         self._session_id = session_id
         self._session_platform = str(kwargs.get("platform") or "")
@@ -452,14 +475,24 @@ class LCMEngine(ContextEngine):
             self.threshold_tokens = int(
                 self.context_length * self._config.context_threshold
             )
+        self._bind_lifecycle_state(
+            session_id,
+            conversation_id=kwargs.get("conversation_id"),
+        )
         self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         # Ensure all messages are persisted
         self._ingest_messages(messages)
+        self._lifecycle.finalize_session(
+            self._conversation_id,
+            session_id,
+            frontier_store_id=self._last_compacted_store_id,
+        )
 
     def on_session_reset(self) -> None:
         super().on_session_reset()
+        self._lifecycle.record_reset(self._conversation_id)
         self._last_compacted_store_id = 0
         self._ingest_cursor = 0
         self._context_probed = False
@@ -508,12 +541,13 @@ class LCMEngine(ContextEngine):
         4. optionally move retained summaries into the new session
         """
         previous_messages = previous_messages or []
+        conversation_id = self._conversation_id or old_session_id or new_session_id
 
         if old_session_id:
             self.on_session_end(old_session_id, previous_messages)
             self.on_session_reset()
 
-        self.on_session_start(new_session_id, **kwargs)
+        self.on_session_start(new_session_id, conversation_id=conversation_id, **kwargs)
 
         if not carry_over_context:
             return 0
@@ -547,6 +581,7 @@ class LCMEngine(ContextEngine):
 
     def get_status(self) -> Dict[str, Any]:
         status = super().get_status()
+        lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
         if self._session_id:
             status["engine"] = "lcm"
             status["store_messages"] = self._store.get_session_count(self._session_id)
@@ -560,6 +595,20 @@ class LCMEngine(ContextEngine):
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
+            status["conversation_id"] = self._conversation_id
+            if lifecycle_state is not None:
+                status["lifecycle"] = {
+                    "conversation_id": lifecycle_state.conversation_id,
+                    "current_session_id": lifecycle_state.current_session_id,
+                    "last_finalized_session_id": lifecycle_state.last_finalized_session_id,
+                    "current_frontier_store_id": lifecycle_state.current_frontier_store_id,
+                    "last_finalized_frontier_store_id": lifecycle_state.last_finalized_frontier_store_id,
+                    "current_bound_at": lifecycle_state.current_bound_at,
+                    "last_finalized_at": lifecycle_state.last_finalized_at,
+                    "last_rollover_at": lifecycle_state.last_rollover_at,
+                    "last_reset_at": lifecycle_state.last_reset_at,
+                    "updated_at": lifecycle_state.updated_at,
+                }
         return status
 
     def update_model(self, model: str, context_length: int,

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -1,0 +1,338 @@
+"""Durable lifecycle/checkpoint state for hermes-lcm.
+
+This is the smallest viable substrate for cross-turn/session lifecycle state:
+- which logical conversation a session belongs to
+- which session is currently bound
+- which session was last finalized
+- the active session frontier/checkpoint marker
+- the last finalized frontier marker
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .db_bootstrap import configure_connection, run_versioned_migrations
+
+
+@dataclass
+class LifecycleState:
+    conversation_id: str
+    current_session_id: str | None
+    last_finalized_session_id: str | None
+    current_frontier_store_id: int
+    last_finalized_frontier_store_id: int
+    current_bound_at: float | None
+    last_finalized_at: float | None
+    last_rollover_at: float | None
+    last_reset_at: float | None
+    updated_at: float
+
+
+class LifecycleStateStore:
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._conn = sqlite3.connect(
+            str(self.db_path),
+            timeout=30.0,
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        configure_connection(self._conn)
+        self._conn.row_factory = sqlite3.Row
+        run_versioned_migrations(self._conn)
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def row_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS count FROM lcm_lifecycle_state").fetchone()
+        return int(row["count"] if row else 0)
+
+    def _row_to_state(self, row: sqlite3.Row | None) -> LifecycleState | None:
+        if row is None:
+            return None
+        return LifecycleState(
+            conversation_id=row["conversation_id"],
+            current_session_id=row["current_session_id"],
+            last_finalized_session_id=row["last_finalized_session_id"],
+            current_frontier_store_id=int(row["current_frontier_store_id"] or 0),
+            last_finalized_frontier_store_id=int(row["last_finalized_frontier_store_id"] or 0),
+            current_bound_at=row["current_bound_at"],
+            last_finalized_at=row["last_finalized_at"],
+            last_rollover_at=row["last_rollover_at"],
+            last_reset_at=row["last_reset_at"],
+            updated_at=float(row["updated_at"] or 0.0),
+        )
+
+    def get_by_conversation(self, conversation_id: str | None) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        row = self._conn.execute(
+            "SELECT * FROM lcm_lifecycle_state WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        return self._row_to_state(row)
+
+    def get_by_session(self, session_id: str | None) -> LifecycleState | None:
+        if not session_id:
+            return None
+        row = self._conn.execute(
+            """
+            SELECT *
+            FROM lcm_lifecycle_state
+            WHERE current_session_id = ? OR last_finalized_session_id = ?
+            ORDER BY CASE WHEN current_session_id = ? THEN 0 ELSE 1 END, updated_at DESC
+            LIMIT 1
+            """,
+            (session_id, session_id, session_id),
+        ).fetchone()
+        return self._row_to_state(row)
+
+    def bind_session(
+        self,
+        session_id: str,
+        *,
+        conversation_id: str | None = None,
+    ) -> LifecycleState:
+        existing = self.get_by_conversation(conversation_id) if conversation_id else self.get_by_session(session_id)
+        conversation_id = conversation_id or (existing.conversation_id if existing else session_id)
+        now = time.time()
+        current_frontier = 0
+        current_bound_at = now
+        last_finalized_session_id = None
+        last_finalized_frontier = 0
+        last_finalized_at = None
+        last_rollover_at = None
+        last_reset_at = None
+
+        if existing is not None:
+            if existing.current_session_id == session_id:
+                return existing
+            current_frontier = (
+                existing.current_frontier_store_id if existing.current_session_id == session_id else 0
+            )
+            current_bound_at = (
+                existing.current_bound_at if existing.current_session_id == session_id else now
+            )
+            last_finalized_session_id = existing.last_finalized_session_id
+            last_finalized_frontier = existing.last_finalized_frontier_store_id
+            last_finalized_at = existing.last_finalized_at
+            last_rollover_at = (
+                now
+                if (
+                    (existing.current_session_id and existing.current_session_id != session_id)
+                    or (
+                        existing.current_session_id is None
+                        and existing.last_finalized_session_id
+                        and existing.last_finalized_session_id != session_id
+                    )
+                )
+                else existing.last_rollover_at
+            )
+            last_reset_at = existing.last_reset_at
+
+        self._conn.execute(
+            """
+            INSERT INTO lcm_lifecycle_state(
+                conversation_id,
+                current_session_id,
+                last_finalized_session_id,
+                current_frontier_store_id,
+                last_finalized_frontier_store_id,
+                current_bound_at,
+                last_finalized_at,
+                last_rollover_at,
+                last_reset_at,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(conversation_id) DO UPDATE SET
+                current_session_id = excluded.current_session_id,
+                last_finalized_session_id = excluded.last_finalized_session_id,
+                current_frontier_store_id = excluded.current_frontier_store_id,
+                last_finalized_frontier_store_id = excluded.last_finalized_frontier_store_id,
+                current_bound_at = excluded.current_bound_at,
+                last_finalized_at = excluded.last_finalized_at,
+                last_rollover_at = excluded.last_rollover_at,
+                last_reset_at = excluded.last_reset_at,
+                updated_at = excluded.updated_at
+            """,
+            (
+                conversation_id,
+                session_id,
+                last_finalized_session_id,
+                current_frontier,
+                last_finalized_frontier,
+                current_bound_at,
+                last_finalized_at,
+                last_rollover_at,
+                last_reset_at,
+                now,
+            ),
+        )
+        self._conn.commit()
+        state = self.get_by_conversation(conversation_id)
+        assert state is not None
+        return state
+
+    def finalize_session(
+        self,
+        conversation_id: str | None,
+        session_id: str,
+        frontier_store_id: int = 0,
+    ) -> LifecycleState | None:
+        state = self.get_by_conversation(conversation_id)
+        if state is None:
+            return None
+        now = time.time()
+        current_session_id = state.current_session_id
+        current_frontier = state.current_frontier_store_id
+        if current_session_id == session_id:
+            current_session_id = None
+            current_frontier = 0
+        finalized_frontier = max(
+            int(frontier_store_id or 0),
+            state.last_finalized_frontier_store_id,
+        )
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET current_session_id = ?,
+                last_finalized_session_id = ?,
+                current_frontier_store_id = ?,
+                last_finalized_frontier_store_id = ?,
+                last_finalized_at = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (
+                current_session_id,
+                session_id,
+                current_frontier,
+                finalized_frontier,
+                now,
+                now,
+                state.conversation_id,
+            ),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(state.conversation_id)
+
+    def record_rollover(
+        self,
+        conversation_id: str,
+        *,
+        old_session_id: str,
+        new_session_id: str,
+        finalized_frontier_store_id: int = 0,
+    ) -> LifecycleState:
+        state = self.get_by_conversation(conversation_id)
+        if (
+            state is not None
+            and state.current_session_id == new_session_id
+            and state.last_finalized_session_id == old_session_id
+        ):
+            return state
+
+        now = time.time()
+        last_finalized_frontier = max(
+            int(finalized_frontier_store_id or 0),
+            state.last_finalized_frontier_store_id if state else 0,
+        )
+        self._conn.execute(
+            """
+            INSERT INTO lcm_lifecycle_state(
+                conversation_id,
+                current_session_id,
+                last_finalized_session_id,
+                current_frontier_store_id,
+                last_finalized_frontier_store_id,
+                current_bound_at,
+                last_finalized_at,
+                last_rollover_at,
+                last_reset_at,
+                updated_at
+            ) VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(conversation_id) DO UPDATE SET
+                current_session_id = excluded.current_session_id,
+                last_finalized_session_id = excluded.last_finalized_session_id,
+                current_frontier_store_id = 0,
+                last_finalized_frontier_store_id = excluded.last_finalized_frontier_store_id,
+                current_bound_at = excluded.current_bound_at,
+                last_finalized_at = excluded.last_finalized_at,
+                last_rollover_at = excluded.last_rollover_at,
+                last_reset_at = excluded.last_reset_at,
+                updated_at = excluded.updated_at
+            """,
+            (
+                conversation_id,
+                new_session_id,
+                old_session_id,
+                last_finalized_frontier,
+                now,
+                now,
+                now,
+                now,
+                now,
+            ),
+        )
+        self._conn.commit()
+        updated = self.get_by_conversation(conversation_id)
+        assert updated is not None
+        return updated
+
+    def record_reset(self, conversation_id: str | None) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None:
+            return None
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET last_reset_at = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (now, now, conversation_id),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(conversation_id)
+
+    def advance_frontier(
+        self,
+        conversation_id: str | None,
+        session_id: str,
+        frontier_store_id: int,
+    ) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None or state.current_session_id != session_id:
+            return state
+        frontier = max(int(frontier_store_id or 0), state.current_frontier_store_id)
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET current_frontier_store_id = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (frontier, now, conversation_id),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(conversation_id)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -12,6 +12,7 @@ from hermes_lcm.tokens import count_tokens, count_message_tokens, count_messages
 from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG, SummaryNode
 from hermes_lcm.escalation import _deterministic_truncate
+from hermes_lcm.lifecycle_state import LifecycleStateStore
 from hermes_lcm.session_patterns import (
     build_session_match_keys,
     compile_session_pattern,
@@ -211,7 +212,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("2",)
+        assert version == ("3",)
 
         results = store.search("docker", session_id="sess1")
         assert len(results) == 1
@@ -260,7 +261,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("2",)
+        assert version == ("3",)
 
         migration_state = store._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
@@ -540,6 +541,55 @@ class TestMessageStore:
         assert len(msg["tool_calls"]) == 1
 
 
+class TestLifecycleStateStore:
+    def test_init_creates_lifecycle_state_table(self, tmp_path):
+        state = LifecycleStateStore(tmp_path / "lifecycle.db")
+
+        tables = {
+            row[0]
+            for row in state._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='lcm_lifecycle_state'"
+            ).fetchall()
+        }
+        assert tables == {"lcm_lifecycle_state"}
+        assert state.get_by_session("missing") is None
+
+        state.close()
+
+    def test_init_upgrades_legacy_db_and_keeps_missing_state_safe(self, tmp_path):
+        db_path = tmp_path / "legacy-lifecycle.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '2');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        state = LifecycleStateStore(db_path)
+
+        version = state._conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()[0]
+        assert version == "3"
+
+        tables = {
+            row[0]
+            for row in state._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='lcm_lifecycle_state'"
+            ).fetchall()
+        }
+        assert tables == {"lcm_lifecycle_state"}
+        assert state.get_by_session("unknown-session") is None
+
+        state.close()
+
+
 class TestSummaryDAG:
     @pytest.fixture
     def dag(self, tmp_path):
@@ -635,7 +685,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("2",)
+        assert version == ("3",)
 
         results = dag.search("docker", session_id="s1")
         assert len(results) == 1
@@ -687,7 +737,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("2",)
+        assert version == ("3",)
 
         migration_state = dag._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5,6 +5,8 @@ import logging
 import time
 import pytest
 
+import hermes_lcm.engine as lcm_engine
+
 from agent.context_engine import ContextEngine
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
@@ -1029,6 +1031,143 @@ class TestSessionRollover:
         assert sorted(node.summary for node in s3_nodes) == ["fresh d2", "seed d2", "seed d3"]
         assert engine._dag.get_session_nodes("s2") == []
         assert engine._session_id == "s3"
+
+    def test_rollover_session_records_durable_lifecycle_state_idempotently(self, engine):
+        engine._config.new_session_retain_depth = 2
+        from hermes_lcm.dag import SummaryNode
+        import time
+
+        engine.on_session_start("s1", platform="cli", context_length=200000)
+        for depth in range(3):
+            engine._dag.add_node(SummaryNode(
+                session_id="s1", depth=depth,
+                summary=f"seed d{depth}", token_count=100,
+                source_token_count=500, source_ids=[],
+                source_type="messages", created_at=time.time(),
+            ))
+
+        moved = engine.rollover_session("s1", "s2", previous_messages=[], platform="cli", context_length=200000)
+        assert moved == 1
+
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state is not None
+        assert state.current_session_id == "s2"
+        assert state.last_finalized_session_id == "s1"
+
+        moved_repeat = engine.rollover_session("s1", "s2", previous_messages=[], platform="cli", context_length=200000)
+        assert moved_repeat == 0
+
+        state_repeat = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state_repeat is not None
+        assert state_repeat.current_session_id == "s2"
+        assert state_repeat.last_finalized_session_id == "s1"
+        assert engine._lifecycle.row_count() == 1
+
+    def test_on_session_start_recovers_durable_lifecycle_state_after_restart(self, engine, monkeypatch):
+        engine.on_session_start("active-session", platform="cli", context_length=200000)
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("durable summary", 1),
+        )
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "alpha " * 80},
+            {"role": "assistant", "content": "beta " * 80},
+            {"role": "user", "content": "gamma " * 80},
+            {"role": "assistant", "content": "delta " * 80},
+            {"role": "user", "content": "epsilon " * 80},
+            {"role": "assistant", "content": "zeta"},
+        ]
+        engine.compress(messages)
+        old_conversation_id = engine._conversation_id
+        old_frontier = engine._last_compacted_store_id
+        assert old_frontier > 0
+
+        restarted = LCMEngine(config=engine._config)
+        restarted.on_session_start("active-session", platform="cli", context_length=200000)
+
+        assert restarted._conversation_id == old_conversation_id
+        assert restarted._last_compacted_store_id == old_frontier
+        recovered = restarted._lifecycle.get_by_conversation(old_conversation_id)
+        assert recovered is not None
+        assert recovered.current_session_id == "active-session"
+
+    def test_frontier_marker_only_advances_after_successful_leaf_compaction(self, engine, monkeypatch):
+        engine.on_session_start("frontier-session", platform="cli", context_length=200000)
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("frontier summary", 1),
+        )
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "alpha " * 80},
+            {"role": "assistant", "content": "beta " * 80},
+            {"role": "user", "content": "gamma " * 80},
+            {"role": "assistant", "content": "delta " * 80},
+            {"role": "user", "content": "epsilon " * 80},
+            {"role": "assistant", "content": "zeta"},
+        ]
+        engine.compress(messages)
+
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state is not None
+        assert state.current_frontier_store_id == engine._last_compacted_store_id
+        frontier_before_failure = state.current_frontier_store_id
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (_ for _ in ()).throw(TimeoutError("summary timed out")),
+        )
+        failing_messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "epsilon " * 80},
+            {"role": "assistant", "content": "zeta " * 80},
+            {"role": "user", "content": "eta " * 80},
+            {"role": "assistant", "content": "theta " * 80},
+            {"role": "user", "content": "iota " * 80},
+            {"role": "assistant", "content": "kappa"},
+        ]
+        with pytest.raises(TimeoutError):
+            engine.compress(failing_messages)
+
+        after_failure = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert after_failure is not None
+        assert after_failure.current_frontier_store_id == frontier_before_failure
+
+    def test_rollover_resets_active_frontier_but_preserves_last_finalized_frontier(self, engine, monkeypatch):
+        engine.on_session_start("frontier-old", platform="cli", context_length=200000)
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("rollover summary", 1),
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "alpha " * 80},
+            {"role": "assistant", "content": "beta " * 80},
+            {"role": "user", "content": "gamma " * 80},
+            {"role": "assistant", "content": "delta " * 80},
+            {"role": "user", "content": "epsilon " * 80},
+            {"role": "assistant", "content": "zeta"},
+        ]
+        engine.compress(messages)
+        old_frontier = engine._last_compacted_store_id
+
+        engine.rollover_session("frontier-old", "frontier-new", previous_messages=[], platform="cli", context_length=200000)
+
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state is not None
+        assert state.current_session_id == "frontier-new"
+        assert state.current_frontier_store_id == 0
+        assert state.last_finalized_session_id == "frontier-old"
+        assert state.last_finalized_frontier_store_id == old_frontier
+        assert state.last_rollover_at is not None
+        assert state.last_reset_at is not None
 
 
 class TestUnlimitedCondensationDepth:


### PR DESCRIPTION
## Summary
- add a small durable lifecycle state store for session/conversation binding
- persist active and finalized frontier markers across rollover/rebind boundaries
- expose lifecycle metadata in engine status for inspection/debugging
- add regression coverage for bootstrap, rollover idempotence, frontier persistence, and restart recovery

## Why
Right now most lifecycle/checkpoint knowledge only exists in memory. That makes `/new`-style rollover and restart/rebind behavior harder to reason about, and it leaves no durable substrate for later maintenance/debt work.

This keeps the design deliberately small:
- one `lcm_lifecycle_state` table
- no transcript import/replay architecture
- no operator apply flows yet

## Validation
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q` → `123 passed`
- `python3 -m pytest tests/ -q` → `136 passed`
- `python3 -m compileall -q .`
- `git diff --check`
- host/runtime dogfood against the real plugin path confirmed:
  - active frontier persists after compaction
  - rollover moves it into `last_finalized_frontier_store_id`
  - restart/rebind recovers the same lifecycle state
