### PR TITLE
fix: continue LCM state across compression boundaries

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -21,6 +21,7 @@ from .externalize import (
     build_transcript_gc_placeholder,
     maybe_externalize_tool_output,
     find_externalized_payload_for_message,
+    reassign_externalized_payloads,
 )
 from .extraction import (
     extract_before_compaction,
@@ -595,12 +596,19 @@ class LCMEngine(ContextEngine):
             )
             moved_messages = self._store.reassign_session_messages(old_session_id, session_id)
             moved_nodes = self._dag.reassign_session_nodes(old_session_id, session_id)
+            moved_payloads = reassign_externalized_payloads(
+                old_session_id,
+                session_id,
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
             logger.debug(
-                "LCM compression boundary continued %s -> %s: moved %d messages, %d DAG nodes",
+                "LCM compression boundary continued %s -> %s: moved %d messages, %d DAG nodes, %d externalized payloads",
                 old_session_id,
                 session_id,
                 moved_messages,
                 moved_nodes,
+                moved_payloads,
             )
         elif old_session_id:
             logger.warning(
@@ -608,6 +616,14 @@ class LCMEngine(ContextEngine):
                 old_session_id,
                 previous_session_id,
             )
+            self._reset_session_scoped_runtime_state()
+            self._apply_session_start_metadata(session_id, kwargs)
+            self._bind_lifecycle_state(
+                session_id,
+                conversation_id=kwargs.get("conversation_id"),
+            )
+            self._log_session_filter_diagnostics()
+            return
 
         self._apply_session_start_metadata(session_id, kwargs)
         self._bind_lifecycle_state(session_id, conversation_id=conversation_id)

--- a/engine.py
+++ b/engine.py
@@ -548,15 +548,7 @@ class LCMEngine(ContextEngine):
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
 
-    def on_session_start(self, session_id: str, **kwargs) -> None:
-        previous_session_id = self._session_id
-        if previous_session_id and previous_session_id != session_id:
-            self._reset_session_scoped_runtime_state()
-        else:
-            self._ingest_cursor = 0
-            self._last_compacted_store_id = 0
-            self._last_overflow_recovery_failed = False
-            self._last_condensation_suppressed_reason = ""
+    def _apply_session_start_metadata(self, session_id: str, kwargs: Dict[str, Any]) -> None:
         self._session_id = session_id
         self._session_platform = str(kwargs.get("platform") or "")
         self._refresh_session_filters()
@@ -568,6 +560,83 @@ class LCMEngine(ContextEngine):
             self.threshold_tokens = int(
                 self.context_length * self._config.context_threshold
             )
+
+    def _continue_compression_boundary(
+        self,
+        session_id: str,
+        old_session_id: str,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        previous_session_id = self._session_id
+        prior_state = self._lifecycle.get_by_session(old_session_id)
+        conversation_id = (
+            kwargs.get("conversation_id")
+            or self._conversation_id
+            or (prior_state.conversation_id if prior_state else None)
+            or old_session_id
+            or session_id
+        )
+        frontier = max(
+            int(self._last_compacted_store_id or 0),
+            int(prior_state.current_frontier_store_id if prior_state else 0),
+        )
+        can_reassign = bool(
+            old_session_id
+            and session_id
+            and old_session_id != session_id
+            and (not previous_session_id or previous_session_id == old_session_id)
+        )
+
+        if can_reassign:
+            self._lifecycle.finalize_session(
+                conversation_id,
+                old_session_id,
+                frontier_store_id=frontier,
+            )
+            moved_messages = self._store.reassign_session_messages(old_session_id, session_id)
+            moved_nodes = self._dag.reassign_session_nodes(old_session_id, session_id)
+            logger.debug(
+                "LCM compression boundary continued %s -> %s: moved %d messages, %d DAG nodes",
+                old_session_id,
+                session_id,
+                moved_messages,
+                moved_nodes,
+            )
+        elif old_session_id:
+            logger.warning(
+                "LCM compression boundary skipped carry-over: old_session_id=%s does not match bound session=%s",
+                old_session_id,
+                previous_session_id,
+            )
+
+        self._apply_session_start_metadata(session_id, kwargs)
+        self._bind_lifecycle_state(session_id, conversation_id=conversation_id)
+        if frontier > 0:
+            state = self._lifecycle.advance_frontier(
+                self._conversation_id,
+                session_id,
+                frontier,
+            )
+            if state is not None:
+                self._last_compacted_store_id = state.current_frontier_store_id
+        self._log_session_filter_diagnostics()
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        boundary_reason = str(kwargs.get("boundary_reason") or "")
+        old_session_id = str(kwargs.get("old_session_id") or "")
+        if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
+            self._continue_compression_boundary(session_id, old_session_id, kwargs)
+            return
+
+        previous_session_id = self._session_id
+        if previous_session_id and previous_session_id != session_id:
+            self._reset_session_scoped_runtime_state()
+        else:
+            self._ingest_cursor = 0
+            self._last_compacted_store_id = 0
+            self._last_overflow_recovery_failed = False
+            self._last_condensation_suppressed_reason = ""
+        self._apply_session_start_metadata(session_id, kwargs)
         self._bind_lifecycle_state(
             session_id,
             conversation_id=kwargs.get("conversation_id"),
@@ -699,6 +768,14 @@ class LCMEngine(ContextEngine):
 
     def get_status(self) -> Dict[str, Any]:
         status = super().get_status()
+        status.update({
+            "compression_count": self.compression_count,
+            "last_prompt_tokens": self.last_prompt_tokens,
+            "last_completion_tokens": self.last_completion_tokens,
+            "last_total_tokens": self.last_total_tokens,
+            "context_length": self.context_length,
+            "threshold_tokens": self.threshold_tokens,
+        })
         lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
         status["engine"] = "lcm"
         try:

--- a/externalize.py
+++ b/externalize.py
@@ -95,6 +95,46 @@ def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dic
     return summary
 
 
+def reassign_externalized_payloads(
+    old_session_id: str,
+    new_session_id: str,
+    *,
+    config,
+    hermes_home: str = "",
+) -> int:
+    """Move externalized payload session metadata across a logical session boundary."""
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return 0
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    if not storage_dir.exists() or not storage_dir.is_dir():
+        return 0
+
+    moved = 0
+    for path in storage_dir.glob("*.json"):
+        if not path.is_file():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if (payload.get("session_id") or "") != old_session_id:
+            continue
+        payload["session_id"] = new_session_id
+        tmp_path = path.with_name(f"{path.name}.tmp")
+        try:
+            tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            tmp_path.replace(path)
+        except OSError as exc:
+            logger.warning("Externalized payload session reassignment skipped for %s: %s", path.name, exc)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            continue
+        moved += 1
+    return moved
+
+
 def find_externalized_payload_for_message(
     content: str,
     *,

--- a/store.py
+++ b/store.py
@@ -303,6 +303,17 @@ class MessageStore:
                 ids.append(cur.lastrowid)
         return ids
 
+    def reassign_session_messages(self, old_session_id: str, new_session_id: str) -> int:
+        """Move all persisted messages from one session_id to another."""
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return 0
+        cur = self._conn.execute(
+            "UPDATE messages SET session_id = ? WHERE session_id = ?",
+            (new_session_id, old_session_id),
+        )
+        self._conn.commit()
+        return cur.rowcount if cur.rowcount is not None else 0
+
     def delete_session_messages(self, session_id: str) -> int:
         """Delete all messages for a session. Returns count deleted."""
         cur = self._conn.execute(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1397,6 +1397,82 @@ class TestSessionRollover:
         assert status["lifecycle"]["last_rollover_at"] is not None
         assert status["lifecycle"]["last_reset_at"] is None
 
+    def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
+        engine.on_session_start("bound-session", platform="telegram", context_length=200000)
+        engine.compression_count = 3
+        engine.last_prompt_tokens = 900
+        engine.last_completion_tokens = 12
+        engine.last_total_tokens = 912
+        engine._last_compacted_store_id = 42
+        engine._ingest_cursor = 7
+        old_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "new-session",
+            boundary_reason="compression",
+            old_session_id="different-old-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-session"
+        assert engine._conversation_id != old_conversation_id
+        assert engine.compression_count == 0
+        assert engine.last_prompt_tokens == 0
+        assert engine.last_completion_tokens == 0
+        assert engine.last_total_tokens == 0
+        assert engine._last_compacted_store_id == 0
+        assert engine._ingest_cursor == 0
+
+    def test_compression_boundary_reassigns_externalized_payload_session_metadata(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_compression_externalized.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine.on_session_start("old-session", platform="telegram", context_length=200000)
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        payload_file = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json"))
+        placeholder = (
+            "[Externalized tool output: tool_call_id=call_big; "
+            f"chars={len(content)}; bytes={len(content.encode('utf-8'))}; ref={payload_file.name}]"
+        )
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "tool", "tool_call_id": "call_big", "content": placeholder},
+            token_estimate=17,
+            source="telegram",
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-session",
+            depth=0,
+            summary="Externalized tool-output summary",
+            token_count=10,
+            source_token_count=17,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        assert json.loads(payload_file.read_text())["session_id"] == "old-session"
+
+        engine.on_session_start(
+            "new-session",
+            boundary_reason="compression",
+            old_session_id="old-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert json.loads(payload_file.read_text())["session_id"] == "new-session"
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+        assert result["expanded"][0]["externalized"]["session_id"] == "new-session"
+        assert result["expanded"][0]["externalized"]["tool_call_id"] == "call_big"
+
     def test_rollover_session_records_durable_lifecycle_state_idempotently(self, engine):
         engine._config.new_session_retain_depth = 2
         from hermes_lcm.dag import SummaryNode

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1337,6 +1337,66 @@ class TestSessionRollover:
         assert engine._dag.get_session_nodes("attacker-new") == []
         assert engine._session_id == "attacker-new"
 
+    def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
+        engine.on_session_start("old-session", platform="telegram", context_length=200000)
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "important pre-rollover context"},
+            token_estimate=17,
+            source="telegram",
+        )
+        engine._dag.add_node(SummaryNode(
+            session_id="old-session",
+            depth=0,
+            summary="pre-rollover summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine.compression_count = 1
+        engine.last_prompt_tokens = 1000
+        engine.last_completion_tokens = 50
+        engine.last_total_tokens = 1050
+        engine._last_compacted_store_id = store_id
+        engine._ingest_cursor = 2
+        old_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "new-session",
+            boundary_reason="compression",
+            old_session_id="old-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-session"
+        assert engine._conversation_id == old_conversation_id
+        assert engine.compression_count == 1
+        assert engine.last_prompt_tokens == 1000
+        assert engine.last_completion_tokens == 50
+        assert engine.last_total_tokens == 1050
+        assert engine._last_compacted_store_id == store_id
+        assert engine._ingest_cursor == 2
+        assert engine._store.get_session_count("old-session") == 0
+        assert engine._store.get_session_count("new-session") == 1
+        assert engine._dag.get_session_nodes("old-session") == []
+        new_nodes = engine._dag.get_session_nodes("new-session")
+        assert len(new_nodes) == 1
+        assert new_nodes[0].summary == "pre-rollover summary"
+
+        status = engine.get_status()
+        assert status["store_messages"] == 1
+        assert status["dag_nodes"] == 1
+        assert status["compression_count"] == 1
+        assert status["lifecycle"]["current_session_id"] == "new-session"
+        assert status["lifecycle"]["last_finalized_session_id"] == "old-session"
+        assert status["lifecycle"]["current_frontier_store_id"] == store_id
+        assert status["lifecycle"]["last_finalized_frontier_store_id"] == store_id
+        assert status["lifecycle"]["last_rollover_at"] is not None
+        assert status["lifecycle"]["last_reset_at"] is None
+
     def test_rollover_session_records_durable_lifecycle_state_idempotently(self, engine):
         engine._config.new_session_retain_depth = 2
         from hermes_lcm.dag import SummaryNode


### PR DESCRIPTION
## Summary
- consume the Hermes host `boundary_reason="compression"` / `old_session_id` signal in `LCMEngine.on_session_start()`
- continue the same logical LCM conversation across compression-created physical session IDs
- move existing persisted messages and DAG nodes to the new physical session while preserving compaction counters and frontier state

## Why
- Hermes Agent #16306 now emits an explicit compression-boundary signal after automatic session splits
- #68 still needed the plugin-side half: LCM must treat that boundary as continuation, not a fresh `/new`-style bind
- this prevents the bad post-rollover status shape where a live session can show `compression_count > 0` with empty current-session storage/DAG state

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_continues_logical_session_without_resetting_state -q`
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover -q`
- `python -m pytest tests/test_lcm_engine.py tests/test_lcm_command.py -q`
- `ulimit -n 4096 && HERMES_HOME="$tmpdir/.hermes" python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` — 270 passed
- `ulimit -n 4096 && HERMES_HOME="$tmpdir/.hermes" python -m pytest -q` — 295 passed
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`

## Notes
- Refs #68
- Requires a Hermes Agent host that emits the compression boundary signal from NousResearch/hermes-agent#16306 for the live integration path
- This does not cover the separate upstream per-turn ingest hook in NousResearch/hermes-agent#15806
