### PR TITLE
feat: surface source-lineage hygiene diagnostics

### DIFF
--- a/command.py
+++ b/command.py
@@ -51,6 +51,15 @@ def _status_text(engine) -> str:
     db_exists = db_path.exists()
     db_size = db_path.stat().st_size if db_exists else 0
     session_bound = bool(engine._session_id)
+    source_stats = status.get("source_lineage") or {}
+    source_stats = {
+        "messages_total": int(source_stats.get("messages_total", 0) or 0),
+        "attributed_messages": int(source_stats.get("attributed_messages", 0) or 0),
+        "normalized_unknown_messages": int(source_stats.get("normalized_unknown_messages", 0) or 0),
+        "legacy_blank_source_messages": int(source_stats.get("legacy_blank_source_messages", 0) or 0),
+        "effective_unknown_messages": int(source_stats.get("effective_unknown_messages", 0) or 0),
+        **({"error": source_stats.get("error")} if source_stats.get("error") else {}),
+    }
 
     def _safe_scalar(conn, query: str) -> int | str:
         try:
@@ -70,6 +79,11 @@ def _status_text(engine) -> str:
         f"threshold_tokens: {engine.threshold_tokens if session_bound else '(uninitialized)'}",
         f"session_ignored: {_fmt_bool(status.get('session_ignored'))}",
         f"session_stateless: {_fmt_bool(status.get('session_stateless'))}",
+        f"source_messages_total: {source_stats['messages_total']}",
+        f"source_attributed_messages: {source_stats['attributed_messages']}",
+        f"source_unknown_messages: {source_stats['normalized_unknown_messages']}",
+        f"source_legacy_blank_messages: {source_stats['legacy_blank_source_messages']}",
+        f"source_effective_unknown_messages: {source_stats['effective_unknown_messages']}",
     ]
 
     if session_bound:
@@ -94,6 +108,8 @@ def _status_text(engine) -> str:
         lines.append(
             f"stateless_session_patterns_source: {status.get('stateless_session_patterns_source')}"
         )
+    if source_stats.get("error"):
+        lines.append(f"source_lineage_error: {source_stats['error']}")
     return "\n".join(lines)
 
 
@@ -444,6 +460,31 @@ def _doctor_text(engine) -> str:
         recommended_actions.append("create a safety snapshot first with `/lcm backup`")
     else:
         observations.append("cleanup_candidates: none")
+
+    try:
+        source_stats = engine._store.get_source_stats()
+    except Exception as exc:  # pragma: no cover - defensive
+        issues.append("source_lineage")
+        source_stats = {
+            "messages_total": 0,
+            "attributed_messages": 0,
+            "normalized_unknown_messages": 0,
+            "legacy_blank_source_messages": 0,
+            "effective_unknown_messages": 0,
+            "error": str(exc),
+        }
+    observations.append(
+        "source_lineage: "
+        f"attributed={source_stats['attributed_messages']} "
+        f"unknown={source_stats['normalized_unknown_messages']} "
+        f"legacy_blank={source_stats['legacy_blank_source_messages']} "
+        f"effective_unknown={source_stats['effective_unknown_messages']}"
+    )
+    if source_stats.get("error"):
+        observations.append(f"source_lineage_error: {source_stats['error']}")
+    if source_stats["legacy_blank_source_messages"]:
+        recommended_actions.append("review legacy blank-source rows before any destructive cleanup or migration step")
+        recommended_actions.append("treat `source=unknown` as the back-compat filter until legacy blank-source rows are normalized")
 
     if clean_scan.get("protected_count"):
         observations.append(

--- a/engine.py
+++ b/engine.py
@@ -666,8 +666,12 @@ class LCMEngine(ContextEngine):
     def get_status(self) -> Dict[str, Any]:
         status = super().get_status()
         lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
+        status["engine"] = "lcm"
+        try:
+            status["source_lineage"] = self._store.get_source_stats(self._session_id or None)
+        except Exception as exc:  # pragma: no cover - defensive
+            status["source_lineage"] = {"error": str(exc)}
         if self._session_id:
-            status["engine"] = "lcm"
             status["store_messages"] = self._store.get_session_count(self._session_id)
             status["dag_nodes"] = len(self._dag.get_session_nodes(self._session_id))
             status["session_platform"] = self._session_platform

--- a/store.py
+++ b/store.py
@@ -419,6 +419,39 @@ class MessageStore:
         ).fetchone()
         return row[0] if row else 0
 
+    def get_source_stats(self, session_id: str | None = None) -> Dict[str, int]:
+        """Return raw source-bucket counts for diagnostics."""
+        where = ""
+        args: list[Any] = []
+        if session_id is not None:
+            where = "WHERE session_id = ?"
+            args.append(session_id)
+
+        query = f"""
+            SELECT COUNT(*) AS messages_total,
+                   COALESCE(SUM(CASE WHEN source = '{_UNKNOWN_SOURCE}' THEN 1 ELSE 0 END), 0) AS normalized_unknown_messages,
+                   COALESCE(SUM(CASE WHEN source = '' THEN 1 ELSE 0 END), 0) AS legacy_blank_source_messages,
+                   COALESCE(SUM(CASE WHEN source != '' AND source != '{_UNKNOWN_SOURCE}' THEN 1 ELSE 0 END), 0) AS attributed_messages
+            FROM messages
+            {where}
+            """
+        if args:
+            row = self._conn.execute(query, args).fetchone()
+        else:
+            row = self._conn.execute(query).fetchone()
+
+        messages_total = int(row[0] or 0) if row else 0
+        normalized_unknown = int(row[1] or 0) if row else 0
+        legacy_blank = int(row[2] or 0) if row else 0
+        attributed = int(row[3] or 0) if row else 0
+        return {
+            "messages_total": messages_total,
+            "attributed_messages": attributed,
+            "normalized_unknown_messages": normalized_unknown,
+            "legacy_blank_source_messages": legacy_blank,
+            "effective_unknown_messages": normalized_unknown + legacy_blank,
+        }
+
     def get_time_bounds(self, store_ids: List[int]) -> tuple[float | None, float | None]:
         if not store_ids:
             return None, None

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -53,6 +53,26 @@ def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
     assert "note: no active Hermes session has initialized LCM in this process yet" in result
 
 
+def test_lcm_status_reports_source_lineage_breakdown(engine):
+    engine._store.append("test-session", {"role": "user", "content": "cli message"}, source="cli")
+    engine._store.append("test-session", {"role": "user", "content": "unknown message"})
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        ("test-session", "", "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+    )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("status", engine)
+
+    assert "source_messages_total: 3" in result
+    assert "source_attributed_messages: 1" in result
+    assert "source_unknown_messages: 1" in result
+    assert "source_legacy_blank_messages: 1" in result
+    assert "source_effective_unknown_messages: 2" in result
+
+
 def test_lcm_doctor_reports_health_checks(engine):
     result = handle_lcm_command("doctor", engine)
 
@@ -83,6 +103,25 @@ def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path
     assert "cleanup_candidates" in result
     assert "/lcm doctor clean" in result
     assert "/lcm backup" in result
+
+
+def test_lcm_doctor_reports_legacy_blank_source_observation_and_action(engine):
+    engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+    engine._store.append("sess-unknown", {"role": "user", "content": "unknown message"})
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        ("legacy-session", "", "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+    )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "source_lineage:" in result
+    assert "legacy_blank=1" in result
+    assert "effective_unknown=2" in result
+    assert "review legacy blank-source rows before any destructive cleanup" in result
 
 
 def test_lcm_help_on_unknown_subcommand(engine):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -249,6 +249,29 @@ class TestMessageStore:
 
         store.close()
 
+    def test_get_source_stats_reports_attributed_unknown_and_legacy_blank_counts(self, tmp_path):
+        db_path = tmp_path / "source-stats.db"
+        store = MessageStore(db_path)
+        store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+        store.append("sess-unknown", {"role": "user", "content": "unknown message"})
+        store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("legacy-session", "", "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+        )
+        store._conn.commit()
+
+        stats = store.get_source_stats()
+
+        assert stats["messages_total"] == 3
+        assert stats["attributed_messages"] == 1
+        assert stats["normalized_unknown_messages"] == 1
+        assert stats["legacy_blank_source_messages"] == 1
+        assert stats["effective_unknown_messages"] == 2
+
+        store.close()
+
     def test_gc_externalized_tool_result_rewrites_content_and_updates_fts(self, store):
         placeholder = "[GC'd externalized tool output: tool_call_id=call_gc; ref=payload.json]"
         store_id = store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3145,6 +3145,9 @@ class TestEngineTools:
         assert "d0" in result["dag"]["depths"]
         assert result["config"]["fresh_tail_count"] == engine._config.fresh_tail_count
         assert result["session_filters"]["ignored"] is False
+        assert result["source_lineage"]["messages_total"] == 1
+        assert result["source_lineage"]["normalized_unknown_messages"] == 1
+        assert result["source_lineage"]["legacy_blank_source_messages"] == 0
 
     def test_handle_status_shows_compression_ratio(self, engine):
         engine._dag.add_node(

--- a/tools.py
+++ b/tools.py
@@ -537,7 +537,9 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     total_dag_tokens = sum(d["tokens"] for d in depths.values())
     total_source_tokens = sum(d["source_tokens"] for d in depths.values())
     compression_ratio = round(total_source_tokens / total_dag_tokens, 1) if total_dag_tokens > 0 else 0
-    lifecycle = engine.get_status().get("lifecycle")
+    full_status = engine.get_status()
+    lifecycle = full_status.get("lifecycle")
+    source_lineage = full_status.get("source_lineage")
 
     return json.dumps({
         "session_id": session_id,
@@ -576,6 +578,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "ignored": engine._session_ignored,
             "stateless": engine._session_stateless,
         },
+        "source_lineage": source_lineage,
         "lifecycle": lifecycle,
     })
 
@@ -668,7 +671,26 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         "detail": config_warnings if config_warnings else "all settings within normal ranges",
     })
 
-    # 5. Context pressure
+    # 5. Source-lineage hygiene
+    try:
+        source_stats = engine._store.get_source_stats()
+        legacy_blank_messages = source_stats["legacy_blank_source_messages"]
+        checks.append({
+            "check": "source_lineage_hygiene",
+            "status": "pass" if legacy_blank_messages == 0 else "warn",
+            "detail": {
+                **source_stats,
+                "normalization_mode": "backcompat-normalization",
+            },
+        })
+    except Exception as e:
+        checks.append({
+            "check": "source_lineage_hygiene",
+            "status": "fail",
+            "detail": str(e),
+        })
+
+    # 6. Context pressure
     if engine.context_length > 0:
         usage_pct = round(engine.last_prompt_tokens / engine.context_length * 100, 1) if engine.context_length else 0
         threshold_pct = round(c.context_threshold * 100, 1)


### PR DESCRIPTION
## Summary
- add `MessageStore.get_source_stats()` to report attributed, normalized-unknown, legacy-blank, and effective-unknown source counts
- surface source-lineage hygiene in `engine.get_status()`, `lcm_status`, `/lcm status`, and `/lcm doctor`
- add explicit operator guidance when legacy blank-source rows are still present so back-compat behavior stays visible before any destructive migration

## Why
- legacy blank-source rows undermine source-aware retrieval and diagnostics, but silently rewriting them would be risky
- this slice makes the current state observable first, keeps `source='unknown'` back-compat explicit, and gives operators a safer basis for later migration work
- the change stays scoped to diagnostics and status surfaces rather than claiming a full migration/backfill that is not implemented yet

## Validation
- `pytest tests/test_lcm_core.py -q -k 'source_stats or legacy_blank_source_rows'`
- `pytest tests/test_lcm_command.py -q -k 'source_lineage_breakdown or legacy_blank_source_observation'`
- `pytest tests/test_lcm_engine.py -q -k 'handle_status_returns_session_overview or unknown_source_filter_matches_unknown_messages_and_summaries'`
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_command.py -q`
- `python -m compileall -q .`
- `git diff --check`
- local `/lcm status` and `/lcm doctor` smoke check against a temp db with attributed, explicit-unknown, and legacy blank-source rows

## Notes
- this PR does **not** perform a destructive migration or physical backfill of legacy blank-source rows
- `source='unknown'` remains the explicit back-compat filter while legacy blank-source rows still exist
- operator-facing command output was tested directly, not just helper internals