### PR TITLE
docs: define retrieval source and session semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,53 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
 
+### Retrieval contract: `session_scope` × `source`
+
+`hermes-lcm` treats `session_scope` and `source` as independent filters:
+
+- **`session_scope`** decides which sessions are eligible
+- **`source`** decides which content inside those eligible sessions is allowed to match
+
+That contract applies across:
+
+- raw message retrieval
+- DAG summary retrieval
+- merged outputs like `lcm_grep`
+- carry-over/reassigned summary nodes after `/new`
+
+#### Raw messages
+
+- `current` + no `source` → all raw rows in the current session
+- `current` + `source='discord'` → only current-session raw rows with source `discord`
+- `all` + no `source` → all raw rows across sessions
+- `all` + `source='discord'` → all raw rows across sessions with source `discord`
+
+#### DAG summaries
+
+- `current` + no `source` → all summaries eligible in the current session
+- `current` + `source='discord'` → only current-session summaries whose descendant raw-message lineage includes `discord`
+- `all` + no `source` → all eligible summaries across sessions
+- `all` + `source='discord'` → only summaries across sessions whose descendant raw-message lineage includes `discord`
+
+Mixed-source nodes may match more than one `source` filter if their descendant lineage is mixed. Filtering is based on actual descendant lineage, not on whether the surrounding session happens to contain some message from that source.
+
+#### `unknown` source
+
+`unknown` is treated as a real source value, not as a wildcard.
+
+- omitting `source` means **no source filtering**
+- `source='unknown'` means only content whose stored source is `unknown`
+- legacy blank-source rows are treated as `unknown` for backward compatibility
+
+#### Carry-over semantics
+
+`carry_over_new_session_context()` may reassign retained summary nodes into a new session, but that does **not** erase source lineage.
+
+- session eligibility may change because the node now belongs to the new session
+- source eligibility still comes from the node's descendant raw-message lineage
+
+So a carried-over node can be current-session content in the new session while still matching `source='discord'` only if its descendant raw messages include `discord`.
+
 ## Gateway Slash Commands
 
 When Hermes host support for plugin slash commands is available, `hermes-lcm` also exposes a `/lcm` operator surface for quick diagnostics and safe maintenance prep from chat:

--- a/dag.py
+++ b/dag.py
@@ -26,6 +26,7 @@ from .db_bootstrap import (
     run_versioned_migrations,
 )
 from .search_query import (
+    AGE_DECAY_RATE,
     compute_directness_rank_bonus_upper_bound,
     compute_directness_score,
     compute_search_fetch_limit,
@@ -36,9 +37,10 @@ from .search_query import (
     extract_search_terms,
     normalize_search_sort,
     requires_like_fallback,
-    AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
+from .store import _normalize_source_value, _UNKNOWN_SOURCE
+
 
 logger = logging.getLogger(__name__)
 
@@ -325,7 +327,14 @@ class SummaryDAG:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None,
                source: str | None = None) -> List[SummaryNode]:
-        """FTS5 search across all summary nodes."""
+        """FTS5 search across summary nodes.
+
+        Retrieval contract:
+        - ``session_id`` limits which sessions are eligible
+        - ``source`` filters summaries by descendant raw-message lineage, not by
+          session-level source presence
+        - mixed-source nodes may match more than one ``source`` filter
+        """
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
@@ -452,6 +461,7 @@ class SummaryDAG:
     ) -> bool:
         if not source:
             return True
+        normalized_source = _normalize_source_value(source)
         if cache is not None and node_id in cache:
             return cache[node_id]
         row = self._conn.execute(
@@ -475,10 +485,13 @@ class SummaryDAG:
             JOIN messages m
               ON walk.source_type = 'messages'
              AND m.store_id = walk.source_id
-            WHERE m.source = ?
+            WHERE CASE
+                    WHEN ? = ? THEN (m.source = ? OR m.source = '')
+                    ELSE m.source = ?
+                  END
             LIMIT 1
             """,
-            (node_id, source),
+            (node_id, normalized_source, _UNKNOWN_SOURCE, normalized_source, normalized_source),
         ).fetchone()
         matched = row is not None
         if cache is not None:

--- a/engine.py
+++ b/engine.py
@@ -589,7 +589,14 @@ class LCMEngine(ContextEngine):
                 self._dag.delete_below_depth(self._session_id, retain)
 
     def carry_over_new_session_context(self, old_session_id: str, new_session_id: str) -> int:
-        """Move retained summaries from the old session into the new one."""
+        """Move retained summaries from the old session into the new one.
+
+        This reassigns session ownership for retained summary nodes, but it does
+        not rewrite the nodes' descendant raw-message lineage. Retrieval under
+        ``session_scope='current'`` may therefore include a carried-over node in
+        the new session, while ``source`` filtering still evaluates against the
+        node's original descendant message sources.
+        """
         if not old_session_id or not new_session_id or old_session_id == new_session_id:
             return 0
         if self._session_ignored and new_session_id == self._session_id:

--- a/schemas.py
+++ b/schemas.py
@@ -42,7 +42,11 @@ LCM_GREP = {
             },
             "source": {
                 "type": "string",
-                "description": "Optional source/platform filter (for example cli, discord, telegram).",
+                "description": (
+                    "Optional source/platform filter (for example cli, discord, telegram). "
+                    "Applies directly to raw messages and to summaries via descendant source lineage. "
+                    "Use 'unknown' for explicit unknown-source content."
+                ),
             },
         },
         "required": ["query"],

--- a/store.py
+++ b/store.py
@@ -45,6 +45,21 @@ _MESSAGE_SELECT_COLUMNS = (
     "store_id, session_id, source, role, content, tool_call_id, "
     "tool_calls, tool_name, timestamp, token_estimate, pinned"
 )
+_UNKNOWN_SOURCE = "unknown"
+
+
+def _normalize_source_value(source: str | None) -> str:
+    normalized = (source or "").strip()
+    return normalized or _UNKNOWN_SOURCE
+
+
+def _source_filter_clause(column: str, source: str | None) -> tuple[str | None, list[str]]:
+    normalized = _normalize_source_value(source) if source is not None else ""
+    if not normalized:
+        return None, []
+    if normalized == _UNKNOWN_SOURCE:
+        return f"({column} = ? OR {column} = '')", [_UNKNOWN_SOURCE]
+    return f"{column} = ?", [normalized]
 
 
 def _message_role_bias(role: str | None) -> float:
@@ -236,7 +251,7 @@ class MessageStore:
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 session_id,
-                source or "",
+                _normalize_source_value(source),
                 msg.get("role", "unknown"),
                 msg.get("content"),
                 msg.get("tool_call_id"),
@@ -271,7 +286,7 @@ class MessageStore:
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
-                        source or "",
+                        _normalize_source_value(source),
                         msg.get("role", "unknown"),
                         msg.get("content"),
                         msg.get("tool_call_id"),
@@ -421,7 +436,14 @@ class MessageStore:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None,
                source: str | None = None) -> List[Dict[str, Any]]:
-        """FTS5 search across messages. Returns matches with snippets."""
+        """FTS5 search across raw messages.
+
+        Retrieval contract:
+        - ``session_id`` limits which sessions are eligible
+        - ``source`` limits which raw rows inside those sessions are eligible
+        - ``source='unknown'`` means the explicit unknown-source bucket, with
+          legacy blank-source rows treated as equivalent for back-compat
+        """
         terms = extract_search_terms(query)
         phrases = extract_quoted_phrases(query)
         if requires_like_fallback(query):
@@ -435,60 +457,31 @@ class MessageStore:
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 3e-7
+        source_clause, source_args = _source_filter_clause("m.source", source)
         offset = 0
         results: list[Dict[str, Any]] = []
         while True:
             try:
+                where = ["messages_fts MATCH ?"]
+                args: list[Any] = [query]
                 if session_id:
-                    if source:
-                        rows = self._conn.execute(
-                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
-                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
-                                      rank as search_rank,
-                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                               FROM messages_fts fts
-                               JOIN messages m ON m.store_id = fts.rowid
-                               WHERE messages_fts MATCH ? AND m.session_id = ? AND m.source = ?
-                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                            (query, session_id, source, fetch_limit, offset),
-                        ).fetchall()
-                    else:
-                        rows = self._conn.execute(
-                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
-                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
-                                      rank as search_rank,
-                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                               FROM messages_fts fts
-                               JOIN messages m ON m.store_id = fts.rowid
-                               WHERE messages_fts MATCH ? AND m.session_id = ?
-                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                            (query, session_id, fetch_limit, offset),
-                        ).fetchall()
-                else:
-                    if source:
-                        rows = self._conn.execute(
-                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
-                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
-                                      rank as search_rank,
-                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                               FROM messages_fts fts
-                               JOIN messages m ON m.store_id = fts.rowid
-                               WHERE messages_fts MATCH ? AND m.source = ?
-                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                            (query, source, fetch_limit, offset),
-                        ).fetchall()
-                    else:
-                        rows = self._conn.execute(
-                            f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
-                                      m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
-                                      rank as search_rank,
-                                      snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
-                               FROM messages_fts fts
-                               JOIN messages m ON m.store_id = fts.rowid
-                               WHERE messages_fts MATCH ?
-                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                            (query, fetch_limit, offset),
-                        ).fetchall()
+                    where.append("m.session_id = ?")
+                    args.append(session_id)
+                if source_clause:
+                    where.append(source_clause)
+                    args.extend(source_args)
+                args.extend([fetch_limit, offset])
+                rows = self._conn.execute(
+                    f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
+                              m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                              rank as search_rank,
+                              snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                       FROM messages_fts fts
+                       JOIN messages m ON m.store_id = fts.rowid
+                       WHERE {' AND '.join(where)}
+                       ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                    args,
+                ).fetchall()
             except sqlite3.Error as exc:
                 logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
@@ -532,9 +525,10 @@ class MessageStore:
         if session_id:
             where.append("session_id = ?")
             args.append(session_id)
-        if source:
-            where.append("source = ?")
-            args.append(source)
+        source_clause, source_args = _source_filter_clause("source", source)
+        if source_clause:
+            where.append(source_clause)
+            args.extend(source_args)
         like_clauses = []
         for term in terms:
             like_clauses.append("content LIKE ? ESCAPE '\\'")
@@ -578,6 +572,7 @@ class MessageStore:
             "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned",
         ]
         d = dict(zip(cols, row[:len(cols)]))
+        d["source"] = _normalize_source_value(d.get("source"))
         # Deserialize tool_calls JSON
         if d.get("tool_calls"):
             try:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -217,6 +217,38 @@ class TestMessageStore:
         assert discord_results[0]["source"] == "discord"
         assert discord_results[0]["session_id"] == "sess2"
 
+    def test_missing_source_is_normalized_to_unknown_and_filterable(self, store):
+        store_id = store.append("sess-unknown", {"role": "user", "content": "docker with unknown source"})
+
+        stored = store.get(store_id)
+        unknown_results = store.search("docker", source="unknown")
+
+        assert stored["source"] == "unknown"
+        assert len(unknown_results) == 1
+        assert unknown_results[0]["store_id"] == store_id
+        assert unknown_results[0]["source"] == "unknown"
+
+    def test_source_unknown_filter_matches_legacy_blank_source_rows(self, tmp_path):
+        db_path = tmp_path / "legacy-unknown-source.db"
+        store = MessageStore(db_path)
+        store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("legacy-session", "", "user", "docker with blank source", None, None, None, 1.0, 5, 0),
+        )
+        store._conn.commit()
+
+        result = store.search("docker", source="unknown")
+        fetched = store.get(1)
+
+        assert len(result) == 1
+        assert result[0]["session_id"] == "legacy-session"
+        assert result[0]["source"] == "unknown"
+        assert fetched["source"] == "unknown"
+
+        store.close()
+
     def test_gc_externalized_tool_result_rewrites_content_and_updates_fts(self, store):
         placeholder = "[GC'd externalized tool output: tool_call_id=call_gc; ref=payload.json]"
         store_id = store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -49,6 +49,8 @@ class TestEngineABC:
         grep_props = grep_schema["parameters"]["properties"]
         assert "session_scope" in grep_props
         assert "source" in grep_props
+        assert "descendant source lineage" in grep_props["source"]["description"]
+        assert "unknown" in grep_props["source"]["description"]
 
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)
@@ -966,6 +968,44 @@ class TestSessionRetainDepth:
         new_nodes = engine._dag.get_session_nodes("new-session")
         assert len(new_nodes) == 2
         assert all(node.depth >= 2 for node in new_nodes)
+
+    def test_carry_over_preserves_source_lineage_for_reassigned_nodes(self, engine):
+        discord_store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "docker logs from discord"},
+            source="discord",
+        )
+        engine._dag.add_node(SummaryNode(
+            session_id="old-session",
+            depth=2,
+            summary="retained discord docker summary",
+            token_count=100,
+            source_token_count=200,
+            source_ids=[discord_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+
+        engine._session_id = "old-session"
+        engine.on_session_reset()
+        moved = engine.carry_over_new_session_context("old-session", "new-session")
+        engine._session_id = "new-session"
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "current", "source": "discord", "limit": 10},
+            )
+        )
+
+        assert moved == 1
+        assert any(item["type"] == "summary" for item in result["results"])
+        assert all(item.get("session_id") == "new-session" for item in result["results"])
+        assert any(
+            "retained discord docker summary" in item.get("snippet", "")
+            for item in result["results"]
+            if item["type"] == "summary"
+        )
 
 
 class TestSessionRollover:
@@ -1925,6 +1965,43 @@ class TestEngineTools:
         )
         assert any(
             "discord summary" in item.get("snippet", "")
+            for item in result["results"]
+            if item["type"] == "summary"
+        )
+
+    def test_handle_grep_unknown_source_filter_matches_unknown_messages_and_summaries(self, engine):
+        unknown_store_id = engine._store.append(
+            "unknown-session",
+            {"role": "user", "content": "docker logs from unknown source"},
+            source="unknown",
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="unknown-session",
+                depth=0,
+                summary="unknown summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[unknown_store_id],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "source": "unknown", "limit": 10},
+            )
+        )
+
+        assert result["source"] == "unknown"
+        assert any(item["type"] == "message" for item in result["results"])
+        assert any(item["type"] == "summary" for item in result["results"])
+        assert all(item.get("session_id") == "unknown-session" for item in result["results"])
+        assert all(item.get("source", "unknown") == "unknown" for item in result["results"] if item["type"] == "message")
+        assert any(
+            "unknown summary" in item.get("snippet", "")
             for item in result["results"]
             if item["type"] == "summary"
         )

--- a/tools.py
+++ b/tools.py
@@ -218,7 +218,12 @@ def _synthesize_expansion_answer(
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
-    """Search across the full DAG and raw messages."""
+    """Search raw messages + summaries using independent session/source filters.
+
+    ``session_scope`` decides which sessions are eligible.
+    ``source`` then filters raw rows directly and summaries by descendant source
+    lineage within that eligible set.
+    """
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})


### PR DESCRIPTION
## Summary
- define the retrieval contract for `session_scope` and `source` across raw messages, DAG summaries, and merged `lcm_grep` results
- normalize missing persisted sources to `unknown` and treat legacy blank-source rows as `unknown` at retrieval time
- add regression tests for `unknown` filtering and carry-over/source-lineage behavior

## Why
- issue #37 asks for an explicit retrieval contract instead of letting source/session semantics stay implicit
- the contract needs to match the full-propagation direction from Stephen's comment and stay consistent across raw rows, summaries, and merged tool output
- explicit `unknown` handling keeps cross-session/source filtering testable instead of silently broadening matches

## Validation
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_lcm_core.py::TestMessageStore::test_missing_source_is_normalized_to_unknown_and_filterable tests/test_lcm_core.py::TestMessageStore::test_source_unknown_filter_matches_legacy_blank_source_rows tests/test_lcm_engine.py::TestEngineTools::test_handle_grep_unknown_source_filter_matches_unknown_messages_and_summaries tests/test_lcm_engine.py::TestSessionRetainDepth::test_carry_over_preserves_source_lineage_for_reassigned_nodes -q`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && pytest -q`
- `source /home/nabu/.hermes/hermes-agent/venv/bin/activate && python -m compileall -q .`
- `git diff --check`

## Notes
- this keeps the fix plugin-side; no Hermes core changes are required for the retrieval contract itself
- `source='unknown'` is treated as an explicit stored value, while an omitted `source` still means no source filtering
- legacy rows with blank persisted `source` values are kept backward-compatible by matching the explicit `unknown` filter

Closes #37
