### PR TITLE
fix: avoid cross-session totals in unbound /lcm status

### DIFF
--- a/command.py
+++ b/command.py
@@ -61,11 +61,6 @@ def _status_text(engine) -> str:
         **({"error": source_stats.get("error")} if source_stats.get("error") else {}),
     }
 
-    def _safe_scalar(conn, query: str) -> int | str:
-        try:
-            return int(conn.execute(query).fetchone()[0])
-        except Exception as exc:  # pragma: no cover - defensive
-            return f"error: {exc}"
 
     lines = [
         "LCM status",
@@ -92,13 +87,9 @@ def _status_text(engine) -> str:
             f"dag_nodes: {status.get('dag_nodes', 0)}",
         ])
     else:
-        lines.extend([
-            f"messages_total: {_safe_scalar(engine._store._conn, 'SELECT COUNT(*) FROM messages')}",
-            f"message_sessions_total: {_safe_scalar(engine._store._conn, 'SELECT COUNT(DISTINCT session_id) FROM messages')}",
-            f"summary_nodes_total: {_safe_scalar(engine._dag._conn, 'SELECT COUNT(*) FROM summary_nodes')}",
-            f"summary_node_sessions_total: {_safe_scalar(engine._dag._conn, 'SELECT COUNT(DISTINCT session_id) FROM summary_nodes')}",
-            "note: no active Hermes session has initialized LCM in this process yet — after a fresh restart, send one normal message first if you want live per-session runtime details",
-        ])
+        lines.append(
+            "note: no active Hermes session has initialized LCM in this process yet — after a fresh restart, send one normal message first if you want live per-session runtime details"
+        )
 
     if "ignore_session_patterns_source" in status:
         lines.append(

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -48,8 +48,10 @@ def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
     assert "session_id: (unbound)" in result
     assert "session_platform: (unbound)" in result
     assert "threshold_tokens: (uninitialized)" in result
-    assert "message_sessions_total:" not in result
-    assert "messages_total:" not in result
+    assert "\nmessage_sessions_total:" not in result
+    assert "\nmessages_total:" not in result
+    assert "\nsummary_nodes_total:" not in result
+    assert "\nsummary_node_sessions_total:" not in result
     assert "note: no active Hermes session has initialized LCM in this process yet" in result
 
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -48,8 +48,8 @@ def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
     assert "session_id: (unbound)" in result
     assert "session_platform: (unbound)" in result
     assert "threshold_tokens: (uninitialized)" in result
-    assert "message_sessions_total: 1" in result
-    assert "messages_total: 1" in result
+    assert "message_sessions_total:" not in result
+    assert "messages_total:" not in result
     assert "note: no active Hermes session has initialized LCM in this process yet" in result
 
 


### PR DESCRIPTION
### Motivation
- The unbound `/lcm status` path previously executed global `COUNT` queries and exposed aggregate cross-session metadata when no Hermes session was bound. This leaks usage information in multi-tenant or shared-profile deployments.
- The intent is to keep the unbound status informative without exposing database-wide totals.

### Description
- Remove global `COUNT(*)` and `COUNT(DISTINCT session_id)` queries from the unbound branch of `_status_text` in `command.py` so unbound status no longer reports cross-session totals.
- Remove the now-unused helper `_safe_scalar` from `command.py` which was only used for those removed queries.
- Preserve the existing explanatory note for the unbound runtime state so behavior remains informative when no session is bound.
- Update `tests/test_lcm_command.py` to assert that `messages_total` and `message_sessions_total` are not present in the unbound status output.

### Testing
- Ran `python -m py_compile command.py tests/test_lcm_command.py` which succeeded without syntax errors. 
- Ran `pytest -q tests/test_lcm_command.py` which failed during collection in this environment due to an unrelated import error: `ImportError: cannot import name 'LCMEngine' from 'hermes_lcm.engine'` (test environment issue), so full test execution could not be completed here. 
- Verified the local diff updates `command.py` and `tests/test_lcm_command.py` to remove the global totals and adjust expectations accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5348e11d4832b9f0f8c46007fe1ac)