### PR TITLE
fix: bound LIKE fallback search queries to prevent unbounded fetch

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -401,6 +401,7 @@ class SummaryDAG:
         phrases = extract_quoted_phrases(query)
         if not terms:
             return []
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
 
         where: list[str] = ["summary IS NOT NULL"]
         args: list[Any] = []
@@ -412,9 +413,12 @@ class SummaryDAG:
             like_clauses.append("summary LIKE ? ESCAPE '\\'")
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
+        args.append(fetch_limit)
 
         rows = self._conn.execute(
-            f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)}",
+            f"""SELECT * FROM summary_nodes
+                WHERE {' AND '.join(where)}
+                LIMIT ?""",
             args,
         ).fetchall()
         collapse_risky_repeats = contains_risky_fts_ascii(query)

--- a/store.py
+++ b/store.py
@@ -519,6 +519,7 @@ class MessageStore:
         phrases = extract_quoted_phrases(query)
         if not terms:
             return []
+        fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
 
         where: list[str] = ["content IS NOT NULL"]
         args: list[Any] = []
@@ -534,9 +535,13 @@ class MessageStore:
             like_clauses.append("content LIKE ? ESCAPE '\\'")
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
+        args.append(fetch_limit)
 
         rows = self._conn.execute(
-            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE {' AND '.join(where)}",
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+                FROM messages
+                WHERE {' AND '.join(where)}
+                LIMIT ?""",
             args,
         ).fetchall()
         results: List[Dict[str, Any]] = []

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -572,6 +572,28 @@ class TestMessageStore:
         assert recency_results[0]["store_id"] == newer_weak
         assert relevance_results[0]["store_id"] == older_strong
 
+    def test_search_like_fallback_applies_sql_limit_for_messages(self, store):
+        for index in range(40):
+            store.append(
+                "sess1",
+                {"role": "user", "content": f"bulk message {index} 🚀"},
+            )
+
+        statements: list[str] = []
+        store._conn.set_trace_callback(statements.append)
+        try:
+            results = store.search("🚀", session_id="sess1", limit=5, sort="relevance")
+        finally:
+            store._conn.set_trace_callback(None)
+
+        assert len(results) == 5
+        like_sql = next(
+            statement
+            for statement in statements
+            if "FROM messages" in statement and "LIKE" in statement
+        )
+        assert "LIMIT " in like_sql
+
     def test_search_hyphenated_operator_queries_fall_back_cleanly(self, store):
         target = store.append(
             "sess1",
@@ -1452,6 +1474,32 @@ class TestSummaryDAG:
 
         assert recency_results[0].node_id == newer_weak
         assert relevance_results[0].node_id == older_strong
+
+    def test_search_like_fallback_applies_sql_limit_for_summary_nodes(self, dag):
+        for index in range(40):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"bulk summary {index} 🚀",
+                token_count=4, source_ids=[index + 1], source_type="messages",
+                created_at=1_700_000_000 + index,
+                earliest_at=1_700_000_000 + index,
+                latest_at=1_700_000_000 + index,
+            ))
+
+        statements: list[str] = []
+        dag._conn.set_trace_callback(statements.append)
+        try:
+            results = dag.search("🚀", session_id="s1", limit=5, sort="relevance")
+        finally:
+            dag._conn.set_trace_callback(None)
+
+        assert len(results) == 5
+        like_sql = next(
+            statement
+            for statement in statements
+            if "FROM summary_nodes" in statement and "LIKE" in statement
+        )
+        assert "LIMIT " in like_sql
 
     def test_search_hyphenated_operator_queries_fall_back_cleanly(self, dag):
         target = dag.add_node(SummaryNode(


### PR DESCRIPTION
### Motivation
- The LIKE fallback used for CJK/emoji queries executed unbounded `SELECT *` queries and materialized all matching rows in memory, which can be abused to cause high CPU/memory usage and denial-of-service. 
- Add a minimal, low-risk mitigation that keeps the fallback behavior but prevents full-table materialization by bounding the SQL fetch size.

### Description
- Compute a fetch bound with `compute_search_fetch_limit(limit, terms, phrases)` and use it as a SQL `LIMIT ?` parameter in `MessageStore._search_like` so the fallback `SELECT` is no longer unbounded (`store.py`).
- Apply the same change to `SummaryDAG._search_like`, adding the computed fetch limit and `LIMIT ?` to the summary-node LIKE fallback query (`dag.py`).
- Add regression tests in `tests/test_lcm_core.py` that trigger the LIKE fallback (emoji queries) and assert the executed SQL includes a `LIMIT` clause, while preserving existing scoring/sorting behavior.

### Testing
- Ran `pytest -q tests/test_lcm_core.py -k "search_like_fallback_applies_sql_limit"` and the new checks passed (`2 passed`).
- Ran `pytest -q tests/test_lcm_core.py -k "cjk_queries_fall_back_with_aligned_sort_modes or emoji_queries_fall_back_with_aligned_sort_modes"` to confirm existing fallback semantics remain correct and those tests passed (`4 passed`).
- Verified the changed code still performs the in-Python scoring/sorting and then returns the top `limit` results so external behavior is preserved while preventing unbounded result sets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e531f2ef48832bbe8b9f46ee153758)