### PR TITLE
fix: restrict lcm_grep to active session only

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -6,9 +6,8 @@ LCM_GREP = {
         "Search the current session's conversation history — raw messages AND summaries across all depths — "
         "to recover details from earlier in the active conversation, even if those turns were compacted. "
         "Prefer this for intra-session recall. If the user is asking about an earlier separate conversation "
-        "or broad cross-session history, prefer session_search instead. When you intentionally want the LCM "
-        "store across sessions, use session_scope='all' explicitly. Returns matches with depth labels showing "
-        "where each result lives."
+        "or broad cross-session history, prefer session_search instead. Returns matches with depth labels "
+        "showing where each result lives."
     ),
     "parameters": {
         "type": "object",
@@ -37,11 +36,10 @@ LCM_GREP = {
             },
             "session_scope": {
                 "type": "string",
-                "enum": ["current", "all"],
+                "enum": ["current"],
                 "description": (
-                    "Whether to search only the current session or all stored LCM sessions. "
-                    "Default is current. Use all only when you intentionally want cross-session LCM store hits; "
-                    "for general earlier-conversation recall, prefer session_search instead."
+                    "Whether to search only the current session. "
+                    "Cross-session recall should use session_search instead."
                 ),
                 "default": "current",
             },

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1928,18 +1928,18 @@ class TestEngineTools:
 
     def test_handle_grep_source_filter_excludes_unrelated_summaries_in_mixed_source_session(self, engine):
         discord_store_id = engine._store.append(
-            "mixed-session",
+            "test-session",
             {"role": "user", "content": "docker logs from discord"},
             source="discord",
         )
         telegram_store_id = engine._store.append(
-            "mixed-session",
+            "test-session",
             {"role": "user", "content": "docker logs from telegram"},
             source="telegram",
         )
         engine._dag.add_node(
             SummaryNode(
-                session_id="mixed-session",
+                session_id="test-session",
                 depth=0,
                 summary="discord summary about docker logs",
                 token_count=10,
@@ -1951,7 +1951,7 @@ class TestEngineTools:
         )
         engine._dag.add_node(
             SummaryNode(
-                session_id="mixed-session",
+                session_id="test-session",
                 depth=0,
                 summary="telegram summary about docker logs",
                 token_count=10,
@@ -1971,7 +1971,7 @@ class TestEngineTools:
 
         assert any(item["type"] == "message" for item in result["results"])
         assert any(item["type"] == "summary" for item in result["results"])
-        assert all(item.get("session_id") == "mixed-session" for item in result["results"])
+        assert all(item.get("session_id") == "test-session" for item in result["results"])
         assert all(
             "telegram summary" not in item.get("snippet", "")
             for item in result["results"]
@@ -1985,13 +1985,13 @@ class TestEngineTools:
 
     def test_handle_grep_unknown_source_filter_matches_unknown_messages_and_summaries(self, engine):
         unknown_store_id = engine._store.append(
-            "unknown-session",
+            "test-session",
             {"role": "user", "content": "docker logs from unknown source"},
             source="unknown",
         )
         engine._dag.add_node(
             SummaryNode(
-                session_id="unknown-session",
+                session_id="test-session",
                 depth=0,
                 summary="unknown summary about docker logs",
                 token_count=10,
@@ -2012,7 +2012,7 @@ class TestEngineTools:
         assert result["source"] == "unknown"
         assert any(item["type"] == "message" for item in result["results"])
         assert any(item["type"] == "summary" for item in result["results"])
-        assert all(item.get("session_id") == "unknown-session" for item in result["results"])
+        assert all(item.get("session_id") == "test-session" for item in result["results"])
         assert all(item.get("source", "unknown") == "unknown" for item in result["results"] if item["type"] == "message")
         assert any(
             "unknown summary" in item.get("snippet", "")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -53,7 +53,6 @@ class TestEngineABC:
         assert "unknown" in grep_props["source"]["description"]
         assert "current session" in grep_schema["description"].lower()
         assert "session_search" in grep_schema["description"]
-        assert "session_scope='all'" in grep_schema["description"]
         assert "session_search" in grep_props["session_scope"]["description"]
 
         describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
@@ -1885,12 +1884,12 @@ class TestEngineTools:
         )
         assert result["sort"] == "relevance"
 
-    def test_handle_grep_source_filter_across_sessions_includes_only_matching_summaries(self, engine):
-        engine._store.append("s-discord", {"role": "user", "content": "docker logs from discord"}, source="discord")
+    def test_handle_grep_source_filter_in_current_session_includes_only_matching_summaries(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker logs from discord"}, source="discord")
         engine._store.append("s-telegram", {"role": "user", "content": "docker logs from telegram"}, source="telegram")
         engine._dag.add_node(
             SummaryNode(
-                session_id="s-discord",
+                session_id="test-session",
                 depth=0,
                 summary="discord summary about docker logs",
                 token_count=10,
@@ -1916,15 +1915,15 @@ class TestEngineTools:
         result = json.loads(
             engine.handle_tool_call(
                 "lcm_grep",
-                {"query": "docker", "session_scope": "all", "source": "discord", "limit": 10},
+                {"query": "docker", "session_scope": "current", "source": "discord", "limit": 10},
             )
         )
 
-        assert result["session_scope"] == "all"
+        assert result["session_scope"] == "current"
         assert result["source"] == "discord"
         assert any(item["type"] == "message" for item in result["results"])
         assert any(item["type"] == "summary" for item in result["results"])
-        assert all(item.get("session_id") == "s-discord" for item in result["results"])
+        assert all(item.get("session_id") == "test-session" for item in result["results"])
         assert all(item.get("source", "discord") == "discord" for item in result["results"] if item["type"] == "message")
 
     def test_handle_grep_source_filter_excludes_unrelated_summaries_in_mixed_source_session(self, engine):
@@ -1966,7 +1965,7 @@ class TestEngineTools:
         result = json.loads(
             engine.handle_tool_call(
                 "lcm_grep",
-                {"query": "docker", "session_scope": "all", "source": "discord", "limit": 10},
+                {"query": "docker", "session_scope": "current", "source": "discord", "limit": 10},
             )
         )
 
@@ -2006,7 +2005,7 @@ class TestEngineTools:
         result = json.loads(
             engine.handle_tool_call(
                 "lcm_grep",
-                {"query": "docker", "session_scope": "all", "source": "unknown", "limit": 10},
+                {"query": "docker", "session_scope": "current", "source": "unknown", "limit": 10},
             )
         )
 

--- a/tools.py
+++ b/tools.py
@@ -218,12 +218,7 @@ def _synthesize_expansion_answer(
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
-    """Search raw messages + summaries using independent session/source filters.
-
-    ``session_scope`` decides which sessions are eligible.
-    ``source`` then filters raw rows directly and summaries by descendant source
-    lineage within that eligible set.
-    """
+    """Search raw messages + summaries in the active session with optional source filtering."""
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
@@ -235,9 +230,12 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     limit = args.get("limit", 10)
     sort = normalize_search_sort(args.get("sort"))
     source_limit = max(limit * 4, limit, 20)
-    session_scope = str(args.get("session_scope", "current")).lower()
+    requested_session_scope = str(args.get("session_scope", "current")).lower()
+    session_scope = "current"
     source = str(args.get("source") or "").strip() or None
-    session_id = None if session_scope == "all" else engine._session_id
+    if requested_session_scope != "current":
+        logger.warning("Ignoring unsupported session_scope=%s for lcm_grep", requested_session_scope)
+    session_id = engine._session_id
     results = []
 
     try:


### PR DESCRIPTION
### Motivation
- Prevent a cross-session data exposure introduced by allowing `session_scope='all'` in `lcm_grep`, restoring per-session confidentiality by enforcing active-session-only searches.

### Description
- Remove the `all` option and cross-session guidance from the `lcm_grep` schema in `schemas.py`, leaving `session_scope` limited to `"current"` only.
- Update the `lcm_grep` handler in `tools.py` to always enforce the active session (`engine._session_id`) and to ignore/log any non-`current` `session_scope` values instead of dropping the session filter.
- Adjust tests in `tests/test_lcm_engine.py` to remove expectations for cross-session behavior and to validate source filtering inside the active session.
- Simplify the `lcm_grep` docstring to reflect active-session-only behavior.

### Testing
- Attempted to run the targeted pytest subset with `pytest -q tests/test_lcm_engine.py -k "tool_schemas or handle_grep_source_filter_in_current_session_includes_only_matching_summaries or handle_grep_source_filter_excludes_unrelated_summaries_in_mixed_source_session or handle_grep_unknown_source_filter_matches_unknown_messages_and_summaries"`, but test collection failed due to `ModuleNotFoundError: No module named 'agent'` so the suite could not be executed in this environment.
- Compiled modified files with `python -m compileall schemas.py tools.py tests/test_lcm_engine.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4869a2854832bb83e347c441c2388)