### PR TITLE
fix: cherry-pick PR #26 (operator remediation flows)

### DIFF
--- a/command.py
+++ b/command.py
@@ -37,6 +37,7 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm or /lcm status: show current LCM runtime/session status",
         "- /lcm doctor: run read-only LCM health checks",
         "- /lcm doctor clean: best-effort scan of obvious junk/noise session candidates without deleting anything",
+        "- /lcm doctor clean apply: backup-first cleanup for safe pattern-matched candidates only",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
         "- /lcm help: show this help",
     ])
@@ -95,6 +96,128 @@ def _status_text(engine) -> str:
     return "\n".join(lines)
 
 
+def _scan_clean_candidates(engine) -> dict[str, Any]:
+    conn = engine._store._conn
+    try:
+        rows = conn.execute(
+            """
+            WITH session_ids AS (
+                SELECT session_id FROM messages
+                UNION
+                SELECT session_id FROM summary_nodes
+            ),
+            message_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS message_count,
+                       COALESCE(SUM(token_estimate), 0) AS token_total
+                FROM messages
+                GROUP BY session_id
+            ),
+            node_stats AS (
+                SELECT session_id, COUNT(*) AS node_count
+                FROM summary_nodes
+                GROUP BY session_id
+            )
+            SELECT s.session_id,
+                   COALESCE(m.message_count, 0) AS message_count,
+                   COALESCE(m.token_total, 0) AS token_total,
+                   COALESCE(n.node_count, 0) AS node_count
+            FROM session_ids s
+            LEFT JOIN message_stats m ON m.session_id = s.session_id
+            LEFT JOIN node_stats n ON n.session_id = s.session_id
+            ORDER BY s.session_id
+            """
+        ).fetchall()
+    except Exception as exc:  # pragma: no cover - defensive
+        return {
+            "error": str(exc),
+            "candidates": [],
+            "ignored_count": 0,
+            "stateless_count": 0,
+            "protected_count": 0,
+        }
+
+    candidates = []
+    ignored_count = 0
+    stateless_count = 0
+    protected_count = 0
+
+    for session_id, message_count, token_total, node_count in rows:
+        keys = build_session_match_keys(session_id)
+        matched_classes = []
+        if matches_session_pattern(keys, engine._compiled_ignore_session_patterns):
+            matched_classes.append("ignored-pattern")
+            ignored_count += 1
+        elif matches_session_pattern(keys, engine._compiled_stateless_session_patterns):
+            matched_classes.append("stateless-pattern")
+            stateless_count += 1
+        if not matched_classes:
+            continue
+        if session_id == getattr(engine, "_session_id", ""):
+            protected_count += 1
+            continue
+        candidates.append(
+            {
+                "session_id": session_id,
+                "classes": matched_classes,
+                "message_count": int(message_count),
+                "node_count": int(node_count),
+                "token_total": int(token_total),
+            }
+        )
+
+    return {
+        "error": None,
+        "candidates": candidates,
+        "ignored_count": ignored_count,
+        "stateless_count": stateless_count,
+        "protected_count": protected_count,
+    }
+
+
+def _backup_database(engine) -> dict[str, Any]:
+    db_path = Path(engine._store.db_path)
+    if not db_path.exists():
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "error": "database file does not exist",
+        }
+
+    backup_root = Path(engine._hermes_home).expanduser() if getattr(engine, "_hermes_home", "") else db_path.parent
+    backup_dir = backup_root / "backups" / "lcm"
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = backup_dir / f"{db_path.stem}-{timestamp}.sqlite3"
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        engine._store._conn.commit()
+        engine._dag._conn.commit()
+        lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
+        if lifecycle_conn is not None:
+            lifecycle_conn.commit()
+
+        dest = sqlite3.connect(str(backup_path))
+        try:
+            engine._store._conn.backup(dest)
+        finally:
+            dest.close()
+    except (OSError, sqlite3.Error) as exc:
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "error": str(exc),
+        }
+
+    backup_size = backup_path.stat().st_size if backup_path.exists() else 0
+    return {
+        "ok": True,
+        "db_path": db_path,
+        "backup_path": backup_path,
+        "backup_size": backup_size,
+    }
+
+
 def _doctor_text(engine) -> str:
     db_path = Path(engine._store.db_path)
     store_conn = engine._store._conn
@@ -147,8 +270,55 @@ def _doctor_text(engine) -> str:
 
     db_exists = db_path.exists()
     db_size = db_path.stat().st_size if db_exists else 0
+    clean_scan = _scan_clean_candidates(engine)
 
-    doctor_status = "ok" if integrity == "ok" and not issues else "issues-found"
+    debt_rows = []
+    lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
+    if lifecycle_conn is not None:
+        try:
+            debt_rows = lifecycle_conn.execute(
+                """
+                SELECT conversation_id, debt_kind, debt_size_estimate
+                FROM lcm_lifecycle_state
+                WHERE debt_kind IS NOT NULL AND debt_size_estimate > 0
+                ORDER BY updated_at DESC
+                """
+            ).fetchall()
+        except Exception as exc:  # pragma: no cover - defensive
+            issues.append("lifecycle_state")
+            debt_rows = [(f"error: {exc}", "error", 0)]
+
+    observations: list[str] = []
+    recommended_actions: list[str] = []
+
+    if debt_rows:
+        first = debt_rows[0]
+        observations.append(
+            f"maintenance_debt: {len(debt_rows)} conversation(s) currently carry deferred maintenance debt; first={first[0]} kind={first[1]} size={first[2]}"
+        )
+        recommended_actions.append(
+            "let normal compaction turns reduce maintenance debt before attempting broader cleanup"
+        )
+
+    if clean_scan["error"]:
+        observations.append(f"cleanup_candidates: scan error: {clean_scan['error']}")
+    elif clean_scan["candidates"]:
+        observations.append(
+            f"cleanup_candidates: {len(clean_scan['candidates'])} pattern-matched junk/noise session candidate(s) detected"
+        )
+        recommended_actions.append("inspect candidate sessions with `/lcm doctor clean`")
+        recommended_actions.append("create a safety snapshot first with `/lcm backup`")
+    else:
+        observations.append("cleanup_candidates: none")
+
+    if clean_scan.get("protected_count"):
+        observations.append(
+            f"protected_sessions: skipped {clean_scan['protected_count']} currently bound session(s) from cleanup candidates"
+        )
+
+    doctor_status = "issues-found" if integrity != "ok" or issues else (
+        "action-recommended" if recommended_actions else "ok"
+    )
     lines = [
         "LCM doctor",
         f"status: {doctor_status}",
@@ -169,81 +339,38 @@ def _doctor_text(engine) -> str:
         lines.append(f"issues: {', '.join(issues)}")
     else:
         lines.append("issues: none")
+    lines.append("observations:")
+    for item in observations:
+        lines.append(f"- {item}")
+    lines.append("recommended_actions:")
+    if recommended_actions:
+        for item in recommended_actions:
+            lines.append(f"- {item}")
+    else:
+        lines.append("- none")
     return "\n".join(lines)
 
 
 def _doctor_clean_text(engine) -> str:
-    conn = engine._store._conn
-    try:
-        rows = conn.execute(
-            """
-            WITH session_ids AS (
-                SELECT session_id FROM messages
-                UNION
-                SELECT session_id FROM summary_nodes
-            ),
-            message_stats AS (
-                SELECT session_id,
-                       COUNT(*) AS message_count,
-                       COALESCE(SUM(token_estimate), 0) AS token_total
-                FROM messages
-                GROUP BY session_id
-            ),
-            node_stats AS (
-                SELECT session_id, COUNT(*) AS node_count
-                FROM summary_nodes
-                GROUP BY session_id
-            )
-            SELECT s.session_id,
-                   COALESCE(m.message_count, 0) AS message_count,
-                   COALESCE(m.token_total, 0) AS token_total,
-                   COALESCE(n.node_count, 0) AS node_count
-            FROM session_ids s
-            LEFT JOIN message_stats m ON m.session_id = s.session_id
-            LEFT JOIN node_stats n ON n.session_id = s.session_id
-            ORDER BY s.session_id
-            """
-        ).fetchall()
-    except Exception as exc:  # pragma: no cover - defensive
+    scan = _scan_clean_candidates(engine)
+    if scan["error"]:
         return "\n".join([
             "LCM doctor clean",
             "status: error",
-            f"error: {exc}",
+            f"error: {scan['error']}",
             "note: read-only scan only — no rows were deleted",
         ])
 
-    candidates = []
-    ignored_count = 0
-    stateless_count = 0
-
-    for session_id, message_count, token_total, node_count in rows:
-        keys = build_session_match_keys(session_id)
-        matched_classes = []
-        if matches_session_pattern(keys, engine._compiled_ignore_session_patterns):
-            matched_classes.append("ignored-pattern")
-            ignored_count += 1
-        elif matches_session_pattern(keys, engine._compiled_stateless_session_patterns):
-            matched_classes.append("stateless-pattern")
-            stateless_count += 1
-        if not matched_classes:
-            continue
-        candidates.append(
-            {
-                "session_id": session_id,
-                "classes": matched_classes,
-                "message_count": int(message_count),
-                "node_count": int(node_count),
-                "token_total": int(token_total),
-            }
-        )
-
+    candidates = scan["candidates"]
     lines = [
         "LCM doctor clean",
         f"status: {'candidates-found' if candidates else 'ok'}",
         f"candidate_sessions: {len(candidates)}",
-        f"ignored_pattern_matches: {ignored_count}",
-        f"stateless_pattern_matches: {stateless_count}",
+        f"ignored_pattern_matches: {scan['ignored_count']}",
+        f"stateless_pattern_matches: {scan['stateless_count']}",
     ]
+    if scan["protected_count"]:
+        lines.append(f"protected_sessions_skipped: {scan['protected_count']}")
 
     if not candidates:
         lines.append("result: no obvious junk/noise session candidates detected")
@@ -261,49 +388,79 @@ def _doctor_clean_text(engine) -> str:
         lines.append(f"... {len(candidates) - 20} more candidate session(s) omitted")
     lines.append("note: best-effort stored-session scan only — platform-only matches may not be reconstructable from the SQLite state")
     lines.append("note: read-only scan only — no rows were deleted")
+    lines.append("note: use `/lcm doctor clean apply` only after a backup-first review of these safe candidates")
     return "\n".join(lines)
 
 
+def _doctor_clean_apply_text(engine) -> str:
+    scan = _scan_clean_candidates(engine)
+    if scan["error"]:
+        return "\n".join([
+            "LCM doctor clean apply",
+            "status: error",
+            f"error: {scan['error']}",
+            "note: cleanup apply aborted before any rows were deleted",
+        ])
+
+    candidates = scan["candidates"]
+    if not candidates:
+        return "\n".join([
+            "LCM doctor clean apply",
+            "status: ok",
+            "candidate_sessions: 0",
+            "result: no safe cleanup candidates detected",
+            "note: nothing was deleted",
+        ])
+
+    backup = _backup_database(engine)
+    if not backup["ok"]:
+        return "\n".join([
+            "LCM doctor clean apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"error: backup failed: {backup['error']}",
+            "note: cleanup apply aborted before any rows were deleted",
+        ])
+
+    session_ids = {item["session_id"] for item in candidates}
+    messages_deleted = sum(engine._store.delete_session_messages(session_id) for session_id in session_ids)
+    nodes_deleted = sum(engine._dag.delete_session_nodes(session_id) for session_id in session_ids)
+    lifecycle_deleted, lifecycle_skipped = engine._lifecycle.delete_safe_rows_for_sessions(
+        session_ids,
+        protected_session_ids={getattr(engine, "_session_id", "")},
+    )
+
+    return "\n".join([
+        "LCM doctor clean apply",
+        "status: ok",
+        f"database_path: {backup['db_path']}",
+        f"backup_path: {backup['backup_path']}",
+        f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+        f"candidate_sessions: {len(candidates)}",
+        f"messages_deleted: {messages_deleted}",
+        f"nodes_deleted: {nodes_deleted}",
+        f"lifecycle_rows_deleted: {lifecycle_deleted}",
+        f"lifecycle_rows_skipped: {lifecycle_skipped}",
+        "note: backup created before cleanup apply",
+    ])
+
+
 def _backup_text(engine) -> str:
-    db_path = Path(engine._store.db_path)
-    if not db_path.exists():
+    backup = _backup_database(engine)
+    if not backup["ok"]:
         return "\n".join([
             "LCM backup",
             "status: error",
-            f"database_path: {db_path}",
-            "error: database file does not exist",
+            f"database_path: {backup['db_path']}",
+            f"error: {backup['error']}",
         ])
 
-    backup_root = Path(engine._hermes_home).expanduser() if getattr(engine, "_hermes_home", "") else db_path.parent
-    backup_dir = backup_root / "backups" / "lcm"
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup_path = backup_dir / f"{db_path.stem}-{timestamp}.sqlite3"
-
-    try:
-        backup_dir.mkdir(parents=True, exist_ok=True)
-        engine._store._conn.commit()
-        engine._dag._conn.commit()
-
-        dest = sqlite3.connect(str(backup_path))
-        try:
-            engine._store._conn.backup(dest)
-        finally:
-            dest.close()
-    except (OSError, sqlite3.Error) as exc:
-        return "\n".join([
-            "LCM backup",
-            "status: error",
-            f"database_path: {db_path}",
-            f"error: {exc}",
-        ])
-
-    backup_size = backup_path.stat().st_size if backup_path.exists() else 0
     return "\n".join([
         "LCM backup",
         "status: ok",
-        f"database_path: {db_path}",
-        f"backup_path: {backup_path}",
-        f"backup_size: {_fmt_size(backup_size)}",
+        f"database_path: {backup['db_path']}",
+        f"backup_path: {backup['backup_path']}",
+        f"backup_size: {_fmt_size(int(backup['backup_size']))}",
         "note: backup created before any future cleanup/apply workflow",
     ])
 
@@ -327,8 +484,8 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
         if len(rest) == 1 and rest[0].lower() == "clean":
             return _doctor_clean_text(engine)
         if len(rest) == 2 and rest[0].lower() == "clean" and rest[1].lower() == "apply":
-            return _help_text("`/lcm doctor clean apply` is not implemented yet. This slice is read-only diagnostics only.")
-        return _help_text("`/lcm doctor` currently supports only `clean` as an extra subcommand.")
+            return _doctor_clean_apply_text(engine)
+        return _help_text("`/lcm doctor` currently supports `clean` and `clean apply` as extra subcommands.")
 
     if head == "backup":
         if rest:

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -409,6 +409,42 @@ class LifecycleStateStore:
         self._conn.commit()
         return self.get_by_conversation(conversation_id)
 
+    def delete_safe_rows_for_sessions(
+        self,
+        session_ids: set[str] | list[str] | tuple[str, ...],
+        *,
+        protected_session_ids: set[str] | list[str] | tuple[str, ...] | None = None,
+    ) -> tuple[int, int]:
+        candidates = {str(s) for s in session_ids if s}
+        if not candidates:
+            return 0, 0
+        protected = {str(s) for s in (protected_session_ids or ()) if s}
+        deleted = 0
+        skipped = 0
+        rows = self._conn.execute("SELECT * FROM lcm_lifecycle_state").fetchall()
+        for row in rows:
+            refs = {
+                str(value)
+                for value in (row["current_session_id"], row["last_finalized_session_id"])
+                if value
+            }
+            if not refs or not (refs & candidates):
+                continue
+            if refs & protected:
+                skipped += 1
+                continue
+            if refs <= candidates:
+                self._conn.execute(
+                    "DELETE FROM lcm_lifecycle_state WHERE conversation_id = ?",
+                    (row["conversation_id"],),
+                )
+                deleted += 1
+                continue
+            skipped += 1
+        if deleted:
+            self._conn.commit()
+        return deleted, skipped
+
     def advance_frontier(
         self,
         conversation_id: str | None,

--- a/store.py
+++ b/store.py
@@ -260,6 +260,17 @@ class MessageStore:
                 ids.append(cur.lastrowid)
         return ids
 
+    def delete_session_messages(self, session_id: str) -> int:
+        """Delete all messages for a session. Returns count deleted."""
+        cur = self._conn.execute(
+            "DELETE FROM messages WHERE session_id = ?",
+            (session_id,),
+        )
+        deleted = cur.rowcount
+        if deleted:
+            self._conn.commit()
+        return deleted
+
     def pin(self, store_id: int) -> None:
         """Mark a message as pinned (protected from pruning)."""
         self._conn.execute(

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -10,6 +10,7 @@ import pytest
 import hermes_lcm.command as command_mod
 from hermes_lcm.command import _fmt_size, handle_lcm_command
 from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
 
 
@@ -61,6 +62,29 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "nodes_fts: ok" in result
 
 
+def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_doctor_actions.db"),
+        ignore_session_patterns=["cron*"],
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+    engine._lifecycle.record_debt("live-session", kind="raw_backlog", size_estimate=321)
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "observations:" in result
+    assert "recommended_actions:" in result
+    assert "maintenance_debt" in result
+    assert "cleanup_candidates" in result
+    assert "/lcm doctor clean" in result
+    assert "/lcm backup" in result
+
+
 def test_lcm_help_on_unknown_subcommand(engine):
     result = handle_lcm_command("wat", engine)
 
@@ -72,8 +96,8 @@ def test_lcm_help_on_unknown_subcommand(engine):
 def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
     result = handle_lcm_command("doctor clean foo", engine)
 
-    assert "currently supports only `clean`" in result
-    assert "clean apply" not in result
+    assert "currently supports `clean` and `clean apply`" in result
+    assert "/lcm doctor clean apply" in result
 
 
 def test_lcm_doctor_clean_reports_pattern_matched_junk_candidates(tmp_path):
@@ -144,6 +168,70 @@ def test_lcm_backup_returns_error_when_sqlite_backup_fails(engine, monkeypatch):
     assert "LCM backup" in result
     assert "status: error" in result
     assert "disk I/O error" in result
+
+
+def test_lcm_doctor_clean_apply_is_backup_first_and_deletes_safe_candidates(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_clean_apply.db"),
+        ignore_session_patterns=["cron*"],
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+    engine._store.append("normal_session", {"role": "user", "content": "real conversation"}, token_estimate=20)
+    engine._dag.add_node(SummaryNode(
+        session_id="cron_20260414",
+        depth=0,
+        summary="scheduled report summary",
+        token_count=5,
+        source_token_count=12,
+        source_ids=[1],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._lifecycle.bind_session("cron_20260414")
+    engine._lifecycle.finalize_session("cron_20260414", "cron_20260414", frontier_store_id=1)
+
+    result = handle_lcm_command("doctor clean apply", engine)
+
+    assert "LCM doctor clean apply" in result
+    assert "status: ok" in result
+    backup_line = next(line for line in result.splitlines() if line.startswith("backup_path: "))
+    backup_path = Path(backup_line.split(": ", 1)[1])
+    assert backup_path.exists()
+    assert engine._store.get_range("cron_20260414") == []
+    assert engine._dag.get_session_nodes("cron_20260414") == []
+    assert engine._lifecycle.get_by_conversation("cron_20260414") is None
+    assert len(engine._store.get_range("normal_session")) == 1
+
+
+def test_lcm_doctor_clean_apply_aborts_if_backup_fails(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_clean_apply_fail.db"),
+        ignore_session_patterns=["cron*"],
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+
+    def boom(_path):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(command_mod.sqlite3, "connect", boom)
+
+    result = handle_lcm_command("doctor clean apply", engine)
+
+    assert "LCM doctor clean apply" in result
+    assert "status: error" in result
+    assert "backup failed" in result.lower()
+    assert len(engine._store.get_range("cron_20260414")) == 1
 
 
 class _FakeCursor:


### PR DESCRIPTION
## Summary
- Cherry-pick of #26 which was accidentally merged into the feature branch instead of main

Original PR: #26 (feat: broaden operator remediation flows)
- Broadens `/lcm doctor` to separate observations from recommended remediation
- Adds backup-first `doctor clean apply` flow for safe pattern-matched cleanup candidates
- Keeps remediation limited to well-understood state transitions

Co-Authored-By: Tosko4 <tosko4@gmail.com>