### PR TITLE
fix: make expand-query synthesis failures visible

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3992,6 +3992,130 @@ class TestEngineTools:
         assert seen["prompt"] == "What was the plan?"
         assert seen["context_blocks"]
 
+    def test_handle_expand_query_timeout_returns_explicit_degraded_error(self, engine, monkeypatch):
+        engine._config.expansion_timeout_ms = 2500
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            raise TimeoutError("expansion timed out")
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?"},
+            )
+        )
+
+        assert result["degraded"] is True
+        assert "timed out" in result["error"]
+        assert result["timeout_seconds"] == 2.5
+        assert result["node_ids"] == [node_id]
+        assert result["matches"]
+        assert "answer" not in result
+
+    def test_handle_expand_query_unexpected_synthesis_error_is_not_degraded(self, engine, monkeypatch):
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            raise RuntimeError("schema bug")
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+
+        with pytest.raises(RuntimeError, match="schema bug"):
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?"},
+            )
+
+    def test_handle_expand_query_blank_synthesis_is_not_false_success(self, engine, monkeypatch):
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", lambda **kwargs: "   ")
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"query": "docker", "prompt": "What was the plan?"},
+            )
+        )
+
+        assert result["degraded"] is True
+        assert "empty answer" in result["error"]
+        assert result["node_ids"] == [node_id]
+        assert result["matches"]
+        assert "answer" not in result
+
+    def test_handle_expand_query_node_ids_timeout_preserves_requested_match(self, engine, monkeypatch):
+        engine._store.append("test-session", {"role": "user", "content": "Discussed docker rollout plan"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Docker rollout summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[1],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            raise TimeoutError("expansion timed out")
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {"node_ids": [node_id], "prompt": "What was the plan?"},
+            )
+        )
+
+        assert result["degraded"] is True
+        assert "timed out" in result["error"]
+        assert result["query"] == ""
+        assert result["node_ids"] == [node_id]
+        assert result["matches"][0]["node_id"] == node_id
+        assert "answer" not in result
+
     def test_handle_expand_query_hyphenated_operator_query_falls_back_cleanly(self, engine, monkeypatch):
         engine._store.append(
             "test-session",

--- a/tools.py
+++ b/tools.py
@@ -522,15 +522,53 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     for node in nodes[:max_results]:
         context_blocks.extend(_collect_context_blocks_for_node(engine, node, max_tokens=max_tokens))
 
+    selected_nodes = nodes[:max_results]
+    matches = [
+        {
+            "node_id": node.node_id,
+            "depth": node.depth,
+            "summary": node.summary[:300],
+            "expand_hint": node.expand_hint,
+        }
+        for node in selected_nodes
+    ]
+    node_ids = [node.node_id for node in selected_nodes]
+
+    def _degraded_payload(reason: str, *, include_timeout: bool = False) -> str:
+        payload: Dict[str, Any] = {
+            "prompt": prompt,
+            "query": query,
+            "error": reason,
+            "degraded": True,
+            "model": model,
+            "node_ids": node_ids,
+            "matches": matches,
+        }
+        if include_timeout:
+            payload["timeout_seconds"] = timeout
+        return json.dumps(payload)
+
     model = engine._config.expansion_model or engine._config.summary_model or ""
     timeout = engine._config.expansion_timeout_ms / 1000
-    answer = _synthesize_expansion_answer(
-        prompt=prompt,
-        context_blocks=context_blocks,
-        model=model,
-        max_tokens=max_tokens,
-        timeout=timeout,
-    )
+    try:
+        answer = _synthesize_expansion_answer(
+            prompt=prompt,
+            context_blocks=context_blocks,
+            model=model,
+            max_tokens=max_tokens,
+            timeout=timeout,
+        )
+    except TimeoutError:
+        logger.warning("LCM expand_query synthesis timed out after %.3fs", timeout)
+        return _degraded_payload(
+            f"lcm_expand_query synthesis timed out after {timeout:.3g}s",
+            include_timeout=True,
+        )
+
+    answer = str(answer).strip() if answer is not None else ""
+    if not answer:
+        logger.warning("LCM expand_query synthesis returned an empty answer")
+        return _degraded_payload("lcm_expand_query synthesis returned an empty answer")
 
     return json.dumps(
         {
@@ -538,16 +576,8 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "query": query,
             "answer": answer,
             "model": model,
-            "node_ids": [node.node_id for node in nodes[:max_results]],
-            "matches": [
-                {
-                    "node_id": node.node_id,
-                    "depth": node.depth,
-                    "summary": node.summary[:300],
-                    "expand_hint": node.expand_hint,
-                }
-                for node in nodes[:max_results]
-            ],
+            "node_ids": node_ids,
+            "matches": matches,
         }
     )
 


### PR DESCRIPTION
## Summary

`lcm_expand_query` now returns an explicit degraded payload when answer synthesis times out or comes back blank. That avoids two bad outcomes: an exception leaking out of the tool call, or a successful response with an empty answer.

The degraded response keeps the selected `node_ids` and `matches`, so callers can still see what context was found. Unexpected non-timeout synthesis errors still fail hard instead of being hidden as degraded output.

## Validation

• `pytest tests/test_lcm_engine.py::TestEngineTools -q --tb=short`
• `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
• `pytest -q`
• `python -m compileall -q .`
• `bash -n scripts/install.sh scripts/update.sh`
• `git diff --check`
• repo-shipped Hermes Agent host-load smoke for timeout and blank synthesis degradation
