### PR TITLE
fix(security): gate `/lcm doctor clean apply` behind explicit config opt-in

### DIFF
--- a/command.py
+++ b/command.py
@@ -571,6 +571,15 @@ def _doctor_retention_text(engine) -> str:
 
 
 def _doctor_clean_apply_text(engine) -> str:
+    if not getattr(getattr(engine, "_config", None), "doctor_clean_apply_enabled", False):
+        return "\n".join([
+            "LCM doctor clean apply",
+            "status: denied",
+            "error: destructive cleanup is disabled by default",
+            "note: set LCM_DOCTOR_CLEAN_APPLY_ENABLED=true only in trusted operator environments",
+            "note: no rows were deleted",
+        ])
+
     scan = _scan_clean_candidates(engine)
     if scan["error"]:
         return "\n".join([

--- a/config.py
+++ b/config.py
@@ -132,6 +132,8 @@ class LCMConfig:
     # -- Session carry-over ---
     # Depth retained after /new (-1 = all, 0 = nothing, 2 = keep d2+)
     new_session_retain_depth: int = 2
+    # Safety gate: destructive `/lcm doctor clean apply` workflow is disabled by default.
+    doctor_clean_apply_enabled: bool = False
 
     @classmethod
     def from_env(cls) -> "LCMConfig":
@@ -196,6 +198,10 @@ class LCMConfig:
         c.expansion_timeout_ms = _int("LCM_EXPANSION_TIMEOUT_MS", c.expansion_timeout_ms)
         c.database_path = _str("LCM_DATABASE_PATH", c.database_path)
         c.new_session_retain_depth = _int("LCM_NEW_SESSION_RETAIN_DEPTH", c.new_session_retain_depth)
+        c.doctor_clean_apply_enabled = _parse_bool_env(
+            "LCM_DOCTOR_CLEAN_APPLY_ENABLED",
+            c.doctor_clean_apply_enabled,
+        )
 
         raw_ignore = os.environ.get("LCM_IGNORE_SESSION_PATTERNS")
         if raw_ignore is not None:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -267,6 +267,7 @@ def test_lcm_doctor_clean_apply_is_backup_first_and_deletes_safe_candidates(tmp_
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_clean_apply.db"),
         ignore_session_patterns=["cron*"],
+        doctor_clean_apply_enabled=True,
     )
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
     engine._session_id = "live-session"
@@ -306,6 +307,7 @@ def test_lcm_doctor_clean_apply_aborts_if_backup_fails(tmp_path, monkeypatch):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_clean_apply_fail.db"),
         ignore_session_patterns=["cron*"],
+        doctor_clean_apply_enabled=True,
     )
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
     engine._session_id = "live-session"
@@ -324,6 +326,22 @@ def test_lcm_doctor_clean_apply_aborts_if_backup_fails(tmp_path, monkeypatch):
     assert "LCM doctor clean apply" in result
     assert "status: error" in result
     assert "backup failed" in result.lower()
+    assert len(engine._store.get_range("cron_20260414")) == 1
+
+
+def test_lcm_doctor_clean_apply_denied_by_default(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_clean_apply_denied.db"),
+        ignore_session_patterns=["cron*"],
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+
+    result = handle_lcm_command("doctor clean apply", engine)
+
+    assert "LCM doctor clean apply" in result
+    assert "status: denied" in result
+    assert "disabled by default" in result
     assert len(engine._store.get_range("cron_20260414")) == 1
 
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated destructive cleanup from running by default when `/lcm doctor clean apply` is invoked. 
- Provide an explicit operator opt-in so destructive behavior is only enabled in trusted deployments.

### Description
- Add `LCMConfig.doctor_clean_apply_enabled: bool = False` and wire an env toggle `LCM_DOCTOR_CLEAN_APPLY_ENABLED` in `config.py` to allow explicit opt-in. 
- Add a default-deny check at the top of `_doctor_clean_apply_text` in `command.py` that returns a `status: denied` response unless the config flag is enabled. 
- Update `tests/test_lcm_command.py` to enable the new flag for tests that intentionally exercise cleanup and add `test_lcm_doctor_clean_apply_denied_by_default` to verify the default-deny behavior. 
- Files changed: `config.py`, `command.py`, `tests/test_lcm_command.py`.

### Testing
- Ran `python -m py_compile command.py config.py tests/test_lcm_command.py`, which succeeded. 
- Ran `pytest -q tests/test_lcm_command.py` in this environment; test collection failed due to local import/package resolution (`ModuleNotFoundError` / `ImportError` during import of `hermes_lcm`), so full pytest could not be executed here. 
- Unit test changes exercise both paths: destructive flow enabled via `doctor_clean_apply_enabled=True` (existing tests preserved) and default-denied path covered by the new test `test_lcm_doctor_clean_apply_denied_by_default`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5333a8fc8832b909c34ba18376e9f)