### PR TITLE
fix: route provider-prefixed LCM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Environment variables (all optional):
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Character threshold above which tool results are externalized |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH` | `~/.hermes/lcm-large-outputs` | Override storage directory for externalized payloads |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
-| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. Direct provider prefixes such as `cerebras/gpt-oss-120b` route as `provider=cerebras`, `model=gpt-oss-120b`; aggregator model slugs such as `meta-llama/...` stay model-only. |
+| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. The explicit direct prefix `cerebras/gpt-oss-120b` routes as `provider=cerebras`, `model=gpt-oss-120b`; aggregator model slugs such as `meta-llama/...` and `anthropic/...` stay model-only. |
 | `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Supports the same provider-prefixed routing as `LCM_SUMMARY_MODEL`. |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |

--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ Environment variables (all optional):
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Character threshold above which tool results are externalized |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH` | `~/.hermes/lcm-large-outputs` | Override storage directory for externalized payloads |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
-| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. The explicit direct prefix `cerebras/gpt-oss-120b` routes as `provider=cerebras`, `model=gpt-oss-120b`; aggregator model slugs such as `meta-llama/...` and `anthropic/...` stay model-only. |
-| `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Supports the same provider-prefixed routing as `LCM_SUMMARY_MODEL`. |
+| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. Slash-bearing aggregator model slugs such as `meta-llama/...`, `anthropic/...`, and unresolved `cerebras/...` stay model-only. |
+| `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Uses the same routing rules as `LCM_SUMMARY_MODEL`. |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
@@ -261,6 +261,8 @@ Environment variables (all optional):
 | `LCM_ENABLE_SLASH_COMMAND` | `false` | Opt-in registration for `/lcm` gateway slash commands (recommended only for trusted operator contexts) |
 
 The point-8 compaction knobs are intentionally opt-in. `cache_friendly_*` is a plugin-local prompt-stability heuristic, not a claim that Hermes currently passes true prompt-cache metrics into `hermes-lcm`.
+
+Provider-prefixed LCM model overrides are conservative. `cerebras/gpt-oss-120b` routes as `provider=cerebras`, `model=gpt-oss-120b` only when the Hermes host can resolve `cerebras` as a built-in provider or as a named custom provider in `providers:` / `custom_providers`. If not, it remains `model=cerebras/gpt-oss-120b` so aggregator-style slugs do not accidentally become unknown direct providers.
 
 ### Threshold ownership when `context.engine: lcm` is active
 

--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ Environment variables (all optional):
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Character threshold above which tool results are externalized |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH` | `~/.hermes/lcm-large-outputs` | Override storage directory for externalized payloads |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
-| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization |
-| `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis |
+| `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. Direct provider prefixes such as `cerebras/gpt-oss-120b` route as `provider=cerebras`, `model=gpt-oss-120b`; aggregator model slugs such as `meta-llama/...` stay model-only. |
+| `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Supports the same provider-prefixed routing as `LCM_SUMMARY_MODEL`. |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |

--- a/escalation.py
+++ b/escalation.py
@@ -12,6 +12,7 @@ import logging
 import re
 from typing import List, Optional
 
+from .model_routing import apply_lcm_model_route
 from .tokens import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -50,8 +51,7 @@ def _call_llm_for_summary(prompt: str, max_tokens: int,
             "temperature": 0.3,
             "max_tokens": max_tokens,
         }
-        if model:
-            call_kwargs["model"] = model
+        apply_lcm_model_route(call_kwargs, model)
         if timeout is not None:
             call_kwargs["timeout"] = timeout
         response = call_llm(**call_kwargs)

--- a/extraction.py
+++ b/extraction.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .model_routing import apply_lcm_model_route
+
 logger = logging.getLogger(__name__)
 
 _MEDIA_DATA_URI_RE = re.compile(
@@ -52,8 +54,7 @@ def _call_extraction_llm(prompt: str, model: str = "",
             "temperature": 0.2,
             "max_tokens": 2000,
         }
-        if model:
-            call_kwargs["model"] = model
+        apply_lcm_model_route(call_kwargs, model)
         if timeout is not None:
             call_kwargs["timeout"] = timeout
         response = call_llm(**call_kwargs)

--- a/model_routing.py
+++ b/model_routing.py
@@ -1,0 +1,66 @@
+"""LCM model override routing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    provider: str | None
+    model: str
+
+
+# Conservative allowlist: only split prefixes that are intended to be Hermes
+# provider IDs in LCM overrides. Do not infer from arbitrary model namespaces,
+# because aggregator slugs such as ``meta-llama/...`` and ``google/...`` must
+# remain model-only overrides.
+_PROVIDER_PREFIXES = frozenset(
+    {
+        "alibaba",
+        "anthropic",
+        "arcee",
+        "cerebras",
+        "deepseek",
+        "gemini",
+        "kimi-for-coding",
+        "minimax",
+        "minimax-cn",
+        "nous",
+        "nvidia",
+        "openrouter",
+        "stepfun",
+        "xai",
+        "xiaomi",
+        "zai",
+    }
+)
+
+
+def parse_lcm_model_override(value: str | None) -> ModelRoute:
+    """Parse an LCM model override into explicit provider/model routing.
+
+    Values whose first path segment is a conservative known provider prefix are
+    split into ``provider=<prefix>`` and ``model=<rest>``. Other values, even
+    when they contain ``/``, remain model-only overrides.
+    """
+    model = (value or "").strip()
+    if not model:
+        return ModelRoute(provider=None, model="")
+
+    provider, sep, rest = model.partition("/")
+    provider = provider.strip().lower()
+    rest = rest.strip()
+    if sep and provider in _PROVIDER_PREFIXES and rest:
+        return ModelRoute(provider=provider, model=rest)
+
+    return ModelRoute(provider=None, model=model)
+
+
+def apply_lcm_model_route(call_kwargs: dict, model: str | None) -> None:
+    """Apply parsed LCM provider/model overrides to Hermes auxiliary kwargs."""
+    route = parse_lcm_model_override(model)
+    if route.provider:
+        call_kwargs["provider"] = route.provider
+    if route.model:
+        call_kwargs["model"] = route.model

--- a/model_routing.py
+++ b/model_routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 
@@ -11,6 +12,9 @@ class ModelRoute:
     model: str
 
 
+ProviderResolver = Callable[[str], bool]
+
+
 # Conservative allowlist: only split prefixes explicitly supported by LCM
 # overrides. Do not infer from arbitrary provider names, because many Hermes
 # provider IDs are also valid OpenRouter model namespaces, for example
@@ -18,12 +22,34 @@ class ModelRoute:
 _PROVIDER_PREFIXES = frozenset({"cerebras"})
 
 
-def parse_lcm_model_override(value: str | None) -> ModelRoute:
+def _provider_route_is_resolvable(provider: str) -> bool:
+    """Return whether Hermes can route an explicit auxiliary provider."""
+    try:
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+
+        if _get_named_custom_provider(provider):
+            return True
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        return provider in PROVIDER_REGISTRY
+    except Exception:
+        return False
+
+
+def parse_lcm_model_override(
+    value: str | None,
+    *,
+    provider_resolver: ProviderResolver | None = None,
+) -> ModelRoute:
     """Parse an LCM model override into explicit provider/model routing.
 
-    Values whose first path segment is a conservative known provider prefix are
-    split into ``provider=<prefix>`` and ``model=<rest>``. Other values, even
-    when they contain ``/``, remain model-only overrides.
+    Values whose first path segment is both allowlisted and resolvable by the
+    Hermes host are split into ``provider=<prefix>`` and ``model=<rest>``.
+    Other values, even when they contain ``/``, remain model-only overrides.
     """
     model = (value or "").strip()
     if not model:
@@ -32,7 +58,8 @@ def parse_lcm_model_override(value: str | None) -> ModelRoute:
     provider, sep, rest = model.partition("/")
     provider = provider.strip().lower()
     rest = rest.strip()
-    if sep and provider in _PROVIDER_PREFIXES and rest:
+    can_resolve_provider = provider_resolver or _provider_route_is_resolvable
+    if sep and provider in _PROVIDER_PREFIXES and rest and can_resolve_provider(provider):
         return ModelRoute(provider=provider, model=rest)
 
     return ModelRoute(provider=None, model=model)

--- a/model_routing.py
+++ b/model_routing.py
@@ -11,30 +11,11 @@ class ModelRoute:
     model: str
 
 
-# Conservative allowlist: only split prefixes that are intended to be Hermes
-# provider IDs in LCM overrides. Do not infer from arbitrary model namespaces,
-# because aggregator slugs such as ``meta-llama/...`` and ``google/...`` must
-# remain model-only overrides.
-_PROVIDER_PREFIXES = frozenset(
-    {
-        "alibaba",
-        "anthropic",
-        "arcee",
-        "cerebras",
-        "deepseek",
-        "gemini",
-        "kimi-for-coding",
-        "minimax",
-        "minimax-cn",
-        "nous",
-        "nvidia",
-        "openrouter",
-        "stepfun",
-        "xai",
-        "xiaomi",
-        "zai",
-    }
-)
+# Conservative allowlist: only split prefixes explicitly supported by LCM
+# overrides. Do not infer from arbitrary provider names, because many Hermes
+# provider IDs are also valid OpenRouter model namespaces, for example
+# ``anthropic/...``, ``deepseek/...``, ``google/...``, and ``x-ai/...``.
+_PROVIDER_PREFIXES = frozenset({"cerebras"})
 
 
 def parse_lcm_model_override(value: str | None) -> ModelRoute:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -5,6 +5,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -22,6 +23,116 @@ from hermes_lcm.session_patterns import (
     compile_session_patterns,
     matches_session_pattern,
 )
+
+
+class TestModelRouting:
+    def test_provider_prefixed_direct_model_is_split(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override("cerebras/gpt-oss-120b")
+
+        assert route.provider == "cerebras"
+        assert route.model == "gpt-oss-120b"
+
+    def test_openrouter_organization_slug_stays_model_only(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override("meta-llama/Llama-3.3-70B-Instruct")
+
+        assert route.provider is None
+        assert route.model == "meta-llama/Llama-3.3-70B-Instruct"
+
+    def test_google_namespace_slug_stays_model_only(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override("google/gemini-3-flash-preview")
+
+        assert route.provider is None
+        assert route.model == "google/gemini-3-flash-preview"
+
+
+class TestProviderPrefixedAuxiliaryCalls:
+    def _fake_response(self, content="ok"):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
+    def test_summary_call_passes_provider_and_stripped_model(self, monkeypatch):
+        import agent.auxiliary_client as auxiliary_client
+        from hermes_lcm.escalation import _call_llm_for_summary
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("summary")
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+
+        result = _call_llm_for_summary("summarize", 200, model="cerebras/gpt-oss-120b")
+
+        assert result == "summary"
+        assert seen["provider"] == "cerebras"
+        assert seen["model"] == "gpt-oss-120b"
+
+    def test_summary_call_keeps_openrouter_slug_as_model_only(self, monkeypatch):
+        import agent.auxiliary_client as auxiliary_client
+        from hermes_lcm.escalation import _call_llm_for_summary
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("summary")
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+
+        _call_llm_for_summary("summarize", 200, model="meta-llama/Llama-3.3-70B-Instruct")
+
+        assert "provider" not in seen
+        assert seen["model"] == "meta-llama/Llama-3.3-70B-Instruct"
+
+    def test_extraction_call_passes_provider_and_stripped_model(self, monkeypatch):
+        import agent.auxiliary_client as auxiliary_client
+        from hermes_lcm.extraction import _call_extraction_llm
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("- decision")
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+
+        result = _call_extraction_llm("extract", model="cerebras/gpt-oss-120b")
+
+        assert result == "- decision"
+        assert seen["provider"] == "cerebras"
+        assert seen["model"] == "gpt-oss-120b"
+
+    def test_expansion_call_passes_provider_and_stripped_model(self, monkeypatch):
+        import agent.auxiliary_client as auxiliary_client
+        from hermes_lcm.tools import _synthesize_expansion_answer
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("answer")
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+
+        result = _synthesize_expansion_answer(
+            prompt="question",
+            context_blocks=[{"content": "context"}],
+            model="cerebras/gpt-oss-120b",
+            max_tokens=300,
+            timeout=12,
+        )
+
+        assert result == "answer"
+        assert seen["provider"] == "cerebras"
+        assert seen["model"] == "gpt-oss-120b"
 
 
 class TestConfig:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2,10 +2,11 @@
 
 import json
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -57,8 +58,12 @@ class TestProviderPrefixedAuxiliaryCalls:
             choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
         )
 
+    def _install_fake_auxiliary_client(self, monkeypatch, fake_call_llm):
+        auxiliary_client = ModuleType("agent.auxiliary_client")
+        auxiliary_client.call_llm = fake_call_llm
+        monkeypatch.setitem(sys.modules, "agent.auxiliary_client", auxiliary_client)
+
     def test_summary_call_passes_provider_and_stripped_model(self, monkeypatch):
-        import agent.auxiliary_client as auxiliary_client
         from hermes_lcm.escalation import _call_llm_for_summary
 
         seen = {}
@@ -67,7 +72,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             seen.update(kwargs)
             return self._fake_response("summary")
 
-        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = _call_llm_for_summary("summarize", 200, model="cerebras/gpt-oss-120b")
 
@@ -76,7 +81,6 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert seen["model"] == "gpt-oss-120b"
 
     def test_summary_call_keeps_openrouter_slug_as_model_only(self, monkeypatch):
-        import agent.auxiliary_client as auxiliary_client
         from hermes_lcm.escalation import _call_llm_for_summary
 
         seen = {}
@@ -85,7 +89,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             seen.update(kwargs)
             return self._fake_response("summary")
 
-        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         _call_llm_for_summary("summarize", 200, model="meta-llama/Llama-3.3-70B-Instruct")
 
@@ -93,7 +97,6 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert seen["model"] == "meta-llama/Llama-3.3-70B-Instruct"
 
     def test_extraction_call_passes_provider_and_stripped_model(self, monkeypatch):
-        import agent.auxiliary_client as auxiliary_client
         from hermes_lcm.extraction import _call_extraction_llm
 
         seen = {}
@@ -102,7 +105,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             seen.update(kwargs)
             return self._fake_response("- decision")
 
-        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = _call_extraction_llm("extract", model="cerebras/gpt-oss-120b")
 
@@ -111,7 +114,6 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert seen["model"] == "gpt-oss-120b"
 
     def test_expansion_call_passes_provider_and_stripped_model(self, monkeypatch):
-        import agent.auxiliary_client as auxiliary_client
         from hermes_lcm.tools import _synthesize_expansion_answer
 
         seen = {}
@@ -120,7 +122,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             seen.update(kwargs)
             return self._fake_response("answer")
 
-        monkeypatch.setattr(auxiliary_client, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = _synthesize_expansion_answer(
             prompt="question",

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -51,6 +51,14 @@ class TestModelRouting:
         assert route.provider is None
         assert route.model == "google/gemini-3-flash-preview"
 
+    def test_anthropic_namespace_slug_stays_model_only(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override("anthropic/claude-sonnet-4.5")
+
+        assert route.provider is None
+        assert route.model == "anthropic/claude-sonnet-4.5"
+
 
 class TestProviderPrefixedAuxiliaryCalls:
     def _fake_response(self, content="ok"):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -27,10 +27,24 @@ from hermes_lcm.session_patterns import (
 
 
 class TestModelRouting:
-    def test_provider_prefixed_direct_model_is_split(self):
+    def test_provider_prefixed_model_stays_model_only_when_provider_unresolved(self):
         from hermes_lcm.model_routing import parse_lcm_model_override
 
-        route = parse_lcm_model_override("cerebras/gpt-oss-120b")
+        route = parse_lcm_model_override(
+            "cerebras/gpt-oss-120b",
+            provider_resolver=lambda _provider: False,
+        )
+
+        assert route.provider is None
+        assert route.model == "cerebras/gpt-oss-120b"
+
+    def test_provider_prefixed_direct_model_is_split_when_provider_resolves(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override(
+            "cerebras/gpt-oss-120b",
+            provider_resolver=lambda provider: provider == "cerebras",
+        )
 
         assert route.provider == "cerebras"
         assert route.model == "gpt-oss-120b"
@@ -71,7 +85,47 @@ class TestProviderPrefixedAuxiliaryCalls:
         auxiliary_client.call_llm = fake_call_llm
         monkeypatch.setitem(sys.modules, "agent.auxiliary_client", auxiliary_client)
 
+    def _install_fake_cerebras_provider(self, monkeypatch):
+        hermes_cli = ModuleType("hermes_cli")
+        hermes_cli.__path__ = []
+
+        runtime_provider = ModuleType("hermes_cli.runtime_provider")
+
+        def fake_get_named_custom_provider(provider):
+            if provider == "cerebras":
+                return {"name": "cerebras", "base_url": "https://api.cerebras.ai/v1"}
+            return None
+
+        runtime_provider._get_named_custom_provider = fake_get_named_custom_provider
+
+        auth = ModuleType("hermes_cli.auth")
+        auth.PROVIDER_REGISTRY = {}
+
+        hermes_cli.runtime_provider = runtime_provider
+        hermes_cli.auth = auth
+        monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", runtime_provider)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", auth)
+
     def test_summary_call_passes_provider_and_stripped_model(self, monkeypatch):
+        from hermes_lcm.escalation import _call_llm_for_summary
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("summary")
+
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
+        self._install_fake_cerebras_provider(monkeypatch)
+
+        result = _call_llm_for_summary("summarize", 200, model="cerebras/gpt-oss-120b")
+
+        assert result == "summary"
+        assert seen["provider"] == "cerebras"
+        assert seen["model"] == "gpt-oss-120b"
+
+    def test_summary_call_keeps_unresolved_direct_slug_model_only(self, monkeypatch):
         from hermes_lcm.escalation import _call_llm_for_summary
 
         seen = {}
@@ -85,8 +139,8 @@ class TestProviderPrefixedAuxiliaryCalls:
         result = _call_llm_for_summary("summarize", 200, model="cerebras/gpt-oss-120b")
 
         assert result == "summary"
-        assert seen["provider"] == "cerebras"
-        assert seen["model"] == "gpt-oss-120b"
+        assert "provider" not in seen
+        assert seen["model"] == "cerebras/gpt-oss-120b"
 
     def test_summary_call_keeps_openrouter_slug_as_model_only(self, monkeypatch):
         from hermes_lcm.escalation import _call_llm_for_summary
@@ -114,6 +168,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             return self._fake_response("- decision")
 
         self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
+        self._install_fake_cerebras_provider(monkeypatch)
 
         result = _call_extraction_llm("extract", model="cerebras/gpt-oss-120b")
 
@@ -131,6 +186,7 @@ class TestProviderPrefixedAuxiliaryCalls:
             return self._fake_response("answer")
 
         self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
+        self._install_fake_cerebras_provider(monkeypatch)
 
         result = _synthesize_expansion_answer(
             prompt="question",

--- a/tools.py
+++ b/tools.py
@@ -13,6 +13,7 @@ from .externalize import (
     load_externalized_payload,
 )
 from .extraction import sanitize_pre_compaction_content
+from .model_routing import apply_lcm_model_route
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 
 if TYPE_CHECKING:
@@ -231,8 +232,7 @@ def _synthesize_expansion_answer(
         "max_tokens": max_tokens,
         "timeout": timeout,
     }
-    if model:
-        call_kwargs["model"] = model
+    apply_lcm_model_route(call_kwargs, model)
     response = call_llm(**call_kwargs)
     content = response.choices[0].message.content
     if not isinstance(content, str):


### PR DESCRIPTION
## Summary
- Add a conservative LCM model routing helper for provider-prefixed overrides
- Route summary, extraction, and expansion calls with explicit provider/model kwargs when applicable
- Preserve aggregator-style model slugs like meta-llama/... and google/... as model-only overrides
- Document provider-prefixed LCM model overrides

## Test Plan
- pytest -q

Closes #71