### PR TITLE
feat: add deferred maintenance debt catch-up

### DIFF
--- a/config.py
+++ b/config.py
@@ -65,6 +65,12 @@ class LCMConfig:
     # Minimum number of same-depth fanin groups before one follow-on
     # condensation pass is allowed in cache-friendly mode
     cache_friendly_min_debt_groups: int = 2
+    # When enabled, turns can persist raw-backlog maintenance debt and use
+    # later bounded catch-up passes to reduce it.
+    deferred_maintenance_enabled: bool = False
+    # Maximum extra leaf passes a debt-triggered later turn may spend on
+    # catch-up work.
+    deferred_maintenance_max_passes: int = 4
 
     # -- Escalation ---
     # L2 bullet budget as fraction of L1
@@ -139,6 +145,14 @@ class LCMConfig:
         c.cache_friendly_min_debt_groups = _int(
             "LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS",
             c.cache_friendly_min_debt_groups,
+        )
+        c.deferred_maintenance_enabled = _parse_bool_env(
+            "LCM_DEFERRED_MAINTENANCE_ENABLED",
+            c.deferred_maintenance_enabled,
+        )
+        c.deferred_maintenance_max_passes = _int(
+            "LCM_DEFERRED_MAINTENANCE_MAX_PASSES",
+            c.deferred_maintenance_max_passes,
         )
         c.l2_budget_ratio = _float("LCM_L2_BUDGET_RATIO", c.l2_budget_ratio)
         c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, Sequence
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 SQLITE_BUSY_TIMEOUT_MS = 30_000
 
 
@@ -79,8 +79,12 @@ def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
             last_finalized_session_id TEXT,
             current_frontier_store_id INTEGER NOT NULL DEFAULT 0,
             last_finalized_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+            debt_kind TEXT,
+            debt_size_estimate INTEGER NOT NULL DEFAULT 0,
             current_bound_at REAL,
             last_finalized_at REAL,
+            debt_updated_at REAL,
+            last_maintenance_attempt_at REAL,
             last_rollover_at REAL,
             last_reset_at REAL,
             updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))
@@ -93,6 +97,25 @@ def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_lcm_lifecycle_last_finalized_session ON lcm_lifecycle_state(last_finalized_session_id)"
     )
+
+
+def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
+    ensure_lifecycle_state_table(conn)
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(lcm_lifecycle_state)").fetchall()
+    }
+    if "debt_kind" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_kind TEXT")
+    if "debt_size_estimate" not in columns:
+        conn.execute(
+            "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_size_estimate INTEGER NOT NULL DEFAULT 0"
+        )
+    if "debt_updated_at" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_updated_at REAL")
+    if "last_maintenance_attempt_at" not in columns:
+        conn.execute(
+            "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_maintenance_attempt_at REAL"
+        )
 
 
 def mark_migration_step_complete(conn: sqlite3.Connection, step_name: str) -> None:
@@ -230,5 +253,10 @@ def run_versioned_migrations(conn: sqlite3.Connection) -> None:
         current_version = 3
     else:
         ensure_lifecycle_state_table(conn)
+
+    ensure_lifecycle_state_columns(conn)
+    if current_version < 4:
+        mark_migration_step_complete(conn, "v4_lifecycle_debt_columns")
+        current_version = 4
 
     set_schema_version(conn, current_version)

--- a/engine.py
+++ b/engine.py
@@ -143,7 +143,10 @@ class LCMEngine(ContextEngine):
         rough = count_messages_tokens(messages)
         if self._should_force_overflow_recovery(observed_tokens=rough):
             return True
-        return rough >= self.threshold_tokens
+        if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
+            return True
+        self._refresh_raw_backlog_debt(messages)
+        return self._should_run_deferred_maintenance(messages)
 
     def _working_leaf_chunk_tokens(self, raw_tokens_outside_tail: int) -> int:
         base = max(1, self._config.leaf_chunk_tokens)
@@ -301,7 +304,15 @@ class LCMEngine(ContextEngine):
         working_messages = list(messages)
         leaf_compacted_this_turn = False
         leaf_passes = 0
-        max_leaf_passes = 4 if self._config.dynamic_leaf_chunk_enabled else 1
+        deferred_maintenance_active = (
+            not force_overflow and self._should_run_deferred_maintenance(working_messages)
+        )
+        if deferred_maintenance_active:
+            self._lifecycle.record_maintenance_attempt(self._conversation_id)
+        base_max_leaf_passes = 4 if self._config.dynamic_leaf_chunk_enabled else 1
+        max_leaf_passes = base_max_leaf_passes
+        if deferred_maintenance_active:
+            max_leaf_passes = max(1, self._config.deferred_maintenance_max_passes)
         estimated_active_tokens = (
             observed_prompt_tokens
             if observed_prompt_tokens is not None and observed_prompt_tokens > 0
@@ -378,7 +389,7 @@ class LCMEngine(ContextEngine):
                 break
 
             if not force_overflow:
-                if self.threshold_tokens > 0 and estimated_active_tokens < self.threshold_tokens:
+                if (not deferred_maintenance_active) and self.threshold_tokens > 0 and estimated_active_tokens < self.threshold_tokens:
                     break
                 remaining_raw = working_messages[1:max(0, len(working_messages) - self._config.fresh_tail_count)]
                 if not remaining_raw:
@@ -389,6 +400,7 @@ class LCMEngine(ContextEngine):
                     break
 
         if not leaf_compacted_this_turn:
+            self._refresh_raw_backlog_debt(working_messages)
             if force_overflow and len(messages) >= 1:
                 compressed = self._assemble_overflow_recovery_context(
                     messages[0],
@@ -410,6 +422,7 @@ class LCMEngine(ContextEngine):
         )
 
         # Step 7: Assemble new active context
+        self._refresh_raw_backlog_debt(working_messages)
         compressed = self._assemble_context(
             working_messages[0],
             working_messages[1:],
@@ -465,6 +478,53 @@ class LCMEngine(ContextEngine):
             self._session_id,
             self._last_compacted_store_id,
         )
+
+    def _raw_backlog_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        n = len(messages)
+        fresh_tail_start = max(0, n - self._config.fresh_tail_count)
+        if fresh_tail_start <= 1:
+            return []
+        return messages[1:fresh_tail_start]
+
+    def _raw_backlog_tokens(self, messages: List[Dict[str, Any]]) -> int:
+        backlog = self._raw_backlog_messages(messages)
+        if not backlog:
+            return 0
+        return count_messages_tokens(backlog)
+
+    def _raw_backlog_threshold(self, raw_tokens: int) -> int:
+        if self._config.dynamic_leaf_chunk_enabled:
+            return self._working_leaf_chunk_tokens(raw_tokens)
+        return max(1, self._config.leaf_chunk_tokens)
+
+    def _has_raw_backlog_debt(self) -> bool:
+        if not self._config.deferred_maintenance_enabled or not self._conversation_id:
+            return False
+        state = self._lifecycle.get_by_conversation(self._conversation_id)
+        return bool(state and state.debt_kind == "raw_backlog" and state.debt_size_estimate > 0)
+
+    def _should_run_deferred_maintenance(self, messages: List[Dict[str, Any]]) -> bool:
+        if not self._has_raw_backlog_debt():
+            return False
+        raw_tokens = self._raw_backlog_tokens(messages)
+        if raw_tokens <= 0:
+            return False
+        return raw_tokens >= self._raw_backlog_threshold(raw_tokens)
+
+    def _refresh_raw_backlog_debt(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._config.deferred_maintenance_enabled or not self._conversation_id:
+            return
+        raw_tokens = self._raw_backlog_tokens(messages)
+        threshold = self._raw_backlog_threshold(raw_tokens) if raw_tokens > 0 else 0
+        if raw_tokens > 0 and raw_tokens >= threshold:
+            self._lifecycle.record_debt(
+                self._conversation_id,
+                kind="raw_backlog",
+                size_estimate=raw_tokens,
+            )
+            return
+        if self._has_raw_backlog_debt():
+            self._lifecycle.clear_debt(self._conversation_id)
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         self._session_id = session_id
@@ -610,8 +670,12 @@ class LCMEngine(ContextEngine):
                     "last_finalized_session_id": lifecycle_state.last_finalized_session_id,
                     "current_frontier_store_id": lifecycle_state.current_frontier_store_id,
                     "last_finalized_frontier_store_id": lifecycle_state.last_finalized_frontier_store_id,
+                    "debt_kind": lifecycle_state.debt_kind,
+                    "debt_size_estimate": lifecycle_state.debt_size_estimate,
                     "current_bound_at": lifecycle_state.current_bound_at,
                     "last_finalized_at": lifecycle_state.last_finalized_at,
+                    "debt_updated_at": lifecycle_state.debt_updated_at,
+                    "last_maintenance_attempt_at": lifecycle_state.last_maintenance_attempt_at,
                     "last_rollover_at": lifecycle_state.last_rollover_at,
                     "last_reset_at": lifecycle_state.last_reset_at,
                     "updated_at": lifecycle_state.updated_at,

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -26,8 +26,12 @@ class LifecycleState:
     last_finalized_session_id: str | None
     current_frontier_store_id: int
     last_finalized_frontier_store_id: int
+    debt_kind: str | None
+    debt_size_estimate: int
     current_bound_at: float | None
     last_finalized_at: float | None
+    debt_updated_at: float | None
+    last_maintenance_attempt_at: float | None
     last_rollover_at: float | None
     last_reset_at: float | None
     updated_at: float
@@ -70,8 +74,12 @@ class LifecycleStateStore:
             last_finalized_session_id=row["last_finalized_session_id"],
             current_frontier_store_id=int(row["current_frontier_store_id"] or 0),
             last_finalized_frontier_store_id=int(row["last_finalized_frontier_store_id"] or 0),
+            debt_kind=row["debt_kind"],
+            debt_size_estimate=int(row["debt_size_estimate"] or 0),
             current_bound_at=row["current_bound_at"],
             last_finalized_at=row["last_finalized_at"],
+            debt_updated_at=row["debt_updated_at"],
+            last_maintenance_attempt_at=row["last_maintenance_attempt_at"],
             last_rollover_at=row["last_rollover_at"],
             last_reset_at=row["last_reset_at"],
             updated_at=float(row["updated_at"] or 0.0),
@@ -114,7 +122,11 @@ class LifecycleStateStore:
         current_bound_at = now
         last_finalized_session_id = None
         last_finalized_frontier = 0
+        debt_kind = None
+        debt_size_estimate = 0
         last_finalized_at = None
+        debt_updated_at = None
+        last_maintenance_attempt_at = None
         last_rollover_at = None
         last_reset_at = None
 
@@ -129,7 +141,11 @@ class LifecycleStateStore:
             )
             last_finalized_session_id = existing.last_finalized_session_id
             last_finalized_frontier = existing.last_finalized_frontier_store_id
+            debt_kind = existing.debt_kind
+            debt_size_estimate = existing.debt_size_estimate
             last_finalized_at = existing.last_finalized_at
+            debt_updated_at = existing.debt_updated_at
+            last_maintenance_attempt_at = existing.last_maintenance_attempt_at
             last_rollover_at = (
                 now
                 if (
@@ -152,19 +168,27 @@ class LifecycleStateStore:
                 last_finalized_session_id,
                 current_frontier_store_id,
                 last_finalized_frontier_store_id,
+                debt_kind,
+                debt_size_estimate,
                 current_bound_at,
                 last_finalized_at,
+                debt_updated_at,
+                last_maintenance_attempt_at,
                 last_rollover_at,
                 last_reset_at,
                 updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(conversation_id) DO UPDATE SET
                 current_session_id = excluded.current_session_id,
                 last_finalized_session_id = excluded.last_finalized_session_id,
                 current_frontier_store_id = excluded.current_frontier_store_id,
                 last_finalized_frontier_store_id = excluded.last_finalized_frontier_store_id,
+                debt_kind = excluded.debt_kind,
+                debt_size_estimate = excluded.debt_size_estimate,
                 current_bound_at = excluded.current_bound_at,
                 last_finalized_at = excluded.last_finalized_at,
+                debt_updated_at = excluded.debt_updated_at,
+                last_maintenance_attempt_at = excluded.last_maintenance_attempt_at,
                 last_rollover_at = excluded.last_rollover_at,
                 last_reset_at = excluded.last_reset_at,
                 updated_at = excluded.updated_at
@@ -175,8 +199,12 @@ class LifecycleStateStore:
                 last_finalized_session_id,
                 current_frontier,
                 last_finalized_frontier,
+                debt_kind,
+                debt_size_estimate,
                 current_bound_at,
                 last_finalized_at,
+                debt_updated_at,
+                last_maintenance_attempt_at,
                 last_rollover_at,
                 last_reset_at,
                 now,
@@ -213,6 +241,8 @@ class LifecycleStateStore:
                 last_finalized_session_id = ?,
                 current_frontier_store_id = ?,
                 last_finalized_frontier_store_id = ?,
+                debt_kind = debt_kind,
+                debt_size_estimate = debt_size_estimate,
                 last_finalized_at = ?,
                 updated_at = ?
             WHERE conversation_id = ?
@@ -292,6 +322,73 @@ class LifecycleStateStore:
         updated = self.get_by_conversation(conversation_id)
         assert updated is not None
         return updated
+
+    def record_debt(
+        self,
+        conversation_id: str | None,
+        *,
+        kind: str,
+        size_estimate: int,
+    ) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None:
+            return None
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET debt_kind = ?,
+                debt_size_estimate = ?,
+                debt_updated_at = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (kind, max(0, int(size_estimate or 0)), now, now, conversation_id),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(conversation_id)
+
+    def clear_debt(self, conversation_id: str | None) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None:
+            return None
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET debt_kind = NULL,
+                debt_size_estimate = 0,
+                debt_updated_at = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (now, now, conversation_id),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(conversation_id)
+
+    def record_maintenance_attempt(self, conversation_id: str | None) -> LifecycleState | None:
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None:
+            return None
+        now = time.time()
+        self._conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET last_maintenance_attempt_at = ?,
+                updated_at = ?
+            WHERE conversation_id = ?
+            """,
+            (now, now, conversation_id),
+        )
+        self._conn.commit()
+        return self.get_by_conversation(conversation_id)
 
     def record_reset(self, conversation_id: str | None) -> LifecycleState | None:
         if not conversation_id:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -37,6 +37,8 @@ class TestConfig:
         assert c.extraction_enabled is False
         assert c.extraction_model == ""
         assert c.extraction_output_path == ""
+        assert c.deferred_maintenance_enabled is False
+        assert c.deferred_maintenance_max_passes == 4
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
         assert c.ignore_session_patterns_source == "default"
@@ -225,7 +227,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("3",)
+        assert version == ("4",)
 
         results = store.search("docker", session_id="sess1")
         assert len(results) == 1
@@ -274,12 +276,13 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("3",)
+        assert version == ("4",)
 
         migration_state = store._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
         ).fetchall()
         assert ("v2_external_content_fts_triggers",) in migration_state
+        assert ("v4_lifecycle_debt_columns",) in migration_state
 
         trigger_names = {
             row[0]
@@ -902,7 +905,7 @@ class TestLifecycleStateStore:
         version = state._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()[0]
-        assert version == "3"
+        assert version == "4"
 
         tables = {
             row[0]
@@ -911,7 +914,33 @@ class TestLifecycleStateStore:
             ).fetchall()
         }
         assert tables == {"lcm_lifecycle_state"}
+        columns = {
+            row[1]
+            for row in state._conn.execute("PRAGMA table_info(lcm_lifecycle_state)").fetchall()
+        }
+        assert {"debt_kind", "debt_size_estimate", "debt_updated_at", "last_maintenance_attempt_at"} <= columns
         assert state.get_by_session("unknown-session") is None
+
+        state.close()
+
+    def test_record_debt_and_clear_debt(self, tmp_path):
+        state = LifecycleStateStore(tmp_path / "lifecycle-debt.db")
+        bound = state.bind_session("sess-1")
+
+        updated = state.record_debt(bound.conversation_id, kind="raw_backlog", size_estimate=321)
+        assert updated is not None
+        assert updated.debt_kind == "raw_backlog"
+        assert updated.debt_size_estimate == 321
+        assert updated.debt_updated_at is not None
+
+        attempted = state.record_maintenance_attempt(bound.conversation_id)
+        assert attempted is not None
+        assert attempted.last_maintenance_attempt_at is not None
+
+        cleared = state.clear_debt(bound.conversation_id)
+        assert cleared is not None
+        assert cleared.debt_kind is None
+        assert cleared.debt_size_estimate == 0
 
         state.close()
 
@@ -1011,7 +1040,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("3",)
+        assert version == ("4",)
 
         results = dag.search("docker", session_id="s1")
         assert len(results) == 1
@@ -1063,12 +1092,13 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("3",)
+        assert version == ("4",)
 
         migration_state = dag._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
         ).fetchall()
         assert ("v2_external_content_fts_triggers",) in migration_state
+        assert ("v4_lifecycle_debt_columns",) in migration_state
 
         trigger_names = {
             row[0]

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1170,6 +1170,104 @@ class TestSessionRollover:
         assert state.last_reset_at is not None
 
 
+class TestDeferredMaintenanceDebt:
+    @staticmethod
+    def _make_backlog_messages(count: int = 12) -> list[dict]:
+        messages = [{"role": "system", "content": "sys"}]
+        for i in range(count):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": (f"chunk-{i} " * 220).strip()})
+        return messages
+
+    def test_debt_persists_when_bounded_leaf_passes_leave_raw_backlog(self, engine, monkeypatch):
+        engine._config.dynamic_leaf_chunk_enabled = True
+        engine._config.dynamic_leaf_chunk_max = 100
+        engine._config.leaf_chunk_tokens = 100
+        engine._config.fresh_tail_count = 2
+        engine._config.deferred_maintenance_enabled = True
+        engine._config.deferred_maintenance_max_passes = 1
+        engine.on_session_start("debt-session", platform="cli", context_length=200000)
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", lambda **kwargs: ("debt summary", 1))
+        monkeypatch.setattr(engine, "_working_leaf_chunk_tokens", lambda raw_tokens: 100)
+        monkeypatch.setattr(
+            engine,
+            "_assemble_context",
+            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+        )
+
+        compressed = engine.compress(self._make_backlog_messages())
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+
+        assert state is not None
+        assert state.debt_kind == "raw_backlog"
+        assert state.debt_size_estimate > 0
+        assert engine.should_compress_preflight(compressed) is True
+        refreshed = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert refreshed is not None
+        assert refreshed.debt_kind == "raw_backlog"
+
+    def test_bounded_catchup_reduces_then_clears_debt_only_after_backlog_shrinks(self, engine, monkeypatch):
+        engine._config.dynamic_leaf_chunk_enabled = True
+        engine._config.dynamic_leaf_chunk_max = 100
+        engine._config.leaf_chunk_tokens = 100
+        engine._config.fresh_tail_count = 2
+        engine._config.deferred_maintenance_enabled = True
+        engine.on_session_start("debt-session", platform="cli", context_length=200000)
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", lambda **kwargs: ("debt summary", 1))
+        monkeypatch.setattr(engine, "_working_leaf_chunk_tokens", lambda raw_tokens: 100)
+        monkeypatch.setattr(
+            engine,
+            "_assemble_context",
+            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+        )
+
+        first = engine.compress(self._make_backlog_messages())
+        debt1 = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert debt1 is not None and debt1.debt_kind == "raw_backlog"
+
+        engine._config.deferred_maintenance_max_passes = 1
+        second = engine.compress(first)
+        debt2 = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert debt2 is not None and debt2.debt_kind == "raw_backlog"
+        assert debt2.debt_size_estimate < debt1.debt_size_estimate
+        assert debt2.last_maintenance_attempt_at is not None
+
+        engine._config.deferred_maintenance_max_passes = 10
+        third = engine.compress(second)
+        debt3 = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert debt3 is not None
+        assert debt3.debt_kind is None
+        assert debt3.debt_size_estimate == 0
+        assert third[0]["role"] == "system"
+
+    def test_status_and_lcm_status_surface_debt_state(self, engine, monkeypatch):
+        engine._config.dynamic_leaf_chunk_enabled = True
+        engine._config.dynamic_leaf_chunk_max = 100
+        engine._config.leaf_chunk_tokens = 100
+        engine._config.fresh_tail_count = 2
+        engine._config.deferred_maintenance_enabled = True
+        engine.on_session_start("debt-session", platform="cli", context_length=200000)
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", lambda **kwargs: ("debt summary", 1))
+        monkeypatch.setattr(engine, "_working_leaf_chunk_tokens", lambda raw_tokens: 100)
+        monkeypatch.setattr(
+            engine,
+            "_assemble_context",
+            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+        )
+
+        engine.compress(self._make_backlog_messages())
+        status = engine.get_status()
+        assert status["lifecycle"]["debt_kind"] == "raw_backlog"
+        assert status["lifecycle"]["debt_size_estimate"] > 0
+
+        tool_status = json.loads(engine.handle_tool_call("lcm_status", {}))
+        assert tool_status["lifecycle"]["debt_kind"] == "raw_backlog"
+        assert tool_status["config"]["deferred_maintenance_enabled"] is True
+
+
 class TestUnlimitedCondensationDepth:
     """Tests for issue #2b — max_depth=-1 should be truly unlimited."""
 

--- a/tools.py
+++ b/tools.py
@@ -435,6 +435,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     total_dag_tokens = sum(d["tokens"] for d in depths.values())
     total_source_tokens = sum(d["source_tokens"] for d in depths.values())
     compression_ratio = round(total_source_tokens / total_dag_tokens, 1) if total_dag_tokens > 0 else 0
+    lifecycle = engine.get_status().get("lifecycle")
 
     return json.dumps({
         "session_id": session_id,
@@ -461,6 +462,8 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "dynamic_leaf_chunk_max": engine._config.dynamic_leaf_chunk_max,
             "cache_friendly_condensation_enabled": engine._config.cache_friendly_condensation_enabled,
             "cache_friendly_min_debt_groups": engine._config.cache_friendly_min_debt_groups,
+            "deferred_maintenance_enabled": engine._config.deferred_maintenance_enabled,
+            "deferred_maintenance_max_passes": engine._config.deferred_maintenance_max_passes,
             "context_threshold": engine._config.context_threshold,
             "max_depth": engine._config.incremental_max_depth,
             "condensation_fanin": engine._config.condensation_fanin,
@@ -471,6 +474,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "ignored": engine._session_ignored,
             "stateless": engine._session_stateless,
         },
+        "lifecycle": lifecycle,
     })
 
 


### PR DESCRIPTION
## Summary
- persist deferred maintenance debt in durable lifecycle state
- add bounded cross-turn catch-up for raw backlog debt
- surface debt state in status output so operators can see when maintenance work is still owed

## Details
- lifecycle state now stores debt kind/size and maintenance timestamps
- config adds deferred maintenance toggles and bounded pass limits
- raw backlog debt is preserved until backlog is actually reduced below threshold
- later turns can consume debt in bounded passes instead of turning foreground work into an unbounded cleanup sweep

## Validation
- python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q
- python3 -m pytest tests/ -q
- python3 -m compileall -q .
- git diff --check

I also re-based this branch onto current main after the other slices landed and re-ran the validation on the rebased result.