### PR TITLE
fix: reset session-scoped runtime on rebind

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -536,13 +536,29 @@ class LCMEngine(ContextEngine):
         if self._has_raw_backlog_debt():
             self._lifecycle.clear_debt(self._conversation_id)
 
-    def on_session_start(self, session_id: str, **kwargs) -> None:
-        self._session_id = session_id
-        self._session_platform = str(kwargs.get("platform") or "")
-        self._ingest_cursor = 0
+    def _reset_session_scoped_runtime_state(self) -> None:
+        self.compression_count = 0
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
         self._last_compacted_store_id = 0
+        self._ingest_cursor = 0
+        self._context_probed = False
+        self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        previous_session_id = self._session_id
+        if previous_session_id and previous_session_id != session_id:
+            self._reset_session_scoped_runtime_state()
+        else:
+            self._ingest_cursor = 0
+            self._last_compacted_store_id = 0
+            self._last_overflow_recovery_failed = False
+            self._last_condensation_suppressed_reason = ""
+        self._session_id = session_id
+        self._session_platform = str(kwargs.get("platform") or "")
         self._refresh_session_filters()
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -37,6 +37,19 @@ def test_lcm_status_default_reports_current_session(engine):
     assert "dag_nodes: 0" in result
 
 
+def test_lcm_status_does_not_leak_prior_session_compaction_count_after_rebind(engine):
+    engine.compression_count = 4
+    engine.last_prompt_tokens = 8000
+    engine.on_session_start("fresh-session", platform="telegram", context_length=200000)
+
+    result = handle_lcm_command("status", engine)
+
+    assert "session_id: fresh-session" in result
+    assert "compression_count: 0" in result
+    assert "store_messages: 0" in result
+    assert "dag_nodes: 0" in result
+
+
 def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "lcm_unbound.db"))
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -96,6 +96,27 @@ class TestEngineABC:
         assert engine.compression_count == 0
         assert engine.last_prompt_tokens == 0
 
+    def test_on_session_start_resets_session_scoped_runtime_when_binding_new_session(self, engine):
+        engine.compression_count = 5
+        engine.last_prompt_tokens = 9999
+        engine.last_completion_tokens = 333
+        engine.last_total_tokens = 10332
+        engine._last_compacted_store_id = 42
+        engine._ingest_cursor = 7
+        engine._context_probed = True
+        engine._context_probe_persistable = True
+        engine.on_session_start("fresh-session", platform="telegram", context_length=200000)
+
+        assert engine._session_id == "fresh-session"
+        assert engine.compression_count == 0
+        assert engine.last_prompt_tokens == 0
+        assert engine.last_completion_tokens == 0
+        assert engine.last_total_tokens == 0
+        assert engine._last_compacted_store_id == 0
+        assert engine._ingest_cursor == 0
+        assert engine._context_probed is False
+        assert engine._context_probe_persistable is False
+
     def test_get_status(self, engine):
         status = engine.get_status()
         assert status["engine"] == "lcm"


### PR DESCRIPTION
## Summary
- reset session-scoped runtime counters when the same `LCMEngine` instance is rebound to a different session
- add regression coverage for the stale `compression_count` leak seen in #68
- verify `/lcm status` reports a clean new session after rebind instead of inheriting prior-session compaction state

## Why
- #68 exposed a real operator-facing failure mode: a reused engine instance could report `compression_count > 0` for a fresh session with `store_messages: 0` and `dag_nodes: 0`
- the host-side singleton reuse is still the larger integration problem, but `LCMEngine` was also leaking session-scoped runtime state across `on_session_start()` rebinds
- resetting those counters on session change makes the engine more robust and keeps status output honest without claiming to solve host lifecycle ownership by itself

## Validation
- `pytest tests/test_lcm_engine.py::TestEngineABC::test_on_session_start_resets_session_scoped_runtime_when_binding_new_session tests/test_lcm_command.py::test_lcm_status_does_not_leak_prior_session_compaction_count_after_rebind -q`
- `pytest tests/test_lcm_engine.py tests/test_lcm_command.py -q`
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
- `ulimit -n 4096 && pytest -q`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`

## Notes
- Refs #68
- This is intentionally scoped to the LCM-side leak: `compression_count`, token usage, probe state, and compaction cursors now reset when the engine binds a different session id
- It does not claim to fix Hermes host singleton lifecycle reuse by itself; it hardens `hermes-lcm` so the stale-status symptom is no longer inherited across rebinds
