### PR TITLE
fix: bound LIKE fallback candidate scans

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -29,6 +29,7 @@ from .search_query import (
     AGE_DECAY_RATE,
     compute_directness_rank_bonus_upper_bound,
     compute_directness_score,
+    compute_like_fallback_fetch_limit,
     compute_search_fetch_limit,
     contains_risky_fts_ascii,
     count_term_matches,
@@ -415,9 +416,11 @@ class SummaryDAG:
             like_clauses.append("summary LIKE ? ESCAPE '\\'")
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
+        fetch_limit = compute_like_fallback_fetch_limit(limit, terms, phrases)
+        args.append(fetch_limit)
 
         rows = self._conn.execute(
-            f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)}",
+            f"SELECT * FROM summary_nodes WHERE {' AND '.join(where)} LIMIT ?",
             args,
         ).fetchall()
         collapse_risky_repeats = contains_risky_fts_ascii(query)

--- a/search_query.py
+++ b/search_query.py
@@ -243,6 +243,11 @@ def compute_search_fetch_limit(limit: int, terms: List[str], phrases: List[str] 
     return base
 
 
+def compute_like_fallback_fetch_limit(limit: int, terms: List[str], phrases: List[str] | None = None) -> int:
+    """Bound LIKE fallback candidate rows before Python-side scoring/sorting."""
+    return compute_search_fetch_limit(limit, terms, phrases)
+
+
 AGE_DECAY_RATE = 0.001
 
 

--- a/store.py
+++ b/store.py
@@ -24,6 +24,7 @@ from .search_query import (
     build_snippet,
     compute_directness_rank_bonus_upper_bound,
     compute_directness_score,
+    compute_like_fallback_fetch_limit,
     compute_search_fetch_limit,
     contains_risky_fts_ascii,
     count_term_matches,
@@ -570,9 +571,11 @@ class MessageStore:
             like_clauses.append("content LIKE ? ESCAPE '\\'")
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
+        fetch_limit = compute_like_fallback_fetch_limit(limit, terms, phrases)
+        args.append(fetch_limit)
 
         rows = self._conn.execute(
-            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE {' AND '.join(where)}",
+            f"SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages WHERE {' AND '.join(where)} LIMIT ?",
             args,
         ).fetchall()
         results: List[Dict[str, Any]] = []

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -704,6 +704,23 @@ class TestMessageStore:
         assert results[0]["store_id"] == target
         assert results[0]["snippet"]
 
+    def test_search_like_fallback_applies_sql_limit(self, store):
+        for idx in range(80):
+            store.append("sess1", {"role": "assistant", "content": f"plugin-only fallback load test {idx}"})
+
+        traced: list[str] = []
+        store._conn.set_trace_callback(traced.append)
+        try:
+            results = store.search("plugin-only", session_id="sess1", limit=2, sort="relevance")
+        finally:
+            store._conn.set_trace_callback(None)
+
+        assert len(results) == 2
+        assert any(
+            "FROM messages" in statement and "content LIKE" in statement and "LIMIT 20" in statement
+            for statement in traced
+        )
+
     def test_search_prefers_conversational_hits_over_tool_output_noise(self, store):
         user_id = store.append(
             "sess1",
@@ -1724,6 +1741,30 @@ class TestSummaryDAG:
 
         assert len(results) == 1
         assert results[0].node_id == target
+
+    def test_search_like_fallback_applies_sql_limit(self, dag):
+        for idx in range(80):
+            dag.add_node(SummaryNode(
+                session_id="s1", depth=0,
+                summary=f"plugin-only dag fallback load test {idx}",
+                token_count=8, source_ids=[idx + 10_000], source_type="messages",
+                created_at=1_700_000_000 + idx,
+                earliest_at=1_700_000_000 + idx,
+                latest_at=1_700_000_000 + idx,
+            ))
+
+        traced: list[str] = []
+        dag._conn.set_trace_callback(traced.append)
+        try:
+            results = dag.search("plugin-only", session_id="s1", limit=2, sort="relevance")
+        finally:
+            dag._conn.set_trace_callback(None)
+
+        assert len(results) == 2
+        assert any(
+            "FROM summary_nodes" in statement and "summary LIKE" in statement and "LIMIT 20" in statement
+            for statement in traced
+        )
 
     def test_search_hybrid_clamps_future_timestamps_consistently(self, dag):
         now = time.time()


### PR DESCRIPTION
### Motivation
- Hyphenated/colon/slash tokens were routed into the LIKE fallback path which executed unbounded `SELECT ... LIKE '%...%'` queries and performed Python-side scoring/sorting, enabling expensive full-table scans for common queries.
- The goal is to limit the number of rows materialized by the LIKE fallback so Python-side ranking/sorting operates on a bounded candidate set and avoids trivial DoS via crafted queries.

### Description
- Added `compute_like_fallback_fetch_limit()` in `search_query.py` to centralize sizing for LIKE-fallback candidate fetches and align it with existing FTS fetch-limit logic.
- Updated message-store fallback (`MessageStore._search_like`) to append a computed fetch limit and execute the SQL with `LIMIT ?` to bound rows returned from the database.
- Updated summary DAG fallback (`SummaryDAG._search_like`) to apply the same `LIMIT ?` behavior and added the new import for `compute_like_fallback_fetch_limit`.
- Added regression tests in `tests/test_lcm_core.py` (`test_search_like_fallback_applies_sql_limit` for both store and dag) that assert the emitted SQL for hyphen-triggered fallback includes a bounded `LIMIT`.

### Testing
- Ran `pytest -q tests/test_lcm_core.py -k 'search_like_fallback_applies_sql_limit'` which passed (`2 passed, 118 deselected`).
- Ran `pytest -q tests/test_lcm_core.py -k 'hyphenated_operator_queries_fall_back_cleanly or cjk_queries_fall_back_with_aligned_sort_modes or emoji_queries_fall_back_with_aligned_sort_modes'` which passed (`6 passed, 114 deselected`).
- Attempted `pytest -q tests/test_lcm_engine.py -k 'hyphenated_operator_query_falls_back_cleanly'` but collection failed in this environment due to a missing `agent` module, unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e535706940832b8c86967cbac256df)