### PR TITLE
refactor: deduplicate search constants, upgrade logging, add extraction test

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -34,22 +34,17 @@ from .search_query import (
     escape_like,
     extract_quoted_phrases,
     extract_search_terms,
+    normalize_search_sort,
     requires_like_fallback,
+    AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
 
 logger = logging.getLogger(__name__)
 
-AGE_DECAY_RATE = 0.001
-
-
-def _normalize_search_sort(sort: str | None) -> str:
-    normalized = (sort or "recency").strip().lower()
-    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
-
 
 def _build_search_order_by(sort: str | None, recency_expr: str) -> str:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     if normalized == "relevance":
         return f"rank ASC, {recency_expr} DESC"
     if normalized == "hybrid":
@@ -61,7 +56,7 @@ def _build_search_order_by(sort: str | None, recency_expr: str) -> str:
 
 
 def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     score = float(node.search_rank or 0.0) * -1.0
     recency = float(node.latest_at or node.created_at or 0.0)
     directness = float(node.search_directness or 0.0)
@@ -76,7 +71,7 @@ def _fallback_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[fl
 
 
 def _fts_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, float, float]:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     rank = node.search_rank
     rank_value = float(rank) if rank is not None else float("inf")
     recency = float(node.latest_at or node.created_at or 0.0)
@@ -93,7 +88,7 @@ def _fts_result_sort_key(node: "SummaryNode", sort: str | None) -> tuple[float, 
 
 
 def _fts_primary_value(node: "SummaryNode", sort: str | None) -> float:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     rank = node.search_rank
     rank_value = float(rank) if rank is not None else float("inf")
     if normalized == "hybrid":
@@ -359,7 +354,8 @@ class SummaryDAG:
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
                         (query, fetch_limit, offset),
                     ).fetchall()
-            except sqlite3.Error:
+            except sqlite3.Error as exc:
+                logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
 
             raw_nodes = [self._row_to_node(r) for r in rows]

--- a/engine.py
+++ b/engine.py
@@ -142,7 +142,7 @@ class LCMEngine(ContextEngine):
             try:
                 self._ingest_messages(messages)
             except Exception as e:
-                logger.debug("Ingest during preflight: %s", e)
+                logger.warning("Ingest during preflight: %s", e)
         from .tokens import count_messages_tokens
         rough = count_messages_tokens(messages)
         if self._should_force_overflow_recovery(observed_tokens=rough):
@@ -635,7 +635,7 @@ class LCMEngine(ContextEngine):
             try:
                 self._ingest_messages(messages)
             except Exception as e:
-                logger.debug("Ingest during tool call failed: %s", e)
+                logger.warning("Ingest during tool call failed: %s", e)
 
         handlers = {
             "lcm_grep": lcm_tools.lcm_grep,
@@ -825,7 +825,7 @@ class LCMEngine(ContextEngine):
                 timeout=self._config.summary_timeout_ms / 1000,
             )
         except Exception as e:
-            logger.debug("Pre-compaction extraction failed (non-blocking): %s", e)
+            logger.warning("Pre-compaction extraction failed (non-blocking): %s", e)
 
     def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Serialize messages into labeled text for the summarizer."""

--- a/search_query.py
+++ b/search_query.py
@@ -206,6 +206,15 @@ def compute_search_fetch_limit(limit: int, terms: List[str], phrases: List[str] 
     return base
 
 
+AGE_DECAY_RATE = 0.001
+
+
+def normalize_search_sort(sort: str | None) -> str:
+    """Normalize sort parameter to one of: recency, relevance, hybrid."""
+    normalized = (sort or "recency").strip().lower()
+    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
+
+
 def build_snippet(text: str, terms: List[str], width: int = 80) -> str:
     content = (text or "")
     if not content:

--- a/store.py
+++ b/store.py
@@ -29,13 +29,13 @@ from .search_query import (
     escape_like,
     extract_quoted_phrases,
     extract_search_terms,
+    normalize_search_sort,
     requires_like_fallback,
+    AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
 
 logger = logging.getLogger(__name__)
-
-AGE_DECAY_RATE = 0.001
 
 
 _MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
@@ -60,17 +60,12 @@ def _message_directness_score(role: str | None, content: str | None, terms: List
     return score
 
 
-def _normalize_search_sort(sort: str | None) -> str:
-    normalized = (sort or "recency").strip().lower()
-    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
-
-
 def _build_search_order_by(
     sort: str | None,
     timestamp_expr: str,
     role_penalty_expr: str | None = None,
 ) -> str:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     order_parts: list[str] = []
     if normalized == "relevance":
         if role_penalty_expr:
@@ -93,7 +88,7 @@ def _build_search_order_by(
 
 
 def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     score = float(result.get("_fallback_score") or 0.0)
     directness = float(result.get("_directness_score") or 0.0)
     timestamp = float(result.get("timestamp") or 0.0)
@@ -109,7 +104,7 @@ def _fallback_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple
 
 
 def _fts_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[float, float, float, float]:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     rank = result.get("search_rank")
     rank_value = float(rank) if rank is not None else float("inf")
     directness = float(result.get("_directness_score") or 0.0)
@@ -126,7 +121,7 @@ def _fts_result_sort_key(result: Dict[str, Any], sort: str | None) -> tuple[floa
 
 
 def _fts_primary_value(result: Dict[str, Any], sort: str | None) -> float:
-    normalized = _normalize_search_sort(sort)
+    normalized = normalize_search_sort(sort)
     rank = result.get("search_rank")
     rank_value = float(rank) if rank is not None else float("inf")
     if normalized == "hybrid":
@@ -408,7 +403,8 @@ class MessageStore:
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
                         (query, fetch_limit, offset),
                     ).fetchall()
-            except sqlite3.Error:
+            except sqlite3.Error as exc:
+                logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
 
             raw_primary_values: list[float] = []

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2677,3 +2677,98 @@ class TestEngineTools:
 
         orphan_check = next(c for c in result["checks"] if c["check"] == "orphaned_dag_nodes")
         assert orphan_check["status"] == "warn"
+
+
+class TestExtractionDuringCompress:
+    """Integration test: extraction runs end-to-end through engine.compress()."""
+
+    def test_compress_with_extraction_enabled_writes_daily_file(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        import hermes_lcm.engine as engine_module
+        import hermes_lcm.extraction as ext_module
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_extract.db"),
+            extraction_enabled=True,
+            extraction_output_path=str(tmp_path / "extractions"),
+            extraction_model="test-extract-model",
+            fresh_tail_count=4,
+            leaf_chunk_tokens=100,
+        )
+        eng = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        eng._session_id = "extract-integration"
+        eng.context_length = 200000
+        eng.threshold_tokens = 500
+
+        extraction_calls = []
+
+        def mock_extraction_llm(prompt, model="", timeout=None):
+            extraction_calls.append({"prompt": prompt, "model": model, "timeout": timeout})
+            return "- Decided to use PostgreSQL\n- Will migrate by Friday"
+
+        def mock_summary(**kwargs):
+            return "Leaf summary.\nExpand for details about: test", 1
+
+        monkeypatch.setattr(ext_module, "_call_extraction_llm", mock_extraction_llm)
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(20):
+            messages.append({"role": "user", "content": f"Q{i}: " + "x" * 200})
+            messages.append({"role": "assistant", "content": f"A{i}: " + "y" * 200})
+
+        result = eng.compress(messages)
+
+        # Extraction was invoked with correct model
+        assert len(extraction_calls) > 0
+        assert extraction_calls[0]["model"] == "test-extract-model"
+
+        # Extraction prompt contains serialized message roles
+        assert "[USER]:" in extraction_calls[0]["prompt"]
+        assert "[ASSISTANT]:" in extraction_calls[0]["prompt"]
+
+        # Daily file created with extracted content
+        files = list(Path(tmp_path / "extractions").glob("*.md"))
+        assert len(files) >= 1
+        content = files[0].read_text()
+        assert "PostgreSQL" in content
+        assert "extract-integration" in content
+
+        # Compression still completed (extraction didn't block it)
+        assert result[0]["role"] == "system"
+        assert len(eng._dag.get_session_nodes("extract-integration")) > 0
+
+    def test_compress_proceeds_when_extraction_fails(self, tmp_path, monkeypatch):
+        import hermes_lcm.engine as engine_module
+        import hermes_lcm.extraction as ext_module
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_extract_fail.db"),
+            extraction_enabled=True,
+            extraction_output_path=str(tmp_path / "extractions"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=100,
+        )
+        eng = LCMEngine(config=config)
+        eng._session_id = "extract-fail"
+        eng.context_length = 200000
+        eng.threshold_tokens = 500
+
+        def failing_extraction_llm(prompt, model="", timeout=None):
+            raise RuntimeError("LLM service down")
+
+        def mock_summary(**kwargs):
+            return "Leaf summary.\nExpand for details about: test", 1
+
+        monkeypatch.setattr(ext_module, "_call_extraction_llm", failing_extraction_llm)
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        messages = [{"role": "system", "content": "You are helpful."}]
+        for i in range(20):
+            messages.append({"role": "user", "content": f"Q{i}: " + "x" * 200})
+            messages.append({"role": "assistant", "content": f"A{i}: " + "y" * 200})
+
+        # Should not raise — extraction failure is non-blocking
+        result = eng.compress(messages)
+        assert result[0]["role"] == "system"
+        assert len(eng._dag.get_session_nodes("extract-fail")) > 0

--- a/tools.py
+++ b/tools.py
@@ -7,18 +7,13 @@ import logging
 import time
 from typing import Any, Dict, TYPE_CHECKING
 
+from .search_query import AGE_DECAY_RATE, normalize_search_sort
+
 if TYPE_CHECKING:
     from .engine import LCMEngine
 
 
 logger = logging.getLogger(__name__)
-
-AGE_DECAY_RATE = 0.001
-
-
-def _normalize_search_sort(sort: str | None) -> str:
-    normalized = (sort or "recency").strip().lower()
-    return normalized if normalized in {"recency", "relevance", "hybrid"} else "recency"
 
 
 def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple:
@@ -195,7 +190,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": "No query provided"})
 
     limit = args.get("limit", 10)
-    sort = _normalize_search_sort(args.get("sort"))
+    sort = normalize_search_sort(args.get("sort"))
     source_limit = max(limit * 4, limit, 20)
     session_id = engine._session_id
     results = []
@@ -216,7 +211,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                 }
             )
     except Exception as exc:
-        logger.debug("Message search failed: %s", exc)
+        logger.warning("Message search failed: %s", exc)
 
     try:
         node_hits = engine._dag.search(query, session_id=session_id, limit=source_limit, sort=sort)
@@ -237,7 +232,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                 }
             )
     except Exception as exc:
-        logger.debug("Node search failed: %s", exc)
+        logger.warning("Node search failed: %s", exc)
 
     if sort == "hybrid":
         max_message_directness = max(


### PR DESCRIPTION
## Summary
- Consolidate `_normalize_search_sort` and `AGE_DECAY_RATE` from store.py, dag.py, and tools.py into `search_query.py` (single source of truth)
- Upgrade 5 `logger.debug` calls to `logger.warning` in error/fallback paths (tools.py, engine.py) and add warning logs to 2 previously silent FTS→LIKE fallbacks (store.py, dag.py)
- Add 2 integration tests: extraction runs end-to-end through `engine.compress()`, and compression proceeds when extraction fails

## Details

**Deduplication:** Three files each had their own copy of `_normalize_search_sort` (identical) and `AGE_DECAY_RATE = 0.001`. Now imported from `search_query.py`.

**Logging upgrades:**
| File | Path | Before | After |
|------|------|--------|-------|
| tools.py | Message/node search except | `debug` | `warning` |
| engine.py | Preflight ingest except | `debug` | `warning` |
| engine.py | Tool call ingest except | `debug` | `warning` |
| engine.py | Pre-compaction extraction except | `debug` | `warning` |
| store.py | FTS search → LIKE fallback | silent | `warning` |
| dag.py | FTS search → LIKE fallback | silent | `warning` |

**Integration tests:**
- `test_compress_with_extraction_enabled_writes_daily_file` — verifies extraction model, prompt content, file output, and that compression completes
- `test_compress_proceeds_when_extraction_fails` — verifies RuntimeError in extraction LLM doesn't block compaction

## Test plan
- [x] 210 passed, 0 failed (2 new tests)
- [x] No regressions in existing search or compaction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)