### PR TITLE
fix: preserve lifecycle reset boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 
 - **Manual `/new`** should call `rollover_session(old_session_id, new_session_id, ...)`. This finalizes the old physical session, records reset/rollover lifecycle state, binds the new physical session, and applies `LCM_NEW_SESSION_RETAIN_DEPTH` before carrying retained summary nodes forward.
 - **Compression-created session splits** should call `on_session_start(new_session_id, boundary_reason="compression", old_session_id=old_session_id, ...)`. Compression is a continuation of the same logical conversation, so LCM preserves the conversation id and carries all current DAG/message state forward, including depth-0 nodes.
-- For host compatibility, `rollover_session(..., boundary_reason="compression")` is also treated as a compression continuation, not as manual `/new` pruning.
+- For host compatibility, `rollover_session(..., boundary_reason="compression")` is also treated as a compression continuation when `carry_over_context` is enabled, not as manual `/new` pruning. If an integration explicitly passes `carry_over_context=False`, no prior-session messages or DAG nodes are moved into the new session.
 - Older hosts that only call `on_session_reset()` followed later by `on_session_start(new_session_id, ...)` are supported by delayed reset-boundary finalization: same-session reset stays current, while a later fresh bind finalizes the previous lifecycle row with the latest known frontier.
 
 ## Agent Tools

--- a/README.md
+++ b/README.md
@@ -321,6 +321,15 @@ Hermes currently matches each pattern against multiple candidate keys for flexib
 
 That means patterns like `cron:*` can catch Hermes cron sessions today, while plain raw session-id matching still works if you know the exact IDs you want to target.
 
+## Session boundary contract
+
+`hermes-lcm` distinguishes manual new-session boundaries from Hermes compression continuations:
+
+- **Manual `/new`** should call `rollover_session(old_session_id, new_session_id, ...)`. This finalizes the old physical session, records reset/rollover lifecycle state, binds the new physical session, and applies `LCM_NEW_SESSION_RETAIN_DEPTH` before carrying retained summary nodes forward.
+- **Compression-created session splits** should call `on_session_start(new_session_id, boundary_reason="compression", old_session_id=old_session_id, ...)`. Compression is a continuation of the same logical conversation, so LCM preserves the conversation id and carries all current DAG/message state forward, including depth-0 nodes.
+- For host compatibility, `rollover_session(..., boundary_reason="compression")` is also treated as a compression continuation, not as manual `/new` pruning.
+- Older hosts that only call `on_session_reset()` followed later by `on_session_start(new_session_id, ...)` are supported by delayed reset-boundary finalization: same-session reset stays current, while a later fresh bind finalizes the previous lifecycle row with the latest known frontier.
+
 ## Agent Tools
 
 | Tool | Description |

--- a/engine.py
+++ b/engine.py
@@ -874,7 +874,7 @@ class LCMEngine(ContextEngine):
             old_session_id and bound_session_id and old_session_id == bound_session_id
         )
 
-        if boundary_reason == "compression" and old_session_id and old_session_id != new_session_id:
+        if carry_over_context and boundary_reason == "compression" and old_session_id and old_session_id != new_session_id:
             before_node_ids = {node.node_id for node in self._dag.get_session_nodes(new_session_id)}
             if can_carry_over:
                 self.on_session_end(old_session_id, previous_messages)

--- a/engine.py
+++ b/engine.py
@@ -174,6 +174,9 @@ class LCMEngine(ContextEngine):
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
         self._logged_filter_config = False
+        self._pending_reset_session_id: str = ""
+        self._pending_reset_conversation_id: str = ""
+        self._pending_reset_frontier_store_id: int = 0
 
     @property
     def name(self) -> str:
@@ -562,6 +565,34 @@ class LCMEngine(ContextEngine):
             self._last_compacted_store_id,
         )
 
+    def _clear_pending_reset_boundary(self) -> None:
+        self._pending_reset_session_id = ""
+        self._pending_reset_conversation_id = ""
+        self._pending_reset_frontier_store_id = 0
+
+    def _finalize_pending_reset_boundary(self, session_id: str) -> None:
+        if not self._pending_reset_session_id:
+            return
+        if self._pending_reset_session_id != session_id:
+            self._clear_pending_reset_boundary()
+            return
+        if not self._pending_reset_conversation_id:
+            self._clear_pending_reset_boundary()
+            return
+        state = self._lifecycle.get_by_conversation(self._pending_reset_conversation_id)
+        frontier_store_id = self._pending_reset_frontier_store_id
+        if state is not None and state.current_session_id == session_id:
+            frontier_store_id = max(
+                frontier_store_id,
+                int(state.current_frontier_store_id or 0),
+            )
+        self._lifecycle.finalize_session(
+            self._pending_reset_conversation_id,
+            self._pending_reset_session_id,
+            frontier_store_id=frontier_store_id,
+        )
+        self._clear_pending_reset_boundary()
+
     def _raw_backlog_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         n = len(messages)
         fresh_tail_start = max(0, n - self._config.fresh_tail_count)
@@ -682,6 +713,12 @@ class LCMEngine(ContextEngine):
         frontier = max(
             int(self._last_compacted_store_id or 0),
             int(source_state.current_frontier_store_id if source_state else 0),
+            int(
+                self._pending_reset_frontier_store_id
+                if self._pending_reset_session_id
+                and self._pending_reset_session_id in {source_session_id, old_session_id, previous_session_id}
+                else 0
+            ),
         )
         can_reassign = bool(
             source_session_id
@@ -717,12 +754,14 @@ class LCMEngine(ContextEngine):
                 old_session_id,
                 previous_session_id,
             )
+            self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
             self._apply_session_start_metadata(session_id, kwargs)
             self._bind_lifecycle_state(
                 session_id,
                 conversation_id=kwargs.get("conversation_id"),
             )
+            self._clear_pending_reset_boundary()
             self._log_session_filter_diagnostics()
             return
 
@@ -736,6 +775,7 @@ class LCMEngine(ContextEngine):
             )
             if state is not None:
                 self._last_compacted_store_id = state.current_frontier_store_id
+        self._clear_pending_reset_boundary()
         self._log_session_filter_diagnostics()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
@@ -747,8 +787,10 @@ class LCMEngine(ContextEngine):
 
         previous_session_id = self._session_id
         if previous_session_id and previous_session_id != session_id:
+            self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
         else:
+            self._clear_pending_reset_boundary()
             self._ingest_cursor = 0
             self._last_compacted_store_id = 0
             self._last_overflow_recovery_failed = False
@@ -770,6 +812,9 @@ class LCMEngine(ContextEngine):
         )
 
     def on_session_reset(self) -> None:
+        self._pending_reset_session_id = self._session_id
+        self._pending_reset_conversation_id = self._conversation_id
+        self._pending_reset_frontier_store_id = self._last_compacted_store_id
         super().on_session_reset()
         self._lifecycle.record_reset(self._conversation_id)
         self._reset_session_scoped_runtime_state()
@@ -822,11 +867,30 @@ class LCMEngine(ContextEngine):
         4. optionally move retained summaries into the new session
         """
         previous_messages = previous_messages or []
+        boundary_reason = str(kwargs.get("boundary_reason") or "")
         conversation_id = self._conversation_id or old_session_id or new_session_id
         bound_session_id = self._session_id
         can_carry_over = bool(
             old_session_id and bound_session_id and old_session_id == bound_session_id
         )
+
+        if boundary_reason == "compression" and old_session_id and old_session_id != new_session_id:
+            before_node_ids = {node.node_id for node in self._dag.get_session_nodes(new_session_id)}
+            if can_carry_over:
+                self.on_session_end(old_session_id, previous_messages)
+            else:
+                logger.warning(
+                    "LCM compression rollover old_session_id=%s does not match bound session=%s; using boundary handler fallback",
+                    old_session_id,
+                    bound_session_id,
+                )
+            self.on_session_start(
+                new_session_id,
+                old_session_id=old_session_id,
+                **kwargs,
+            )
+            after_node_ids = {node.node_id for node in self._dag.get_session_nodes(new_session_id)}
+            return len(after_node_ids - before_node_ids)
 
         if old_session_id and can_carry_over:
             self.on_session_end(old_session_id, previous_messages)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1574,6 +1574,51 @@ class TestSessionRollover:
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
         assert expanded["expanded"][0]["content"] == "compression rollover keeps depth zero"
 
+    def test_rollover_session_compression_boundary_respects_disabled_carry_over(self, engine):
+        engine._config.new_session_retain_depth = 2
+        engine.on_session_start("compress-no-carry-old", platform="telegram", context_length=200000)
+        store_id = engine._store.append(
+            "compress-no-carry-old",
+            {"role": "user", "content": "do not leak compression carry over"},
+            token_estimate=13,
+            source="telegram",
+        )
+        retained_node_id = engine._dag.add_node(SummaryNode(
+            session_id="compress-no-carry-old",
+            depth=2,
+            summary="do not leak retained summary",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+        old_conversation_id = engine._conversation_id
+
+        moved = engine.rollover_session(
+            "compress-no-carry-old",
+            "compress-no-carry-new",
+            previous_messages=[],
+            carry_over_context=False,
+            boundary_reason="compression",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert moved == 0
+        assert engine._session_id == "compress-no-carry-new"
+        assert engine._conversation_id == old_conversation_id
+        assert engine._store.get_session_count("compress-no-carry-old") == 1
+        assert engine._store.get_session_count("compress-no-carry-new") == 0
+        assert [node.node_id for node in engine._dag.get_session_nodes("compress-no-carry-old")] == [retained_node_id]
+        assert engine._dag.get_session_nodes("compress-no-carry-new") == []
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "leak", "session_scope": "current", "sort": "relevance", "limit": 10},
+        ))
+        assert result["total_results"] == 0
+
     def test_rollover_session_skips_carry_over_when_old_session_is_not_bound(self, engine):
         engine._config.new_session_retain_depth = 2
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1470,6 +1470,110 @@ class TestSessionRollover:
         assert engine._dag.get_session_nodes("s2") == []
         assert engine._session_id == "s3"
 
+    def test_rollover_session_current_session_retrieval_uses_new_session_after_carry_over(self, engine):
+        engine._config.new_session_retain_depth = 2
+        engine.on_session_start("old-retrieval", platform="cli", context_length=200000)
+        old_store_id = engine._store.append(
+            "old-retrieval",
+            {"role": "user", "content": "phoenix raw old-only context"},
+            token_estimate=9,
+            source="cli",
+        )
+        retained_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-retrieval",
+            depth=2,
+            summary="phoenix retained rollover summary",
+            token_count=7,
+            source_token_count=9,
+            source_ids=[old_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        pruned_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-retrieval",
+            depth=0,
+            summary="phoenix pruned rollover summary",
+            token_count=7,
+            source_token_count=9,
+            source_ids=[old_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+
+        moved = engine.rollover_session(
+            "old-retrieval",
+            "new-retrieval",
+            previous_messages=[],
+            platform="cli",
+            context_length=200000,
+        )
+
+        assert moved == 1
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "phoenix", "session_scope": "current", "sort": "relevance", "limit": 10},
+        ))
+        assert result["session_scope"] == "current"
+        assert result["total_results"] == 1
+        assert result["results"] == [
+            {
+                "type": "summary",
+                "depth": "d2",
+                "node_id": retained_node_id,
+                "session_id": "new-retrieval",
+                "snippet": "phoenix retained rollover summary",
+                "token_count": 7,
+                "expand_hint": "",
+                "earliest_at": None,
+                "latest_at": None,
+            }
+        ]
+        assert engine._dag.get_node(pruned_node_id) is None
+        assert engine._store.get_session_count("old-retrieval") == 1
+        assert engine._store.get_session_count("new-retrieval") == 0
+
+    def test_rollover_session_compression_boundary_keeps_depth_zero_nodes(self, engine):
+        engine._config.new_session_retain_depth = 2
+        engine.on_session_start("compress-rollover-old", platform="telegram", context_length=200000)
+        store_id = engine._store.append(
+            "compress-rollover-old",
+            {"role": "user", "content": "compression rollover keeps depth zero"},
+            token_estimate=13,
+            source="telegram",
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="compress-rollover-old",
+            depth=0,
+            summary="compression rollover depth zero summary",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+        old_conversation_id = engine._conversation_id
+
+        moved = engine.rollover_session(
+            "compress-rollover-old",
+            "compress-rollover-new",
+            previous_messages=[],
+            boundary_reason="compression",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert moved == 1
+        assert engine._session_id == "compress-rollover-new"
+        assert engine._conversation_id == old_conversation_id
+        assert engine._store.get_session_count("compress-rollover-old") == 0
+        assert engine._store.get_session_count("compress-rollover-new") == 1
+        assert engine._dag.get_session_nodes("compress-rollover-old") == []
+        new_nodes = engine._dag.get_session_nodes("compress-rollover-new")
+        assert [node.node_id for node in new_nodes] == [node_id]
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+        assert expanded["expanded"][0]["content"] == "compression rollover keeps depth zero"
+
     def test_rollover_session_skips_carry_over_when_old_session_is_not_bound(self, engine):
         engine._config.new_session_retain_depth = 2
 
@@ -1741,6 +1845,174 @@ class TestSessionRollover:
         assert state_repeat.current_session_id == "s2"
         assert state_repeat.last_finalized_session_id == "s1"
         assert engine._lifecycle.row_count() == 1
+
+    def test_legacy_reset_then_start_finalizes_old_lifecycle_before_new_bind(self, engine):
+        engine.on_session_start("legacy-old", platform="cli", context_length=200000)
+        store_id = engine._store.append(
+            "legacy-old",
+            {"role": "user", "content": "legacy host context before /new"},
+            token_estimate=17,
+            source="cli",
+        )
+        engine._last_compacted_store_id = store_id
+        old_conversation_id = engine._conversation_id
+
+        # Older Hermes hosts may not call rollover_session(...) yet. They can
+        # still call the older lifecycle pair: reset current state, then bind a
+        # fresh session. LCM must not leave the old conversation marked current.
+        engine.on_session_reset()
+        engine.on_session_start("legacy-new", platform="cli", context_length=200000)
+
+        old_state = engine._lifecycle.get_by_conversation(old_conversation_id)
+        assert old_state is not None
+        assert old_state.current_session_id is None
+        assert old_state.last_finalized_session_id == "legacy-old"
+        assert old_state.last_finalized_frontier_store_id == store_id
+        assert old_state.last_reset_at is not None
+
+        new_state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert new_state is not None
+        assert new_state.conversation_id == "legacy-new"
+        assert new_state.current_session_id == "legacy-new"
+        assert new_state.last_finalized_session_id is None
+        assert engine._lifecycle.row_count() == 2
+
+    def test_same_session_reset_keeps_lifecycle_current_and_allows_future_frontier_updates(self, engine):
+        engine.on_session_start("same-session", platform="cli", context_length=200000)
+        first_store_id = engine._store.append(
+            "same-session",
+            {"role": "user", "content": "before reset"},
+            token_estimate=7,
+            source="cli",
+        )
+        engine._last_compacted_store_id = first_store_id
+
+        engine.on_session_reset()
+        after_reset = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert after_reset is not None
+        assert after_reset.current_session_id == "same-session"
+        assert after_reset.last_finalized_session_id is None
+        assert after_reset.last_reset_at is not None
+
+        second_store_id = engine._store.append(
+            "same-session",
+            {"role": "assistant", "content": "after reset"},
+            token_estimate=9,
+            source="cli",
+        )
+        engine._last_compacted_store_id = second_store_id
+        engine._persist_frontier_marker()
+
+        after_frontier = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert after_frontier is not None
+        assert after_frontier.current_session_id == "same-session"
+        assert after_frontier.current_frontier_store_id == second_store_id
+
+    def test_same_session_reset_then_later_new_session_preserves_latest_frontier(self, engine):
+        engine.on_session_start("same-then-new", platform="cli", context_length=200000)
+        first_store_id = engine._store.append(
+            "same-then-new",
+            {"role": "user", "content": "before reset"},
+            token_estimate=7,
+            source="cli",
+        )
+        engine._last_compacted_store_id = first_store_id
+        old_conversation_id = engine._conversation_id
+
+        engine.on_session_reset()
+        second_store_id = engine._store.append(
+            "same-then-new",
+            {"role": "assistant", "content": "same session continued after reset"},
+            token_estimate=11,
+            source="cli",
+        )
+        engine._last_compacted_store_id = second_store_id
+        engine._persist_frontier_marker()
+
+        engine.on_session_start("eventual-new", platform="cli", context_length=200000)
+
+        old_state = engine._lifecycle.get_by_conversation(old_conversation_id)
+        assert old_state is not None
+        assert old_state.current_session_id is None
+        assert old_state.last_finalized_session_id == "same-then-new"
+        assert old_state.last_finalized_frontier_store_id == second_store_id
+        assert engine._pending_reset_session_id == ""
+
+    def test_reset_before_compression_boundary_does_not_leave_stale_pending_reset(self, engine):
+        engine.on_session_start("compress-old", platform="telegram", context_length=200000)
+        store_id = engine._store.append(
+            "compress-old",
+            {"role": "user", "content": "compression boundary after reset"},
+            token_estimate=13,
+            source="telegram",
+        )
+        engine._dag.add_node(SummaryNode(
+            session_id="compress-old",
+            depth=0,
+            summary="compression summary",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+
+        engine.on_session_reset()
+        assert engine._pending_reset_session_id == "compress-old"
+
+        engine.on_session_start(
+            "compress-new",
+            boundary_reason="compression",
+            old_session_id="compress-old",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._pending_reset_session_id == ""
+        status = engine.get_status()
+        assert status["lifecycle"]["current_session_id"] == "compress-new"
+        assert status["lifecycle"]["last_finalized_session_id"] == "compress-old"
+        assert status["lifecycle"]["last_finalized_frontier_store_id"] == store_id
+
+    def test_reset_before_compression_boundary_mismatch_finalizes_pending_old_session(self, engine):
+        engine.on_session_start("bound-after-reset", platform="telegram", context_length=200000)
+        store_id = engine._store.append(
+            "bound-after-reset",
+            {"role": "user", "content": "pending reset before mismatch"},
+            token_estimate=13,
+            source="telegram",
+        )
+        engine._dag.add_node(SummaryNode(
+            session_id="bound-after-reset",
+            depth=0,
+            summary="will be pruned on reset",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+        old_conversation_id = engine._conversation_id
+
+        engine.on_session_reset()
+        assert engine._pending_reset_session_id == "bound-after-reset"
+
+        engine.on_session_start(
+            "new-after-mismatch",
+            boundary_reason="compression",
+            old_session_id="stale-host-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        old_state = engine._lifecycle.get_by_conversation(old_conversation_id)
+        assert old_state is not None
+        assert old_state.current_session_id is None
+        assert old_state.last_finalized_session_id == "bound-after-reset"
+        assert old_state.last_finalized_frontier_store_id == store_id
+        assert engine._pending_reset_session_id == ""
 
     def test_on_session_start_recovers_durable_lifecycle_state_after_restart(self, engine, monkeypatch):
         engine.on_session_start("active-session", platform="cli", context_length=200000)


### PR DESCRIPTION
## Summary

This PR hardens the LCM session lifecycle boundary handling around reset, manual new sessions, and compression-created session splits.

Changes included:

* Records reset boundaries without immediately finalizing same-session resets.
* Finalizes a pending reset only when a later bind proves the session changed.
* Preserves the newest known frontier when finalizing after reset continuation.
* Keeps compression continuations distinct from manual new-session pruning.
* Treats `rollover_session(..., boundary_reason="compression")` as a compression continuation for host compatibility.
* Documents the manual new-session versus compression boundary contract.

## Why

Hermes hosts do not all notify context engines through the same lifecycle path yet. Some older or fallback paths can call `on_session_reset()` and later `on_session_start(new_session_id)` without using `rollover_session(...)`.

LCM needs to remain safe in both cases:

* A plain same-session reset should stay current and keep accepting frontier updates.
* A later fresh session bind should finalize the previous lifecycle row correctly.
* Compression-created session splits should preserve the logical conversation and carry depth-zero DAG state forward, not behave like manual `/new` pruning.

## Validation

Focused lifecycle coverage:

```bash
python -m pytest tests/test_lcm_engine.py::TestSessionRollover -q --tb=short
```

Result: 18 passed.

Default contributing validation:

```bash
pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
pytest -q
python -m compileall -q .
bash -n scripts/install.sh scripts/update.sh
git diff --check
```

Results: targeted suite 290 passed. Full suite 321 passed. Compile, shell syntax, and diff checks passed.

Install-path smoke:

Used `scripts/install.sh` with a temporary `HERMES_HOME` and profile-scoped plugin symlink pointing at this branch. Registered the plugin through its entrypoint, exercised `rollover_session(..., boundary_reason="compression")`, verified depth-zero DAG carry-over, and expanded the moved node successfully.

## Notes

This PR covers the LCM-owned lifecycle compatibility surface. Host CLI and gateway lifecycle notification work remains a separate Hermes Agent integration concern.