### PR TITLE
fix: make cleanup apply rollback atomically

### DIFF
--- a/command.py
+++ b/command.py
@@ -618,6 +618,76 @@ def _doctor_retention_text(engine) -> str:
     return "\n".join(lines)
 
 
+def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[str, int]:
+    """Delete cleanup candidates in one SQLite transaction.
+
+    All LCM tables live in the same SQLite database, but the store, DAG, and
+    lifecycle helpers use separate connections and commit internally. Cleanup
+    apply is destructive, so do the coordinated deletes on one connection to
+    avoid half-cleaned state if a later table delete fails.
+    """
+    conn = engine._store._conn
+    protected_session_ids = {getattr(engine, "_session_id", "")}
+    protected_session_ids = {str(s) for s in protected_session_ids if s}
+    session_ids = {str(s) for s in session_ids if s and str(s) not in protected_session_ids}
+    if not session_ids:
+        return {
+            "messages_deleted": 0,
+            "nodes_deleted": 0,
+            "lifecycle_deleted": 0,
+            "lifecycle_skipped": 0,
+        }
+
+    placeholders = ",".join("?" for _ in session_ids)
+    params = tuple(sorted(session_ids))
+    lifecycle_rows = conn.execute(
+        """
+        SELECT conversation_id, current_session_id, last_finalized_session_id
+        FROM lcm_lifecycle_state
+        """
+    ).fetchall()
+    lifecycle_delete_conversation_ids: list[str] = []
+    lifecycle_skipped = 0
+    for conversation_id, current_session_id, last_finalized_session_id in lifecycle_rows:
+        refs = {
+            str(value)
+            for value in (current_session_id, last_finalized_session_id)
+            if value
+        }
+        if not refs or not (refs & session_ids):
+            continue
+        if refs & protected_session_ids:
+            lifecycle_skipped += 1
+            continue
+        if refs <= session_ids:
+            lifecycle_delete_conversation_ids.append(str(conversation_id))
+            continue
+        lifecycle_skipped += 1
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        msg_cur = conn.execute(f"DELETE FROM messages WHERE session_id IN ({placeholders})", params)
+        node_cur = conn.execute(f"DELETE FROM summary_nodes WHERE session_id IN ({placeholders})", params)
+        lifecycle_deleted = 0
+        for conversation_id in lifecycle_delete_conversation_ids:
+            cur = conn.execute(
+                "DELETE FROM lcm_lifecycle_state WHERE conversation_id = ?",
+                (conversation_id,),
+            )
+            lifecycle_deleted += cur.rowcount if cur.rowcount is not None else 0
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return {
+        "messages_deleted": msg_cur.rowcount if msg_cur.rowcount is not None else 0,
+        "nodes_deleted": node_cur.rowcount if node_cur.rowcount is not None else 0,
+        "lifecycle_deleted": lifecycle_deleted,
+        "lifecycle_skipped": lifecycle_skipped,
+    }
+
+
 def _doctor_clean_apply_text(engine) -> str:
     if not getattr(getattr(engine, "_config", None), "doctor_clean_apply_enabled", False):
         return "\n".join([
@@ -658,12 +728,18 @@ def _doctor_clean_apply_text(engine) -> str:
         ])
 
     session_ids = {item["session_id"] for item in candidates}
-    messages_deleted = sum(engine._store.delete_session_messages(session_id) for session_id in session_ids)
-    nodes_deleted = sum(engine._dag.delete_session_nodes(session_id) for session_id in session_ids)
-    lifecycle_deleted, lifecycle_skipped = engine._lifecycle.delete_safe_rows_for_sessions(
-        session_ids,
-        protected_session_ids={getattr(engine, "_session_id", "")},
-    )
+    try:
+        deleted = _delete_clean_candidates_atomically(engine, session_ids)
+    except sqlite3.Error as exc:
+        return "\n".join([
+            "LCM doctor clean apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"backup_path: {backup['backup_path']}",
+            f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+            f"error: cleanup apply failed: {exc}",
+            "note: cleanup apply rolled back; restore from the backup if you need to inspect pre-apply state",
+        ])
 
     return "\n".join([
         "LCM doctor clean apply",
@@ -672,10 +748,10 @@ def _doctor_clean_apply_text(engine) -> str:
         f"backup_path: {backup['backup_path']}",
         f"backup_size: {_fmt_size(int(backup['backup_size']))}",
         f"candidate_sessions: {len(candidates)}",
-        f"messages_deleted: {messages_deleted}",
-        f"nodes_deleted: {nodes_deleted}",
-        f"lifecycle_rows_deleted: {lifecycle_deleted}",
-        f"lifecycle_rows_skipped: {lifecycle_skipped}",
+        f"messages_deleted: {deleted['messages_deleted']}",
+        f"nodes_deleted: {deleted['nodes_deleted']}",
+        f"lifecycle_rows_deleted: {deleted['lifecycle_deleted']}",
+        f"lifecycle_rows_skipped: {deleted['lifecycle_skipped']}",
         "note: backup created before cleanup apply",
     ])
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -389,6 +389,56 @@ def test_lcm_doctor_clean_apply_aborts_if_backup_fails(tmp_path, monkeypatch):
     assert len(engine._store.get_range("cron_20260414")) == 1
 
 
+def test_lcm_doctor_clean_apply_rolls_back_if_delete_fails_after_backup(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_clean_apply_rollback.db"),
+        ignore_session_patterns=["cron*"],
+        doctor_clean_apply_enabled=True,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session")
+
+    store_id = engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
+    engine._dag.add_node(SummaryNode(
+        session_id="cron_20260414",
+        depth=0,
+        summary="scheduled report summary",
+        token_count=5,
+        source_token_count=12,
+        source_ids=[store_id],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._lifecycle.bind_session("cron_20260414")
+    engine._lifecycle.finalize_session("cron_20260414", "cron_20260414", frontier_store_id=store_id)
+    engine._store._conn.execute(
+        """
+        CREATE TRIGGER fail_cron_node_delete
+        BEFORE DELETE ON summary_nodes
+        WHEN old.session_id = 'cron_20260414'
+        BEGIN
+            SELECT RAISE(ABORT, 'node delete failed');
+        END
+        """
+    )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor clean apply", engine)
+
+    assert "LCM doctor clean apply" in result
+    assert "status: error" in result
+    assert "node delete failed" in result
+    assert "cleanup apply rolled back" in result
+    backup_line = next(line for line in result.splitlines() if line.startswith("backup_path: "))
+    assert Path(backup_line.split(": ", 1)[1]).exists()
+    assert len(engine._store.get_range("cron_20260414")) == 1
+    assert len(engine._dag.get_session_nodes("cron_20260414")) == 1
+    assert engine._lifecycle.get_by_conversation("cron_20260414") is not None
+
+
 def test_lcm_doctor_clean_apply_denied_by_default(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_clean_apply_denied.db"),


### PR DESCRIPTION
## Summary
- make `/lcm doctor clean apply` delete cleanup candidates through one SQLite transaction
- keep the existing safety gates: disabled by default, explicit `LCM_DOCTOR_CLEAN_APPLY_ENABLED=true`, backup-first, and pattern-limited candidates only
- return a rollback error with the already-created backup path if a post-backup delete fails

## Why
The existing cleanup apply path was backup-first, but it coordinated deletes through helper methods that committed independently. If a later delete step failed after an earlier table was already committed, operators could be left with half-cleaned LCM state.

This keeps the existing command shape and opt-in semantics, but makes the destructive part atomic across messages, summary nodes, and lifecycle rows.

## Validation
- TDD: added a failing rollback regression first using a `summary_nodes` delete trigger that raises after backup creation, then implemented the atomic delete path
- `python -m pytest tests/test_lcm_command.py -q` → `26 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_command.py tests/test_packaging_install.py -q` → `304 passed`
- `python -m pytest -q` → `304 passed`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- runtime smoke through the active plugin path with a temp DB and explicit cleanup opt-in confirmed a safe `cron*` candidate is backed up and removed from store, DAG, and lifecycle state
