### PR TITLE
Harden /lcm slash command registration with explicit opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Environment variables (all optional):
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after `/new` (`-1` = all, `0` = none, `2` = keep d2+) |
+| `LCM_ENABLE_SLASH_COMMAND` | `false` | Opt-in registration for `/lcm` gateway slash commands (recommended only for trusted operator contexts) |
 
 The point-8 compaction knobs are intentionally opt-in. `cache_friendly_*` is a plugin-local prompt-stability heuristic, not a claim that Hermes currently passes true prompt-cache metrics into `hermes-lcm`.
 
@@ -262,7 +263,9 @@ That split is intentional:
 
 ## Gateway Slash Commands
 
-When Hermes host support for plugin slash commands is available, `hermes-lcm` also exposes a `/lcm` operator surface for quick diagnostics and safe maintenance prep from chat:
+When Hermes host support for plugin slash commands is available, `hermes-lcm` can expose a `/lcm` operator surface for quick diagnostics and safe maintenance prep from chat.
+
+This surface is **disabled by default** and requires `LCM_ENABLE_SLASH_COMMAND=1` (or `true/yes/on`) before registration.
 
 - `/lcm` or `/lcm status` — current session/runtime status
 - `/lcm doctor` — SQLite + FTS health checks and store/node totals

--- a/__init__.py
+++ b/__init__.py
@@ -7,8 +7,16 @@ Based on the LCM paper by Ehrlich & Blackman (Voltropy PBC, Feb 2026).
 """
 
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag_enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def register(ctx):
@@ -33,7 +41,8 @@ def register(ctx):
     ctx.register_context_engine(engine)
 
     register_command = getattr(ctx, "register_command", None)
-    if callable(register_command):
+    slash_enabled = _env_flag_enabled("LCM_ENABLE_SLASH_COMMAND", default=False)
+    if callable(register_command) and slash_enabled:
         from .command import handle_lcm_command
 
         register_command(
@@ -41,6 +50,8 @@ def register(ctx):
             lambda raw_args: handle_lcm_command(raw_args, engine),
             description="LCM status and diagnostics",
         )
+    elif callable(register_command):
+        logger.info("LCM slash command registration disabled (set LCM_ENABLE_SLASH_COMMAND=1 to enable /lcm)")
     else:
         logger.info("LCM slash command registration unavailable on this Hermes host; continuing without /lcm")
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -421,3 +421,67 @@ def test_register_skips_slash_command_when_host_context_has_no_register_command(
     module.register(ctx)
 
     assert ctx.engine is not None
+
+
+def test_register_skips_lcm_slash_command_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.delenv("LCM_ENABLE_SLASH_COMMAND", raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_lcm_init_runtime_disabled",
+        str(Path(__file__).resolve().parent.parent / "__init__.py"),
+        submodule_search_locations=[str(Path(__file__).resolve().parent.parent)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+            self.commands = {}
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_command(self, name, handler, description=""):
+            self.commands[name] = (handler, description)
+
+    ctx = _Ctx()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert "lcm" not in ctx.commands
+
+
+def test_register_allows_lcm_slash_command_when_explicitly_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("LCM_ENABLE_SLASH_COMMAND", "1")
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_lcm_init_runtime_enabled",
+        str(Path(__file__).resolve().parent.parent / "__init__.py"),
+        submodule_search_locations=[str(Path(__file__).resolve().parent.parent)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+            self.commands = {}
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_command(self, name, handler, description=""):
+            self.commands[name] = (handler, description)
+
+    ctx = _Ctx()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert "lcm" in ctx.commands


### PR DESCRIPTION
### Motivation
- The `/lcm` slash surface was being registered unconditionally when the host exposed `register_command`, allowing any caller with slash access to reach handlers that expose DB/session metadata and create on-demand SQLite backups.
- This presents confidentiality and availability risks (metadata leakage and unbounded backup creation) in multi-tenant or untrusted gateway contexts.

### Description
- Gate slash-command registration behind an explicit environment opt-in: `LCM_ENABLE_SLASH_COMMAND` (default `false`) with a small boolean parser helper `_env_flag_enabled` in `__init__.py` and a log message when the surface is disabled.
- Only register `/lcm` when `register_command` is callable and `LCM_ENABLE_SLASH_COMMAND` is enabled; otherwise skip registration and log that it is disabled or unavailable.
- Add two tests in `tests/test_lcm_command.py` to assert that the slash command is not registered by default and that it is registered when `LCM_ENABLE_SLASH_COMMAND=1`.
- Document the new environment variable and default-off behavior in `README.md`.

### Testing
- Ran `python -m py_compile __init__.py tests/test_lcm_command.py` which succeeded to validate syntax for the changed files.
- Ran `pytest -q tests/test_lcm_command.py` which failed during collection with an `ImportError` (`cannot import name 'LCMEngine' from 'hermes_lcm.engine'`) due to the test environment lacking the full runtime package dependencies, not due to the registration change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5348d8a4c832bbefb0ac4356879ce)