### PR TITLE
feat: package hermes-lcm as a standalone plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,10 @@ Do **not** claim behavior that is only partially implemented. If a filter, featu
 Default validation for code changes:
 
 ```bash
-pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q
+pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
 pytest -q
 python -m compileall -q .
+bash -n scripts/install.sh scripts/update.sh
 git diff --check
 ```
 
@@ -102,6 +103,16 @@ If your PR only touches a narrow surface area, include the focused command too. 
 
 ```bash
 pytest tests/test_lcm_command.py -q
+```
+
+Packaging or install-flow changes should also verify the standalone user-plugin path:
+
+```bash
+export HERMES_HOME=/tmp/hermes-lcm-smoke
+mkdir -p "$HERMES_HOME/plugins"
+git clone https://github.com/stephenschoettler/hermes-lcm "$HERMES_HOME/plugins/hermes-lcm"
+# then enable `hermes-lcm` in plugins.enabled and set context.engine: lcm
+hermes plugins
 ```
 
 If you skip part of the default validation, explain why in the PR body.

--- a/README.md
+++ b/README.md
@@ -81,47 +81,87 @@ That is why LCM positioning should focus on **retrieval quality, autonomy, and d
 
 ## Install
 
-```bash
-# Clone into the context engine plugin directory
-git clone https://github.com/stephenschoettler/hermes-lcm \
-  ~/.hermes/hermes-agent/plugins/context_engine/lcm
-
-# Or for a specific profile
-git clone https://github.com/stephenschoettler/hermes-lcm \
-  ~/.hermes/profiles/myprofile/hermes-agent/plugins/context_engine/lcm
-```
-
-## Update
+Canonical install path: clone `hermes-lcm` as a **general user plugin**.
 
 ```bash
-cd ~/.hermes/hermes-agent/plugins/context_engine/lcm && git pull
+git clone https://github.com/stephenschoettler/hermes-lcm \
+  ~/.hermes/plugins/hermes-lcm
 ```
 
-Restart Hermes after updating.
+For a profile-specific install:
 
-> **Note:** Context engines must be installed under `plugins/context_engine/<name>/`,
-> not `plugins/<name>/`. The general `~/.hermes/plugins/` directory is for tools,
-> hooks, and CLI extensions — context engines are discovered separately.
-
-Restart Hermes. Activate the engine — either via the interactive UI or config file:
-
-**Option A — `hermes plugins` UI:**
-
-```
-hermes plugins
+```bash
+git clone https://github.com/stephenschoettler/hermes-lcm \
+  ~/.hermes/profiles/myprofile/plugins/hermes-lcm
 ```
 
-The composite plugins screen shows provider categories at the bottom.
-Select **Context Engine** and pick `lcm` from the radiolist.
+Or, from an existing checkout, install a symlink with the helper script:
 
-**Option B — config.yaml:**
+```bash
+./scripts/install.sh
+# Optional profile-aware install:
+HERMES_PROFILE=myprofile ./scripts/install.sh
+```
+
+## Activation
+
+This install path uses **two names**:
+
+- plugin manifest name: `hermes-lcm`
+- runtime context engine name: `lcm`
+
+Your config must include both:
 
 ```yaml
+plugins:
+  enabled:
+    - hermes-lcm
+
 context:
   engine: lcm
 ```
 
-Verify with `hermes plugins`:
+Why both matter:
+
+- `plugins.enabled` loads the standalone plugin from `~/.hermes/plugins/hermes-lcm`
+- `context.engine: lcm` selects the registered context engine at runtime
+
+## Update
+
+If you cloned directly into the final plugin directory:
+
+```bash
+cd ~/.hermes/plugins/hermes-lcm && git pull --ff-only
+```
+
+For a profile-specific install:
+
+```bash
+cd ~/.hermes/profiles/myprofile/plugins/hermes-lcm && git pull --ff-only
+```
+
+If you used the helper scripts from a separate checkout:
+
+```bash
+./scripts/update.sh
+```
+
+Restart Hermes after updating.
+
+## Verification
+
+Run:
+
+```bash
+hermes plugins
+```
+
+Expected signals:
+
+- the plugin list includes `hermes-lcm`
+- the selected context engine is `lcm`
+
+Typical output looks like:
 
 ```
 Plugins (1):
@@ -129,6 +169,38 @@ Plugins (1):
 
 Provider Plugins:
   Context Engine: lcm
+```
+
+At runtime the tool list should include:
+
+- `lcm_grep`
+- `lcm_describe`
+- `lcm_expand`
+- `lcm_expand_query`
+- `lcm_status`
+- `lcm_doctor`
+
+## Legacy install path
+
+Hermes still supports repo-shipped context engines under `plugins/context_engine/<name>/`, and older `hermes-lcm` installs may still live there.
+
+That path is now a compatibility fallback, not the preferred install model. The standalone general-plugin path above is canonical because it survives Hermes updates cleanly.
+
+If you are migrating an older install, move the checkout and then enable the plugin explicitly:
+
+```bash
+mv ~/.hermes/hermes-agent/plugins/context_engine/lcm ~/.hermes/plugins/hermes-lcm
+```
+
+Then make sure your config includes:
+
+```yaml
+plugins:
+  enabled:
+    - hermes-lcm
+
+context:
+  engine: lcm
 ```
 
 ## Configuration

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: hermes-lcm
 version: 0.6.0
-description: "Lossless Context Management — DAG-based context engine that never loses a message"
+description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:
   - lcm_grep

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+HERMES_HOME_DIR="${HERMES_HOME:-$HOME/.hermes}"
+if [[ -n "${HERMES_PROFILE:-}" ]]; then
+  TARGET_DIR="$HERMES_HOME_DIR/profiles/${HERMES_PROFILE}/plugins/hermes-lcm"
+else
+  TARGET_DIR="$HERMES_HOME_DIR/plugins/hermes-lcm"
+fi
+
+mkdir -p "$(dirname "$TARGET_DIR")"
+
+if [[ -L "$TARGET_DIR" ]]; then
+  CURRENT_TARGET="$(readlink "$TARGET_DIR")"
+  if [[ "$CURRENT_TARGET" != "$REPO_ROOT" ]]; then
+    echo "Refusing to replace existing symlink: $TARGET_DIR -> $CURRENT_TARGET" >&2
+    echo "Remove it manually or point it at this checkout before rerunning install.sh." >&2
+    exit 1
+  fi
+elif [[ -e "$TARGET_DIR" ]]; then
+  echo "Refusing to replace existing path: $TARGET_DIR" >&2
+  echo "Move it aside or remove it manually before rerunning install.sh." >&2
+  exit 1
+else
+  ln -s "$REPO_ROOT" "$TARGET_DIR"
+fi
+
+cat <<EOF
+Installed hermes-lcm at:
+  $TARGET_DIR
+
+Activation requires both:
+
+plugins:
+  enabled:
+    - hermes-lcm
+
+context:
+  engine: lcm
+
+Verification:
+  1. Restart Hermes.
+  2. Run: hermes plugins
+  3. Confirm the plugin list includes hermes-lcm and the selected context engine is lcm.
+EOF

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if command -v git >/dev/null 2>&1; then
+  git -C "$REPO_ROOT" pull --ff-only
+fi
+
+"$SCRIPT_DIR/install.sh"
+
+echo "Update complete. Restart Hermes if it is running."

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,22 +1,36 @@
 from pathlib import Path
+import importlib.util
 import subprocess
+import sys
 
 
-def _install_repo_as_user_plugin(tmp_path: Path) -> Path:
+def _load_plugin_entrypoint_module(module_name: str):
     repo_root = Path(__file__).resolve().parent.parent
-    hermes_home = tmp_path / "hermes-home"
-    plugin_dir = hermes_home / "plugins" / "hermes-lcm"
-    plugin_dir.parent.mkdir(parents=True, exist_ok=True)
-    plugin_dir.symlink_to(repo_root, target_is_directory=True)
-    (hermes_home / "config.yaml").write_text(
-        "plugins:\n"
-        "  enabled:\n"
-        "    - hermes-lcm\n"
-        "context:\n"
-        "  engine: lcm\n",
-        encoding="utf-8",
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        str(repo_root / "__init__.py"),
+        submodule_search_locations=[str(repo_root)],
     )
-    return hermes_home
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _register_plugin_engine(module_name: str):
+    module = _load_plugin_entrypoint_module(module_name)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _Ctx()
+    module.register(ctx)
+    return ctx.engine
 
 
 def test_standalone_install_scripts_exist_and_are_shell_scripts():
@@ -84,20 +98,9 @@ def test_install_script_refuses_to_replace_existing_non_symlink_path(tmp_path):
     assert target.is_dir()
 
 
-def test_user_plugin_manager_loads_hermes_lcm_as_context_engine(monkeypatch, tmp_path):
-    hermes_home = _install_repo_as_user_plugin(tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+def test_plugin_entrypoint_registers_lcm_context_engine():
+    engine = _register_plugin_engine("hermes_lcm_packaging_entrypoint")
 
-    from hermes_cli import plugins as plugins_mod
-
-    manager = plugins_mod.PluginManager()
-    manager.discover_and_load()
-
-    loaded = manager._plugins["hermes-lcm"]
-    assert loaded.enabled
-    assert loaded.manifest.source == "user"
-
-    engine = manager._context_engine
     assert engine is not None
     assert engine.name == "lcm"
 
@@ -112,14 +115,8 @@ def test_user_plugin_manager_loads_hermes_lcm_as_context_engine(monkeypatch, tmp
     }.issubset(tool_names)
 
 
-def test_get_plugin_context_engine_returns_lcm_for_enabled_user_plugin(monkeypatch, tmp_path):
-    hermes_home = _install_repo_as_user_plugin(tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-
-    from hermes_cli import plugins as plugins_mod
-
-    plugins_mod._plugin_manager = plugins_mod.PluginManager()
-    engine = plugins_mod.get_plugin_context_engine()
+def test_plugin_entrypoint_registration_is_repeatable_and_returns_lcm_engine():
+    engine = _register_plugin_engine("hermes_lcm_packaging_entrypoint_repeat")
 
     assert engine is not None
     assert engine.name == "lcm"

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+import subprocess
+
+import yaml
+
+
+def _install_repo_as_user_plugin(tmp_path: Path) -> Path:
+    repo_root = Path(__file__).resolve().parent.parent
+    hermes_home = tmp_path / "hermes-home"
+    plugin_dir = hermes_home / "plugins" / "hermes-lcm"
+    plugin_dir.parent.mkdir(parents=True, exist_ok=True)
+    plugin_dir.symlink_to(repo_root, target_is_directory=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"enabled": ["hermes-lcm"]},
+                "context": {"engine": "lcm"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return hermes_home
+
+
+def test_standalone_install_scripts_exist_and_are_shell_scripts():
+    repo_root = Path(__file__).resolve().parent.parent
+
+    install_script = repo_root / "scripts" / "install.sh"
+    update_script = repo_root / "scripts" / "update.sh"
+
+    assert install_script.exists(), "scripts/install.sh should exist"
+    assert update_script.exists(), "scripts/update.sh should exist"
+    assert install_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
+    assert update_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
+
+
+def test_install_script_creates_profile_aware_symlink_and_prints_activation_steps(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    hermes_home = tmp_path / "hermes-home"
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "HERMES_HOME": str(hermes_home),
+        "HERMES_PROFILE": "sandbox",
+    }
+
+    result = subprocess.run(
+        ["bash", str(repo_root / "scripts" / "install.sh")],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    target = hermes_home / "profiles" / "sandbox" / "plugins" / "hermes-lcm"
+    assert target.is_symlink()
+    assert target.resolve() == repo_root.resolve()
+    assert "plugins:" in result.stdout
+    assert "- hermes-lcm" in result.stdout
+    assert "context:" in result.stdout
+    assert "engine: lcm" in result.stdout
+
+
+def test_install_script_refuses_to_replace_existing_non_symlink_path(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    hermes_home = tmp_path / "hermes-home"
+    target = hermes_home / "plugins" / "hermes-lcm"
+    target.mkdir(parents=True)
+    (target / "README.txt").write_text("existing checkout", encoding="utf-8")
+
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "HERMES_HOME": str(hermes_home),
+    }
+
+    result = subprocess.run(
+        ["bash", str(repo_root / "scripts" / "install.sh")],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Refusing to replace existing path" in result.stderr
+    assert target.is_dir()
+
+
+def test_user_plugin_manager_loads_hermes_lcm_as_context_engine(monkeypatch, tmp_path):
+    hermes_home = _install_repo_as_user_plugin(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import plugins as plugins_mod
+
+    manager = plugins_mod.PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins["hermes-lcm"]
+    assert loaded.enabled
+    assert loaded.manifest.source == "user"
+
+    engine = manager._context_engine
+    assert engine is not None
+    assert engine.name == "lcm"
+
+    tool_names = {schema["name"] for schema in engine.get_tool_schemas()}
+    assert {
+        "lcm_grep",
+        "lcm_describe",
+        "lcm_expand",
+        "lcm_expand_query",
+        "lcm_status",
+        "lcm_doctor",
+    }.issubset(tool_names)
+
+
+def test_get_plugin_context_engine_returns_lcm_for_enabled_user_plugin(monkeypatch, tmp_path):
+    hermes_home = _install_repo_as_user_plugin(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import plugins as plugins_mod
+
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    engine = plugins_mod.get_plugin_context_engine()
+
+    assert engine is not None
+    assert engine.name == "lcm"

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 import subprocess
 
-import yaml
-
 
 def _install_repo_as_user_plugin(tmp_path: Path) -> Path:
     repo_root = Path(__file__).resolve().parent.parent
@@ -11,12 +9,11 @@ def _install_repo_as_user_plugin(tmp_path: Path) -> Path:
     plugin_dir.parent.mkdir(parents=True, exist_ok=True)
     plugin_dir.symlink_to(repo_root, target_is_directory=True)
     (hermes_home / "config.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "plugins": {"enabled": ["hermes-lcm"]},
-                "context": {"engine": "lcm"},
-            }
-        ),
+        "plugins:\n"
+        "  enabled:\n"
+        "    - hermes-lcm\n"
+        "context:\n"
+        "  engine: lcm\n",
         encoding="utf-8",
     )
     return hermes_home


### PR DESCRIPTION
## Summary
- make standalone general-plugin install the canonical `hermes-lcm` path
- add install/update helper scripts for the standalone user-plugin flow
- add packaging tests covering install-script behavior and plugin-manager loading
- update contributor/operator docs for activation, validation, and legacy-path migration

## Why
- the current mature `hermes-lcm` implementation should be the source of truth, not a stripped-down rewrite
- installing under `~/.hermes/plugins/hermes-lcm` survives Hermes updates cleanly
- the new packaging path needs executable docs and regression coverage, not just README claims

## Validation
- `python -m pytest -q tests/test_packaging_install.py`
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
- `pytest -q`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- real standalone smoke test with isolated `HERMES_HOME`:
  - `./scripts/install.sh`
  - `hermes plugins list`

## Notes
- runtime engine name stays `lcm`
- plugin manifest name stays `hermes-lcm`
- legacy `plugins/context_engine/lcm` installs are documented as compatibility fallback only
- unrelated untracked `manim-lcm-explainer/` content was not included in this PR
