### PR TITLE
fix: salvage verified search and FTS hardening from #41

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -37,6 +37,7 @@ from .search_query import (
     extract_search_terms,
     normalize_search_sort,
     requires_like_fallback,
+    sanitize_fts5_query,
     should_apply_directness_rank_adjustment,
 )
 from .store import _normalize_source_value, _UNKNOWN_SOURCE
@@ -335,8 +336,9 @@ class SummaryDAG:
           session-level source presence
         - mixed-source nodes may match more than one ``source`` filter
         """
-        terms = extract_search_terms(query)
-        phrases = extract_quoted_phrases(query)
+        safe_query = sanitize_fts5_query(query)
+        terms = extract_search_terms(safe_query)
+        phrases = extract_quoted_phrases(safe_query)
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
@@ -355,7 +357,7 @@ class SummaryDAG:
                            JOIN summary_nodes n ON n.node_id = fts.rowid
                            WHERE nodes_fts MATCH ? AND n.session_id = ?
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, session_id, fetch_limit, offset),
+                        (safe_query, session_id, fetch_limit, offset),
                     ).fetchall()
                 else:
                     rows = self._conn.execute(
@@ -363,7 +365,7 @@ class SummaryDAG:
                            JOIN summary_nodes n ON n.node_id = fts.rowid
                            WHERE nodes_fts MATCH ?
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (query, fetch_limit, offset),
+                        (safe_query, fetch_limit, offset),
                     ).fetchall()
             except sqlite3.Error as exc:
                 logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
@@ -397,8 +399,9 @@ class SummaryDAG:
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,
                      source: str | None = None) -> List[SummaryNode]:
-        terms = extract_search_terms(query)
-        phrases = extract_quoted_phrases(query)
+        safe_query = sanitize_fts5_query(query)
+        terms = extract_search_terms(safe_query)
+        phrases = extract_quoted_phrases(safe_query)
         if not terms:
             return []
 

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sqlite3
 from typing import Iterable, Sequence
 
@@ -223,6 +224,29 @@ def _drop_fts_table(conn: sqlite3.Connection, table_name: str) -> None:
         conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(shadow_name)}")
 
 
+def _extract_trigger_name(trigger_sql: str) -> str | None:
+    match = re.search(
+        r"CREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))",
+        trigger_sql,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def _drop_fts_triggers(conn: sqlite3.Connection, trigger_sqls: Sequence[str]) -> None:
+    for trigger_sql in trigger_sqls:
+        trigger_name = _extract_trigger_name(trigger_sql)
+        if trigger_name:
+            conn.execute(f"DROP TRIGGER IF EXISTS {quote_sql_identifier(trigger_name)}")
+
+
+def _drop_fts_artifacts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
+    _drop_fts_triggers(conn, spec.trigger_sqls)
+    _drop_fts_table(conn, spec.table_name)
+
+
 def _check_disk_space(db_path: str) -> bool:
     try:
         parent = os.path.dirname(os.path.abspath(db_path)) or "."
@@ -243,6 +267,7 @@ def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentF
                     spec.table_name,
                     _MIN_DISK_SPACE_BYTES // (1024 * 1024),
                 )
+                _drop_fts_artifacts(conn, spec)
                 return
         _drop_fts_table(conn, spec.table_name)
         conn.execute(

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -6,11 +6,16 @@ same schema-version marker, PRAGMA settings, and FTS repair behavior.
 
 from __future__ import annotations
 
+import logging
+import os
 import sqlite3
 from typing import Iterable, Sequence
 
+logger = logging.getLogger(__name__)
+
 SCHEMA_VERSION = 4
 SQLITE_BUSY_TIMEOUT_MS = 30_000
+_MIN_DISK_SPACE_BYTES = 50 * 1024 * 1024
 
 
 class ExternalContentFtsSpec:
@@ -218,8 +223,27 @@ def _drop_fts_table(conn: sqlite3.Connection, table_name: str) -> None:
         conn.execute(f"DROP TABLE IF EXISTS {quote_sql_identifier(shadow_name)}")
 
 
+def _check_disk_space(db_path: str) -> bool:
+    try:
+        parent = os.path.dirname(os.path.abspath(db_path)) or "."
+        usage = os.statvfs(parent)
+        return usage.f_bavail * usage.f_frsize >= _MIN_DISK_SPACE_BYTES
+    except OSError:
+        return True
+
+
 def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
     if _fts_needs_rebuild(conn, spec):
+        db_path = conn.execute("PRAGMA database_list").fetchone()
+        if db_path:
+            db_file = db_path[2]
+            if db_file and not _check_disk_space(db_file):
+                logger.warning(
+                    "Low disk space for FTS rebuild of '%s' (%d MB needed), degrading to LIKE search",
+                    spec.table_name,
+                    _MIN_DISK_SPACE_BYTES // (1024 * 1024),
+                )
+                return
         _drop_fts_table(conn, spec.table_name)
         conn.execute(
             f"""

--- a/search_query.py
+++ b/search_query.py
@@ -30,21 +30,38 @@ _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
 _FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}')
 
 
+def _sanitize_unquoted_fts5_fragment(text: str) -> str:
+    return "".join(" " if char in _FTS5_SPECIAL_CHARS else char for char in text)
+
+
 def sanitize_fts5_query(query: str) -> str:
     """Strip FTS5 syntax operators while preserving balanced phrase quotes."""
     if not query:
         return ""
 
     result: list[str] = []
+    quote_buffer: list[str] = []
     in_quote = False
     for char in query:
         if char == '"':
-            in_quote = not in_quote
-            result.append('"')
-        elif in_quote or char not in _FTS5_SPECIAL_CHARS:
-            result.append(char)
-        else:
-            result.append(" ")
+            if in_quote:
+                result.append('"')
+                result.extend(quote_buffer)
+                result.append('"')
+                quote_buffer = []
+                in_quote = False
+            else:
+                if result and not result[-1].isspace():
+                    result.append(" ")
+                in_quote = True
+                quote_buffer = []
+            continue
+        if in_quote:
+            quote_buffer.append(char)
+            continue
+        result.append(" " if char in _FTS5_SPECIAL_CHARS else char)
+    if in_quote and quote_buffer:
+        result.extend(_sanitize_unquoted_fts5_fragment("".join(quote_buffer)))
     return "".join(result).strip()
 
 

--- a/search_query.py
+++ b/search_query.py
@@ -26,6 +26,26 @@ _BOOLEAN_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
 _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
 _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
+# Characters that are special in FTS5 query syntax
+_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}')
+
+
+def sanitize_fts5_query(query: str) -> str:
+    """Strip FTS5 syntax operators while preserving balanced phrase quotes."""
+    if not query:
+        return ""
+
+    result: list[str] = []
+    in_quote = False
+    for char in query:
+        if char == '"':
+            in_quote = not in_quote
+            result.append('"')
+        elif in_quote or char not in _FTS5_SPECIAL_CHARS:
+            result.append(char)
+        else:
+            result.append(" ")
+    return "".join(result).strip()
 
 
 _WORD_RE = re.compile(r"[\w-]+", re.UNICODE)

--- a/store.py
+++ b/store.py
@@ -445,12 +445,12 @@ class MessageStore:
         - ``source='unknown'`` means the explicit unknown-source bucket, with
           legacy blank-source rows treated as equivalent for back-compat
         """
-        terms = extract_search_terms(query)
-        phrases = extract_quoted_phrases(query)
+        safe_query = sanitize_fts5_query(query)
+        terms = extract_search_terms(safe_query)
+        phrases = extract_quoted_phrases(safe_query)
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
-        safe_query = sanitize_fts5_query(query)
         order_by = _build_search_order_by(
             sort,
             "m.timestamp",

--- a/store.py
+++ b/store.py
@@ -32,6 +32,7 @@ from .search_query import (
     extract_search_terms,
     normalize_search_sort,
     requires_like_fallback,
+    sanitize_fts5_query,
     AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
@@ -449,6 +450,7 @@ class MessageStore:
         if requires_like_fallback(query):
             return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
+        safe_query = sanitize_fts5_query(query)
         order_by = _build_search_order_by(
             sort,
             "m.timestamp",
@@ -463,7 +465,7 @@ class MessageStore:
         while True:
             try:
                 where = ["messages_fts MATCH ?"]
-                args: list[Any] = [query]
+                args: list[Any] = [safe_query]
                 if session_id:
                     where.append("m.session_id = ?")
                     args.append(session_id)
@@ -515,8 +517,9 @@ class MessageStore:
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,
                      source: str | None = None) -> List[Dict[str, Any]]:
-        terms = extract_search_terms(query)
-        phrases = extract_quoted_phrases(query)
+        safe_query = sanitize_fts5_query(query)
+        terms = extract_search_terms(safe_query)
+        phrases = extract_quoted_phrases(safe_query)
         if not terms:
             return []
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -14,6 +14,8 @@ from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG, SummaryNode
 from hermes_lcm.escalation import _deterministic_truncate
 from hermes_lcm.lifecycle_state import LifecycleStateStore
+from hermes_lcm.db_bootstrap import ExternalContentFtsSpec, ensure_external_content_fts
+from hermes_lcm.search_query import sanitize_fts5_query
 from hermes_lcm.session_patterns import (
     build_session_match_keys,
     compile_session_pattern,
@@ -399,6 +401,14 @@ class TestMessageStore:
         assert len(results) == 1
         assert results[0]["content"] == "docker fallback search still works"
         assert "fallback" in results[0]["snippet"].lower()
+
+    def test_search_like_fallback_sanitizes_fts_syntax_chars(self, store):
+        store.append("sess1", {"role": "user", "content": "vendoring external support stays plugin-only"})
+
+        results = store.search("vendoring*", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "vendoring external support stays plugin-only"
 
     def test_init_repairs_message_fts_drifted_row_count(self, tmp_path):
         db_path = tmp_path / "message-fts-drift.db"
@@ -1079,6 +1089,38 @@ class TestLifecycleStateStore:
         assert after_reset.last_reset_at is not None
 
         state.close()
+
+
+class TestDbBootstrapGuards:
+    def test_sanitize_fts5_query_preserves_balanced_phrase_quotes(self):
+        assert sanitize_fts5_query('"vendoring external" *') == '"vendoring external"'
+
+    def test_ensure_external_content_fts_skips_rebuild_when_disk_is_low(self, tmp_path, monkeypatch):
+        conn = sqlite3.connect(tmp_path / "low-disk.db")
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content TEXT
+            );
+            INSERT INTO messages(content) VALUES ('fresh searchable message');
+            """
+        )
+        spec = ExternalContentFtsSpec(
+            table_name="messages_fts",
+            content_table="messages",
+            content_rowid="store_id",
+            indexed_column="content",
+            trigger_sqls=(),
+        )
+        monkeypatch.setattr("hermes_lcm.db_bootstrap._check_disk_space", lambda _path: False)
+
+        ensure_external_content_fts(conn, spec)
+
+        existing = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
+        ).fetchone()
+        assert existing is None
 
 
 class TestSummaryDAG:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -405,10 +405,86 @@ class TestMessageStore:
     def test_search_like_fallback_sanitizes_fts_syntax_chars(self, store):
         store.append("sess1", {"role": "user", "content": "vendoring external support stays plugin-only"})
 
-        results = store.search("vendoring*", session_id="sess1")
+        results = store.search('"vendoring*', session_id="sess1")
 
         assert len(results) == 1
         assert results[0]["content"] == "vendoring external support stays plugin-only"
+
+    def test_search_like_fallback_splits_unbalanced_quote_terms(self, store):
+        store.append("sess1", {"role": "user", "content": "foo bar baz"})
+
+        results = store.search('foo"bar', session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "foo bar baz"
+
+    def test_search_uses_sanitized_terms_for_directness_scoring(self, store):
+        store.append("sess1", {"role": "user", "content": "vendoring external support stays plugin-only"})
+
+        results = store.search("vendoring*", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["_directness_score"] > 0
+
+    def test_search_sanitizes_fts_wildcards_without_prefix_matching(self, store):
+        store.append("sess1", {"role": "user", "content": "dockerization notes"})
+
+        results = store.search("docker*", session_id="sess1")
+
+        assert results == []
+
+    def test_init_low_disk_degrades_without_leaving_broken_message_fts_triggers(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "low-disk-broken-message-fts.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                source TEXT DEFAULT 'unknown',
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE TRIGGER msg_fts_insert
+                AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content)
+                    VALUES (new.store_id, new.content);
+            END;
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '4');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr("hermes_lcm.db_bootstrap._check_disk_space", lambda _path: False)
+
+        store = MessageStore(db_path)
+        try:
+            store.append("sess1", {"role": "user", "content": "fallback remains writable"})
+
+            results = store.search("fallback", session_id="sess1")
+            trigger_names = {
+                row[0]
+                for row in store._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('msg_fts_insert', 'msg_fts_delete')"
+                ).fetchall()
+            }
+
+            assert len(results) == 1
+            assert results[0]["content"] == "fallback remains writable"
+            assert trigger_names == set()
+        finally:
+            store.close()
 
     def test_init_repairs_message_fts_drifted_row_count(self, tmp_path):
         db_path = tmp_path / "message-fts-drift.db"
@@ -1095,6 +1171,9 @@ class TestDbBootstrapGuards:
     def test_sanitize_fts5_query_preserves_balanced_phrase_quotes(self):
         assert sanitize_fts5_query('"vendoring external" *') == '"vendoring external"'
 
+    def test_sanitize_fts5_query_breaks_unbalanced_quotes_into_separate_terms(self):
+        assert sanitize_fts5_query('foo"bar') == 'foo bar'
+
     def test_ensure_external_content_fts_skips_rebuild_when_disk_is_low(self, tmp_path, monkeypatch):
         conn = sqlite3.connect(tmp_path / "low-disk.db")
         conn.executescript(
@@ -1121,6 +1200,7 @@ class TestDbBootstrapGuards:
             "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
         ).fetchone()
         assert existing is None
+        conn.close()
 
 
 class TestSummaryDAG:
@@ -1301,6 +1381,109 @@ class TestSummaryDAG:
 
         assert len(results) == 1
         assert results[0].summary == "dag fallback search still works"
+
+    def test_search_like_fallback_sanitizes_fts_syntax_chars(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring external support stays plugin-only",
+            token_count=8, source_ids=[1], source_type="messages",
+        ))
+
+        results = dag.search('"vendoring*', session_id="s1")
+
+        assert len(results) == 1
+        assert results[0].summary == "vendoring external support stays plugin-only"
+
+    def test_search_like_fallback_splits_unbalanced_quote_terms(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="foo bar baz",
+            token_count=4, source_ids=[1], source_type="messages",
+        ))
+
+        results = dag.search('foo"bar', session_id="s1")
+
+        assert len(results) == 1
+        assert results[0].summary == "foo bar baz"
+
+    def test_search_sanitizes_fts_wildcards_without_prefix_matching(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="dockerization notes",
+            token_count=4, source_ids=[1], source_type="messages",
+        ))
+
+        results = dag.search("docker*", session_id="s1")
+
+        assert results == []
+
+    def test_search_uses_sanitized_terms_for_directness_scoring(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="vendoring external support stays plugin-only",
+            token_count=8, source_ids=[1], source_type="messages",
+        ))
+
+        results = dag.search("vendoring*", session_id="s1")
+
+        assert len(results) == 1
+        assert results[0].search_directness > 0
+
+    def test_init_low_disk_degrades_without_leaving_broken_nodes_fts_triggers(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "low-disk-broken-nodes-fts.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE TRIGGER nodes_fts_insert
+                AFTER INSERT ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(rowid, summary)
+                    VALUES (new.node_id, new.summary);
+            END;
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '4');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr("hermes_lcm.db_bootstrap._check_disk_space", lambda _path: False)
+
+        dag = SummaryDAG(db_path)
+        try:
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary="fallback dag stays writable",
+                token_count=5, source_ids=[1], source_type="messages",
+            ))
+
+            results = dag.search("fallback", session_id="s1")
+            trigger_names = {
+                row[0]
+                for row in dag._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('nodes_fts_insert', 'nodes_fts_delete')"
+                ).fetchall()
+            }
+
+            assert len(results) == 1
+            assert results[0].summary == "fallback dag stays writable"
+            assert trigger_names == set()
+        finally:
+            dag.close()
 
     def test_init_repairs_nodes_fts_drifted_row_count(self, tmp_path):
         db_path = tmp_path / "nodes-fts-drift.db"


### PR DESCRIPTION
## Summary
- salvage the verified query-sanitization changes from #41 into a fresh branch from `main`
- sanitize FTS `MATCH` queries and LIKE-fallback term extraction while preserving balanced phrase quotes
- degrade external-content FTS rebuilds to LIKE search when disk space is too low instead of rebuilding
- add focused regression tests for the salvaged paths

## Why
- #41 mixed good changes with unresolved blockers in other files and was not merge-ready
- this PR carries forward only the subset that was validated locally and leaves the broken areas out
- important constraint: this PR does not attempt to fix the remaining `engine.py`, `extraction.py`, or `command.py` concerns from #41

## Validation
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q`
- `ulimit -n 4096 && pytest -q`
- `python -m compileall -q .`
- `git diff --check`
- `pytest -q tests/test_lcm_core.py::TestMessageStore::test_search_relevance_still_surfaces_direct_phrase_hit_when_phrase_matches_many_spammy_candidates tests/test_lcm_core.py::TestMessageStore::test_search_like_fallback_sanitizes_fts_syntax_chars tests/test_lcm_core.py::TestDbBootstrapGuards::test_sanitize_fts5_query_preserves_balanced_phrase_quotes tests/test_lcm_core.py::TestDbBootstrapGuards::test_ensure_external_content_fts_skips_rebuild_when_disk_is_low tests/test_lcm_engine.py::TestPostCompactionIngestion::test_ingest_after_compaction tests/test_lcm_engine.py::TestPostCompactionIngestion::test_multiple_compactions`

## Notes
- supersedes the verified subset of #41 rather than extending that branch
- intentionally excludes the unresolved `engine.py`, `extraction.py`, and `command.py` work from #41
- credit to @cedricwyh for the original hardening attempt and for surfacing the target areas that this narrower salvage PR carries forward
- after this replacement PR is open, #41 should be closed as superseded rather than merged
