### PR TITLE
fix: scope lcm_doctor FTS sync check to current session

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3214,6 +3214,17 @@ class TestEngineTools:
         orphan_check = next(c for c in result["checks"] if c["check"] == "orphaned_dag_nodes")
         assert orphan_check["status"] == "warn"
 
+    def test_handle_doctor_fts_sync_is_session_scoped(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "session A"})
+        engine._store.append("other-session", {"role": "user", "content": "session B 1"})
+        engine._store.append("other-session", {"role": "assistant", "content": "session B 2"})
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        fts_check = next(c for c in result["checks"] if c["check"] == "fts_index_sync")
+        assert fts_check["status"] == "pass"
+        assert fts_check["detail"] == "1 session FTS rows, 1 session messages"
+
 
 class TestExtractionDuringCompress:
     """Integration test: extraction runs end-to-end through engine.compress()."""

--- a/tools.py
+++ b/tools.py
@@ -617,7 +617,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             """
             SELECT COUNT(*)
             FROM messages_fts
-            JOIN messages ON messages_fts.rowid = messages.id
+            JOIN messages ON messages_fts.rowid = messages.store_id
             WHERE messages.session_id = ?
             """,
             (session_id,),

--- a/tools.py
+++ b/tools.py
@@ -614,12 +614,18 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
         ).fetchone()[0]
         fts_count = engine._store._conn.execute(
-            "SELECT COUNT(*) FROM messages_fts"
+            """
+            SELECT COUNT(*)
+            FROM messages_fts
+            JOIN messages ON messages_fts.rowid = messages.id
+            WHERE messages.session_id = ?
+            """,
+            (session_id,),
         ).fetchone()[0]
         checks.append({
             "check": "fts_index_sync",
             "status": "pass" if fts_count >= msg_count else "warn",
-            "detail": f"{fts_count} FTS rows, {msg_count} session messages",
+            "detail": f"{fts_count} session FTS rows, {msg_count} session messages",
         })
     except Exception as e:
         checks.append({


### PR DESCRIPTION
### Motivation
- The `lcm_doctor` FTS sync check previously counted rows from `messages_fts` without scoping to the current session, leaking cross-session message-volume metadata in multi-tenant environments.
- The change aims to preserve the diagnostic while removing the information disclosure by ensuring counts are limited to the current session.

### Description
- Changed the FTS sync SQL in `lcm_doctor` to join `messages_fts` to `messages` and filter by `messages.session_id = ?` so `fts_count` is session-scoped (`tools.py`).
- Updated the diagnostic detail string to read `"{fts_count} session FTS rows, {msg_count} session messages"` to explicitly indicate session-scoped counts (`tools.py`).
- Added a regression test `test_handle_doctor_fts_sync_is_session_scoped` to `tests/test_lcm_engine.py` that inserts messages across two sessions and asserts the doctor only reports the current session’s FTS rows.

### Testing
- Ran `python -m compileall tools.py tests/test_lcm_engine.py`, which succeeded. 
- Attempted `pytest -q tests/test_lcm_engine.py -k "doctor"`, but test collection failed in this environment due to a missing external dependency (`agent.context_engine`), so the full test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5348b3b8c832b98d2788d8fa1fd44)