### PR TITLE
fix: batch fetch in lcm_expand to eliminate N+1 query

### DIFF
--- a/store.py
+++ b/store.py
@@ -293,6 +293,20 @@ class MessageStore:
         ).fetchone()
         return self._row_to_dict(row) if row else None
 
+    def get_batch(self, store_ids: List[int]) -> Dict[int, Dict[str, Any]]:
+        """Retrieve multiple messages by store_id in a single query.
+
+        Returns a dict mapping store_id → message dict.
+        """
+        if not store_ids:
+            return {}
+        placeholders = ",".join("?" for _ in store_ids)
+        rows = self._conn.execute(
+            f"SELECT * FROM messages WHERE store_id IN ({placeholders})",
+            store_ids,
+        ).fetchall()
+        return {row[0]: self._row_to_dict(row) for row in rows}
+
     def get_range(self, session_id: str, start_id: int = 0,
                   end_id: int | None = None,
                   limit: int = 1000) -> List[Dict[str, Any]]:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -853,6 +853,29 @@ class TestMessageStore:
 
         assert [result["store_id"] for result in results] == [future_id]
 
+    def test_get_batch_returns_multiple_messages_in_single_query(self, store):
+        id1 = store.append("sess1", {"role": "user", "content": "first"})
+        id2 = store.append("sess1", {"role": "assistant", "content": "second"})
+        id3 = store.append("sess1", {"role": "user", "content": "third"})
+
+        result = store.get_batch([id1, id3])
+
+        assert len(result) == 2
+        assert result[id1]["content"] == "first"
+        assert result[id3]["content"] == "third"
+        assert id2 not in result
+
+    def test_get_batch_returns_empty_dict_for_empty_input(self, store):
+        assert store.get_batch([]) == {}
+
+    def test_get_batch_skips_missing_store_ids(self, store):
+        id1 = store.append("sess1", {"role": "user", "content": "exists"})
+
+        result = store.get_batch([id1, 99999])
+
+        assert len(result) == 1
+        assert result[id1]["content"] == "exists"
+
     def test_pin_unpin(self, store):
         sid = store.append("sess1", {"role": "user", "content": "important"})
         store.pin(sid)

--- a/tools.py
+++ b/tools.py
@@ -68,10 +68,12 @@ def _get_session_node(engine: "LCMEngine", node_id: int):
 def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
     from .tokens import count_tokens
 
+    stored_by_id = engine._store.get_batch(node.source_ids)
+
     messages = []
     budget_used = 0
     for store_id in node.source_ids:
-        stored = engine._store.get(store_id)
+        stored = stored_by_id.get(store_id)
         if not stored or stored.get("session_id") != engine._session_id:
             continue
         content = stored.get("content", "")


### PR DESCRIPTION
## Summary
- Add `store.get_batch(store_ids)` for fetching multiple messages in a single SQL query
- Replace per-message `store.get()` loop in `_expand_message_sources()` with batch fetch

## Why
`lcm_expand` was making one DB query per source message in a summary node. For a node with 100 source messages, that's 100 queries instead of 1. This replaces the N+1 pattern with a single `SELECT ... WHERE store_id IN (...)` query.

## Test plan
- [x] 3 new tests for `get_batch`: multi-fetch, empty input, missing IDs
- [x] Existing expand tests pass with batch fetch path
- [x] Full suite: 204 passed (3 pre-existing failures from main, fixed in #29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)