### PR TITLE
fix: clear maintenance debt on session reset

### DIFF
--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -401,10 +401,13 @@ class LifecycleStateStore:
             """
             UPDATE lcm_lifecycle_state
             SET last_reset_at = ?,
+                debt_kind = NULL,
+                debt_size_estimate = 0,
+                debt_updated_at = ?,
                 updated_at = ?
             WHERE conversation_id = ?
             """,
-            (now, now, conversation_id),
+            (now, now, now, conversation_id),
         )
         self._conn.commit()
         return self.get_by_conversation(conversation_id)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -944,6 +944,24 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_record_reset_clears_pending_debt(self, tmp_path):
+        state = LifecycleStateStore(tmp_path / "lifecycle-reset-debt.db")
+        bound = state.bind_session("sess-1")
+
+        state.record_debt(bound.conversation_id, kind="raw_backlog", size_estimate=500)
+        with_debt = state.get_by_conversation(bound.conversation_id)
+        assert with_debt is not None
+        assert with_debt.debt_kind == "raw_backlog"
+        assert with_debt.debt_size_estimate == 500
+
+        after_reset = state.record_reset(bound.conversation_id)
+        assert after_reset is not None
+        assert after_reset.debt_kind is None
+        assert after_reset.debt_size_estimate == 0
+        assert after_reset.last_reset_at is not None
+
+        state.close()
+
 
 class TestSummaryDAG:
     @pytest.fixture


### PR DESCRIPTION
## Summary
- `record_reset()` now clears `debt_kind`, `debt_size_estimate`, and `debt_updated_at` alongside `last_reset_at`

## Why
If a session reset mid-maintenance, stale debt carried over to the next session. The new session would see pending debt from a context that no longer exists, potentially triggering unnecessary deferred maintenance passes.

## Test plan
- [x] New test: `test_record_reset_clears_pending_debt` — records debt, resets, verifies debt is cleared
- [x] Existing lifecycle tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)