### PR TITLE
fix: harden SQLite message persistence

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -238,8 +238,7 @@ class SummaryDAG:
             (session_id, min_depth),
         )
         deleted = cur.rowcount
-        if deleted:
-            self._conn.commit()
+        self._conn.commit()
         return deleted
 
     def delete_session_nodes(self, session_id: str) -> int:
@@ -249,8 +248,7 @@ class SummaryDAG:
             (session_id,),
         )
         deleted = cur.rowcount
-        if deleted:
-            self._conn.commit()
+        self._conn.commit()
         return deleted
 
     def reassign_session_nodes(self, old_session_id: str, new_session_id: str) -> int:
@@ -264,8 +262,7 @@ class SummaryDAG:
             (new_session_id, old_session_id),
         )
         moved = cur.rowcount
-        if moved:
-            self._conn.commit()
+        self._conn.commit()
         return moved
 
     # -- Read ---------------------------------------------------------------

--- a/engine.py
+++ b/engine.py
@@ -35,7 +35,8 @@ from .session_patterns import (
     matches_session_pattern,
 )
 from .lifecycle_state import LifecycleStateStore
-from .store import MessageStore, _normalize_content_value
+from .message_content import normalize_content_value
+from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
@@ -943,7 +944,7 @@ class LCMEngine(ContextEngine):
         store_idx = 0
         for msg in messages:
             role = msg.get("role", "")
-            content = _normalize_content_value(msg.get("content")) or ""
+            content = normalize_content_value(msg.get("content")) or ""
             probe_idx = store_idx
             while probe_idx < len(candidates):
                 stored = candidates[probe_idx]

--- a/engine.py
+++ b/engine.py
@@ -35,7 +35,7 @@ from .session_patterns import (
     matches_session_pattern,
 )
 from .lifecycle_state import LifecycleStateStore
-from .store import MessageStore
+from .store import MessageStore, _normalize_content_value
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
@@ -943,7 +943,7 @@ class LCMEngine(ContextEngine):
         store_idx = 0
         for msg in messages:
             role = msg.get("role", "")
-            content = msg.get("content") or ""
+            content = _normalize_content_value(msg.get("content")) or ""
             probe_idx = store_idx
             while probe_idx < len(candidates):
                 stored = candidates[probe_idx]

--- a/message_content.py
+++ b/message_content.py
@@ -1,0 +1,30 @@
+"""Message content normalization helpers.
+
+Hermes/OpenAI-format messages may carry ``content`` as plain text or as
+structured content parts (for example text + image blocks). LCM persists and
+accounts for message content as text, so all write/matching/token paths should
+use the same normalization.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def normalize_content_value(content: Any) -> str | None:
+    """Return a stable text representation for message content.
+
+    ``None`` remains ``None`` so callers that distinguish SQL NULL from an empty
+    string can preserve that behavior. Strings are returned unchanged. Structured
+    content is serialized deterministically so storage, source-id matching, and
+    token accounting all see the same value.
+    """
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(content)

--- a/store.py
+++ b/store.py
@@ -56,6 +56,18 @@ def _normalize_source_value(source: str | None) -> str:
     return normalized or _UNKNOWN_SOURCE
 
 
+def _normalize_content_value(content: Any) -> str | None:
+    """Return a SQLite-safe text value for message content."""
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(content)
+
+
 def _source_filter_clause(column: str, source: str | None) -> tuple[str | None, list[str]]:
     normalized = _normalize_source_value(source) if source is not None else ""
     if not normalized:
@@ -256,7 +268,7 @@ class MessageStore:
                 session_id,
                 _normalize_source_value(source),
                 msg.get("role", "unknown"),
-                msg.get("content"),
+                _normalize_content_value(msg.get("content")),
                 msg.get("tool_call_id"),
                 tc_json,
                 msg.get("tool_name"),
@@ -291,7 +303,7 @@ class MessageStore:
                         session_id,
                         _normalize_source_value(source),
                         msg.get("role", "unknown"),
-                        msg.get("content"),
+                        _normalize_content_value(msg.get("content")),
                         msg.get("tool_call_id"),
                         tc_json,
                         msg.get("tool_name"),

--- a/store.py
+++ b/store.py
@@ -38,6 +38,7 @@ from .search_query import (
     AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
+from .message_content import normalize_content_value as _normalize_content_value
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -54,18 +55,6 @@ _UNKNOWN_SOURCE = "unknown"
 def _normalize_source_value(source: str | None) -> str:
     normalized = (source or "").strip()
     return normalized or _UNKNOWN_SOURCE
-
-
-def _normalize_content_value(content: Any) -> str | None:
-    """Return a SQLite-safe text value for message content."""
-    if content is None:
-        return None
-    if isinstance(content, str):
-        return content
-    try:
-        return json.dumps(content, ensure_ascii=False, sort_keys=True)
-    except (TypeError, ValueError):
-        return str(content)
 
 
 def _source_filter_clause(column: str, source: str | None) -> tuple[str | None, list[str]]:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1470,6 +1470,30 @@ class TestSummaryDAG:
     def dag(self, tmp_path):
         return SummaryDAG(tmp_path / "test.db")
 
+    def _assert_write_lock_obtainable(self, db_path):
+        conn = sqlite3.connect(db_path, timeout=0.1)
+        conn.execute("PRAGMA busy_timeout=100")
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.rollback()
+        finally:
+            conn.close()
+
+    def test_noop_write_helpers_do_not_leave_database_locked(self, tmp_path):
+        db_path = tmp_path / "noop-write-lock.db"
+        dag = SummaryDAG(db_path)
+
+        assert dag.reassign_session_nodes("missing-old", "missing-new") == 0
+        self._assert_write_lock_obtainable(db_path)
+
+        assert dag.delete_session_nodes("missing-session") == 0
+        self._assert_write_lock_obtainable(db_path)
+
+        assert dag.delete_below_depth("missing-session", 1) == 0
+        self._assert_write_lock_obtainable(db_path)
+
+        dag.close()
+
     def test_add_and_get(self, dag):
         node = SummaryNode(
             session_id="s1", depth=0,

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -333,6 +333,20 @@ class TestTokens:
         msg = {"role": "user", "content": "hello world this is a test"}
         assert count_message_tokens(msg) > 0
 
+    def test_count_message_tokens_normalizes_content_parts(self):
+        content = [
+            {"type": "text", "text": "hello from content parts " * 50},
+            {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+        ]
+        msg = {"role": "user", "content": content}
+        normalized_msg = {
+            "role": "user",
+            "content": json.dumps(content, ensure_ascii=False, sort_keys=True),
+        }
+
+        assert count_message_tokens(msg) == count_message_tokens(normalized_msg)
+        assert count_message_tokens(msg) > 100
+
     def test_count_messages_tokens(self):
         msgs = [
             {"role": "user", "content": "hello"},

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -363,6 +363,36 @@ class TestMessageStore:
         assert len(ids) == 3
         assert ids[0] < ids[1] < ids[2]
 
+    def test_append_batch_accepts_content_parts(self, store):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello from content parts"},
+                    {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+                ],
+            }
+        ]
+
+        ids = store.append_batch("sess1", msgs, [7], source="telegram")
+
+        retrieved = store.get(ids[0])
+        assert isinstance(retrieved["content"], str)
+        assert "hello from content parts" in retrieved["content"]
+        results = store.search("hello", session_id="sess1")
+        assert [result["store_id"] for result in results] == ids
+
+    def test_append_accepts_content_parts(self, store):
+        sid = store.append(
+            "sess1",
+            {"role": "assistant", "content": [{"type": "text", "text": "assistant part text"}]},
+            token_estimate=3,
+        )
+
+        retrieved = store.get(sid)
+        assert isinstance(retrieved["content"], str)
+        assert "assistant part text" in retrieved["content"]
+
     def test_get_range(self, store):
         msgs = [{"role": "user", "content": f"msg {i}"} for i in range(10)]
         ids = store.append_batch("sess1", msgs)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -555,6 +555,49 @@ class TestEngineCompress:
         finally:
             engine_module.summarize_with_escalation = original_fn
 
+    def test_compress_leaf_node_tracks_source_ids_for_content_part_messages(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_content_parts.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("content-parts-session", platform="cli", context_length=200000)
+
+        def mock_summary(**kwargs):
+            return "Content parts summary.\nExpand for details about: content parts", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        compacted_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "question text inside content parts"},
+                    {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "answer text inside content parts"}],
+            },
+        ]
+        fresh_tail = [
+            {"role": "user", "content": "fresh user tail"},
+            {"role": "assistant", "content": "fresh assistant tail"},
+        ]
+        messages = [{"role": "system", "content": "sys"}] + compacted_messages + fresh_tail
+
+        result = instance.compress(messages)
+
+        nodes = instance._dag.get_session_nodes("content-parts-session")
+        stored_rows = instance._store.get_session_messages("content-parts-session")
+        expected_store_ids = [row["store_id"] for row in stored_rows[1:3]]
+        assert len(nodes) == 1
+        assert nodes[0].source_ids == expected_store_ids
+        assert instance._last_compacted_store_id == expected_store_ids[-1]
+        assert result[-2:] == fresh_tail
+
     def test_condensed_parent_node_tracks_child_source_window(self, engine, monkeypatch):
         child_windows = [
             (1_700_000_010, 1_700_000_020),

--- a/tokens.py
+++ b/tokens.py
@@ -6,6 +6,8 @@ Uses tiktoken when available, falls back to char-based estimate.
 import logging
 from typing import Any, Dict, List
 
+from .message_content import normalize_content_value
+
 logger = logging.getLogger(__name__)
 
 _CHARS_PER_TOKEN = 4
@@ -43,7 +45,7 @@ def count_tokens(text: str) -> int:
 def count_message_tokens(msg: Dict[str, Any]) -> int:
     """Estimate tokens for a single OpenAI-format message."""
     total = 4  # role + overhead
-    content = msg.get("content") or ""
+    content = normalize_content_value(msg.get("content")) or ""
     total += count_tokens(content)
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):


### PR DESCRIPTION
## Summary
- commit SQLite write transactions even when DAG update/delete helpers affect zero rows
- normalize non-string message content before inserting into the message store
- add regressions for no-op DAG write locks and list-form content parts

## Why
- no-op DAG writes can still open SQLite write transactions, which can leave later LCM ingestion blocked with `database is locked`
- gateway message history can contain OpenAI-style content-part lists, but the message store persists `content` into a SQLite `TEXT` column
- storing those lists directly raises `sqlite3.ProgrammingError: Error binding parameter 4: type 'list' is not supported`

## Validation
- `python -m pytest tests/test_lcm_core.py::TestMessageStore::test_append_batch_accepts_content_parts tests/test_lcm_core.py::TestMessageStore::test_append_accepts_content_parts -q -o addopts=''` -> 2 passed
- `python -m pytest tests/test_lcm_core.py::TestMessageStore tests/test_lcm_core.py::TestSummaryDAG tests/test_lcm_engine.py::TestSessionRollover -q -o addopts=''` -> 95 passed
- `HERMES_HOME="$tmpdir/.hermes" python -m pytest -q -o addopts=''` -> 300 passed
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check origin/main..HEAD`
- isolated MessageStore smoke test with list-form content parts
- isolated LCMEngine.compress smoke test with list-form content parts
- live Turing gateway restart plus `lcm_doctor` healthy

## Notes
- no matching open PRs or issues found for `database is locked`, `Error binding parameter 4`, content parts, `append_batch`, or `MessageStore`
- docs not updated because this is internal persistence hardening with no user-facing command, schema, or config change
