### PR TITLE
fix: strip thinking-model reasoning tags before persisting summaries

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -9,11 +9,34 @@ Each level checks if Tokens(summary) < Tokens(source). If not, escalates.
 
 import inspect
 import logging
+import re
 from typing import List, Optional
 
 from .tokens import count_tokens
 
 logger = logging.getLogger(__name__)
+
+
+# Strip inline reasoning blocks emitted by thinking models (MiniMax-M2.7,
+# GLM-5.1, Qwen QwQ, DeepSeek R1, etc.) before persisting summary text.
+# Without this, the reasoning content — which often quotes the summarizer
+# system prompt verbatim — gets stored as the summary and later confuses
+# lcm_expand_query, which feeds the summary back to the model as context.
+# Tags mirror the set handled in hermes-agent run_agent.py.
+_THINK_BLOCK_RE = re.compile(
+    r"<(?P<tag>think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\s*>"
+    r".*?"
+    r"</(?P=tag)\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _strip_reasoning_blocks(text: str) -> str:
+    """Remove <think>/<thinking>/<reasoning>/<thought>/<REASONING_SCRATCHPAD>
+    blocks from ``text``. Idempotent and safe on text without any tags."""
+    if not text or "<" not in text:
+        return text
+    return _THINK_BLOCK_RE.sub("", text)
 
 
 def _call_llm_for_summary(prompt: str, max_tokens: int,
@@ -35,7 +58,7 @@ def _call_llm_for_summary(prompt: str, max_tokens: int,
         content = response.choices[0].message.content
         if not isinstance(content, str):
             content = str(content) if content else ""
-        return content.strip()
+        return _strip_reasoning_blocks(content).strip()
     except Exception as e:
         logger.warning("LLM summarization failed: %s", e)
         return None

--- a/extraction.py
+++ b/extraction.py
@@ -60,7 +60,8 @@ def _call_extraction_llm(prompt: str, model: str = "",
         content = response.choices[0].message.content
         if not isinstance(content, str):
             content = str(content) if content else ""
-        return content.strip()
+        from .escalation import _strip_reasoning_blocks
+        return _strip_reasoning_blocks(content).strip()
     except Exception as e:
         logger.debug("Extraction LLM call failed: %s", e)
         return None

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -35,6 +35,20 @@ class TestEscalationStripReasoning:
     blocks within message.content; without stripping, the reasoning text gets
     persisted as the summary node and confuses downstream lcm_expand_query."""
 
+    def _install_fake_auxiliary_client(self, monkeypatch, fake_call_llm):
+        """Install a minimal agent.auxiliary_client module for CI, where the
+        hermes-agent package is only stubbed enough for ContextEngine tests."""
+        import sys
+        import types
+
+        agent_mod = sys.modules.get("agent") or types.ModuleType("agent")
+        aux_mod = types.ModuleType("agent.auxiliary_client")
+        aux_mod.call_llm = fake_call_llm
+        agent_mod.auxiliary_client = aux_mod
+        monkeypatch.setitem(sys.modules, "agent", agent_mod)
+        monkeypatch.setitem(sys.modules, "agent.auxiliary_client", aux_mod)
+        return aux_mod
+
     def test_strip_reasoning_blocks_handles_each_supported_tag(self):
         from hermes_lcm.escalation import _strip_reasoning_blocks
 
@@ -97,10 +111,9 @@ class TestEscalationStripReasoning:
         def fake_call_llm(**kwargs):
             return _FakeResponse(contaminated)
 
-        # Patch the import inside _call_llm_for_summary by monkeypatching the
+        # Patch the import inside _call_llm_for_summary by providing the
         # module the function imports from at call time.
-        import agent.auxiliary_client as aux
-        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = esc._call_llm_for_summary(
             prompt="please summarize",
@@ -144,8 +157,7 @@ class TestEscalationStripReasoning:
         def fake_call_llm(**kwargs):
             return _FakeResponse(contaminated)
 
-        import agent.auxiliary_client as aux
-        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = tools_mod._synthesize_expansion_answer(
             prompt="What was discussed?",
@@ -193,8 +205,7 @@ class TestEscalationStripReasoning:
         def fake_call_llm(**kwargs):
             return _FakeResponse(contaminated)
 
-        import agent.auxiliary_client as aux
-        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
 
         result = extr._call_extraction_llm(
             prompt="extract decisions",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -161,6 +161,53 @@ class TestEscalationStripReasoning:
         assert "We discussed the docker rollout plan" in result
 
 
+    def test_call_extraction_llm_strips_reasoning_from_response(self, monkeypatch):
+        """Integration: pre-compaction extraction routes through
+        extraction._call_extraction_llm, the third LLM call path on top of
+        _call_llm_for_summary (escalation) and _synthesize_expansion_answer
+        (tools). All three must strip reasoning blocks before returning,
+        otherwise the daily extraction .md file ends up with the model's
+        internal reasoning instead of clean bullet points."""
+        import hermes_lcm.extraction as extr
+
+        class _FakeMessage:
+            def __init__(self, content):
+                self.content = content
+
+        class _FakeChoice:
+            def __init__(self, content):
+                self.message = _FakeMessage(content)
+
+        class _FakeResponse:
+            def __init__(self, content):
+                self.choices = [_FakeChoice(content)]
+
+        contaminated = (
+            "<think>Let me extract the relevant information from this "
+            "conversation segment. Decisions made: ... Let me format these "
+            "as clean bullet points.</think>"
+            "- Decision: ship docker rollout on 2026-07-22\n"
+            "- Action: Yvonne files FCC paperwork by 2026-06-30"
+        )
+
+        def fake_call_llm(**kwargs):
+            return _FakeResponse(contaminated)
+
+        import agent.auxiliary_client as aux
+        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+
+        result = extr._call_extraction_llm(
+            prompt="extract decisions",
+            model="any",
+            timeout=10.0,
+        )
+
+        assert result is not None
+        assert "<think>" not in result
+        assert "</think>" not in result
+        assert "Decision: ship docker rollout" in result
+
+
 class TestEngineABC:
     def test_is_context_engine(self, engine):
         assert isinstance(engine, ContextEngine)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -28,6 +28,93 @@ def engine(tmp_path):
     return e
 
 
+class TestEscalationStripReasoning:
+    """Regression tests for thinking-model reasoning-tag stripping in
+    escalation._call_llm_for_summary. Some thinking models (MiniMax-M2.7,
+    GLM-5.1, Qwen QwQ, DeepSeek R1) inline reasoning inside <think>...</think>
+    blocks within message.content; without stripping, the reasoning text gets
+    persisted as the summary node and confuses downstream lcm_expand_query."""
+
+    def test_strip_reasoning_blocks_handles_each_supported_tag(self):
+        from hermes_lcm.escalation import _strip_reasoning_blocks
+
+        cases = [
+            ("<think>internal reasoning</think>final summary", "final summary"),
+            ("<thinking>plan</thinking>actual content", "actual content"),
+            ("<reasoning>scratch</reasoning>output", "output"),
+            ("<thought>idea</thought>summary text", "summary text"),
+            ("<REASONING_SCRATCHPAD>foo</REASONING_SCRATCHPAD>bar", "bar"),
+            ("multi\n<think>line\nblock</think>\nrest", "multi\n\nrest"),
+            ("plain text without tags", "plain text without tags"),
+            ("", ""),
+        ]
+        for raw, expected in cases:
+            got = _strip_reasoning_blocks(raw)
+            assert got == expected, f"input={raw!r} expected={expected!r} got={got!r}"
+
+    def test_strip_reasoning_blocks_is_idempotent(self):
+        from hermes_lcm.escalation import _strip_reasoning_blocks
+
+        once = _strip_reasoning_blocks("<think>foo</think>bar")
+        twice = _strip_reasoning_blocks(once)
+        assert once == twice == "bar"
+
+    def test_strip_reasoning_blocks_handles_multiple_blocks(self):
+        from hermes_lcm.escalation import _strip_reasoning_blocks
+
+        raw = "<think>a</think>visible1<think>b</think>visible2"
+        assert _strip_reasoning_blocks(raw) == "visible1visible2"
+
+    def test_strip_reasoning_blocks_preserves_content_with_unrelated_angle_brackets(self):
+        from hermes_lcm.escalation import _strip_reasoning_blocks
+
+        raw = "Decision: x < y, and config <foo> stays"
+        assert _strip_reasoning_blocks(raw) == raw
+
+    def test_call_llm_for_summary_strips_reasoning_from_response(self, monkeypatch):
+        """Integration: when the auxiliary LLM returns reasoning-contaminated
+        content, _call_llm_for_summary returns the stripped summary text."""
+        import hermes_lcm.escalation as esc
+
+        class _FakeMessage:
+            def __init__(self, content):
+                self.content = content
+
+        class _FakeChoice:
+            def __init__(self, content):
+                self.message = _FakeMessage(content)
+
+        class _FakeResponse:
+            def __init__(self, content):
+                self.choices = [_FakeChoice(content)]
+
+        contaminated = (
+            "<think>The user asks me to compress this into bullet points. "
+            "I should focus on decisions, files, errors, current state...</think>"
+            "Summary: docker rollout completed. Auth migration pending review."
+        )
+
+        def fake_call_llm(**kwargs):
+            return _FakeResponse(contaminated)
+
+        # Patch the import inside _call_llm_for_summary by monkeypatching the
+        # module the function imports from at call time.
+        import agent.auxiliary_client as aux
+        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+
+        result = esc._call_llm_for_summary(
+            prompt="please summarize",
+            max_tokens=200,
+            model="any",
+            timeout=10.0,
+        )
+
+        assert result is not None
+        assert "<think>" not in result
+        assert "</think>" not in result
+        assert "Summary: docker rollout completed" in result
+
+
 class TestEngineABC:
     def test_is_context_engine(self, engine):
         assert isinstance(engine, ContextEngine)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -115,6 +115,52 @@ class TestEscalationStripReasoning:
         assert "Summary: docker rollout completed" in result
 
 
+    def test_synthesize_expansion_answer_strips_reasoning_from_response(self, monkeypatch):
+        """Integration: lcm_expand_query routes through
+        tools._synthesize_expansion_answer, which is a separate LLM call path
+        from _call_llm_for_summary. Both must strip reasoning blocks before
+        returning, otherwise expand_query answers leak the model's internal
+        reasoning back to the caller."""
+        import hermes_lcm.tools as tools_mod
+
+        class _FakeMessage:
+            def __init__(self, content):
+                self.content = content
+
+        class _FakeChoice:
+            def __init__(self, content):
+                self.message = _FakeMessage(content)
+
+        class _FakeResponse:
+            def __init__(self, content):
+                self.choices = [_FakeChoice(content)]
+
+        contaminated = (
+            "<think>The user is asking what was discussed. Let me look at the "
+            "context blocks and synthesize an answer...</think>"
+            "We discussed the docker rollout plan and auth migration."
+        )
+
+        def fake_call_llm(**kwargs):
+            return _FakeResponse(contaminated)
+
+        import agent.auxiliary_client as aux
+        monkeypatch.setattr(aux, "call_llm", fake_call_llm)
+
+        result = tools_mod._synthesize_expansion_answer(
+            prompt="What was discussed?",
+            context_blocks=[{"role": "user", "content": "ignored in fake"}],
+            model="any",
+            max_tokens=200,
+            timeout=10.0,
+        )
+
+        assert result is not None
+        assert "<think>" not in result
+        assert "</think>" not in result
+        assert "We discussed the docker rollout plan" in result
+
+
 class TestEngineABC:
     def test_is_context_engine(self, engine):
         assert isinstance(engine, ContextEngine)

--- a/tools.py
+++ b/tools.py
@@ -237,7 +237,8 @@ def _synthesize_expansion_answer(
     content = response.choices[0].message.content
     if not isinstance(content, str):
         content = str(content) if content else ""
-    return content.strip()
+    from .escalation import _strip_reasoning_blocks
+    return _strip_reasoning_blocks(content).strip()
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:


### PR DESCRIPTION
Some thinking models (MiniMax-M2.7, GLM-5.1, Qwen QwQ, DeepSeek R1) inline their reasoning inside <think>...</think> blocks within message.content. _call_llm_for_summary returns this content directly to the engine, which persists it as the summary node text.

This causes two downstream problems:

1. The stored summary contains the model's internal reasoning, not just the requested summary, so it consumes tokens that should have been the actual summary.
2. The reasoning text frequently quotes the summarizer system prompt verbatim. When lcm_expand_query later feeds that summary back to the model as context for synthesis, the model treats it as a summarization task and produces a reply that talks about the summarization process rather than answering the user's actual question.

Reproduction with MiniMax-M2.7-highspeed: the stored DAG summary contained a verbatim <think>...</think> block quoting the summarizer's bullet-point instructions, and a subsequent lcm_expand_query call produced an answer that re-stated the summarization instructions instead of answering the asked question.

The host hermes-agent already strips these tags from primary responses in run_agent.py around line 3098-3100; the auxiliary client used by LCM does not, so the same pattern needs to apply locally before the summary text is returned.

Add _strip_reasoning_blocks() with a regex matching <think>, <thinking>, <reasoning>, <thought>, and <REASONING_SCRATCHPAD> tags (case-insensitive, DOTALL). Call it on the response content before strip() and return.

Tests:
- Unit tests for each supported tag, multiple blocks, idempotency, and preservation of content with unrelated angle brackets.
- Integration test that monkeypatches agent.auxiliary_client.call_llm to return contaminated content and asserts the returned summary is clean.

All 5 tests pass:
  pytest tests/test_lcm_engine.py::TestEscalationStripReasoning -q 5 passed in 0.25s