### PR TITLE
feat: add read-only retention analysis command

### DIFF
--- a/command.py
+++ b/command.py
@@ -38,6 +38,7 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm doctor: run read-only LCM health checks",
         "- /lcm doctor clean: best-effort scan of obvious junk/noise session candidates without deleting anything",
         "- /lcm doctor clean apply: backup-first cleanup for safe pattern-matched candidates only",
+        "- /lcm doctor retention: read-only retention analysis for stored session footprint and age",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
         "- /lcm help: show this help",
     ])
@@ -171,6 +172,139 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
         "candidates": candidates,
         "ignored_count": ignored_count,
         "stateless_count": stateless_count,
+        "protected_count": protected_count,
+    }
+
+
+def _scan_retention_candidates(engine) -> dict[str, Any]:
+    conn = engine._store._conn
+    now = datetime.now().timestamp()
+    try:
+        rows = conn.execute(
+            """
+            WITH session_ids AS (
+                SELECT session_id FROM messages
+                UNION
+                SELECT session_id FROM summary_nodes
+            ),
+            message_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS message_count,
+                       COALESCE(SUM(token_estimate), 0) AS token_total,
+                       MIN(timestamp) AS first_message_at,
+                       MAX(timestamp) AS last_message_at
+                FROM messages
+                GROUP BY session_id
+            ),
+            node_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS node_count,
+                       COALESCE(SUM(token_count), 0) AS node_token_total,
+                       MIN(COALESCE(earliest_at, created_at)) AS first_node_at,
+                       MAX(COALESCE(latest_at, created_at)) AS last_node_at
+                FROM summary_nodes
+                GROUP BY session_id
+            )
+            SELECT s.session_id,
+                   COALESCE(m.message_count, 0) AS message_count,
+                   COALESCE(m.token_total, 0) AS token_total,
+                   COALESCE(n.node_count, 0) AS node_count,
+                   COALESCE(n.node_token_total, 0) AS node_token_total,
+                   m.first_message_at,
+                   m.last_message_at,
+                   n.first_node_at,
+                   n.last_node_at
+            FROM session_ids s
+            LEFT JOIN message_stats m ON m.session_id = s.session_id
+            LEFT JOIN node_stats n ON n.session_id = s.session_id
+            ORDER BY s.session_id
+            """
+        ).fetchall()
+    except Exception as exc:  # pragma: no cover - defensive
+        return {
+            "error": str(exc),
+            "sessions": [],
+            "sessions_analyzed": 0,
+            "stale_sessions_30d": 0,
+            "stale_sessions_90d": 0,
+            "retained_tokens_30d": 0,
+            "retained_tokens_90d": 0,
+            "protected_count": 0,
+        }
+
+    sessions = []
+    protected_count = 0
+    stale_sessions_30d = 0
+    stale_sessions_90d = 0
+    retained_tokens_30d = 0
+    retained_tokens_90d = 0
+
+    for row in rows:
+        (
+            session_id,
+            message_count,
+            token_total,
+            node_count,
+            node_token_total,
+            first_message_at,
+            last_message_at,
+            first_node_at,
+            last_node_at,
+        ) = row
+        timestamps = [
+            ts for ts in (first_message_at, last_message_at, first_node_at, last_node_at)
+            if ts is not None
+        ]
+        if not timestamps:
+            continue
+        first_activity_at = min(float(ts) for ts in (first_message_at, first_node_at) if ts is not None)
+        last_activity_at = max(float(ts) for ts in (last_message_at, last_node_at) if ts is not None)
+        age_days = max(0.0, (now - last_activity_at) / 86400.0)
+        protected = session_id == getattr(engine, "_session_id", "")
+        total_footprint_tokens = int(token_total) + int(node_token_total)
+        if protected:
+            protected_count += 1
+        if age_days >= 30.0:
+            stale_sessions_30d += 1
+            retained_tokens_30d += total_footprint_tokens
+        if age_days >= 90.0:
+            stale_sessions_90d += 1
+            retained_tokens_90d += total_footprint_tokens
+        sessions.append(
+            {
+                "session_id": session_id,
+                "protected": protected,
+                "message_count": int(message_count),
+                "node_count": int(node_count),
+                "token_total": total_footprint_tokens,
+                "raw_token_total": int(token_total),
+                "summary_token_total": int(node_token_total),
+                "first_activity_at": float(first_activity_at),
+                "last_activity_at": float(last_activity_at),
+                "age_days": age_days,
+            }
+        )
+
+    sessions.sort(
+        key=lambda item: (
+            1 if item["protected"] else 0,
+            0 if item["age_days"] >= 30.0 else 1,
+            -item["token_total"],
+            -item["node_count"],
+            -item["message_count"],
+            item["last_activity_at"],
+            item["session_id"],
+        )
+    )
+
+    return {
+        "error": None,
+        "sessions": sessions,
+        "sessions_analyzed": len(sessions),
+        "stale_sessions_30d": stale_sessions_30d,
+        "stale_sessions_90d": stale_sessions_90d,
+        "retained_tokens_30d": retained_tokens_30d,
+        "retained_tokens_90d": retained_tokens_90d,
         "protected_count": protected_count,
     }
 
@@ -392,6 +526,50 @@ def _doctor_clean_text(engine) -> str:
     return "\n".join(lines)
 
 
+def _doctor_retention_text(engine) -> str:
+    scan = _scan_retention_candidates(engine)
+    if scan["error"]:
+        return "\n".join([
+            "LCM doctor retention",
+            "status: error",
+            f"error: {scan['error']}",
+            "note: read-only analysis only — no rows were deleted",
+        ])
+
+    sessions = scan["sessions"]
+    lines = [
+        "LCM doctor retention",
+        f"status: {'analysis-ready' if sessions else 'ok'}",
+        f"sessions_analyzed: {scan['sessions_analyzed']}",
+        f"stale_sessions_30d: {scan['stale_sessions_30d']}",
+        f"stale_sessions_90d: {scan['stale_sessions_90d']}",
+        f"retained_tokens_30d: {scan['retained_tokens_30d']}",
+        f"retained_tokens_90d: {scan['retained_tokens_90d']}",
+    ]
+    if scan["protected_count"]:
+        lines.append(f"protected_sessions: {scan['protected_count']}")
+
+    if not sessions:
+        lines.append("result: no stored sessions found for retention analysis")
+        lines.append("note: read-only analysis only — no rows were deleted")
+        return "\n".join(lines)
+
+    lines.append("retention_candidates:")
+    for item in sessions[:20]:
+        lines.append(
+            "- "
+            f"{item['session_id']} | protected={'yes' if item['protected'] else 'no'} | "
+            f"messages={item['message_count']} | nodes={item['node_count']} | "
+            f"tokens={item['token_total']} | age_days={item['age_days']:.1f}"
+        )
+    if len(sessions) > 20:
+        lines.append(f"... {len(sessions) - 20} more session(s) omitted")
+    lines.append("note: stale sessions are listed before fresh ones; within each bucket, candidates are sorted by footprint (tokens/nodes/messages), with protected current-session entries listed after non-protected ones")
+    lines.append("note: read-only analysis only — no rows were deleted")
+    lines.append("note: if you prune later, create a safety snapshot first with `/lcm backup`")
+    return "\n".join(lines)
+
+
 def _doctor_clean_apply_text(engine) -> str:
     scan = _scan_clean_candidates(engine)
     if scan["error"]:
@@ -483,9 +661,11 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
             return _doctor_text(engine)
         if len(rest) == 1 and rest[0].lower() == "clean":
             return _doctor_clean_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "retention":
+            return _doctor_retention_text(engine)
         if len(rest) == 2 and rest[0].lower() == "clean" and rest[1].lower() == "apply":
             return _doctor_clean_apply_text(engine)
-        return _help_text("`/lcm doctor` currently supports `clean` and `clean apply` as extra subcommands.")
+        return _help_text("`/lcm doctor` currently supports `clean`, `clean apply`, and `retention` as extra subcommands.")
 
     if head == "backup":
         if rest:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -96,8 +96,101 @@ def test_lcm_help_on_unknown_subcommand(engine):
 def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
     result = handle_lcm_command("doctor clean foo", engine)
 
-    assert "currently supports `clean` and `clean apply`" in result
+    assert "currently supports `clean`, `clean apply`, and `retention`" in result
     assert "/lcm doctor clean apply" in result
+    assert "/lcm doctor retention" in result
+
+
+def test_lcm_doctor_retention_reports_old_heavy_sessions(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_retention.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+
+    live_store_id = engine._store.append("live-session", {"role": "user", "content": "fresh chat"}, token_estimate=8)
+    old_store_id = engine._store.append("old-heavy", {"role": "user", "content": "archived chunk"}, token_estimate=240)
+    engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (1.0, old_store_id))
+    engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (2000000000.0, live_store_id))
+    engine._store._conn.commit()
+    engine._dag.add_node(SummaryNode(
+        session_id="old-heavy",
+        depth=0,
+        summary="old heavy summary",
+        token_count=32,
+        source_token_count=240,
+        source_ids=[old_store_id],
+        source_type="messages",
+        created_at=1.0,
+        earliest_at=1.0,
+        latest_at=1.0,
+    ))
+
+    result = handle_lcm_command("doctor retention", engine)
+
+    assert "LCM doctor retention" in result
+    assert "status: analysis-ready" in result
+    assert "sessions_analyzed: 2" in result
+    assert "stale_sessions_30d: 1" in result
+    assert "stale_sessions_90d: 1" in result
+    assert "retained_tokens_30d: 272" in result
+    assert "retained_tokens_90d: 272" in result
+    assert "retention_candidates:" in result
+    assert "old-heavy | protected=no | messages=1 | nodes=1 | tokens=272" in result
+    assert "live-session | protected=yes" in result
+    assert "note: read-only analysis only — no rows were deleted" in result
+
+
+def test_lcm_doctor_retention_counts_summary_only_sessions(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_retention_summary_only.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+
+    engine._dag.add_node(SummaryNode(
+        session_id="summary-only",
+        depth=0,
+        summary="summary only node",
+        token_count=37,
+        source_token_count=200,
+        source_ids=[101],
+        source_type="messages",
+        created_at=1.0,
+        earliest_at=1.0,
+        latest_at=1.0,
+    ))
+
+    result = handle_lcm_command("doctor retention", engine)
+
+    assert "sessions_analyzed: 1" in result
+    assert "stale_sessions_30d: 1" in result
+    assert "retained_tokens_30d: 37" in result
+    assert "summary-only | protected=no | messages=0 | nodes=1 | tokens=37" in result
+
+
+def test_lcm_doctor_retention_keeps_stale_sessions_visible_when_list_is_truncated(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_retention_many.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+
+    for idx in range(21):
+        store_id = engine._store.append(f"fresh-heavy-{idx:02d}", {"role": "user", "content": "fresh heavy"}, token_estimate=500 + idx)
+        engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (2000000000.0, store_id))
+
+    stale_id = engine._store.append("stale-small", {"role": "user", "content": "old tiny"}, token_estimate=5)
+    engine._store._conn.execute("UPDATE messages SET timestamp = ? WHERE store_id = ?", (1.0, stale_id))
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor retention", engine)
+
+    assert "stale_sessions_30d: 1" in result
+    assert "stale-small | protected=no | messages=1 | nodes=0 | tokens=5" in result
 
 
 def test_lcm_doctor_clean_reports_pattern_matched_junk_candidates(tmp_path):


### PR DESCRIPTION
## Summary
- add a read-only `/lcm doctor retention` subcommand
- report per-session footprint and age without deleting anything
- include summary-node footprint in the reported token totals
- keep stale sessions visible in the candidate list instead of letting them disappear behind fresh heavy sessions

## Why
This gives operators a safe first retention-analysis step before any future prune/apply workflow. It makes it easier to see which stored sessions are old, large, or both, without jumping straight to destructive cleanup.

## Validation
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_lcm_command.py -q`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest -q`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && python -m compileall -q . && git diff --check`
