### PR TITLE
feat: externalize oversized tool outputs

### DIFF
--- a/config.py
+++ b/config.py
@@ -106,6 +106,15 @@ class LCMConfig:
     # Directory for daily extraction files (empty = auto: ~/.hermes/lcm-extractions/)
     extraction_output_path: str = ""
 
+    # -- Large tool-output externalization ---
+    # When enabled, oversized tool results are written to plugin-managed storage
+    # and replaced with compact references in pre-compaction serializer input.
+    large_output_externalization_enabled: bool = False
+    # Character threshold above which tool results are externalized.
+    large_output_externalization_threshold_chars: int = 12_000
+    # Explicit storage directory for externalized payloads (empty = auto under hermes home).
+    large_output_externalization_path: str = ""
+
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
@@ -162,6 +171,18 @@ class LCMConfig:
         c.extraction_enabled = _parse_bool_env("LCM_EXTRACTION_ENABLED", c.extraction_enabled)
         c.extraction_model = _str("LCM_EXTRACTION_MODEL", c.extraction_model)
         c.extraction_output_path = _str("LCM_EXTRACTION_OUTPUT_PATH", c.extraction_output_path)
+        c.large_output_externalization_enabled = _parse_bool_env(
+            "LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED",
+            c.large_output_externalization_enabled,
+        )
+        c.large_output_externalization_threshold_chars = _int(
+            "LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS",
+            c.large_output_externalization_threshold_chars,
+        )
+        c.large_output_externalization_path = _str(
+            "LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH",
+            c.large_output_externalization_path,
+        )
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
         c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)

--- a/engine.py
+++ b/engine.py
@@ -17,6 +17,7 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
+from .externalize import maybe_externalize_tool_output
 from .extraction import (
     extract_before_compaction,
     sanitize_pre_compaction_content,
@@ -837,7 +838,16 @@ class LCMEngine(ContextEngine):
 
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
-                if len(content) > 3000:
+                externalized = maybe_externalize_tool_output(
+                    content,
+                    tool_call_id=tool_id,
+                    session_id=self._session_id,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                if externalized:
+                    content = externalized["placeholder"]
+                elif len(content) > 3000:
                     content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
                 parts.append(f"[TOOL RESULT {tool_id}]: {content}")
                 continue

--- a/externalize.py
+++ b/externalize.py
@@ -49,6 +49,13 @@ def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]
     }
 
 
+def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
+    return (
+        f"[Externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
+        f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
+    )
+
+
 def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dict[str, Any] | None:
     if not ref or Path(ref).name != ref:
         return None
@@ -127,6 +134,21 @@ def maybe_externalize_tool_output(
     except OSError as exc:
         logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
         return None
+
+    existing = find_externalized_payload_for_message(
+        content,
+        tool_call_id=tool_call_id,
+        session_id=session_id,
+        config=config,
+        hermes_home=hermes_home,
+    )
+    if existing is not None:
+        return {
+            "placeholder": _build_externalized_placeholder(existing),
+            "path": storage_dir / existing["ref"],
+            "payload": existing,
+        }
+
     digest_prefix = _content_digest_prefix(content)
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
     unique_suffix = f"{time.time_ns():x}"
@@ -149,9 +171,13 @@ def maybe_externalize_tool_output(
         logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
         return None
 
-    placeholder = (
-        f"[Externalized tool output: tool_call_id={tool_call_id or '?'}; "
-        f"chars={payload['content_chars']}; bytes={payload['content_bytes']}; ref={path.name}]"
+    placeholder = _build_externalized_placeholder(
+        {
+            "tool_call_id": tool_call_id,
+            "content_chars": payload["content_chars"],
+            "content_bytes": payload["content_bytes"],
+            "ref": path.name,
+        }
     )
     return {
         "placeholder": placeholder,

--- a/externalize.py
+++ b/externalize.py
@@ -1,0 +1,160 @@
+"""Helpers for optional large tool-output externalization during pre-compaction serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+DEFAULT_LARGE_OUTPUT_DIRNAME = "lcm-large-outputs"
+logger = logging.getLogger(__name__)
+
+
+def _tool_call_stub(tool_call_id: str) -> str:
+    return (tool_call_id or "tool-result").replace("/", "-").replace(":", "-")[:48]
+
+
+def _content_digest_prefix(content: str) -> str:
+    return hashlib.sha256((content or "").encode("utf-8")).hexdigest()[:12]
+
+
+def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool) -> Path:
+    configured = getattr(config, "large_output_externalization_path", "") or ""
+    if configured:
+        path = Path(configured).expanduser()
+    else:
+        base = Path(hermes_home).expanduser() if hermes_home else Path("~/.hermes").expanduser()
+        path = base / DEFAULT_LARGE_OUTPUT_DIRNAME
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def resolve_large_output_storage_dir(config, hermes_home: str = "") -> Path:
+    return get_large_output_storage_dir(config, hermes_home=hermes_home, create=True)
+
+
+def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "ref": path.name,
+        "kind": payload.get("kind", "tool_result"),
+        "tool_call_id": payload.get("tool_call_id", ""),
+        "session_id": payload.get("session_id", ""),
+        "content_chars": payload.get("content_chars", len(payload.get("content", ""))),
+        "content_bytes": payload.get("content_bytes", len((payload.get("content", "") or "").encode("utf-8"))),
+        "created_at": payload.get("created_at"),
+    }
+
+
+def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dict[str, Any] | None:
+    if not ref or Path(ref).name != ref:
+        return None
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    if not storage_dir.exists() or not storage_dir.is_dir():
+        return None
+    path = storage_dir / ref
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    summary = _externalized_summary(path, payload)
+    summary["content"] = payload.get("content", "")
+    return summary
+
+
+def find_externalized_payload_for_message(
+    content: str,
+    *,
+    tool_call_id: str = "",
+    session_id: str = "",
+    config,
+    hermes_home: str = "",
+) -> Dict[str, Any] | None:
+    if not content:
+        return None
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    if not storage_dir.exists() or not storage_dir.is_dir():
+        return None
+
+    digest_prefix = _content_digest_prefix(content)
+    tool_stub = _tool_call_stub(tool_call_id)
+    candidates = sorted(storage_dir.glob(f"*_{tool_stub}_{digest_prefix}_*.json"))
+    fallback_match = None
+    for path in candidates:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if payload.get("kind") != "tool_result":
+            continue
+        if (payload.get("tool_call_id") or "") != (tool_call_id or ""):
+            continue
+        if payload.get("content") != content:
+            continue
+        summary = _externalized_summary(path, payload)
+        payload_session_id = (payload.get("session_id") or "")
+        if session_id:
+            if payload_session_id == session_id:
+                return summary
+            continue
+        if fallback_match is None:
+            fallback_match = summary
+    return fallback_match
+
+
+def maybe_externalize_tool_output(
+    content: str,
+    *,
+    tool_call_id: str = "",
+    session_id: str = "",
+    config,
+    hermes_home: str = "",
+) -> Dict[str, Any] | None:
+    if not getattr(config, "large_output_externalization_enabled", False):
+        return None
+
+    threshold = max(1, int(getattr(config, "large_output_externalization_threshold_chars", 0) or 0))
+    if not content or len(content) <= threshold:
+        return None
+
+    try:
+        storage_dir = resolve_large_output_storage_dir(config, hermes_home=hermes_home)
+    except OSError as exc:
+        logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
+        return None
+    digest_prefix = _content_digest_prefix(content)
+    timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+    unique_suffix = f"{time.time_ns():x}"
+    tool_stub = _tool_call_stub(tool_call_id)
+    filename = f"{timestamp}_{tool_stub}_{digest_prefix}_{unique_suffix}.json"
+    path = storage_dir / filename
+
+    payload = {
+        "kind": "tool_result",
+        "tool_call_id": tool_call_id,
+        "session_id": session_id,
+        "content": content,
+        "content_chars": len(content),
+        "content_bytes": len(content.encode("utf-8")),
+        "created_at": time.time(),
+    }
+    try:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
+        return None
+
+    placeholder = (
+        f"[Externalized tool output: tool_call_id={tool_call_id or '?'}; "
+        f"chars={payload['content_chars']}; bytes={payload['content_bytes']}; ref={path.name}]"
+    )
+    return {
+        "placeholder": placeholder,
+        "path": path,
+        "payload": payload,
+    }

--- a/schemas.py
+++ b/schemas.py
@@ -55,6 +55,10 @@ LCM_DESCRIBE = {
                 "type": "integer",
                 "description": "Summary node ID to inspect. Omit for session overview.",
             },
+            "externalized_ref": {
+                "type": "string",
+                "description": "Optional externalized payload ref filename to inspect instead of a summary node.",
+            },
         },
         "required": [],
     },
@@ -75,13 +79,17 @@ LCM_EXPAND = {
                 "type": "integer",
                 "description": "Summary node ID to expand",
             },
+            "externalized_ref": {
+                "type": "string",
+                "description": "Optional externalized payload ref filename to expand instead of a summary node.",
+            },
             "max_tokens": {
                 "type": "integer",
                 "description": "Token budget for returned content (default 4000)",
                 "default": 4000,
             },
         },
-        "required": ["node_id"],
+        "required": [],
     },
 }
 

--- a/schemas.py
+++ b/schemas.py
@@ -43,10 +43,12 @@ LCM_DESCRIBE = {
     "name": "lcm_describe",
     "description": (
         "Inspect a summary node's subtree metadata WITHOUT loading full "
-        "content. Returns token counts, child manifest, and expand hints. "
-        "Use this to plan retrieval strategy before spending tokens on "
-        "lcm_expand. If called with no node_id, returns the top-level "
-        "DAG overview for the current session."
+        "content, or inspect an externalized payload ref without opening the "
+        "full payload. Returns token counts, child manifest, expand hints, "
+        "or externalized payload metadata/preview. Use this to plan retrieval "
+        "strategy before spending tokens on lcm_expand. If called with no "
+        "node_id or externalized_ref, returns the top-level DAG overview for "
+        "the current session."
     ),
     "parameters": {
         "type": "object",
@@ -67,10 +69,13 @@ LCM_DESCRIBE = {
 LCM_EXPAND = {
     "name": "lcm_expand",
     "description": (
-        "Recover the original detail behind a summary node. Given a node_id, "
-        "returns the source messages or lower-depth summaries that were "
-        "compacted into that node. Use after lcm_describe to drill into "
-        "specific parts of the conversation history."
+        "Recover the original detail behind a summary node, or open an "
+        "externalized payload ref directly. Given a node_id, returns the "
+        "source messages or lower-depth summaries that were compacted into "
+        "that node. Given externalized_ref, returns the stored payload "
+        "content plus metadata. Use after lcm_describe to drill into "
+        "specific parts of the conversation history or large externalized "
+        "tool output."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1983,6 +1983,39 @@ class TestExtraction:
         payloads = [json.loads(path.read_text()) for path in payload_files]
         assert sorted(payload["session_id"] for payload in payloads) == ["telegram:first", "telegram:second"]
 
+    def test_serialize_messages_reuses_existing_externalized_payload_for_same_session_content_and_tool_id(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        hermes_home = tmp_path / "hermes-home"
+        engine = LCMEngine(
+            config=LCMConfig(
+                database_path=str(tmp_path / "lcm.db"),
+                large_output_externalization_enabled=True,
+                large_output_externalization_threshold_chars=200,
+            ),
+            hermes_home=str(hermes_home),
+        )
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        first_serialized = engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_reuse", "content": content}
+        ])
+        second_serialized = engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_reuse", "content": content}
+        ])
+
+        payload_dir = hermes_home / "lcm-large-outputs"
+        payload_files = sorted(payload_dir.glob("*.json"))
+        assert len(payload_files) == 1
+        assert first_serialized == second_serialized
+
+        payload = json.loads(payload_files[0].read_text())
+        assert payload["session_id"] == "test-session"
+        assert payload["tool_call_id"] == "call_reuse"
+        assert payload["content"] == content
+
     def test_serialize_messages_externalizes_large_tool_output_to_configured_path(self, tmp_path):
         from hermes_lcm.config import LCMConfig
         from hermes_lcm.engine import LCMEngine

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -37,6 +37,9 @@ class TestConfig:
         assert c.extraction_enabled is False
         assert c.extraction_model == ""
         assert c.extraction_output_path == ""
+        assert c.large_output_externalization_enabled is False
+        assert c.large_output_externalization_threshold_chars == 12_000
+        assert c.large_output_externalization_path == ""
         assert c.deferred_maintenance_enabled is False
         assert c.deferred_maintenance_max_passes == 4
         assert c.ignore_session_patterns == []
@@ -64,6 +67,9 @@ class TestConfig:
         monkeypatch.setenv("LCM_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("LCM_EXTRACTION_MODEL", "openai/gpt-5.4-mini")
         monkeypatch.setenv("LCM_EXTRACTION_OUTPUT_PATH", "/tmp/extractions")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", "true")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", "4096")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", "/tmp/lcm-large-outputs")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
@@ -82,6 +88,9 @@ class TestConfig:
         assert c.extraction_enabled is True
         assert c.extraction_model == "openai/gpt-5.4-mini"
         assert c.extraction_output_path == "/tmp/extractions"
+        assert c.large_output_externalization_enabled is True
+        assert c.large_output_externalization_threshold_chars == 4096
+        assert c.large_output_externalization_path == "/tmp/lcm-large-outputs"
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")
@@ -1837,6 +1846,177 @@ class TestExtraction:
         assert "type=input_file" in serialized
         assert "file_123" in serialized
         assert "requirements.pdf" in serialized
+
+    def test_serialize_messages_uses_profile_safe_default_externalization_path_for_large_tool_output(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        hermes_home = tmp_path / "hermes-home"
+        engine = LCMEngine(
+            config=LCMConfig(
+                database_path=str(tmp_path / "lcm.db"),
+                large_output_externalization_enabled=True,
+                large_output_externalization_threshold_chars=200,
+            ),
+            hermes_home=str(hermes_home),
+        )
+
+        content = "tool-output:" + ("x" * 5000)
+        serialized = engine._serialize_messages([
+            {
+                "role": "tool",
+                "tool_call_id": "call_big_default",
+                "content": content,
+            }
+        ])
+
+        assert "[Externalized tool output" in serialized
+        assert "call_big_default" in serialized
+        assert content[:500] not in serialized
+
+        payload_dir = hermes_home / "lcm-large-outputs"
+        payload_files = list(payload_dir.glob("*.json"))
+        assert len(payload_files) == 1
+
+        payload = json.loads(payload_files[0].read_text())
+        assert payload["kind"] == "tool_result"
+        assert payload["tool_call_id"] == "call_big_default"
+        assert payload["content"] == content
+
+    def test_serialize_messages_leaves_large_tool_output_inline_when_externalization_disabled(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        hermes_home = tmp_path / "hermes-home"
+        engine = LCMEngine(
+            config=LCMConfig(
+                database_path=str(tmp_path / "lcm.db"),
+                large_output_externalization_enabled=False,
+                large_output_externalization_threshold_chars=200,
+            ),
+            hermes_home=str(hermes_home),
+        )
+
+        content = "tool-output:" + ("x" * 5000)
+        serialized = engine._serialize_messages([
+            {
+                "role": "tool",
+                "tool_call_id": "call_disabled",
+                "content": content,
+            }
+        ])
+
+        assert "[Externalized tool output" not in serialized
+        assert "...[truncated]..." in serialized
+        assert not (hermes_home / "lcm-large-outputs").exists()
+
+    def test_serialize_messages_falls_back_to_truncation_when_externalization_path_is_unwritable(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        blocked_path = tmp_path / "not-a-dir"
+        blocked_path.write_text("occupied")
+        engine = LCMEngine(
+            config=LCMConfig(
+                database_path=str(tmp_path / "lcm.db"),
+                large_output_externalization_enabled=True,
+                large_output_externalization_threshold_chars=200,
+                large_output_externalization_path=str(blocked_path),
+            )
+        )
+
+        content = "tool-output:" + ("x" * 5000)
+        serialized = engine._serialize_messages([
+            {
+                "role": "tool",
+                "tool_call_id": "call_unwritable",
+                "content": content,
+            }
+        ])
+
+        assert "[Externalized tool output" not in serialized
+        assert "...[truncated]..." in serialized
+
+    def test_serialize_messages_externalized_payloads_do_not_collide_for_same_second_same_tool_id(self, tmp_path, monkeypatch):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+        import hermes_lcm.externalize as ext_module
+
+        output_dir = tmp_path / "externalized"
+        original_strftime = ext_module.time.strftime
+        monkeypatch.setattr(ext_module.time, "strftime", lambda *args, **kwargs: "20260418_060000")
+        try:
+            first = LCMEngine(
+                config=LCMConfig(
+                    database_path=str(tmp_path / "first.db"),
+                    large_output_externalization_enabled=True,
+                    large_output_externalization_threshold_chars=200,
+                    large_output_externalization_path=str(output_dir),
+                )
+            )
+            first._session_id = "telegram:first"
+
+            second = LCMEngine(
+                config=LCMConfig(
+                    database_path=str(tmp_path / "second.db"),
+                    large_output_externalization_enabled=True,
+                    large_output_externalization_threshold_chars=200,
+                    large_output_externalization_path=str(output_dir),
+                )
+            )
+            second._session_id = "telegram:second"
+
+            content = "RESULT:\n" + ("abcdef" * 2000)
+            first_serialized = first._serialize_messages([
+                {"role": "tool", "tool_call_id": "call_same", "content": content}
+            ])
+            second_serialized = second._serialize_messages([
+                {"role": "tool", "tool_call_id": "call_same", "content": content}
+            ])
+        finally:
+            monkeypatch.setattr(ext_module.time, "strftime", original_strftime)
+
+        payload_files = sorted(output_dir.glob("*.json"))
+        assert len(payload_files) == 2
+        assert first_serialized != second_serialized
+
+        payloads = [json.loads(path.read_text()) for path in payload_files]
+        assert sorted(payload["session_id"] for payload in payloads) == ["telegram:first", "telegram:second"]
+
+    def test_serialize_messages_externalizes_large_tool_output_to_configured_path(self, tmp_path):
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        output_dir = tmp_path / "externalized"
+        engine = LCMEngine(
+            config=LCMConfig(
+                database_path=str(tmp_path / "lcm.db"),
+                large_output_externalization_enabled=True,
+                large_output_externalization_threshold_chars=200,
+                large_output_externalization_path=str(output_dir),
+            )
+        )
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        serialized = engine._serialize_messages([
+            {
+                "role": "tool",
+                "tool_call_id": "call_big_custom",
+                "content": content,
+            }
+        ])
+
+        assert "[Externalized tool output" in serialized
+        assert "call_big_custom" in serialized
+        assert content[:500] not in serialized
+
+        payload_files = list(output_dir.glob("*.json"))
+        assert len(payload_files) == 1
+
+        payload = json.loads(payload_files[0].read_text())
+        assert payload["kind"] == "tool_result"
+        assert payload["tool_call_id"] == "call_big_custom"
+        assert payload["content"] == content
 
     def test_run_pre_compaction_extraction_uses_media_cleaned_text(self, tmp_path):
         from hermes_lcm.config import LCMConfig

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2430,6 +2430,168 @@ class TestEngineTools:
         assert "session_id" in result
         assert "store_message_count" in result
 
+    def test_handle_expand_includes_externalized_metadata_for_large_tool_result_sources(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_expand.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_big", "content": content},
+        )
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Externalized tool-output summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+
+        assert result["source_type"] == "messages"
+        assert result["expanded"][0]["store_id"] == store_id
+        assert result["expanded"][0]["externalized"]["tool_call_id"] == "call_big"
+        assert result["expanded"][0]["externalized"]["content_chars"] == len(content)
+        assert result["expanded"][0]["externalized"]["ref"].endswith(".json")
+
+    def test_handle_expand_does_not_attach_other_sessions_externalized_metadata(self, tmp_path):
+        shared_home = tmp_path / "hermes"
+        config_a = LCMConfig(
+            database_path=str(tmp_path / "a.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine_a = LCMEngine(config=config_a, hermes_home=str(shared_home))
+        engine_a._session_id = "session-a"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine_a._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_shared", "content": content}
+        ])
+
+        config_b = LCMConfig(
+            database_path=str(tmp_path / "b.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine_b = LCMEngine(config=config_b, hermes_home=str(shared_home))
+        engine_b._session_id = "session-b"
+        store_id = engine_b._store.append(
+            "session-b",
+            {"role": "tool", "tool_call_id": "call_shared", "content": content},
+        )
+        node_id = engine_b._dag.add_node(
+            SummaryNode(
+                session_id="session-b",
+                depth=0,
+                summary="Other session summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(engine_b.handle_tool_call("lcm_expand", {"node_id": node_id}))
+
+        assert "externalized" not in result["expanded"][0]
+
+    def test_handle_expand_finds_externalized_metadata_for_sanitized_tool_output(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_sanitized.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        raw_content = (("Chart screenshot notes. " * 80) + "\n\n" + "data:image/png;base64," + ("A" * 5000))
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_media", "content": raw_content},
+        )
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_media", "content": raw_content}
+        ])
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Sanitized externalized tool-output summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+
+        assert result["expanded"][0]["externalized"]["tool_call_id"] == "call_media"
+        assert result["expanded"][0]["externalized"]["session_id"] == "test-session"
+
+    def test_handle_describe_externalized_ref_returns_metadata(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_describe.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+
+        result = json.loads(engine.handle_tool_call("lcm_describe", {"externalized_ref": ref}))
+
+        assert result["externalized_ref"] == ref
+        assert result["kind"] == "tool_result"
+        assert result["tool_call_id"] == "call_big"
+        assert result["session_id"] == "test-session"
+        assert result["content_chars"] == len(content)
+        assert result["content_preview"].startswith("RESULT:")
+
+    def test_handle_expand_externalized_ref_returns_payload_content(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_payload.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"externalized_ref": ref}))
+
+        assert result["externalized_ref"] == ref
+        assert result["source_type"] == "externalized_payload"
+        assert result["content"] == content
+        assert result["tool_call_id"] == "call_big"
+
     def test_handle_unknown_tool(self, engine):
         result = json.loads(engine.handle_tool_call("unknown_tool", {}))
         assert "error" in result

--- a/tools.py
+++ b/tools.py
@@ -7,6 +7,8 @@ import logging
 import time
 from typing import Any, Dict, TYPE_CHECKING
 
+from .externalize import find_externalized_payload_for_message, load_externalized_payload
+from .extraction import sanitize_pre_compaction_content
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 
 if TYPE_CHECKING:
@@ -60,6 +62,16 @@ def _get_session_node(engine: "LCMEngine", node_id: int):
     return node
 
 
+def _get_externalized_payload(engine: "LCMEngine", ref: str) -> dict[str, Any] | None:
+    payload = load_externalized_payload(ref, config=engine._config, hermes_home=engine._hermes_home)
+    if payload is None:
+        return None
+    payload_session_id = payload.get("session_id") or ""
+    if payload_session_id and payload_session_id != engine._session_id:
+        return None
+    return payload
+
+
 def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
     from .tokens import count_tokens
 
@@ -80,13 +92,28 @@ def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[
                 }
             )
             break
-        messages.append(
-            {
-                "store_id": stored["store_id"],
-                "role": stored["role"],
-                "content": content[:2000] if len(content) > 2000 else content,
-            }
-        )
+        expanded = {
+            "store_id": stored["store_id"],
+            "role": stored["role"],
+            "content": content[:2000] if len(content) > 2000 else content,
+        }
+        if stored.get("role") == "tool":
+            lookup_candidates = [content]
+            sanitized_content = sanitize_pre_compaction_content(content)
+            if sanitized_content != content:
+                lookup_candidates.insert(0, sanitized_content)
+            for candidate in lookup_candidates:
+                externalized = find_externalized_payload_for_message(
+                    candidate,
+                    tool_call_id=stored.get("tool_call_id", ""),
+                    session_id=stored.get("session_id", ""),
+                    config=engine._config,
+                    hermes_home=engine._hermes_home,
+                )
+                if externalized is not None:
+                    expanded["externalized"] = externalized
+                    break
+        messages.append(expanded)
         budget_used += msg_tokens
     return messages
 
@@ -253,10 +280,28 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
 
 
 def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
-    """Inspect a node's subtree or get session DAG overview."""
+    """Inspect a summary node's subtree or get session DAG overview."""
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
+
+    externalized_ref = str(args.get("externalized_ref") or "").strip()
+    if externalized_ref:
+        payload = _get_externalized_payload(engine, externalized_ref)
+        if payload is None:
+            return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
+        return json.dumps(
+            {
+                "externalized_ref": externalized_ref,
+                "kind": payload.get("kind", "tool_result"),
+                "tool_call_id": payload.get("tool_call_id", ""),
+                "session_id": payload.get("session_id", ""),
+                "content_chars": payload.get("content_chars", 0),
+                "content_bytes": payload.get("content_bytes", 0),
+                "created_at": payload.get("created_at"),
+                "content_preview": (payload.get("content") or "")[:500],
+            }
+        )
 
     node_id = args.get("node_id")
     session_id = engine._session_id
@@ -300,9 +345,27 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
+    externalized_ref = str(args.get("externalized_ref") or "").strip()
+    if externalized_ref:
+        payload = _get_externalized_payload(engine, externalized_ref)
+        if payload is None:
+            return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
+        return json.dumps(
+            {
+                "externalized_ref": externalized_ref,
+                "source_type": "externalized_payload",
+                "kind": payload.get("kind", "tool_result"),
+                "tool_call_id": payload.get("tool_call_id", ""),
+                "session_id": payload.get("session_id", ""),
+                "content_chars": payload.get("content_chars", 0),
+                "content_bytes": payload.get("content_bytes", 0),
+                "content": payload.get("content", ""),
+            }
+        )
+
     node_id = args.get("node_id")
     if node_id is None:
-        return json.dumps({"error": "node_id is required"})
+        return json.dumps({"error": "node_id or externalized_ref is required"})
 
     node = _get_session_node(engine, node_id)
     if node is None:


### PR DESCRIPTION
## Summary
- add opt-in externalization for oversized tool-result payloads during pre-compaction serialization
- store large tool outputs in plugin-managed files under a profile-safe path while keeping compact transcript refs
- extend `lcm_describe` and `lcm_expand` so externalized payloads remain inspectable through the existing LCM tool surface
- keep externalized payload lookup session-scoped and handle sanitized tool-result matching
- reuse same-session payload refs for identical repeated serializer inputs instead of creating duplicate files

## What changed
- add config flags for large tool-output externalization:
  - `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED`
  - `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS`
  - `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH`
- add `externalize.py` helper for storage path resolution, payload write/load, session-safe lookup, and ref reuse
- update `_serialize_messages(...)` to externalize oversized `tool`-role content when enabled, with non-blocking fallback to existing truncation behavior when storage is unavailable
- add `externalized_ref` support to `lcm_describe` and `lcm_expand`
- attach externalized payload metadata to expanded tool-result source messages when a matching payload exists

## Validation
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q` → `205 passed in 7.72s`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest -q` → `221 passed in 7.84s`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && python -m compileall -q . && git diff --check`

## Notes
- default behavior remains unchanged unless externalization is explicitly enabled
- invalid or unwritable externalization paths degrade cleanly back to truncation behavior
- direct payload inspection remains session-scoped
