### PR TITLE
fix: preserve LCM DAG across split compression boundaries

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -570,42 +570,65 @@ class LCMEngine(ContextEngine):
         kwargs: Dict[str, Any],
     ) -> None:
         previous_session_id = self._session_id
-        prior_state = self._lifecycle.get_by_session(old_session_id)
+        old_state = self._lifecycle.get_by_session(old_session_id)
+        source_session_id = old_session_id
+        source_state = old_state
+
+        if previous_session_id and previous_session_id != old_session_id:
+            bound_state = self._lifecycle.get_by_session(previous_session_id)
+            bound_is_current_conversation = bool(
+                bound_state
+                and bound_state.current_session_id == previous_session_id
+                and (not self._conversation_id or bound_state.conversation_id == self._conversation_id)
+            )
+            bound_has_summary_nodes = bool(self._dag.get_session_nodes(previous_session_id))
+            if bound_is_current_conversation and bound_has_summary_nodes:
+                source_session_id = previous_session_id
+                source_state = bound_state
+                logger.warning(
+                    "LCM compression boundary using bound session %s as carry-over source; host old_session_id=%s does not match",
+                    previous_session_id,
+                    old_session_id,
+                )
+            else:
+                source_session_id = ""
+                source_state = None
+
         conversation_id = (
             kwargs.get("conversation_id")
             or self._conversation_id
-            or (prior_state.conversation_id if prior_state else None)
+            or (source_state.conversation_id if source_state else None)
+            or source_session_id
             or old_session_id
             or session_id
         )
         frontier = max(
             int(self._last_compacted_store_id or 0),
-            int(prior_state.current_frontier_store_id if prior_state else 0),
+            int(source_state.current_frontier_store_id if source_state else 0),
         )
         can_reassign = bool(
-            old_session_id
+            source_session_id
             and session_id
-            and old_session_id != session_id
-            and (not previous_session_id or previous_session_id == old_session_id)
+            and source_session_id != session_id
         )
 
         if can_reassign:
             self._lifecycle.finalize_session(
                 conversation_id,
-                old_session_id,
+                source_session_id,
                 frontier_store_id=frontier,
             )
-            moved_messages = self._store.reassign_session_messages(old_session_id, session_id)
-            moved_nodes = self._dag.reassign_session_nodes(old_session_id, session_id)
+            moved_messages = self._store.reassign_session_messages(source_session_id, session_id)
+            moved_nodes = self._dag.reassign_session_nodes(source_session_id, session_id)
             moved_payloads = reassign_externalized_payloads(
-                old_session_id,
+                source_session_id,
                 session_id,
                 config=self._config,
                 hermes_home=self._hermes_home,
             )
             logger.debug(
                 "LCM compression boundary continued %s -> %s: moved %d messages, %d DAG nodes, %d externalized payloads",
-                old_session_id,
+                source_session_id,
                 session_id,
                 moved_messages,
                 moved_nodes,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1440,6 +1440,83 @@ class TestSessionRollover:
         assert status["lifecycle"]["last_rollover_at"] is not None
         assert status["lifecycle"]["last_reset_at"] is None
 
+    def test_compression_boundary_uses_bound_lcm_source_when_host_old_session_differs(self, engine):
+        engine.on_session_start("lcm-source", platform="telegram", context_length=200000)
+        source_store_id = engine._store.append(
+            "lcm-source",
+            {"role": "user", "content": "important LCM-bound context"},
+            token_estimate=17,
+            source="telegram",
+        )
+        stale_host_store_id = engine._store.append(
+            "old-hermes-session",
+            {"role": "user", "content": "unrelated stale host context"},
+            token_estimate=11,
+            source="telegram",
+        )
+        source_node_id = engine._dag.add_node(SummaryNode(
+            session_id="lcm-source",
+            depth=0,
+            summary="LCM-bound summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[source_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        stale_host_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-hermes-session",
+            depth=0,
+            summary="stale host summary should not move",
+            token_count=5,
+            source_token_count=11,
+            source_ids=[stale_host_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine.compression_count = 2
+        engine.last_prompt_tokens = 1000
+        engine.last_completion_tokens = 50
+        engine.last_total_tokens = 1050
+        engine._last_compacted_store_id = source_store_id
+        engine._ingest_cursor = 2
+        old_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "new-hermes-session",
+            boundary_reason="compression",
+            old_session_id="old-hermes-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-hermes-session"
+        assert engine._conversation_id == old_conversation_id
+        assert engine.compression_count == 2
+        assert engine.last_prompt_tokens == 1000
+        assert engine.last_completion_tokens == 50
+        assert engine.last_total_tokens == 1050
+        assert engine._last_compacted_store_id == source_store_id
+        assert engine._ingest_cursor == 2
+        assert engine._store.get_session_count("lcm-source") == 0
+        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("old-hermes-session") == 1
+        assert engine._dag.get_session_nodes("lcm-source") == []
+        new_nodes = engine._dag.get_session_nodes("new-hermes-session")
+        assert len(new_nodes) == 1
+        assert new_nodes[0].node_id == source_node_id
+        assert new_nodes[0].summary == "LCM-bound summary"
+        stale_host_node = engine._dag.get_node(stale_host_node_id)
+        assert stale_host_node is not None
+        assert stale_host_node.session_id == "old-hermes-session"
+
+        status = engine.get_status()
+        assert status["store_messages"] == 1
+        assert status["dag_nodes"] == 1
+        assert status["compression_count"] == 2
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
+        assert expanded["expanded"][0]["content"] == "important LCM-bound context"
+
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)
         engine.compression_count = 3


### PR DESCRIPTION
## Summary
- Preserves LCM DAG continuity when a Hermes compression rollover passes an `old_session_id` that differs from the currently bound LCM session.
- Uses the bound LCM session as the carry-over source only when it is the current lifecycle session and owns summary nodes.
- Leaves stale host `old_session_id` data untouched so unrelated sessions are not reassigned.

## Why
- Fixes #78.
- Users could see `[Recent Summary (d0, node N)]` blocks in the prompt while `lcm_status()` and `lcm_describe()` reported zero current DAG nodes.
- `lcm_expand(node_id=N)` then failed because the summary node still belonged to the LCM-bound source session instead of the active post-compression session.

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_uses_bound_lcm_source_when_host_old_session_differs tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_mismatch_resets_session_scoped_state tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_continues_logical_session_without_resetting_state tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_reassigns_externalized_payload_session_metadata -q` - 4 passed
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover -q` - 11 passed
- `python -m pytest tests/test_lcm_engine.py -q` - 135 passed
- `HERMES_HOME="$tmpdir/.hermes" python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` - 278 passed
- `HERMES_HOME="$tmpdir/.hermes" python -m pytest -q` - 303 passed
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`

## Notes
- The existing safety behavior remains: if the mismatch does not point to a valid bound LCM source with current lifecycle state and summary nodes, the boundary is treated as a real new-session reset.
- Existing externalized payload reassignment coverage remains intact.
