### PR TITLE
feat: add opt-in transcript GC for externalized tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ into anything that was compacted.
 
 ## Why This Plugin
 
-~5,000 lines of Python. Zero external dependencies. 192 tests that run standalone in under a second. Full lossless context management — immutable store, hierarchical DAG, agent retrieval tools, guided compression, assembly guardrails, session filtering — in a single lightweight plugin that drops into Hermes with no build step, no runtime overhead, and nothing to configure beyond `context.engine: lcm`.
+~5,000 lines of Python. Zero external dependencies. 200+ tests that run standalone in under a second. Full lossless context management — immutable-first store, hierarchical DAG, agent retrieval tools, guided compression, assembly guardrails, session filtering — in a single lightweight plugin that drops into Hermes with no build step, no runtime overhead, and nothing to configure beyond `context.engine: lcm`.
 
 ## What It Does
 
-- **Immutable store** — every message persisted in SQLite, never modified
+- **Immutable-first store** — every message persisted in SQLite, with only narrow explicit opt-in GC tombstones for already-externalized summarized tool results
 - **Summary DAG** — hierarchical compaction (D0 minutes → D1 hours → D2 days)
 - **3-level escalation** — L1 detailed → L2 bullets → L3 deterministic truncate (guaranteed convergence)
 - **Agent tools** — `lcm_grep`, `lcm_describe`, `lcm_expand`, `lcm_expand_query` for structured retrieval
+- **Large tool-output handling** — opt-in externalization for oversized tool results, inspectable later via `externalized_ref`
+- **Optional transcript GC** — opt-in rewrite of already-externalized summarized tool-result rows to compact GC placeholders instead of deleting them
 - **Current-turn search** — live messages ingested before tool execution
 - **Session filtering** — exclude noisy sessions entirely or mark them read-only with glob patterns
 - **Profile-scoped** — separate DB per Hermes profile
@@ -126,6 +128,10 @@ Environment variables (all optional):
 | `LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS` | `2` | Debt threshold multiplier before cache-friendly gating allows a follow-on condensation pass |
 | `LCM_IGNORE_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions to exclude from LCM storage entirely |
 | `LCM_STATELESS_SESSION_PATTERNS` | *(empty)* | Comma-separated glob patterns for sessions that stay read-only (`platform:session_id` matching supported) |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Opt-in externalization of oversized tool-result content into plugin-managed storage |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Character threshold above which tool results are externalized |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH` | `~/.hermes/lcm-large-outputs` | Override storage directory for externalized payloads |
+| `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization |
 | `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
@@ -134,6 +140,22 @@ Environment variables (all optional):
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after `/new` (`-1` = all, `0` = none, `2` = keep d2+) |
 
 The point-8 compaction knobs are intentionally opt-in. `cache_friendly_*` is a plugin-local prompt-stability heuristic, not a claim that Hermes currently passes true prompt-cache metrics into `hermes-lcm`.
+
+### Large tool-output handling
+
+`hermes-lcm` now has a three-step opt-in path for oversized tool results:
+
+1. **9B externalization** — large tool results are written to plugin-managed JSON files instead of being kept inline for compaction prompts
+2. **9C retrieval** — those payloads stay inspectable later through `lcm_describe(externalized_ref=...)`, `lcm_expand(externalized_ref=...)`, or expanded summary sources that attach `externalized` metadata
+3. **9D transcript GC** — if `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED=true`, already-externalized tool-result rows that were successfully summarized can be rewritten to compact GC placeholders instead of keeping the full raw blob inline forever
+
+Important boundaries:
+- all of this remains **opt-in**
+- transcript GC rewrites only **tool-role** rows that already have a same-session externalized payload
+- the row itself is kept (same `store_id`), so summary `source_ids` still resolve cleanly
+- pinned messages are skipped
+- payload files are **not** deleted by transcript GC; retrieval stays lossless via `externalized_ref`
+- transcript GC updates the stored row content and therefore changes raw-message searchability: search should still find summaries / refs, but `lcm_grep` will no longer match the original giant tool blob text after GC
 
 Pattern syntax matches `lossless-claw`:
 - `*` matches within one colon-delimited segment
@@ -151,22 +173,23 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 | Tool | Description |
 |------|-------------|
 | `lcm_grep` | Search raw messages AND summaries across all depths. FTS5 syntax. |
-| `lcm_describe` | Inspect DAG structure — token counts, children, expand hints. No node_id = session overview. |
-| `lcm_expand` | Recover original content from a summary node. Token-budgeted. |
+| `lcm_describe` | Inspect DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
+| `lcm_expand` | Recover original content from a summary node, or open a stored `externalized_ref` payload directly. |
 | `lcm_expand_query` | Answer a question from expanded LCM context using either a query or explicit node_ids. Uses the expansion path/model instead of the summarization path. |
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
 
 ## Gateway Slash Commands
 
-When Hermes host support for plugin slash commands is available, `hermes-lcm` also exposes a `/lcm` operator surface for quick read-only diagnostics from chat:
+When Hermes host support for plugin slash commands is available, `hermes-lcm` also exposes a `/lcm` operator surface for quick diagnostics and safe maintenance prep from chat:
 
 - `/lcm` or `/lcm status` — current session/runtime status
 - `/lcm doctor` — SQLite + FTS health checks and store/node totals
 - `/lcm doctor clean` — best-effort read-only scan for obvious junk/noise sessions matched from stored session keys
+- `/lcm doctor clean apply` — backup-first cleanup for safe pattern-matched junk/noise session candidates
 - `/lcm backup` — create a timestamped SQLite backup before any future cleanup workflow
 
-`/lcm doctor clean apply` is intentionally not implemented yet. This slice is diagnostics-first and backup-first.
+The cleanup path stays intentionally narrow and backup-first; broader retention/prune workflows should still start with diagnostics before any apply/delete step.
 
 ## How It Works
 

--- a/config.py
+++ b/config.py
@@ -114,6 +114,9 @@ class LCMConfig:
     large_output_externalization_threshold_chars: int = 12_000
     # Explicit storage directory for externalized payloads (empty = auto under hermes home).
     large_output_externalization_path: str = ""
+    # When enabled, already-externalized summarized tool-result transcript rows may
+    # be rewritten to compact GC placeholders after successful leaf compaction.
+    large_output_transcript_gc_enabled: bool = False
 
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
@@ -182,6 +185,10 @@ class LCMConfig:
         c.large_output_externalization_path = _str(
             "LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH",
             c.large_output_externalization_path,
+        )
+        c.large_output_transcript_gc_enabled = _parse_bool_env(
+            "LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED",
+            c.large_output_transcript_gc_enabled,
         )
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)

--- a/engine.py
+++ b/engine.py
@@ -17,7 +17,11 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
-from .externalize import maybe_externalize_tool_output
+from .externalize import (
+    build_transcript_gc_placeholder,
+    maybe_externalize_tool_output,
+    find_externalized_payload_for_message,
+)
 from .extraction import (
     extract_before_compaction,
     sanitize_pre_compaction_content,
@@ -382,6 +386,7 @@ class LCMEngine(ContextEngine):
                 expand_hint=self._extract_expand_hint(summary_text),
             )
             self._dag.add_node(node)
+            self._maybe_gc_compacted_tool_results(compacted_chunk, source_store_ids)
             self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
             self._persist_frontier_marker()
 
@@ -832,6 +837,51 @@ class LCMEngine(ContextEngine):
             )
         except Exception as e:
             logger.warning("Pre-compaction extraction failed (non-blocking): %s", e)
+
+    def _maybe_gc_compacted_tool_results(
+        self,
+        compacted_chunk: List[Dict[str, Any]],
+        source_store_ids: List[int],
+    ) -> None:
+        if not getattr(self._config, "large_output_transcript_gc_enabled", False):
+            return
+        if not compacted_chunk or not source_store_ids:
+            return
+
+        stored_by_id = self._store.get_batch(source_store_ids)
+        for store_id in source_store_ids:
+            stored = stored_by_id.get(store_id)
+            if not stored or stored.get("session_id") != self._session_id:
+                continue
+            if stored.get("role") != "tool":
+                continue
+            content = stored.get("content", "") or ""
+            tool_call_id = stored.get("tool_call_id", "") or ""
+            if not content:
+                continue
+
+            lookup_candidates = []
+            sanitized_content = sanitize_pre_compaction_content(content)
+            if sanitized_content and sanitized_content != content:
+                lookup_candidates.append(sanitized_content)
+            lookup_candidates.append(content)
+
+            externalized = None
+            for candidate in lookup_candidates:
+                externalized = find_externalized_payload_for_message(
+                    candidate,
+                    tool_call_id=tool_call_id,
+                    session_id=self._session_id,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                if externalized is not None:
+                    break
+            if externalized is None:
+                continue
+
+            placeholder = build_transcript_gc_placeholder(externalized)
+            self._store.gc_externalized_tool_result(store_id, placeholder)
 
     def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Serialize messages into labeled text for the summarizer."""

--- a/externalize.py
+++ b/externalize.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict
 
 DEFAULT_LARGE_OUTPUT_DIRNAME = "lcm-large-outputs"
+_EXTERNALIZED_REF_RE = re.compile(r"ref=([^;\]\s]+)")
 logger = logging.getLogger(__name__)
 
 
@@ -54,6 +56,25 @@ def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
         f"[Externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
         f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
     )
+
+
+def build_transcript_gc_placeholder(summary: Dict[str, Any]) -> str:
+    return (
+        f"[GC'd externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
+        f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
+    )
+
+
+def extract_externalized_ref(text: str) -> str | None:
+    if not text:
+        return None
+    match = _EXTERNALIZED_REF_RE.search(text)
+    if not match:
+        return None
+    ref = match.group(1).strip()
+    if not ref or Path(ref).name != ref:
+        return None
+    return ref
 
 
 def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dict[str, Any] | None:

--- a/store.py
+++ b/store.py
@@ -1,10 +1,11 @@
-"""Immutable message store — the source of truth.
+"""Immutable-first message store — the source of truth.
 
-Every message is persisted verbatim and never modified. The store is
-append-only with optional pruning of very old messages (configurable).
-
-Each message gets a monotonic store_id used as a stable reference.
+Every message is persisted durably in SQLite. The normal model is append-only,
+with one narrow opt-in exception: already-externalized summarized tool-result
+rows may be rewritten to compact GC tombstones while preserving the original
+row identity (`store_id`) for DAG/source lookup.
 """
+
 
 import json
 import logging
@@ -193,6 +194,15 @@ class MessageStore:
                             VALUES('delete', old.store_id, old.content);
                     END;
                     """,
+                    """
+                    CREATE TRIGGER IF NOT EXISTS msg_fts_update
+                        AFTER UPDATE OF content ON messages BEGIN
+                        INSERT INTO messages_fts(messages_fts, rowid, content)
+                            VALUES('delete', old.store_id, old.content);
+                        INSERT INTO messages_fts(rowid, content)
+                            VALUES (new.store_id, new.content);
+                    END;
+                    """,
                 ),
             ),
         )
@@ -280,12 +290,30 @@ class MessageStore:
             "DELETE FROM messages WHERE session_id = ?",
             (session_id,),
         )
-        deleted = cur.rowcount
-        if deleted:
-            self._conn.commit()
+        self._conn.commit()
+        deleted = cur.rowcount if cur.rowcount is not None else 0
         return deleted
 
+    def gc_externalized_tool_result(self, store_id: int, placeholder: str) -> bool:
+        """Rewrite one unpinned tool-result row to a compact GC placeholder."""
+        row = self._conn.execute(
+            "SELECT role, pinned, content FROM messages WHERE store_id = ?",
+            (store_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        role, pinned, current_content = row
+        if role != "tool" or bool(pinned) or current_content == placeholder:
+            return False
+        self._conn.execute(
+            "UPDATE messages SET content = ? WHERE store_id = ?",
+            (placeholder, store_id),
+        )
+        self._conn.commit()
+        return True
+
     def pin(self, store_id: int) -> None:
+
         """Mark a message as pinned (protected from pruning)."""
         self._conn.execute(
             "UPDATE messages SET pinned = 1 WHERE store_id = ?", (store_id,)

--- a/store.py
+++ b/store.py
@@ -35,6 +35,7 @@ from .search_query import (
     AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
+from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -297,17 +298,24 @@ class MessageStore:
     def gc_externalized_tool_result(self, store_id: int, placeholder: str) -> bool:
         """Rewrite one unpinned tool-result row to a compact GC placeholder."""
         row = self._conn.execute(
-            "SELECT role, pinned, content FROM messages WHERE store_id = ?",
+            "SELECT role, pinned, content, tool_call_id FROM messages WHERE store_id = ?",
             (store_id,),
         ).fetchone()
         if row is None:
             return False
-        role, pinned, current_content = row
+        role, pinned, current_content, tool_call_id = row
         if role != "tool" or bool(pinned) or current_content == placeholder:
             return False
+        placeholder_tokens = count_message_tokens(
+            {
+                "role": "tool",
+                "content": placeholder,
+                "tool_call_id": tool_call_id,
+            }
+        )
         self._conn.execute(
-            "UPDATE messages SET content = ? WHERE store_id = ?",
-            (placeholder, store_id),
+            "UPDATE messages SET content = ?, token_estimate = ? WHERE store_id = ?",
+            (placeholder, placeholder_tokens, store_id),
         )
         self._conn.commit()
         return True

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -40,6 +40,7 @@ class TestConfig:
         assert c.large_output_externalization_enabled is False
         assert c.large_output_externalization_threshold_chars == 12_000
         assert c.large_output_externalization_path == ""
+        assert c.large_output_transcript_gc_enabled is False
         assert c.deferred_maintenance_enabled is False
         assert c.deferred_maintenance_max_passes == 4
         assert c.ignore_session_patterns == []
@@ -70,6 +71,7 @@ class TestConfig:
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", "true")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", "4096")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", "/tmp/lcm-large-outputs")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED", "true")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
         assert c.context_threshold == 0.80
@@ -91,6 +93,7 @@ class TestConfig:
         assert c.large_output_externalization_enabled is True
         assert c.large_output_externalization_threshold_chars == 4096
         assert c.large_output_externalization_path == "/tmp/lcm-large-outputs"
+        assert c.large_output_transcript_gc_enabled is True
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")
@@ -213,6 +216,42 @@ class TestMessageStore:
         assert len(discord_results) == 1
         assert discord_results[0]["source"] == "discord"
         assert discord_results[0]["session_id"] == "sess2"
+
+    def test_gc_externalized_tool_result_rewrites_content_and_updates_fts(self, store):
+        placeholder = "[GC'd externalized tool output: tool_call_id=call_gc; ref=payload.json]"
+        store_id = store.append(
+            "sess1",
+            {"role": "tool", "tool_call_id": "call_gc", "content": "raw payload blob should disappear"},
+            token_estimate=50,
+        )
+
+        rewritten = store.gc_externalized_tool_result(store_id, placeholder)
+
+        assert rewritten is True
+        updated = store.get(store_id)
+        assert updated["content"] == placeholder
+        assert updated["token_estimate"] == count_message_tokens(
+            {"role": "tool", "tool_call_id": "call_gc", "content": placeholder}
+        )
+        assert updated["token_estimate"] < 50
+        assert store.search("payload", session_id="sess1")[0]["store_id"] == store_id
+        assert store.search("blob", session_id="sess1") == []
+
+    def test_gc_externalized_tool_result_skips_pinned_messages(self, store):
+        store_id = store.append(
+            "sess1",
+            {"role": "tool", "tool_call_id": "call_gc", "content": "raw payload blob should stay"},
+            token_estimate=50,
+        )
+        store.pin(store_id)
+
+        rewritten = store.gc_externalized_tool_result(
+            store_id,
+            "[GC'd externalized tool output: tool_call_id=call_gc; ref=payload.json]",
+        )
+
+        assert rewritten is False
+        assert store.get(store_id)["content"] == "raw payload blob should stay"
 
     def test_init_repairs_malformed_message_fts_and_sets_schema_version(self, tmp_path):
         db_path = tmp_path / "legacy-store.db"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2731,6 +2731,12 @@ class TestEngineTools:
         assert stored_tool["content"].startswith("[GC'd externalized tool output:")
         assert "ref=" in stored_tool["content"]
         assert content[:100] not in stored_tool["content"]
+        assert stored_tool["token_estimate"] == count_message_tokens(
+            {"role": "tool", "tool_call_id": "call_gc", "content": stored_tool["content"]}
+        )
+        assert stored_tool["token_estimate"] < count_message_tokens(
+            {"role": "tool", "tool_call_id": "call_gc", "content": content}
+        )
         payload_files = list((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json"))
         assert len(payload_files) == 1
         assert json.loads(payload_files[0].read_text())["content"] == content

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2696,6 +2696,175 @@ class TestEngineTools:
         assert result["content"] == content
         assert result["tool_call_id"] == "call_big"
 
+    def test_compress_gc_rewrites_summarized_externalized_tool_results(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc.db"),
+            fresh_tail_count=0,
+            leaf_chunk_tokens=50,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Summarized tool result.\nExpand for details about: tool result", 1),
+        )
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "tool", "tool_call_id": "call_gc", "content": content},
+        ]
+
+        compressed = engine.compress(messages)
+
+        assert compressed[0]["role"] == "system"
+        assert compressed[1]["role"] == "assistant"
+        assert "Recent Summary" in compressed[1]["content"]
+        stored_tool = next(row for row in engine._store.get_range("test-session") if row["role"] == "tool")
+        assert stored_tool["content"].startswith("[GC'd externalized tool output:")
+        assert "ref=" in stored_tool["content"]
+        assert content[:100] not in stored_tool["content"]
+        payload_files = list((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json"))
+        assert len(payload_files) == 1
+        assert json.loads(payload_files[0].read_text())["content"] == content
+
+    def test_handle_expand_still_resolves_externalized_metadata_after_transcript_gc_rewrite(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc_expand.db"),
+            fresh_tail_count=0,
+            leaf_chunk_tokens=50,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Summarized tool result.\nExpand for details about: tool result", 1),
+        )
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "tool", "tool_call_id": "call_gc", "content": content},
+        ]
+
+        engine.compress(messages)
+        node_id = engine._dag.get_session_nodes("test-session")[0].node_id
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+
+        assert result["expanded"][0]["content"].startswith("[GC'd externalized tool output:")
+        assert result["expanded"][0]["externalized"]["tool_call_id"] == "call_gc"
+        assert result["expanded"][0]["externalized"]["ref"].endswith(".json")
+
+    def test_compress_gc_skips_pinned_tool_results(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc_pinned.db"),
+            fresh_tail_count=0,
+            leaf_chunk_tokens=50,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Summarized tool result.\nExpand for details about: tool result", 1),
+        )
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "tool", "tool_call_id": "call_gc", "content": content},
+        ]
+        engine._ingest_messages(messages)
+        tool_store_id = next(row for row in engine._store.get_range("test-session") if row["role"] == "tool")["store_id"]
+        engine._store.pin(tool_store_id)
+
+        engine.compress(messages)
+
+        assert engine._store.get(tool_store_id)["content"] == content
+
+    def test_gc_helper_does_not_miss_tool_rows_when_chunk_contains_unmatched_synthetic_messages(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc_helper.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        tool_store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_gc", "content": content},
+        )
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_gc", "content": content}
+        ])
+
+        engine._maybe_gc_compacted_tool_results(
+            [
+                {"role": "assistant", "content": "[Recent Summary (d0, node 1)]"},
+                {"role": "tool", "tool_call_id": "call_gc", "content": content},
+            ],
+            [tool_store_id],
+        )
+
+        assert engine._store.get(tool_store_id)["content"].startswith("[GC'd externalized tool output:")
+
+    def test_handle_expand_does_not_inline_full_externalized_payload_for_gc_rows(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc_budget.db"),
+            fresh_tail_count=0,
+            leaf_chunk_tokens=50,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Summarized tool result.\nExpand for details about: tool result", 1),
+        )
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "tool", "tool_call_id": "call_gc", "content": content},
+        ]
+        engine.compress(messages)
+        node_id = engine._dag.get_session_nodes("test-session")[0].node_id
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id, "max_tokens": 1}))
+
+        assert result["expanded"][0]["content"].startswith("[GC'd externalized tool output:")
+        assert result["expanded"][0]["externalized"]["ref"].endswith(".json")
+        assert "content" not in result["expanded"][0]["externalized"]
+
     def test_handle_unknown_tool(self, engine):
         result = json.loads(engine.handle_tool_call("unknown_tool", {}))
         assert "error" in result

--- a/tools.py
+++ b/tools.py
@@ -7,7 +7,11 @@ import logging
 import time
 from typing import Any, Dict, TYPE_CHECKING
 
-from .externalize import find_externalized_payload_for_message, load_externalized_payload
+from .externalize import (
+    extract_externalized_ref,
+    find_externalized_payload_for_message,
+    load_externalized_payload,
+)
 from .extraction import sanitize_pre_compaction_content
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 
@@ -98,21 +102,28 @@ def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[
             "content": content[:2000] if len(content) > 2000 else content,
         }
         if stored.get("role") == "tool":
-            lookup_candidates = [content]
-            sanitized_content = sanitize_pre_compaction_content(content)
-            if sanitized_content != content:
-                lookup_candidates.insert(0, sanitized_content)
-            for candidate in lookup_candidates:
-                externalized = find_externalized_payload_for_message(
-                    candidate,
-                    tool_call_id=stored.get("tool_call_id", ""),
-                    session_id=stored.get("session_id", ""),
-                    config=engine._config,
-                    hermes_home=engine._hermes_home,
-                )
+            ref = extract_externalized_ref(content)
+            if ref:
+                externalized = _get_externalized_payload(engine, ref)
                 if externalized is not None:
+                    externalized.pop("content", None)
                     expanded["externalized"] = externalized
-                    break
+            if "externalized" not in expanded:
+                lookup_candidates = [content]
+                sanitized_content = sanitize_pre_compaction_content(content)
+                if sanitized_content != content:
+                    lookup_candidates.insert(0, sanitized_content)
+                for candidate in lookup_candidates:
+                    externalized = find_externalized_payload_for_message(
+                        candidate,
+                        tool_call_id=stored.get("tool_call_id", ""),
+                        session_id=stored.get("session_id", ""),
+                        config=engine._config,
+                        hermes_home=engine._hermes_home,
+                    )
+                    if externalized is not None:
+                        expanded["externalized"] = externalized
+                        break
         messages.append(expanded)
         budget_used += msg_tokens
     return messages


### PR DESCRIPTION
## Summary
- add explicit opt-in transcript GC for already-externalized summarized tool-result rows
- rewrite eligible tool rows to compact GC placeholders while preserving `store_id` lineage
- keep externalized payloads inspectable through existing `externalized_ref` retrieval paths
- update GC token accounting so retention/footprint reporting reflects the rewritten transcript rows
- clarify the README around externalization, inspectability, and transcript-GC behavior/tradeoffs

## Why
Once oversized tool output can be externalized and inspected separately, keeping the full raw blob inline in the transcript forever is wasteful. This adds a narrow, opt-in cleanup step after successful compaction without breaking summary lineage or payload retrieval.

## Validation
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `pytest -q`
- `python -m compileall -q .`
- `git diff --check`
