### PR TITLE
fix: validate numeric lcm_expand_query arguments

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3077,6 +3077,35 @@ class TestEngineTools:
         assert result["node_ids"] == [node_id]
         assert result["matches"]
 
+    def test_handle_expand_query_rejects_non_numeric_limits(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?", "max_tokens": "invalid"},
+            )
+        )
+
+        assert result["error"] == "max_tokens must be an integer"
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?", "max_results": "invalid"},
+            )
+        )
+
+        assert result["error"] == "max_results must be an integer"
+
+    def test_handle_expand_query_rejects_non_numeric_node_ids(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"node_ids": ["not-a-number"], "prompt": "What was the plan?"},
+            )
+        )
+
+        assert result["error"] == "node_ids must contain only integers"
+
     def test_describe_and_expand_are_session_scoped(self, engine):
         node_id = engine._dag.add_node(
             SummaryNode(

--- a/tools.py
+++ b/tools.py
@@ -450,15 +450,31 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     if not prompt:
         return json.dumps({"error": "prompt is required"})
 
-    max_tokens = int(args.get("max_tokens", 2000))
-    max_results = int(args.get("max_results", 5))
+    def _parse_int_arg(name: str, default: int) -> tuple[int | None, str | None]:
+        raw_value = args.get(name, default)
+        try:
+            return int(raw_value), None
+        except (TypeError, ValueError):
+            return None, f"{name} must be an integer"
+
+    max_tokens, max_tokens_error = _parse_int_arg("max_tokens", 2000)
+    if max_tokens_error:
+        return json.dumps({"error": max_tokens_error})
+
+    max_results, max_results_error = _parse_int_arg("max_results", 5)
+    if max_results_error:
+        return json.dumps({"error": max_results_error})
+
     query = str(args.get("query") or "").strip()
     raw_node_ids = args.get("node_ids") or []
 
     nodes = []
     if raw_node_ids:
         for node_id in raw_node_ids:
-            node = _get_session_node(engine, int(node_id))
+            parsed_node_id, node_id_error = _parse_int_arg("node_ids", node_id)
+            if node_id_error:
+                return json.dumps({"error": "node_ids must contain only integers"})
+            node = _get_session_node(engine, parsed_node_id)
             if node is not None:
                 nodes.append(node)
     elif query:


### PR DESCRIPTION
### Motivation
- `lcm_expand_query` directly cast untrusted inputs (`max_tokens`, `max_results`, and `node_ids`) with `int(...)`, which can raise `ValueError` on malformed input and crash the tool call, causing an availability/DoS condition.
- The change adds defensive parsing so malformed numeric inputs return structured JSON errors instead of raising exceptions.

### Description
- Add a local helper `_parse_int_arg` in `lcm_expand_query` to parse integer arguments and produce an error message for invalid values.
- Validate `max_tokens` and `max_results` using the helper and return `{"error": "... must be an integer"}` when invalid.
- Validate each entry in `node_ids` before lookup and return `{"error": "node_ids must contain only integers"}` if any entry is non-numeric.
- Add regression tests in `tests/test_lcm_engine.py` that exercise invalid `max_tokens`, `max_results`, and `node_ids` inputs and assert the new error responses.

### Testing
- Static sanity check: ran `python -m py_compile tools.py tests/test_lcm_engine.py` which succeeded.
- Attempted to run the new test selection with `PYTHONPATH=. pytest -q tests/test_lcm_engine.py -k 'expand_query_rejects_non_numeric'`, but test collection failed with `ModuleNotFoundError: No module named 'agent'` in this environment, so `pytest` could not be completed here.
- The change is minimal and constrained to input validation and unit tests; the new tests should pass in a normal test environment where test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5348aaa48832bb10d40109a7c788a)