### PR TITLE
fix: isolate LCM storage per profile and add source-aware retrieval

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -323,14 +323,25 @@ class SummaryDAG:
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,
-               limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
+               limit: int = 20, sort: str | None = None,
+               source: str | None = None) -> List[SummaryNode]:
         """FTS5 search across all summary nodes."""
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
-            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
         order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
+        source_clause = ""
+        source_args: list[Any] = []
+        if source:
+            source_clause = (
+                " AND EXISTS ("
+                "SELECT 1 FROM messages m "
+                "WHERE m.session_id = n.session_id AND m.source = ?"
+                ")"
+            )
+            source_args.append(source)
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 2e-7
@@ -342,21 +353,21 @@ class SummaryDAG:
                     rows = self._conn.execute(
                         f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                            JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ? AND n.session_id = ?
+                           WHERE nodes_fts MATCH ? AND n.session_id = ?{source_clause}
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, session_id, fetch_limit, offset),
+                        (query, session_id, *source_args, fetch_limit, offset),
                     ).fetchall()
                 else:
                     rows = self._conn.execute(
                         f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                            JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ?
+                           WHERE nodes_fts MATCH ?{source_clause}
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, fetch_limit, offset),
+                        (query, *source_args, fetch_limit, offset),
                     ).fetchall()
             except sqlite3.Error as exc:
                 logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
-                return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
             raw_nodes = [self._row_to_node(r) for r in rows]
             raw_primary_values: list[float] = []
@@ -382,7 +393,8 @@ class SummaryDAG:
             fetch_limit *= 2
 
     def _search_like(self, query: str, session_id: str | None = None,
-                     limit: int = 20, sort: str | None = None) -> List[SummaryNode]:
+                     limit: int = 20, sort: str | None = None,
+                     source: str | None = None) -> List[SummaryNode]:
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if not terms:
@@ -393,6 +405,11 @@ class SummaryDAG:
         if session_id:
             where.append("session_id = ?")
             args.append(session_id)
+        if source:
+            where.append(
+                "EXISTS (SELECT 1 FROM messages m WHERE m.session_id = summary_nodes.session_id AND m.source = ?)"
+            )
+            args.append(source)
         like_clauses = []
         for term in terms:
             like_clauses.append("summary LIKE ? ESCAPE '\\'")

--- a/dag.py
+++ b/dag.py
@@ -332,38 +332,29 @@ class SummaryDAG:
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
         order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
-        source_clause = ""
-        source_args: list[Any] = []
-        if source:
-            source_clause = (
-                " AND EXISTS ("
-                "SELECT 1 FROM messages m "
-                "WHERE m.session_id = n.session_id AND m.source = ?"
-                ")"
-            )
-            source_args.append(source)
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 2e-7
         offset = 0
         results: list[SummaryNode] = []
+        source_match_cache: dict[int, bool] = {}
         while True:
             try:
                 if session_id:
                     rows = self._conn.execute(
                         f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                            JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ? AND n.session_id = ?{source_clause}
+                           WHERE nodes_fts MATCH ? AND n.session_id = ?
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, session_id, *source_args, fetch_limit, offset),
+                        (query, session_id, fetch_limit, offset),
                     ).fetchall()
                 else:
                     rows = self._conn.execute(
                         f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                            JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ?{source_clause}
+                           WHERE nodes_fts MATCH ?
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, *source_args, fetch_limit, offset),
+                        (query, fetch_limit, offset),
                     ).fetchall()
             except sqlite3.Error as exc:
                 logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
@@ -372,6 +363,8 @@ class SummaryDAG:
             raw_nodes = [self._row_to_node(r) for r in rows]
             raw_primary_values: list[float] = []
             for node in raw_nodes:
+                if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
+                    continue
                 node.search_directness = compute_directness_score(node.summary, terms, phrases)
                 if apply_directness_adjustment and node.search_rank is not None:
                     rank_adjustment = max(float(node.search_directness), 0.0)
@@ -405,11 +398,6 @@ class SummaryDAG:
         if session_id:
             where.append("session_id = ?")
             args.append(session_id)
-        if source:
-            where.append(
-                "EXISTS (SELECT 1 FROM messages m WHERE m.session_id = summary_nodes.session_id AND m.source = ?)"
-            )
-            args.append(source)
         like_clauses = []
         for term in terms:
             like_clauses.append("summary LIKE ? ESCAPE '\\'")
@@ -422,8 +410,11 @@ class SummaryDAG:
         ).fetchall()
         collapse_risky_repeats = contains_risky_fts_ascii(query)
         nodes: list[SummaryNode] = []
+        source_match_cache: dict[int, bool] = {}
         for row in rows:
             node = self._row_to_node(row)
+            if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
+                continue
             score = sum(
                 min(count_term_matches(node.summary, term), 1) if collapse_risky_repeats else count_term_matches(node.summary, term)
                 for term in terms
@@ -451,6 +442,48 @@ class SummaryDAG:
             node.source_ids,
         ).fetchall()
         return [self._row_to_node(r) for r in rows]
+
+    def _node_matches_source(
+        self,
+        node_id: int,
+        source: str,
+        *,
+        cache: dict[int, bool] | None = None,
+    ) -> bool:
+        if not source:
+            return True
+        if cache is not None and node_id in cache:
+            return cache[node_id]
+        row = self._conn.execute(
+            """
+            WITH RECURSIVE source_walk(source_type, source_id) AS (
+                SELECT n.source_type, CAST(j.value AS INTEGER)
+                FROM summary_nodes n, json_each(n.source_ids) j
+                WHERE n.node_id = ?
+
+                UNION ALL
+
+                SELECT child.source_type, CAST(j.value AS INTEGER)
+                FROM summary_nodes child
+                JOIN source_walk walk
+                  ON walk.source_type = 'nodes'
+                 AND child.node_id = walk.source_id
+                JOIN json_each(child.source_ids) j
+            )
+            SELECT 1
+            FROM source_walk walk
+            JOIN messages m
+              ON walk.source_type = 'messages'
+             AND m.store_id = walk.source_id
+            WHERE m.source = ?
+            LIMIT 1
+            """,
+            (node_id, source),
+        ).fetchone()
+        matched = row is not None
+        if cache is not None:
+            cache[node_id] = matched
+        return matched
 
     def get_source_time_window(self, node_ids: List[int]) -> tuple[float | None, float | None]:
         if not node_ids:

--- a/engine.py
+++ b/engine.py
@@ -775,7 +775,12 @@ class LCMEngine(ContextEngine):
             return
 
         estimates = [count_message_tokens(m) for m in new_messages]
-        self._store.append_batch(self._session_id, new_messages, estimates)
+        self._store.append_batch(
+            self._session_id,
+            new_messages,
+            estimates,
+            source=self._session_platform,
+        )
         self._ingest_cursor = n
         logger.debug("Ingested %d messages into LCM store", len(new_messages))
 

--- a/schemas.py
+++ b/schemas.py
@@ -34,6 +34,16 @@ LCM_GREP = {
                 ),
                 "default": "recency",
             },
+            "session_scope": {
+                "type": "string",
+                "enum": ["current", "all"],
+                "description": "Whether to search only the current session or all stored sessions.",
+                "default": "current",
+            },
+            "source": {
+                "type": "string",
+                "description": "Optional source/platform filter (for example cli, discord, telegram).",
+            },
         },
         "required": ["query"],
     },

--- a/store.py
+++ b/store.py
@@ -39,6 +39,10 @@ logger = logging.getLogger(__name__)
 
 
 _MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
+_MESSAGE_SELECT_COLUMNS = (
+    "store_id, session_id, source, role, content, tool_call_id, "
+    "tool_calls, tool_name, timestamp, token_estimate, pinned"
+)
 
 
 def _message_role_bias(role: str | None) -> float:
@@ -147,6 +151,7 @@ class MessageStore:
             CREATE TABLE IF NOT EXISTS messages (
                 store_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL,
+                source TEXT DEFAULT '',
                 role TEXT NOT NULL,
                 content TEXT,
                 tool_call_id TEXT,
@@ -192,23 +197,35 @@ class MessageStore:
             ),
         )
         run_versioned_migrations(self._conn)
+        self._ensure_source_column()
         self._conn.commit()
+
+    def _ensure_source_column(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "source" not in columns:
+            self._conn.execute("ALTER TABLE messages ADD COLUMN source TEXT DEFAULT ''")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_msg_source_session ON messages(source, session_id, store_id)"
+        )
 
     # -- Write operations ---------------------------------------------------
 
     def append(self, session_id: str, msg: Dict[str, Any],
-               token_estimate: int = 0) -> int:
+               token_estimate: int = 0, source: str = "") -> int:
         """Persist a message and return its store_id."""
         tool_calls = msg.get("tool_calls")
         tc_json = json.dumps(tool_calls) if tool_calls else None
 
         cur = self._conn.execute(
             """INSERT INTO messages
-               (session_id, role, content, tool_call_id, tool_calls,
+               (session_id, source, role, content, tool_call_id, tool_calls,
                 tool_name, timestamp, token_estimate, pinned)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session_id,
+                source or "",
                 msg.get("role", "unknown"),
                 msg.get("content"),
                 msg.get("tool_call_id"),
@@ -224,7 +241,8 @@ class MessageStore:
 
     def append_batch(self, session_id: str,
                      messages: List[Dict[str, Any]],
-                     token_estimates: List[int] | None = None) -> List[int]:
+                     token_estimates: List[int] | None = None,
+                     source: str = "") -> List[int]:
         """Persist multiple messages in one transaction. Returns store_ids."""
         if token_estimates is None:
             token_estimates = [0] * len(messages)
@@ -237,11 +255,12 @@ class MessageStore:
                 tc_json = json.dumps(tc) if tc else None
                 cur = self._conn.execute(
                     """INSERT INTO messages
-                       (session_id, role, content, tool_call_id, tool_calls,
+                       (session_id, source, role, content, tool_call_id, tool_calls,
                         tool_name, timestamp, token_estimate, pinned)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
+                        source or "",
                         msg.get("role", "unknown"),
                         msg.get("content"),
                         msg.get("tool_call_id"),
@@ -284,7 +303,7 @@ class MessageStore:
     def get(self, store_id: int) -> Optional[Dict[str, Any]]:
         """Retrieve a single message by store_id."""
         row = self._conn.execute(
-            "SELECT * FROM messages WHERE store_id = ?", (store_id,)
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE store_id = ?", (store_id,)
         ).fetchone()
         return self._row_to_dict(row) if row else None
 
@@ -297,7 +316,7 @@ class MessageStore:
             return {}
         placeholders = ",".join("?" for _ in store_ids)
         rows = self._conn.execute(
-            f"SELECT * FROM messages WHERE store_id IN ({placeholders})",
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE store_id IN ({placeholders})",
             store_ids,
         ).fetchall()
         return {row[0]: self._row_to_dict(row) for row in rows}
@@ -308,14 +327,14 @@ class MessageStore:
         """Get messages in a store_id range for a session."""
         if end_id is not None:
             rows = self._conn.execute(
-                """SELECT * FROM messages
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
                    WHERE session_id = ? AND store_id >= ? AND store_id <= ?
                    ORDER BY store_id LIMIT ?""",
                 (session_id, start_id, end_id, limit),
             ).fetchall()
         else:
             rows = self._conn.execute(
-                """SELECT * FROM messages
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
                    WHERE session_id = ? AND store_id >= ?
                    ORDER BY store_id LIMIT ?""",
                 (session_id, start_id, limit),
@@ -326,7 +345,7 @@ class MessageStore:
                              limit: int = 10000) -> List[Dict[str, Any]]:
         """Get all messages for a session, ordered by store_id."""
         rows = self._conn.execute(
-            """SELECT * FROM messages
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
                WHERE session_id = ?
                ORDER BY store_id LIMIT ?""",
             (session_id, limit),
@@ -364,12 +383,13 @@ class MessageStore:
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,
-               limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
+               limit: int = 20, sort: str | None = None,
+               source: str | None = None) -> List[Dict[str, Any]]:
         """FTS5 search across messages. Returns matches with snippets."""
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
-            return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+            return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
         order_by = _build_search_order_by(
             sort,
@@ -384,34 +404,65 @@ class MessageStore:
         while True:
             try:
                 if session_id:
-                    rows = self._conn.execute(
-                        f"""SELECT m.*, rank as search_rank,
-                                  snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                           FROM messages_fts fts
-                           JOIN messages m ON m.store_id = fts.rowid
-                           WHERE messages_fts MATCH ? AND m.session_id = ?
-                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, session_id, fetch_limit, offset),
-                    ).fetchall()
+                    if source:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.session_id = ? AND m.source = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, session_id, source, fetch_limit, offset),
+                        ).fetchall()
+                    else:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.session_id = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, session_id, fetch_limit, offset),
+                        ).fetchall()
                 else:
-                    rows = self._conn.execute(
-                        f"""SELECT m.*, rank as search_rank,
-                                  snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                           FROM messages_fts fts
-                           JOIN messages m ON m.store_id = fts.rowid
-                           WHERE messages_fts MATCH ?
-                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, fetch_limit, offset),
-                    ).fetchall()
+                    if source:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ? AND m.source = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, source, fetch_limit, offset),
+                        ).fetchall()
+                    else:
+                        rows = self._conn.execute(
+                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                                      rank as search_rank,
+                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                               FROM messages_fts fts
+                               JOIN messages m ON m.store_id = fts.rowid
+                               WHERE messages_fts MATCH ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (query, fetch_limit, offset),
+                        ).fetchall()
             except sqlite3.Error as exc:
                 logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
-                return self._search_like(query, session_id=session_id, limit=limit, sort=sort)
+                return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
             raw_primary_values: list[float] = []
             for r in rows:
                 d = self._row_to_dict(r)
-                d["search_rank"] = r[10] if len(r) > 10 else None
-                d["snippet"] = r[11] if len(r) > 11 else ""
+                base_columns = 11
+                d["search_rank"] = r[base_columns] if len(r) > base_columns else None
+                d["snippet"] = r[base_columns + 1] if len(r) > (base_columns + 1) else ""
                 d["_directness_score"] = _message_directness_score(d.get("role"), d.get("content"), terms, phrases)
                 if apply_directness_adjustment and d["search_rank"] is not None:
                     rank_adjustment = max(float(d["_directness_score"]), 0.0)
@@ -433,7 +484,8 @@ class MessageStore:
             fetch_limit *= 2
 
     def _search_like(self, query: str, session_id: str | None = None,
-                     limit: int = 20, sort: str | None = None) -> List[Dict[str, Any]]:
+                     limit: int = 20, sort: str | None = None,
+                     source: str | None = None) -> List[Dict[str, Any]]:
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if not terms:
@@ -444,6 +496,9 @@ class MessageStore:
         if session_id:
             where.append("session_id = ?")
             args.append(session_id)
+        if source:
+            where.append("source = ?")
+            args.append(source)
         like_clauses = []
         for term in terms:
             like_clauses.append("content LIKE ? ESCAPE '\\'")
@@ -451,7 +506,7 @@ class MessageStore:
         where.append("(" + " OR ".join(like_clauses) + ")")
 
         rows = self._conn.execute(
-            f"SELECT * FROM messages WHERE {' AND '.join(where)}",
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE {' AND '.join(where)}",
             args,
         ).fetchall()
         results: List[Dict[str, Any]] = []
@@ -483,7 +538,7 @@ class MessageStore:
         if row is None:
             return {}
         cols = [
-            "store_id", "session_id", "role", "content", "tool_call_id",
+            "store_id", "session_id", "source", "role", "content", "tool_call_id",
             "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned",
         ]
         d = dict(zip(cols, row[:len(cols)]))

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -199,6 +199,21 @@ class TestMessageStore:
         results = store.search("docker", session_id="sess1")
         assert len(results) >= 1
 
+    def test_source_stored_and_filterable(self, store):
+        store.append("sess1", {"role": "user", "content": "docker in cli"}, source="cli")
+        store.append("sess2", {"role": "user", "content": "docker in discord"}, source="discord")
+
+        cli_results = store.search("docker", source="cli")
+        discord_results = store.search("docker", source="discord")
+
+        assert len(cli_results) == 1
+        assert cli_results[0]["source"] == "cli"
+        assert cli_results[0]["session_id"] == "sess1"
+
+        assert len(discord_results) == 1
+        assert discord_results[0]["source"] == "discord"
+        assert discord_results[0]["session_id"] == "sess2"
+
     def test_init_repairs_malformed_message_fts_and_sets_schema_version(self, tmp_path):
         db_path = tmp_path / "legacy-store.db"
         conn = sqlite3.connect(db_path)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -45,6 +45,11 @@ class TestEngineABC:
         assert "lcm_doctor" in names
         assert "lcm_expand_query" in names
 
+        grep_schema = next(s for s in schemas if s["name"] == "lcm_grep")
+        grep_props = grep_schema["parameters"]["properties"]
+        assert "session_scope" in grep_props
+        assert "source" in grep_props
+
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)
         assert engine.should_compress(engine.threshold_tokens)
@@ -1824,6 +1829,48 @@ class TestEngineTools:
             )
         )
         assert result["sort"] == "relevance"
+
+    def test_handle_grep_source_filter_across_sessions_includes_only_matching_summaries(self, engine):
+        engine._store.append("s-discord", {"role": "user", "content": "docker logs from discord"}, source="discord")
+        engine._store.append("s-telegram", {"role": "user", "content": "docker logs from telegram"}, source="telegram")
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="s-discord",
+                depth=0,
+                summary="discord summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="s-telegram",
+                depth=0,
+                summary="telegram summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[2],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "source": "discord", "limit": 10},
+            )
+        )
+
+        assert result["session_scope"] == "all"
+        assert result["source"] == "discord"
+        assert any(item["type"] == "message" for item in result["results"])
+        assert any(item["type"] == "summary" for item in result["results"])
+        assert all(item.get("session_id") == "s-discord" for item in result["results"])
+        assert all(item.get("source", "discord") == "discord" for item in result["results"] if item["type"] == "message")
 
     def test_handle_grep_prefers_conversational_hits_over_tool_output_noise(self, engine):
         engine._store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1872,6 +1872,63 @@ class TestEngineTools:
         assert all(item.get("session_id") == "s-discord" for item in result["results"])
         assert all(item.get("source", "discord") == "discord" for item in result["results"] if item["type"] == "message")
 
+    def test_handle_grep_source_filter_excludes_unrelated_summaries_in_mixed_source_session(self, engine):
+        discord_store_id = engine._store.append(
+            "mixed-session",
+            {"role": "user", "content": "docker logs from discord"},
+            source="discord",
+        )
+        telegram_store_id = engine._store.append(
+            "mixed-session",
+            {"role": "user", "content": "docker logs from telegram"},
+            source="telegram",
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="mixed-session",
+                depth=0,
+                summary="discord summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[discord_store_id],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="mixed-session",
+                depth=0,
+                summary="telegram summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[telegram_store_id],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "source": "discord", "limit": 10},
+            )
+        )
+
+        assert any(item["type"] == "message" for item in result["results"])
+        assert any(item["type"] == "summary" for item in result["results"])
+        assert all(item.get("session_id") == "mixed-session" for item in result["results"])
+        assert all(
+            "telegram summary" not in item.get("snippet", "")
+            for item in result["results"]
+            if item["type"] == "summary"
+        )
+        assert any(
+            "discord summary" in item.get("snippet", "")
+            for item in result["results"]
+            if item["type"] == "summary"
+        )
+
     def test_handle_grep_prefers_conversational_hits_over_tool_output_noise(self, engine):
         engine._store.append(
             "test-session",

--- a/tools.py
+++ b/tools.py
@@ -207,7 +207,7 @@ def _synthesize_expansion_answer(
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
-    """Search across the full DAG and raw messages for the current session."""
+    """Search across the full DAG and raw messages."""
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
@@ -219,17 +219,27 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     limit = args.get("limit", 10)
     sort = normalize_search_sort(args.get("sort"))
     source_limit = max(limit * 4, limit, 20)
-    session_id = engine._session_id
+    session_scope = str(args.get("session_scope", "current")).lower()
+    source = str(args.get("source") or "").strip() or None
+    session_id = None if session_scope == "all" else engine._session_id
     results = []
 
     try:
-        msg_hits = engine._store.search(query, session_id=session_id, limit=source_limit, sort=sort)
+        msg_hits = engine._store.search(
+            query,
+            session_id=session_id,
+            limit=source_limit,
+            sort=sort,
+            source=source,
+        )
         for hit in msg_hits:
             results.append(
                 {
                     "type": "message",
                     "depth": "raw",
                     "store_id": hit["store_id"],
+                    "session_id": hit["session_id"],
+                    "source": hit.get("source") or "",
                     "role": hit["role"],
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
                     "_sort_ts": hit.get("timestamp", 0),
@@ -241,13 +251,20 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         logger.warning("Message search failed: %s", exc)
 
     try:
-        node_hits = engine._dag.search(query, session_id=session_id, limit=source_limit, sort=sort)
+        node_hits = engine._dag.search(
+            query,
+            session_id=session_id,
+            limit=source_limit,
+            sort=sort,
+            source=source,
+        )
         for node in node_hits:
             results.append(
                 {
                     "type": "summary",
                     "depth": f"d{node.depth}",
                     "node_id": node.node_id,
+                    "session_id": node.session_id,
                     "snippet": node.summary[:300],
                     "token_count": node.token_count,
                     "expand_hint": node.expand_hint,
@@ -276,7 +293,16 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         result.pop("_sort_rank", None)
         result.pop("_sort_directness", None)
         result.pop("_hybrid_summary_override", None)
-    return json.dumps({"query": query, "sort": sort, "total_results": len(results), "results": results[:limit]})
+    return json.dumps(
+        {
+            "query": query,
+            "sort": sort,
+            "session_scope": session_scope,
+            "source": source,
+            "total_results": len(results),
+            "results": results[:limit],
+        }
+    )
 
 
 def lcm_describe(args: Dict[str, Any], **kwargs) -> str:


### PR DESCRIPTION
## Summary
- fix profile-local DB resolution by preferring `HERMES_HOME/lcm.db` when available
- add `source` metadata to LCM message storage and support source-filtered search
- add schema migration for legacy DBs and persist `lcm_schema_version=2`
- extend `lcm_grep` with `session_scope` (current|all) and optional `source` filter
- update README with recall guidance and new grep/path behavior

## Tests
- added regression tests for DB path resolution, source filtering, schema params, and migration/version metadata
- ran full suite: `pytest -q` (40 passed)

## Notes
- left `manim-lcm-explainer/` untracked and excluded from this PR