### PR TITLE
fix: clean noisy transcript shapes before compaction

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -42,6 +42,55 @@ from . import tools as lcm_tools
 
 logger = logging.getLogger(__name__)
 
+_SYNTHETIC_ASSISTANT_NOISE = {
+    "ack",
+    "acknowledged",
+    "heartbeat",
+    "heartbeat ack",
+    "keepalive",
+    "keep alive",
+    "pong",
+}
+
+
+def _tool_call_id(tool_call: Any) -> str:
+    if not isinstance(tool_call, dict):
+        return ""
+    value = tool_call.get("id") or tool_call.get("tool_call_id")
+    return str(value).strip() if value else ""
+
+
+def _assistant_tool_call_ids(messages: List[Dict[str, Any]]) -> set[str]:
+    call_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for tool_call in msg.get("tool_calls") or []:
+            call_id = _tool_call_id(tool_call)
+            if call_id:
+                call_ids.add(call_id)
+    return call_ids
+
+
+def _matched_tool_call_ids(messages: List[Dict[str, Any]]) -> set[str]:
+    assistant_call_ids = _assistant_tool_call_ids(messages)
+    tool_result_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") == "tool":
+            tool_call_id = str(msg.get("tool_call_id") or "").strip()
+            if tool_call_id:
+                tool_result_ids.add(tool_call_id)
+    return assistant_call_ids & tool_result_ids
+
+
+def _is_synthetic_assistant_noise(content: str) -> bool:
+    normalized = re.sub(r"\s+", " ", (content or "").strip()).lower()
+    if not normalized:
+        return True
+    normalized = normalized.strip("`*_ ")
+    bracketless = normalized.strip("[](){} ")
+    return normalized in _SYNTHETIC_ASSISTANT_NOISE or bracketless in _SYNTHETIC_ASSISTANT_NOISE
+
 
 class LCMEngine(ContextEngine):
     """Lossless Context Management engine.
@@ -1048,13 +1097,15 @@ class LCMEngine(ContextEngine):
     def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Serialize messages into labeled text for the summarizer."""
         parts = []
+        assistant_tool_ids = _assistant_tool_call_ids(messages)
+        matched_tool_ids = _matched_tool_call_ids(messages)
         for msg in messages:
             role = msg.get("role", "unknown")
             content = msg.get("content") or ""
             content = sanitize_pre_compaction_content(content)
 
             if role == "tool":
-                tool_id = msg.get("tool_call_id", "")
+                tool_id = str(msg.get("tool_call_id") or "").strip()
                 externalized = maybe_externalize_tool_output(
                     content,
                     tool_call_id=tool_id,
@@ -1070,12 +1121,20 @@ class LCMEngine(ContextEngine):
                 continue
 
             if role == "assistant":
+                tool_calls = msg.get("tool_calls", [])
+                matched_tool_calls = [
+                    tc for tc in tool_calls
+                    if not _tool_call_id(tc) or _tool_call_id(tc) in matched_tool_ids
+                ]
+                if _is_synthetic_assistant_noise(content):
+                    if not matched_tool_calls:
+                        continue
+                    content = ""
                 if len(content) > 3000:
                     content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
-                tool_calls = msg.get("tool_calls", [])
-                if tool_calls:
+                if matched_tool_calls:
                     tc_parts = []
-                    for tc in tool_calls:
+                    for tc in matched_tool_calls:
                         if isinstance(tc, dict):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -470,6 +470,73 @@ class TestEngineCompress:
             messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
         return messages
 
+    def test_compression_serialization_skips_empty_assistant_and_heartbeat_noise(self, engine):
+        messages = [
+            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "ACK"},
+            {"role": "assistant", "content": "[heartbeat]"},
+            {"role": "user", "content": "keep this real user content"},
+            {"role": "assistant", "content": "keep this real assistant content"},
+        ]
+
+        serialized = engine._serialize_messages(messages)
+
+        assert "keep this real user content" in serialized
+        assert "[ASSISTANT]: keep this real assistant content" in serialized
+        assert serialized.count("[ASSISTANT]:") == 1
+        assert "[ASSISTANT]: ACK" not in serialized
+        assert "[ASSISTANT]: [heartbeat]" not in serialized
+
+    def test_compression_serialization_keeps_assistant_text_but_drops_orphaned_tool_calls(self, engine):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "I can still explain the plan without a completed tool call.",
+                "tool_calls": [
+                    {
+                        "id": "call_missing",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"command\": \"rm -rf noisy-orphan\"}"},
+                    }
+                ],
+            }
+        ]
+
+        serialized = engine._serialize_messages(messages)
+
+        assert "I can still explain the plan" in serialized
+        assert "terminal(" not in serialized
+        assert "noisy-orphan" not in serialized
+
+    def test_compression_serialization_keeps_matched_tool_pairs_and_drops_orphaned_results(self, engine):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "I will inspect the repo.",
+                "tool_calls": [
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\": \"README.md\"}"},
+                    },
+                    {
+                        "id": "call_missing",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"command\": \"stale orphan args\"}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_ok", "content": "README says hello"},
+            {"role": "tool", "tool_call_id": "legacy_standalone", "content": "standalone legacy payload should remain canonical history"},
+        ]
+
+        serialized = engine._serialize_messages(messages)
+
+        assert "read_file(" in serialized
+        assert "README says hello" in serialized
+        assert "standalone legacy payload" in serialized
+        assert "stale orphan args" not in serialized
+
     def test_compress_short_conversation_noop(self, engine):
         """Short conversations should pass through unchanged."""
         messages = [


### PR DESCRIPTION
## Summary
- skips empty assistant turns and narrow ACK/keepalive-shaped assistant artifacts before pre-compaction summarization
- preserves assistant text while dropping matched-id orphaned tool-call metadata
- keeps all tool-result messages serialized, including standalone/legacy tool outputs, so compaction does not lose evidence from mixed histories
- keeps raw message storage lossless and preserves legacy/id-less tool calls plus standalone tool results for compatibility

## Why
Long-lived transcripts can accumulate provider abort artifacts, tiny ACK/keepalive-style turns, and broken tool-call metadata. Feeding those directly into summaries makes canonical history noisier without adding useful context.

This does not assume Hermes has a heartbeat feature. It only prevents heartbeat-shaped or ACK/keepalive-style transcript artifacts from being treated as meaningful conversation content if they appear in the message stream.

The immutable store remains unchanged; this only cleans the serializer input used for pre-compaction summarization. Tool results are preserved rather than treated as orphan-cleanup candidates, because standalone/legacy tool outputs can still carry important recall evidence.

## Validation
- `python -m pytest tests/test_lcm_engine.py -q` → `138 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` → `281 passed`
- `python -m pytest -q` → `306 passed`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- runtime smoke through the active plugin path `/home/nabu/.hermes/plugins/hermes-lcm -> /home/nabu/.hermes/dev/hermes-lcm` with a temp DB confirmed matched tool pairs and standalone legacy tool results are preserved while empty/ACK-like/orphaned assistant tool-call metadata is omitted from summarizer serialization
