### PR TITLE
feat: sanitize inline media before compaction

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -17,7 +17,11 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
-from .extraction import extract_before_compaction
+from .extraction import (
+    extract_before_compaction,
+    sanitize_pre_compaction_content,
+    sanitize_pre_compaction_tool_arguments,
+)
 from .schemas import LCM_DESCRIBE, LCM_DOCTOR, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_GREP, LCM_STATUS
 from .session_patterns import (
     build_session_match_keys,
@@ -829,6 +833,7 @@ class LCMEngine(ContextEngine):
         for msg in messages:
             role = msg.get("role", "unknown")
             content = msg.get("content") or ""
+            content = sanitize_pre_compaction_content(content)
 
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
@@ -848,6 +853,7 @@ class LCMEngine(ContextEngine):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
                             args = fn.get("arguments", "")
+                            args = sanitize_pre_compaction_tool_arguments(args)
                             if len(args) > 500:
                                 args = args[:400] + "..."
                             tc_parts.append(f"  {name}({args})")

--- a/extraction.py
+++ b/extraction.py
@@ -4,13 +4,26 @@ Best-effort: failures never block compaction. Extracted content is written to
 daily note files so key decisions survive even if the DAG summary loses nuance.
 """
 
+import json
 import logging
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_MEDIA_DATA_URI_RE = re.compile(
+    r"data:(?:image|audio|video)/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\s]{16,}",
+    re.IGNORECASE,
+)
+_MEDIA_ATTACHMENT_MARKER = "[Media attachment]"
+_MEDIA_ATTACHMENT_SUFFIX = "[with media attachment]"
+_TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
+_MEDIA_BLOCK_HINTS = ("image", "audio", "video")
+_STRUCTURED_METADATA_KEYS = ("file_id", "filename", "name", "mime_type", "url", "file_url", "id")
+
 
 EXTRACTION_PROMPT = """Extract decisions, commitments, outcomes, and rules from this conversation segment.
 
@@ -51,6 +64,128 @@ def _call_extraction_llm(prompt: str, model: str = "",
     except Exception as e:
         logger.debug("Extraction LLM call failed: %s", e)
         return None
+
+
+def _sanitize_string_media(text: str) -> str:
+    if not text:
+        return ""
+    if not _MEDIA_DATA_URI_RE.search(text):
+        return text
+
+    without_media = _MEDIA_DATA_URI_RE.sub("", text)
+    without_media = without_media.strip()
+    without_media = re.sub(r"\n{3,}", "\n\n", without_media)
+
+    if not without_media:
+        return _MEDIA_ATTACHMENT_MARKER
+    if _MEDIA_ATTACHMENT_SUFFIX in without_media:
+        return without_media
+    return f"{without_media}\n{_MEDIA_ATTACHMENT_SUFFIX}"
+
+
+def _looks_like_media_block(block_type: str, block: Dict[str, Any]) -> bool:
+    if any(hint in block_type for hint in _MEDIA_BLOCK_HINTS):
+        return True
+    return any(key in block for key in ("image_url", "input_image", "output_image", "audio_url", "video_url"))
+
+
+def _extract_structured_metadata(block: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    block_type = str(block.get("type", "")).strip()
+    if block_type:
+        parts.append(f"type={block_type}")
+
+    for key in _STRUCTURED_METADATA_KEYS:
+        value = block.get(key)
+        if isinstance(value, dict):
+            for nested_key in _STRUCTURED_METADATA_KEYS:
+                nested_value = value.get(nested_key)
+                if isinstance(nested_value, (str, int, float)) and nested_value:
+                    parts.append(f"{nested_key}={nested_value}")
+                    break
+            continue
+        if isinstance(value, (str, int, float)) and value:
+            parts.append(f"{key}={value}")
+
+    if not parts:
+        return "[Structured content]"
+    return "[Structured content: " + ", ".join(dict.fromkeys(parts)) + "]"
+
+
+def _sanitize_content_block(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return _sanitize_string_media(content)
+    if isinstance(content, list):
+        parts: List[str] = []
+        media_seen = False
+        for block in content:
+            block_text = _sanitize_content_block(block)
+            if not block_text:
+                continue
+            if block_text == _MEDIA_ATTACHMENT_MARKER:
+                media_seen = True
+                continue
+            if block_text.endswith(_MEDIA_ATTACHMENT_SUFFIX):
+                media_seen = True
+                block_text = block_text[: -len(_MEDIA_ATTACHMENT_SUFFIX)].rstrip()
+                if not block_text:
+                    continue
+            parts.append(block_text)
+        combined = "\n".join(part for part in parts if part).strip()
+        combined = re.sub(r"\n{3,}", "\n\n", combined)
+        if media_seen and combined:
+            return f"{combined}\n{_MEDIA_ATTACHMENT_SUFFIX}"
+        if media_seen:
+            return _MEDIA_ATTACHMENT_MARKER
+        return combined
+    if isinstance(content, dict):
+        block_type = str(content.get("type", "")).lower()
+        if block_type in _TEXT_BLOCK_TYPES:
+            text_value = content.get("text")
+            if isinstance(text_value, dict):
+                text_value = text_value.get("value", "")
+            if not text_value:
+                text_value = content.get("content", "")
+            return _sanitize_content_block(text_value)
+        if _looks_like_media_block(block_type, content):
+            return _MEDIA_ATTACHMENT_MARKER
+        for key in ("text", "content"):
+            if key in content:
+                return _sanitize_content_block(content.get(key))
+        return _extract_structured_metadata(content)
+    return str(content)
+
+
+def _sanitize_json_like(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _sanitize_json_like(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_json_like(item) for item in value]
+    if isinstance(value, str):
+        return _sanitize_string_media(value)
+    return value
+
+
+def sanitize_pre_compaction_content(text: Any) -> str:
+    """Replace inline media/base64 payloads with compact attachment markers."""
+    return _sanitize_content_block(text)
+
+
+def sanitize_pre_compaction_tool_arguments(arguments: Any) -> str:
+    """Clean tool-call argument payloads while preserving JSON-like structure when possible."""
+    if arguments is None:
+        return ""
+    if isinstance(arguments, (dict, list)):
+        return json.dumps(_sanitize_json_like(arguments), ensure_ascii=False)
+    if not isinstance(arguments, str):
+        return sanitize_pre_compaction_content(arguments)
+    try:
+        parsed = json.loads(arguments)
+    except Exception:
+        return sanitize_pre_compaction_content(arguments)
+    return json.dumps(_sanitize_json_like(parsed), ensure_ascii=False)
 
 
 def extract_before_compaction(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1620,6 +1620,217 @@ class TestEscalation:
 
 
 class TestExtraction:
+    def test_serialize_messages_replaces_pure_inline_media_with_attachment_marker(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "user",
+                "content": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+            }
+        ])
+
+        assert "[USER]: [Media attachment]" == serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_preserves_text_but_replaces_inline_media_suffix(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "assistant",
+                "content": "Here is the chart you asked for.\n\ndata:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+            }
+        ])
+
+        assert "Here is the chart you asked for." in serialized
+        assert "[with media attachment]" in serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_handles_chat_completions_style_multimodal_blocks(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Please remember this screenshot."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"},
+                    },
+                ],
+            }
+        ])
+
+        assert "Please remember this screenshot." in serialized
+        assert "[with media attachment]" in serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_handles_responses_style_multimodal_blocks(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this."},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+                    },
+                ],
+            }
+        ])
+
+        assert "Describe this." in serialized
+        assert "[with media attachment]" in serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_leaves_non_media_application_data_uri_alone(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        content = "data:application/json;base64,eyJmb28iOiAiYmFyIiwgImJheiI6IDEyfQ=="
+        serialized = engine._serialize_messages([
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": content,
+            }
+        ])
+
+        assert content in serialized
+        assert "[Media attachment]" not in serialized
+        assert "[with media attachment]" not in serialized
+
+    def test_serialize_messages_sanitizes_tool_call_arguments_media_payloads(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "assistant",
+                "content": "Calling the image tool now.",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "vision_analyze",
+                            "arguments": '{"image":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"}',
+                        }
+                    }
+                ],
+            }
+        ])
+
+        assert "vision_analyze" in serialized
+        assert '"image": "[Media attachment]"' in serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_sanitizes_parsed_tool_call_arguments_media_payloads(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "assistant",
+                "content": "Calling the image tool now.",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "vision_analyze",
+                            "arguments": {
+                                "prompt": "Describe the chart",
+                                "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+                            },
+                        }
+                    }
+                ],
+            }
+        ])
+
+        assert '"prompt": "Describe the chart"' in serialized
+        assert '"image": "[Media attachment]"' in serialized
+        assert "data:image/png;base64" not in serialized
+
+    def test_serialize_messages_preserves_structured_file_block_metadata(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "lcm.db")))
+
+        serialized = engine._serialize_messages([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Use the uploaded document."},
+                    {
+                        "type": "input_file",
+                        "file_id": "file_123",
+                        "filename": "requirements.pdf",
+                        "mime_type": "application/pdf",
+                    },
+                ],
+            }
+        ])
+
+        assert "Use the uploaded document." in serialized
+        assert "type=input_file" in serialized
+        assert "file_123" in serialized
+        assert "requirements.pdf" in serialized
+
+    def test_run_pre_compaction_extraction_uses_media_cleaned_text(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+        import hermes_lcm.extraction as ext_module
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_extract.db"),
+            extraction_enabled=True,
+            extraction_output_path=str(tmp_path / "extractions"),
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        original = ext_module._call_extraction_llm
+        seen_prompt = {}
+
+        def mock_llm(prompt, model="", timeout=None):
+            seen_prompt["prompt"] = prompt
+            return "- Captured media cleanup"
+
+        ext_module._call_extraction_llm = mock_llm
+        try:
+            engine._run_pre_compaction_extraction([
+                {
+                    "role": "user",
+                    "content": "Please save this image for later\n\ndata:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+                },
+            ])
+        finally:
+            ext_module._call_extraction_llm = original
+
+        assert "[with media attachment]" in seen_prompt["prompt"]
+        assert "data:image/png;base64" not in seen_prompt["prompt"]
+
     def test_extract_writes_daily_file(self, tmp_path):
         from hermes_lcm.extraction import extract_before_compaction
 


### PR DESCRIPTION
## Summary
- sanitize inline image/audio/video data URIs before pre-compaction serialization
- preserve user text while replacing inline media with attachment markers
- clean assistant tool-call arguments too, including JSON strings and parsed dict/list payloads
- keep safe metadata for structured file blocks instead of dropping them

## Why
Raw inline media/base64 blobs should not be fed straight into pre-compaction extraction and summarization. This keeps the first slice focused on safer transcript preparation without introducing storage/externalization yet.

## Validation
- python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q
- python3 -m pytest tests/ -q
- python3 -m compileall -q .
- git diff --check

## Notes
- scoped as plugin-only work in hermes-lcm
- sits next to the existing pre-compaction extraction path rather than introducing a broader transform framework yet
- covers chat-completions style blocks, Responses-style blocks, tool-call arguments, and structured file metadata preservation
