### PR TITLE
fix: bound FTS candidate expansion in search loops

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -27,6 +27,7 @@ from .db_bootstrap import (
 )
 from .search_query import (
     AGE_DECAY_RATE,
+    compute_search_candidate_cap,
     compute_directness_rank_bonus_upper_bound,
     compute_directness_score,
     compute_search_fetch_limit,
@@ -342,9 +343,11 @@ class SummaryDAG:
 
         order_by = _build_search_order_by(sort, "COALESCE(n.latest_at, n.created_at)")
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        candidate_cap = compute_search_candidate_cap(limit)
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 2e-7
         offset = 0
+        scanned_rows = 0
         results: list[SummaryNode] = []
         source_match_cache: dict[int, bool] = {}
         while True:
@@ -365,6 +368,7 @@ class SummaryDAG:
                            ORDER BY {order_by} LIMIT ? OFFSET ?""",
                         (query, fetch_limit, offset),
                     ).fetchall()
+                scanned_rows += len(rows)
             except sqlite3.Error as exc:
                 logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
@@ -391,8 +395,14 @@ class SummaryDAG:
             if best_unseen_primary > worst_visible_primary:
                 return results[:limit]
 
+            if scanned_rows >= candidate_cap:
+                return results[:limit]
+
             offset += len(rows)
-            fetch_limit *= 2
+            remaining = candidate_cap - scanned_rows
+            if remaining <= 0:
+                return results[:limit]
+            fetch_limit = min(fetch_limit * 2, remaining)
 
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,

--- a/search_query.py
+++ b/search_query.py
@@ -206,6 +206,11 @@ def compute_search_fetch_limit(limit: int, terms: List[str], phrases: List[str] 
     return base
 
 
+def compute_search_candidate_cap(limit: int) -> int:
+    """Return a hard upper bound on candidate rows inspected per search call."""
+    return min(max(limit * 20, limit, 500), 5_000)
+
+
 AGE_DECAY_RATE = 0.001
 
 

--- a/store.py
+++ b/store.py
@@ -22,6 +22,7 @@ from .db_bootstrap import (
 )
 from .search_query import (
     build_snippet,
+    compute_search_candidate_cap,
     compute_directness_rank_bonus_upper_bound,
     compute_directness_score,
     compute_search_fetch_limit,
@@ -455,10 +456,12 @@ class MessageStore:
             _MESSAGE_ROLE_BIAS_SQL,
         )
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
+        candidate_cap = compute_search_candidate_cap(limit)
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 3e-7
         source_clause, source_args = _source_filter_clause("m.source", source)
         offset = 0
+        scanned_rows = 0
         results: list[Dict[str, Any]] = []
         while True:
             try:
@@ -482,6 +485,7 @@ class MessageStore:
                        ORDER BY {order_by} LIMIT ? OFFSET ?""",
                     args,
                 ).fetchall()
+                scanned_rows += len(rows)
             except sqlite3.Error as exc:
                 logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
@@ -509,8 +513,14 @@ class MessageStore:
             if best_unseen_primary > worst_visible_primary:
                 return results[:limit]
 
+            if scanned_rows >= candidate_cap:
+                return results[:limit]
+
             offset += len(rows)
-            fetch_limit *= 2
+            remaining = candidate_cap - scanned_rows
+            if remaining <= 0:
+                return results[:limit]
+            fetch_limit = min(fetch_limit * 2, remaining)
 
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -725,6 +725,29 @@ class TestMessageStore:
 
         assert top_5 == top_50
 
+    def test_search_relevance_caps_fts_batches_for_large_single_term_pool(self, store):
+        for _ in range(5_000):
+            store.append(
+                "sess1",
+                {
+                    "role": "assistant",
+                    "content": "vendoring",
+                },
+            )
+
+        statements: list[str] = []
+        store._conn.set_trace_callback(statements.append)
+        try:
+            _ = store.search("vendoring", session_id="sess1", limit=10, sort="relevance")
+        finally:
+            store._conn.set_trace_callback(None)
+
+        fts_selects = [
+            sql for sql in statements
+            if "FROM messages_fts" in sql and "LIMIT" in sql and "OFFSET" in sql
+        ]
+        assert len(fts_selects) <= 6
+
     def test_search_relevance_prefers_assistant_over_tool_on_similar_match(self, store):
         assistant_id = store.append(
             "sess1",
@@ -1547,6 +1570,30 @@ class TestSummaryDAG:
 
         assert [node.node_id for node in results[:1]] == [direct]
         assert direct in [node.node_id for node in results]
+
+    def test_search_relevance_caps_fts_batches_for_large_single_term_pool(self, dag):
+        for idx in range(5_000):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"Summary {idx}: vendoring",
+                token_count=10, source_ids=[idx + 1], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+
+        statements: list[str] = []
+        dag._conn.set_trace_callback(statements.append)
+        try:
+            _ = dag.search("vendoring", session_id="s1", limit=10, sort="relevance")
+        finally:
+            dag._conn.set_trace_callback(None)
+
+        fts_selects = [
+            sql for sql in statements
+            if "FROM nodes_fts" in sql and "LIMIT" in sql and "OFFSET" in sql
+        ]
+        assert len(fts_selects) <= 6
 
     def test_search_relevance_prefers_direct_summary_over_risky_ascii_repetition_spam_in_like_fallback(self, dag):
         spammy = dag.add_node(SummaryNode(


### PR DESCRIPTION
### Motivation
- Precise FTS queries with directness-based ranking could trigger an unbounded loop that doubles the `LIMIT` and accumulates fetched rows, enabling large scans and high CPU/memory use for adversarial queries. 
- The goal is to keep directness-aware ranking while preventing search from scanning an unbounded number of FTS rows per call.

### Description
- Add `compute_search_candidate_cap(limit)` in `search_query.py` to provide a hard per-search upper bound on inspected FTS candidates. 
- Enforce the cap in `MessageStore.search` by tracking `scanned_rows`, stopping when the cap is reached, and clamping subsequent `fetch_limit` to the remaining budget. 
- Apply the same `scanned_rows` + cap logic to `SummaryDAG.search` so both FTS search paths are bounded. 
- Add regression tests in `tests/test_lcm_core.py` that assert large single-term pools do not produce excessive paged FTS `SELECT ... LIMIT ... OFFSET ...` calls and that relevance behavior is preserved.

### Testing
- Ran `pytest -q tests/test_lcm_core.py -k "caps_fts_batches_for_large_single_term_pool or top_results_do_not_change_when_limit_increases_on_large_single_term_pool or still_surfaces_direct_summary_when_single_term_matches_many_spammy_candidates"` and it passed (4 passed, 102 deselected). 
- Ran `pytest -q tests/test_lcm_core.py -k "TestMessageStore and search_relevance"` and it passed (13 passed, 93 deselected). 
- Ran `pytest -q tests/test_lcm_core.py -k "TestSummaryDAG and search_relevance"` and it passed (9 passed, 97 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e531eebe60832bb876dd9419fddd53)