### PR TITLE
fix: accept valid integer node_ids in lcm_expand_query

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3371,6 +3371,37 @@ class TestEngineTools:
 
         assert result["error"] == "node_ids must contain only integers"
 
+    def test_handle_expand_query_accepts_valid_integer_node_ids(self, engine, monkeypatch):
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            return "Expansion answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"node_ids": [node_id], "prompt": "What was the plan?"},
+            )
+        )
+
+        assert "error" not in result, f"unexpected error: {result.get('error')}"
+        assert result["answer"] == "Expansion answer"
+        assert result["node_ids"] == [node_id]
+
     def test_describe_and_expand_are_session_scoped(self, engine):
         node_id = engine._dag.add_node(
             SummaryNode(

--- a/tools.py
+++ b/tools.py
@@ -495,8 +495,9 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     nodes = []
     if raw_node_ids:
         for node_id in raw_node_ids:
-            parsed_node_id, node_id_error = _parse_int_arg("node_ids", node_id)
-            if node_id_error:
+            try:
+                parsed_node_id = int(node_id)
+            except (TypeError, ValueError):
                 return json.dumps({"error": "node_ids must contain only integers"})
             node = _get_session_node(engine, parsed_node_id)
             if node is not None:


### PR DESCRIPTION
PR #64 introduced a regression: every call with `node_ids` returns `{"error": "node_ids must contain only integers"}`, including valid integer inputs like `[1]`.

Root cause: the `_parse_int_arg` helper added in PR #64 reads from the args dict via `args.get(name, default)`, which always returns the original list when called inside the per-element loop with the same name. `int([1])` raises TypeError, so the loop reports failure for every element regardless of value.

The existing regression test only covered the rejection path (non- numeric strings), which still works because `int(["not-a-number"])` also fails — it just fails for the wrong reason.

Replace the inner-loop call with a direct `int(node_id)` wrapped in a try/except. Same error message is preserved for non-numeric inputs.

Add a regression test that constructs a real DAG node and asserts that calling `lcm_expand_query` with `node_ids: [<that node_id>]` returns the synthesized answer instead of the validation error.

Reproduction (before this fix):

    engine.handle_tool_call(
        "lcm_expand_query",
        {"node_ids": [1], "prompt": "What was discussed?"},
    )
    # -> {"error": "node_ids must contain only integers"}

After:

    # -> {"prompt": ..., "answer": "...", "node_ids": [1], "matches": [...]}