### PR TITLE
fix: treat legacy blank-source rows as healthy

### DIFF
--- a/command.py
+++ b/command.py
@@ -488,8 +488,9 @@ def _doctor_text(engine) -> str:
     if source_stats.get("error"):
         observations.append(f"source_lineage_error: {source_stats['error']}")
     if source_stats["legacy_blank_source_messages"]:
-        recommended_actions.append("review legacy blank-source rows before any destructive cleanup or migration step")
-        recommended_actions.append("treat `source=unknown` as the back-compat filter until legacy blank-source rows are normalized")
+        observations.append(
+            "legacy blank-source rows are normalized as `source=unknown` for back-compat filters"
+        )
 
     if clean_scan.get("protected_count"):
         observations.append(

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -120,7 +120,7 @@ def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path
     assert "/lcm backup" in result
 
 
-def test_lcm_doctor_reports_legacy_blank_source_observation_and_action(engine):
+def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):
     engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
     engine._store.append("sess-unknown", {"role": "user", "content": "unknown message"})
     engine._store._conn.execute(
@@ -133,10 +133,12 @@ def test_lcm_doctor_reports_legacy_blank_source_observation_and_action(engine):
 
     result = handle_lcm_command("doctor", engine)
 
+    assert "status: ok" in result
     assert "source_lineage:" in result
     assert "legacy_blank=1" in result
     assert "effective_unknown=2" in result
-    assert "review legacy blank-source rows before any destructive cleanup" in result
+    assert "recommended_actions:\n- none" in result
+    assert "review legacy blank-source rows before any destructive cleanup" not in result
 
 
 def test_lcm_help_on_unknown_subcommand(engine):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3280,6 +3280,22 @@ class TestEngineTools:
         assert "config_validation" in check_names
         assert all(c["status"] == "pass" for c in result["checks"])
 
+    def test_handle_doctor_treats_legacy_blank_source_rows_as_healthy(self, engine):
+        engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("legacy-session", "", "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+        )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "healthy"
+        lineage_check = next(c for c in result["checks"] if c["check"] == "source_lineage_hygiene")
+        assert lineage_check["status"] == "pass"
+        assert lineage_check["detail"]["legacy_blank_source_messages"] == 1
+
     def test_handle_doctor_warns_on_bad_config(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_doctor.db"),

--- a/tools.py
+++ b/tools.py
@@ -719,10 +719,9 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     # 5. Source-lineage hygiene
     try:
         source_stats = engine._store.get_source_stats()
-        legacy_blank_messages = source_stats["legacy_blank_source_messages"]
         checks.append({
             "check": "source_lineage_hygiene",
-            "status": "pass" if legacy_blank_messages == 0 else "warn",
+            "status": "pass",
             "detail": {
                 **source_stats,
                 "normalization_mode": "backcompat-normalization",


### PR DESCRIPTION
## Summary
- Stop treating legacy blank-source rows as an action-required LCM doctor warning
- Keep source lineage counts visible as observations/backcompat metadata
- Mark `source_lineage_hygiene` healthy when backcompat normalization is working

## Test Plan
- `pytest tests/test_lcm_command.py::test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_treats_legacy_blank_source_rows_as_healthy -q`
- `ulimit -n 8192; pytest -q`
