### PR TITLE
fix: scope `/lcm doctor retention` to active session

### DIFF
--- a/command.py
+++ b/command.py
@@ -179,6 +179,18 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
 def _scan_retention_candidates(engine) -> dict[str, Any]:
     conn = engine._store._conn
     now = datetime.now().timestamp()
+    session_id = getattr(engine, "_session_id", "")
+    if not session_id:
+        return {
+            "error": None,
+            "sessions": [],
+            "sessions_analyzed": 0,
+            "stale_sessions_30d": 0,
+            "stale_sessions_90d": 0,
+            "retained_tokens_30d": 0,
+            "retained_tokens_90d": 0,
+            "protected_count": 0,
+        }
     try:
         rows = conn.execute(
             """
@@ -217,8 +229,10 @@ def _scan_retention_candidates(engine) -> dict[str, Any]:
             FROM session_ids s
             LEFT JOIN message_stats m ON m.session_id = s.session_id
             LEFT JOIN node_stats n ON n.session_id = s.session_id
+            WHERE s.session_id = ?
             ORDER BY s.session_id
-            """
+            """,
+            (session_id,),
         ).fetchall()
     except Exception as exc:  # pragma: no cover - defensive
         return {
@@ -564,6 +578,7 @@ def _doctor_retention_text(engine) -> str:
         )
     if len(sessions) > 20:
         lines.append(f"... {len(sessions) - 20} more session(s) omitted")
+    lines.append("note: retention analysis is scoped to the active session only")
     lines.append("note: stale sessions are listed before fresh ones; within each bucket, candidates are sorted by footprint (tokens/nodes/messages), with protected current-session entries listed after non-protected ones")
     lines.append("note: read-only analysis only — no rows were deleted")
     lines.append("note: if you prune later, create a safety snapshot first with `/lcm backup`")

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -131,14 +131,15 @@ def test_lcm_doctor_retention_reports_old_heavy_sessions(tmp_path):
 
     assert "LCM doctor retention" in result
     assert "status: analysis-ready" in result
-    assert "sessions_analyzed: 2" in result
-    assert "stale_sessions_30d: 1" in result
-    assert "stale_sessions_90d: 1" in result
-    assert "retained_tokens_30d: 272" in result
-    assert "retained_tokens_90d: 272" in result
+    assert "sessions_analyzed: 1" in result
+    assert "stale_sessions_30d: 0" in result
+    assert "stale_sessions_90d: 0" in result
+    assert "retained_tokens_30d: 0" in result
+    assert "retained_tokens_90d: 0" in result
     assert "retention_candidates:" in result
-    assert "old-heavy | protected=no | messages=1 | nodes=1 | tokens=272" in result
     assert "live-session | protected=yes" in result
+    assert "old-heavy" not in result
+    assert "note: retention analysis is scoped to the active session only" in result
     assert "note: read-only analysis only — no rows were deleted" in result
 
 
@@ -165,10 +166,11 @@ def test_lcm_doctor_retention_counts_summary_only_sessions(tmp_path):
 
     result = handle_lcm_command("doctor retention", engine)
 
-    assert "sessions_analyzed: 1" in result
-    assert "stale_sessions_30d: 1" in result
-    assert "retained_tokens_30d: 37" in result
-    assert "summary-only | protected=no | messages=0 | nodes=1 | tokens=37" in result
+    assert "sessions_analyzed: 0" in result
+    assert "stale_sessions_30d: 0" in result
+    assert "retained_tokens_30d: 0" in result
+    assert "summary-only" not in result
+    assert "result: no stored sessions found for retention analysis" in result
 
 
 def test_lcm_doctor_retention_keeps_stale_sessions_visible_when_list_is_truncated(tmp_path):
@@ -189,8 +191,10 @@ def test_lcm_doctor_retention_keeps_stale_sessions_visible_when_list_is_truncate
 
     result = handle_lcm_command("doctor retention", engine)
 
-    assert "stale_sessions_30d: 1" in result
-    assert "stale-small | protected=no | messages=1 | nodes=0 | tokens=5" in result
+    assert "stale_sessions_30d: 0" in result
+    assert "sessions_analyzed: 0" in result
+    assert "stale-small" not in result
+    assert "result: no stored sessions found for retention analysis" in result
 
 
 def test_lcm_doctor_clean_reports_pattern_matched_junk_candidates(tmp_path):


### PR DESCRIPTION
### Motivation
- The `doctor retention` command previously enumerated every stored `session_id` and printed per-session metadata, enabling cross-session metadata disclosure in multi-tenant setups. 
- The goal is to prevent metadata enumeration while preserving the read-only retention analysis for the currently active session. 
- Provide a minimal, defensive change that avoids broad behavioral changes to other LCM commands.

### Description
- Early-return the retention scan when no active session is bound by checking `getattr(engine, "_session_id", "")` and returning an empty analysis. 
- Restrict the retention SQL query to the active session by adding `WHERE s.session_id = ?` and passing the `session_id` parameter. 
- Add a user-facing note `note: retention analysis is scoped to the active session only` to `_doctor_retention_text` output. 
- Update assertions in `tests/test_lcm_command.py` to reflect that `doctor retention` no longer exposes other sessions and to assert the new scoped behavior.

### Testing
- Ran `python -m compileall -q command.py tests/test_lcm_command.py`, which completed successfully to validate syntax. 
- Ran `pytest -q tests/test_lcm_command.py` in this environment but collection failed due to an import error (`ImportError: cannot import name 'LCMEngine' from 'hermes_lcm.engine'`), so the updated tests were not executed end-to-end here. 
- The change is small and covered by updated unit tests in `tests/test_lcm_command.py`, which should pass in a normal test environment where `LCMEngine` imports correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5333a8a68832bb571cf94fa415c3c)