### PR TITLE
fix: upgrade lifecycle rotation columns

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -122,6 +122,10 @@ def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_maintenance_attempt_at REAL"
         )
+    if "last_rollover_at" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_rollover_at REAL")
+    if "last_reset_at" not in columns:
+        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_reset_at REAL")
 
 
 def mark_migration_step_complete(conn: sqlite3.Connection, step_name: str) -> None:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1433,6 +1433,73 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_init_upgrades_existing_lifecycle_table_with_rotation_columns(self, tmp_path):
+        db_path = tmp_path / "legacy-lifecycle-rotation.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata(key, value) VALUES ('schema_version', '4');
+
+            CREATE TABLE lcm_migration_state (
+                step_name TEXT PRIMARY KEY,
+                completed_at REAL NOT NULL
+            );
+
+            CREATE TABLE lcm_lifecycle_state (
+                conversation_id TEXT PRIMARY KEY,
+                current_session_id TEXT,
+                last_finalized_session_id TEXT,
+                current_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+                last_finalized_frontier_store_id INTEGER NOT NULL DEFAULT 0,
+                debt_kind TEXT,
+                debt_size_estimate INTEGER NOT NULL DEFAULT 0,
+                current_bound_at REAL,
+                last_finalized_at REAL,
+                debt_updated_at REAL,
+                last_maintenance_attempt_at REAL,
+                updated_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+            );
+
+            INSERT INTO lcm_lifecycle_state(
+                conversation_id,
+                current_session_id,
+                last_finalized_session_id,
+                current_frontier_store_id,
+                last_finalized_frontier_store_id,
+                debt_kind,
+                debt_size_estimate,
+                current_bound_at,
+                last_finalized_at,
+                debt_updated_at,
+                last_maintenance_attempt_at,
+                updated_at
+            ) VALUES ('conv', 'sess', NULL, 7, 0, NULL, 0, 1.0, NULL, NULL, NULL, 2.0);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        state = LifecycleStateStore(db_path)
+        loaded = state.get_by_session("sess")
+
+        assert loaded is not None
+        assert loaded.current_session_id == "sess"
+        assert loaded.current_frontier_store_id == 7
+        assert loaded.last_rollover_at is None
+        assert loaded.last_reset_at is None
+
+        columns = {
+            row[1]
+            for row in state._conn.execute("PRAGMA table_info(lcm_lifecycle_state)").fetchall()
+        }
+        assert {"last_rollover_at", "last_reset_at"} <= columns
+
+        state.close()
+
     def test_record_debt_and_clear_debt(self, tmp_path):
         state = LifecycleStateStore(tmp_path / "lifecycle-debt.db")
         bound = state.bind_session("sess-1")


### PR DESCRIPTION
## Summary
- Add a regression test for existing lifecycle tables that are missing rotation timestamp columns.
- Extend `ensure_lifecycle_state_columns(...)` to add `last_rollover_at` and `last_reset_at` in place.

## Why
- Older lifecycle/checkpoint DBs can already have `schema_version = 4` and an existing `lcm_lifecycle_state` table, while still missing the later rotation timestamp columns.
- `LifecycleStateStore._row_to_state()` reads those fields unconditionally, so startup/session lookup can fail with `IndexError: No item with that key` before the engine can bind lifecycle state.
- This keeps the fix narrow: it repairs the upgrade path for existing lifecycle tables without adding new transcript import/bootstrap machinery.

## Validation
- `python -m pytest tests/test_lcm_core.py::TestLifecycleStateStore::test_init_upgrades_existing_lifecycle_table_with_rotation_columns -q` → failed before the fix with `IndexError: No item with that key`, then passed after the fix
- `python -m pytest tests/test_lcm_core.py::TestLifecycleStateStore -q` → `5 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` → `279 passed`
- `python -m pytest -q` → `304 passed`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- Runtime smoke via active plugin discovery with a legacy DB confirmed:
  - the active plugin loads from `/home/nabu/.hermes/dev/hermes-lcm`
  - missing `last_rollover_at` / `last_reset_at` columns are added
  - lifecycle state loads successfully
  - the existing frontier marker is preserved

## Notes
- No source rows are rewritten by this migration; it only adds nullable timestamp columns when they are missing.