### PR TITLE
fix: enforce max token budget for externalized lcm_expand payloads

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2787,6 +2787,32 @@ class TestEngineTools:
         assert result["source_type"] == "externalized_payload"
         assert result["content"] == content
         assert result["tool_call_id"] == "call_big"
+        assert result["content_truncated"] is False
+
+    def test_handle_expand_externalized_ref_respects_max_tokens(self, tmp_path):
+        from hermes_lcm.tokens import count_tokens
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_payload_budget.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"externalized_ref": ref, "max_tokens": 10}))
+
+        assert result["externalized_ref"] == ref
+        assert result["source_type"] == "externalized_payload"
+        assert result["content_truncated"] is True
+        assert count_tokens(result["content"]) <= 10
+        assert result["tool_call_id"] == "call_big"
 
     def test_compress_gc_rewrites_summarized_externalized_tool_results(self, tmp_path, monkeypatch):
         config = LCMConfig(

--- a/tools.py
+++ b/tools.py
@@ -76,6 +76,29 @@ def _get_externalized_payload(engine: "LCMEngine", ref: str) -> dict[str, Any] |
     return payload
 
 
+def _truncate_text_to_token_budget(text: str, max_tokens: int) -> tuple[str, bool]:
+    from .tokens import count_tokens
+
+    if max_tokens <= 0 or not text:
+        return "", bool(text)
+
+    if count_tokens(text) <= max_tokens:
+        return text, False
+
+    low = 0
+    high = len(text)
+    best = ""
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = text[:mid]
+        if count_tokens(candidate) <= max_tokens:
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return best, True
+
+
 def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
     from .tokens import count_tokens
 
@@ -388,10 +411,13 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": "LCM engine not initialized"})
 
     externalized_ref = str(args.get("externalized_ref") or "").strip()
+    max_tokens = int(args.get("max_tokens", 4000))
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
         if payload is None:
             return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
+        content = payload.get("content", "")
+        truncated_content, content_truncated = _truncate_text_to_token_budget(content, max_tokens)
         return json.dumps(
             {
                 "externalized_ref": externalized_ref,
@@ -401,7 +427,8 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
                 "session_id": payload.get("session_id", ""),
                 "content_chars": payload.get("content_chars", 0),
                 "content_bytes": payload.get("content_bytes", 0),
-                "content": payload.get("content", ""),
+                "content": truncated_content,
+                "content_truncated": content_truncated,
             }
         )
 
@@ -412,8 +439,6 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     node = _get_session_node(engine, node_id)
     if node is None:
         return json.dumps({"error": f"Node {node_id} not found in current session"})
-
-    max_tokens = args.get("max_tokens", 4000)
 
     if node.source_type == "messages":
         messages = _expand_message_sources(engine, node, max_tokens=max_tokens)


### PR DESCRIPTION
### Motivation
- `lcm_expand` returned the full content of externalized payloads without applying any token budget, allowing unbounded responses for large tool outputs and creating an availability risk. 

### Description
- Add a helper ` _truncate_text_to_token_budget(text, max_tokens)` that truncates free-form text to a token budget using `count_tokens`.
- Apply the `max_tokens` budget in the `externalized_ref` branch of `lcm_expand` and return truncated text instead of the full payload content.
- Include a `content_truncated` boolean in the `lcm_expand` response to signal whether truncation occurred.
- Update `tests/test_lcm_engine.py` to assert non-truncated default behavior and add `test_handle_expand_externalized_ref_respects_max_tokens` to verify enforced token budgets.

### Testing
- Attempted to run `pytest -q tests/test_lcm_engine.py -k "expand_externalized_ref"`, but test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'agent'`).
- Verified Python syntax/compilation with `python -m compileall tools.py tests/test_lcm_engine.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5333b449c832baef3aed88b15cbb9)