### PR TITLE
docs: clarify lcm tool choice vs session_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,26 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 
 | Tool | Description |
 |------|-------------|
-| `lcm_grep` | Search raw messages AND summaries across all depths. FTS5 syntax. |
-| `lcm_describe` | Inspect DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
-| `lcm_expand` | Recover original content from a summary node, or open a stored `externalized_ref` payload directly. |
-| `lcm_expand_query` | Answer a question from expanded LCM context using either a query or explicit node_ids. Uses the expansion path/model instead of the summarization path. |
+| `lcm_grep` | Search raw messages AND summaries for the active/current session. Use this for intra-session recall after compaction; if you intentionally want cross-session LCM store hits, use `session_scope='all'`; otherwise prefer `session_search` for earlier separate sessions. |
+| `lcm_describe` | Inspect current-session DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
+| `lcm_expand` | Recover original content from a current-session summary node, or open a stored `externalized_ref` payload directly. |
+| `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. For cross-session recall, prefer `session_search` first. |
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
+
+### Tool choice guidance: LCM tools vs `session_search`
+
+When both recall paths are available to the model:
+
+- prefer **LCM tools** for recall inside the active/current conversation, especially when the relevant turns were compacted into summary nodes
+- prefer **`session_search`** when the user is asking about an earlier separate conversation, prior work from another session, or broad cross-session history
+- if you explicitly want cross-session hits from the LCM store itself, use `lcm_grep(session_scope='all')` deliberately rather than treating it as the default recall path
+
+That split is intentional:
+
+- `hermes-lcm` is strongest at lossless drill-down inside the current session's DAG/store
+- `session_search` is the broader Hermes-wide cross-session recall tool
+- putting the distinction in the tool-facing docs/schema keeps ACP/API/editor flows from relying only on accidental schema wording when both surfaces are exposed at once
 
 ## Gateway Slash Commands
 

--- a/schemas.py
+++ b/schemas.py
@@ -3,11 +3,12 @@
 LCM_GREP = {
     "name": "lcm_grep",
     "description": (
-        "Search the full conversation history — raw messages AND summaries "
-        "across all depths. Use this to find specific topics, decisions, "
-        "file paths, or error messages from earlier in the conversation, "
-        "even if those turns have been compacted. Returns matches with "
-        "depth labels showing where in the hierarchy each result lives."
+        "Search the current session's conversation history — raw messages AND summaries across all depths — "
+        "to recover details from earlier in the active conversation, even if those turns were compacted. "
+        "Prefer this for intra-session recall. If the user is asking about an earlier separate conversation "
+        "or broad cross-session history, prefer session_search instead. When you intentionally want the LCM "
+        "store across sessions, use session_scope='all' explicitly. Returns matches with depth labels showing "
+        "where each result lives."
     ),
     "parameters": {
         "type": "object",
@@ -37,7 +38,11 @@ LCM_GREP = {
             "session_scope": {
                 "type": "string",
                 "enum": ["current", "all"],
-                "description": "Whether to search only the current session or all stored sessions.",
+                "description": (
+                    "Whether to search only the current session or all stored LCM sessions. "
+                    "Default is current. Use all only when you intentionally want cross-session LCM store hits; "
+                    "for general earlier-conversation recall, prefer session_search instead."
+                ),
                 "default": "current",
             },
             "source": {
@@ -52,11 +57,12 @@ LCM_GREP = {
 LCM_DESCRIBE = {
     "name": "lcm_describe",
     "description": (
-        "Inspect a summary node's subtree metadata WITHOUT loading full "
+        "Inspect a current-session summary node's subtree metadata WITHOUT loading full "
         "content, or inspect an externalized payload ref without opening the "
         "full payload. Returns token counts, child manifest, expand hints, "
         "or externalized payload metadata/preview. Use this to plan retrieval "
-        "strategy before spending tokens on lcm_expand. If called with no "
+        "strategy before spending tokens on lcm_expand inside the active conversation. "
+        "For cross-session recall, use session_search first. If called with no "
         "node_id or externalized_ref, returns the top-level DAG overview for "
         "the current session."
     ),
@@ -79,13 +85,13 @@ LCM_DESCRIBE = {
 LCM_EXPAND = {
     "name": "lcm_expand",
     "description": (
-        "Recover the original detail behind a summary node, or open an "
+        "Recover the original detail behind a current session summary node, or open an "
         "externalized payload ref directly. Given a node_id, returns the "
         "source messages or lower-depth summaries that were compacted into "
         "that node. Given externalized_ref, returns the stored payload "
         "content plus metadata. Use after lcm_describe to drill into "
-        "specific parts of the conversation history or large externalized "
-        "tool output."
+        "specific parts of the active conversation or large externalized "
+        "tool output. For cross-session recall, prefer session_search first."
     ),
     "parameters": {
         "type": "object",
@@ -141,9 +147,10 @@ LCM_DOCTOR = {
 LCM_EXPAND_QUERY = {
     "name": "lcm_expand_query",
     "description": (
-        "Answer a natural-language question using expanded LCM context. Provide a prompt, and either "
+        "Answer a natural-language question using expanded LCM context from the current session. Provide a prompt, and either "
         "query matching summaries to expand or explicit node_ids to inspect. Uses the expansion path "
-        "instead of the summarization path so retrieval/synthesis can use a different model or timeout."
+        "instead of the summarization path so retrieval/synthesis can use a different model or timeout. "
+        "Prefer this for questions about the active conversation after compaction; for cross-session recall, use session_search first."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -49,6 +49,21 @@ class TestEngineABC:
         grep_props = grep_schema["parameters"]["properties"]
         assert "session_scope" in grep_props
         assert "source" in grep_props
+        assert "current session" in grep_schema["description"].lower()
+        assert "session_search" in grep_schema["description"]
+        assert "session_scope='all'" in grep_schema["description"]
+        assert "session_search" in grep_props["session_scope"]["description"]
+
+        describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
+        expand_schema = next(s for s in schemas if s["name"] == "lcm_expand")
+        expand_query_schema = next(s for s in schemas if s["name"] == "lcm_expand_query")
+
+        assert "current session" in describe_schema["description"].lower()
+        assert "session_search" in describe_schema["description"]
+        assert "current session" in expand_schema["description"].lower()
+        assert "session_search" in expand_schema["description"]
+        assert "current session" in expand_query_schema["description"].lower()
+        assert "session_search" in expand_query_schema["description"]
 
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)


### PR DESCRIPTION
## Summary
- clarify the LCM tool schemas so they explicitly describe current-session vs cross-session recall
- document the same guidance in the README, including the deliberate `lcm_grep(session_scope='all')` escape hatch
- add a regression test that verifies the tool-facing schema text keeps this distinction visible

## Why
- issue #38 is about fuzzy tool choice when both LCM tools and `session_search` are visible to the model
- schema wording was doing too much implicit routing work, especially in ACP/API/editor flows where both surfaces can appear together
- this keeps the fix plugin-local for now while still making the routing guidance explicit in the actual tool surface the model sees

## Validation
- `pytest tests/test_lcm_engine.py::TestEngineABC::test_tool_schemas -q`
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `pytest -q`
- `python -m compileall -q .`
- `git diff --check`
- runtime probe with a live Hermes agent confirming `session_search` and `lcm_grep` are both exposed and now advertise distinct recall roles

## Notes
- this does not change Hermes core behavior
- it intentionally keeps `lcm_grep(session_scope='all')` available, but makes that cross-session LCM-store path explicit instead of leaving the overlap implicit
- if stronger host-wide guidance is still wanted later, that can be a separate Hermes-core follow-up

Closes #38
