### PR TITLE
feat: add operator FTS repair command

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,13 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
 
+### Operator slash commands
+
+If `LCM_ENABLE_SLASH_COMMAND=true`, trusted operator contexts can use `/lcm` slash commands for diagnostics and maintenance:
+
+- `/lcm doctor repair` — read-only SQLite/FTS diagnostics for message and summary search indexes. Reports whether `messages_fts` or `nodes_fts` need repair without rebuilding anything.
+- `/lcm doctor repair apply` — backup-first SQLite/FTS repair. Creates a timestamped database backup, then rebuilds/repairs the message and summary FTS indexes without deleting source `messages` or `summary_nodes` rows.
+
 ### Retrieval contract: `session_scope` × `source`
 
 `hermes-lcm` treats `session_scope` and `source` as independent filters:

--- a/command.py
+++ b/command.py
@@ -7,7 +7,10 @@ from pathlib import Path
 import sqlite3
 from typing import Any
 
+from .db_bootstrap import external_content_fts_needs_repair, repair_external_content_fts
+from .dag import build_nodes_fts_spec
 from .session_patterns import build_session_match_keys, matches_session_pattern
+from .store import build_message_fts_spec
 
 
 def _fmt_bool(value: Any) -> str:
@@ -38,6 +41,8 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm doctor: run read-only LCM health checks",
         "- /lcm doctor clean: best-effort scan of obvious junk/noise session candidates without deleting anything",
         "- /lcm doctor clean apply: backup-first cleanup for safe pattern-matched candidates only",
+        "- /lcm doctor repair: read-only scan for SQLite/FTS index repair needs",
+        "- /lcm doctor repair apply: backup-first repair/rebuild of message and summary FTS indexes",
         "- /lcm doctor retention: read-only retention analysis for stored session footprint and age",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
         "- /lcm help: show this help",
@@ -371,6 +376,106 @@ def _backup_database(engine) -> dict[str, Any]:
         "backup_path": backup_path,
         "backup_size": backup_size,
     }
+
+
+def _scan_fts_repair(engine) -> dict[str, Any]:
+    checks: dict[str, dict[str, Any]] = {}
+    specs = {
+        "messages_fts": build_message_fts_spec(),
+        "nodes_fts": build_nodes_fts_spec(),
+    }
+    conn = engine._store._conn
+    for label, spec in specs.items():
+        try:
+            needs_repair = external_content_fts_needs_repair(conn, spec)
+            content_count = int(conn.execute(
+                f"SELECT COUNT(*) FROM {spec.content_table}"
+            ).fetchone()[0])
+            try:
+                fts_count = int(conn.execute(f"SELECT COUNT(*) FROM {spec.table_name}").fetchone()[0])
+            except sqlite3.Error:
+                fts_count = None
+            checks[label] = {
+                "ok": not needs_repair,
+                "needs_repair": needs_repair,
+                "content_rows": content_count,
+                "fts_rows": fts_count,
+                "error": None,
+            }
+        except Exception as exc:  # pragma: no cover - defensive
+            checks[label] = {
+                "ok": False,
+                "needs_repair": True,
+                "content_rows": None,
+                "fts_rows": None,
+                "error": str(exc),
+            }
+    return {
+        "checks": checks,
+        "needs_repair": any(item["needs_repair"] for item in checks.values()),
+    }
+
+
+def _doctor_repair_text(engine) -> str:
+    scan = _scan_fts_repair(engine)
+    lines = [
+        "LCM doctor repair",
+        f"status: {'repair-needed' if scan['needs_repair'] else 'ok'}",
+    ]
+    for label, item in scan["checks"].items():
+        state = "repair-needed" if item["needs_repair"] else "ok"
+        lines.append(f"{label}: {state}")
+        if item["error"]:
+            lines.append(f"{label}_error: {item['error']}")
+        else:
+            lines.append(f"{label}_content_rows: {item['content_rows']}")
+            lines.append(f"{label}_fts_rows: {item['fts_rows']}")
+    lines.append("note: read-only scan only — no FTS tables were repaired")
+    if scan["needs_repair"]:
+        lines.append("note: use `/lcm doctor repair apply` to create a backup and repair FTS indexes")
+    return "\n".join(lines)
+
+
+def _doctor_repair_apply_text(engine) -> str:
+    backup = _backup_database(engine)
+    if not backup["ok"]:
+        return "\n".join([
+            "LCM doctor repair apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"error: backup failed: {backup['error']}",
+            "note: repair apply aborted before any FTS tables were repaired",
+        ])
+
+    conn = engine._store._conn
+    try:
+        messages_result = repair_external_content_fts(conn, build_message_fts_spec())
+        nodes_result = repair_external_content_fts(conn, build_nodes_fts_spec())
+    except sqlite3.Error as exc:
+        return "\n".join([
+            "LCM doctor repair apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"backup_path: {backup['backup_path']}",
+            f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+            f"error: FTS repair failed: {exc}",
+            "note: backup was created before repair apply",
+        ])
+
+    return "\n".join([
+        "LCM doctor repair apply",
+        "status: ok",
+        f"database_path: {backup['db_path']}",
+        f"backup_path: {backup['backup_path']}",
+        f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+        f"messages_fts_rebuilt: {_fmt_bool(messages_result['rebuilt'])}",
+        f"messages_fts_triggers_recreated: {_fmt_bool(messages_result['triggers_recreated'])}",
+        f"messages_fts_degraded: {_fmt_bool(messages_result['degraded'])}",
+        f"nodes_fts_rebuilt: {_fmt_bool(nodes_result['rebuilt'])}",
+        f"nodes_fts_triggers_recreated: {_fmt_bool(nodes_result['triggers_recreated'])}",
+        f"nodes_fts_degraded: {_fmt_bool(nodes_result['degraded'])}",
+        "note: backup created before repair apply",
+    ])
 
 
 def _doctor_text(engine) -> str:
@@ -718,11 +823,15 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
             return _doctor_text(engine)
         if len(rest) == 1 and rest[0].lower() == "clean":
             return _doctor_clean_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "repair":
+            return _doctor_repair_text(engine)
         if len(rest) == 1 and rest[0].lower() == "retention":
             return _doctor_retention_text(engine)
         if len(rest) == 2 and rest[0].lower() == "clean" and rest[1].lower() == "apply":
             return _doctor_clean_apply_text(engine)
-        return _help_text("`/lcm doctor` currently supports `clean`, `clean apply`, and `retention` as extra subcommands.")
+        if len(rest) == 2 and rest[0].lower() == "repair" and rest[1].lower() == "apply":
+            return _doctor_repair_apply_text(engine)
+        return _help_text("`/lcm doctor` currently supports `clean`, `clean apply`, `repair`, `repair apply`, and `retention` as extra subcommands.")
 
     if head == "backup":
         if rest:

--- a/dag.py
+++ b/dag.py
@@ -105,6 +105,31 @@ def _fts_primary_value(node: "SummaryNode", sort: str | None) -> float:
     return rank_value
 
 
+def build_nodes_fts_spec() -> ExternalContentFtsSpec:
+    return ExternalContentFtsSpec(
+        table_name="nodes_fts",
+        content_table="summary_nodes",
+        content_rowid="node_id",
+        indexed_column="summary",
+        trigger_sqls=(
+            """
+            CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
+                AFTER INSERT ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(rowid, summary)
+                    VALUES (new.node_id, new.summary);
+            END;
+            """,
+            """
+            CREATE TRIGGER IF NOT EXISTS nodes_fts_delete
+                AFTER DELETE ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(nodes_fts, rowid, summary)
+                    VALUES('delete', old.node_id, old.summary);
+            END;
+            """,
+        ),
+    )
+
+
 @dataclass
 class SummaryNode:
     """A single node in the summary DAG."""
@@ -160,28 +185,7 @@ class SummaryDAG:
         """)
         ensure_external_content_fts(
             self._conn,
-            ExternalContentFtsSpec(
-                table_name="nodes_fts",
-                content_table="summary_nodes",
-                content_rowid="node_id",
-                indexed_column="summary",
-                trigger_sqls=(
-                    """
-                    CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
-                        AFTER INSERT ON summary_nodes BEGIN
-                        INSERT INTO nodes_fts(rowid, summary)
-                            VALUES (new.node_id, new.summary);
-                    END;
-                    """,
-                    """
-                    CREATE TRIGGER IF NOT EXISTS nodes_fts_delete
-                        AFTER DELETE ON summary_nodes BEGIN
-                        INSERT INTO nodes_fts(nodes_fts, rowid, summary)
-                            VALUES('delete', old.node_id, old.summary);
-                    END;
-                    """,
-                ),
-            ),
+            build_nodes_fts_spec(),
         )
         run_versioned_migrations(self._conn)
         self._ensure_source_window_columns()

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -175,7 +175,7 @@ def quote_sql_identifier(identifier: str) -> str:
     return f'"{identifier}"'
 
 
-def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+def _fts_needs_rebuild_structural(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
     shadow_tables = get_fts_shadow_table_names(spec.table_name)
     existing_tables = get_existing_table_names(conn, [spec.table_name, *shadow_tables])
     if spec.table_name not in existing_tables:
@@ -208,7 +208,16 @@ def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -
         ).fetchone()[0]
         if int(content_count or 0) != int(fts_count or 0):
             return True
+    except sqlite3.DatabaseError:
+        return True
 
+    return False
+
+
+def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    if _fts_needs_rebuild_structural(conn, spec):
+        return True
+    try:
         conn.execute(
             f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}, rank) VALUES('integrity-check', 1)"
         )
@@ -256,7 +265,30 @@ def _check_disk_space(db_path: str) -> bool:
         return True
 
 
-def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
+def _fts_missing_triggers(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    expected = {
+        trigger_name
+        for trigger_name in (_extract_trigger_name(sql) for sql in spec.trigger_sqls)
+        if trigger_name
+    }
+    if not expected:
+        return False
+    placeholders = ",".join("?" for _ in expected)
+    rows = conn.execute(
+        f"SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
+        tuple(sorted(expected)),
+    ).fetchall()
+    existing = {str(row[0]) for row in rows if row and row[0]}
+    return bool(expected - existing)
+
+
+def external_content_fts_needs_repair(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    return _fts_needs_rebuild_structural(conn, spec) or _fts_missing_triggers(conn, spec)
+
+
+def repair_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> dict[str, bool]:
+    rebuilt = False
+    degraded = False
     if _fts_needs_rebuild(conn, spec):
         db_path = conn.execute("PRAGMA database_list").fetchone()
         if db_path:
@@ -268,7 +300,8 @@ def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentF
                     _MIN_DISK_SPACE_BYTES // (1024 * 1024),
                 )
                 _drop_fts_artifacts(conn, spec)
-                return
+                conn.commit()
+                return {"rebuilt": False, "degraded": True, "triggers_recreated": False}
         _drop_fts_table(conn, spec.table_name)
         conn.execute(
             f"""
@@ -282,9 +315,17 @@ def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentF
         conn.execute(
             f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
         )
+        rebuilt = True
 
+    triggers_were_missing = _fts_missing_triggers(conn, spec)
     for trigger_sql in spec.trigger_sqls:
         conn.execute(trigger_sql)
+    conn.commit()
+    return {"rebuilt": rebuilt, "degraded": degraded, "triggers_recreated": triggers_were_missing}
+
+
+def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
+    repair_external_content_fts(conn, spec)
 
 
 def run_versioned_migrations(conn: sqlite3.Connection) -> None:

--- a/store.py
+++ b/store.py
@@ -156,6 +156,40 @@ def _fts_primary_value(result: Dict[str, Any], sort: str | None) -> float:
     return rank_value
 
 
+def build_message_fts_spec() -> ExternalContentFtsSpec:
+    return ExternalContentFtsSpec(
+        table_name="messages_fts",
+        content_table="messages",
+        content_rowid="store_id",
+        indexed_column="content",
+        trigger_sqls=(
+            """
+            CREATE TRIGGER IF NOT EXISTS msg_fts_insert
+                AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content)
+                    VALUES (new.store_id, new.content);
+            END;
+            """,
+            """
+            CREATE TRIGGER IF NOT EXISTS msg_fts_delete
+                AFTER DELETE ON messages BEGIN
+                INSERT INTO messages_fts(messages_fts, rowid, content)
+                    VALUES('delete', old.store_id, old.content);
+            END;
+            """,
+            """
+            CREATE TRIGGER IF NOT EXISTS msg_fts_update
+                AFTER UPDATE OF content ON messages BEGIN
+                INSERT INTO messages_fts(messages_fts, rowid, content)
+                    VALUES('delete', old.store_id, old.content);
+                INSERT INTO messages_fts(rowid, content)
+                    VALUES (new.store_id, new.content);
+            END;
+            """,
+        ),
+    )
+
+
 class MessageStore:
     """SQLite-backed immutable message store."""
 
@@ -194,37 +228,7 @@ class MessageStore:
         """)
         ensure_external_content_fts(
             self._conn,
-            ExternalContentFtsSpec(
-                table_name="messages_fts",
-                content_table="messages",
-                content_rowid="store_id",
-                indexed_column="content",
-                trigger_sqls=(
-                    """
-                    CREATE TRIGGER IF NOT EXISTS msg_fts_insert
-                        AFTER INSERT ON messages BEGIN
-                        INSERT INTO messages_fts(rowid, content)
-                            VALUES (new.store_id, new.content);
-                    END;
-                    """,
-                    """
-                    CREATE TRIGGER IF NOT EXISTS msg_fts_delete
-                        AFTER DELETE ON messages BEGIN
-                        INSERT INTO messages_fts(messages_fts, rowid, content)
-                            VALUES('delete', old.store_id, old.content);
-                    END;
-                    """,
-                    """
-                    CREATE TRIGGER IF NOT EXISTS msg_fts_update
-                        AFTER UPDATE OF content ON messages BEGIN
-                        INSERT INTO messages_fts(messages_fts, rowid, content)
-                            VALUES('delete', old.store_id, old.content);
-                        INSERT INTO messages_fts(rowid, content)
-                            VALUES (new.store_id, new.content);
-                    END;
-                    """,
-                ),
-            ),
+            build_message_fts_spec(),
         )
         run_versioned_migrations(self._conn)
         self._ensure_source_column()

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -152,9 +152,127 @@ def test_lcm_help_on_unknown_subcommand(engine):
 def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
     result = handle_lcm_command("doctor clean foo", engine)
 
-    assert "currently supports `clean`, `clean apply`, and `retention`" in result
+    assert "currently supports `clean`, `clean apply`, `repair`, `repair apply`, and `retention`" in result
     assert "/lcm doctor clean apply" in result
+    assert "/lcm doctor repair" in result
+    assert "/lcm doctor repair apply" in result
     assert "/lcm doctor retention" in result
+
+
+def test_lcm_doctor_repair_reports_fts_drift_without_mutating(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_repair_drift.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._store.append("live-session", {"role": "user", "content": "repairable message search"}, token_estimate=4)
+    engine._dag.add_node(SummaryNode(
+        session_id="live-session",
+        depth=0,
+        summary="repairable summary search",
+        token_count=5,
+        source_token_count=4,
+        source_ids=[1],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._store._conn.execute("DROP TRIGGER msg_fts_insert")
+    engine._store._conn.execute("DROP TRIGGER nodes_fts_insert")
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor repair", engine)
+
+    assert "LCM doctor repair" in result
+    assert "status: repair-needed" in result
+    assert "messages_fts: repair-needed" in result
+    assert "nodes_fts: repair-needed" in result
+    assert "note: read-only scan only — no FTS tables were repaired" in result
+    remaining_triggers = {
+        row[0]
+        for row in engine._store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ('msg_fts_insert', 'nodes_fts_insert')"
+        ).fetchall()
+    }
+    assert remaining_triggers == set()
+
+
+def test_lcm_doctor_repair_dry_run_works_with_read_only_database(tmp_path):
+    db_path = tmp_path / "lcm_repair_readonly.db"
+    config = LCMConfig(database_path=str(db_path))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._store.append("live-session", {"role": "user", "content": "readonly message search"}, token_estimate=4)
+    engine._dag.add_node(SummaryNode(
+        session_id="live-session",
+        depth=0,
+        summary="readonly summary search",
+        token_count=5,
+        source_token_count=4,
+        source_ids=[1],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._store.close()
+    engine._dag.close()
+    engine._lifecycle.close()
+
+    ro_conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+
+    class FakeStore:
+        _conn = ro_conn
+
+    class FakeEngine:
+        _store = FakeStore()
+
+    try:
+        result = handle_lcm_command("doctor repair", FakeEngine())
+    finally:
+        ro_conn.close()
+
+    assert "LCM doctor repair" in result
+    assert "status: ok" in result
+    assert "messages_fts: ok" in result
+    assert "nodes_fts: ok" in result
+    assert "repair-needed" not in result
+    assert "note: read-only scan only — no FTS tables were repaired" in result
+
+
+def test_lcm_doctor_repair_apply_is_backup_first_and_rebuilds_fts(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_repair_apply.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._store.append("live-session", {"role": "user", "content": "repair apply message search"}, token_estimate=4)
+    engine._dag.add_node(SummaryNode(
+        session_id="live-session",
+        depth=0,
+        summary="repair apply summary search",
+        token_count=5,
+        source_token_count=4,
+        source_ids=[1],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._store._conn.execute("DELETE FROM messages_fts")
+    engine._store._conn.execute("DELETE FROM nodes_fts")
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor repair apply", engine)
+
+    assert "LCM doctor repair apply" in result
+    assert "status: ok" in result
+    backup_line = next(line for line in result.splitlines() if line.startswith("backup_path: "))
+    backup_path = Path(backup_line.split(": ", 1)[1])
+    assert backup_path.exists()
+    assert "messages_fts_rebuilt: yes" in result
+    assert "nodes_fts_rebuilt: yes" in result
+    assert engine._store._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 1
+    assert engine._store._conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0] == 1
+    assert len(engine._store.search("message", session_id="live-session")) == 1
+    assert len(engine._dag.search("summary", session_id="live-session")) == 1
 
 
 def test_lcm_doctor_retention_reports_old_heavy_sessions(tmp_path):


### PR DESCRIPTION
## Summary
- Add `/lcm doctor repair` for read-only SQLite/FTS repair diagnostics across message and summary search indexes.
- Add `/lcm doctor repair apply` for backup-first FTS repair/rebuild.
- Share the message/node FTS spec builders between startup bootstrap and operator repair so trigger/table definitions do not drift.
- Keep dry-run repair diagnostics compatible with read-only SQLite connections by avoiding the write-only FTS5 integrity-check probe there.
- Document the new operator slash commands in the README.

## Why
- Startup already attempts FTS repair automatically, but operators sometimes need an explicit way to inspect and repair search-index drift without restarting Hermes.
- The dry-run path is intentionally read-only and should work in read-only database contexts.
- The apply path creates a SQLite backup first and only repairs FTS indexes; it does not delete source `messages` or `summary_nodes` rows.

## Validation
- `python -m pytest tests/test_lcm_command.py -q` → `28 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_command.py tests/test_packaging_install.py -q` → `306 passed`
- `python -m pytest -q` → `306 passed`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- Runtime smoke via active plugin discovery with a temp DB confirmed:
  - `/lcm doctor repair` detects FTS drift without applying repair
  - `/lcm doctor repair` reports healthy FTS as `ok` through a read-only SQLite connection
  - `/lcm doctor repair apply` creates a backup
  - both `messages_fts` and `nodes_fts` rebuild
  - message and summary search work again after apply

## Notes
- This preserves the existing startup/apply repair behavior and exposes the same repair substrate through an explicit operator command surface.
- `repair apply` is backup-first by design because it rebuilds SQLite FTS artifacts.
- The read-only diagnostic path uses structural/table/count/trigger checks only; the write-capable FTS5 integrity-check remains on the apply/startup repair path.