### PR TITLE
fix: clarify current-session retrieval scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,10 +334,10 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 
 | Tool | Description |
 |------|-------------|
-| `lcm_grep` | Search raw messages AND summaries for the active/current session. Use this for intra-session recall after compaction; if you intentionally want cross-session LCM store hits, use `session_scope='all'`; otherwise prefer `session_search` for earlier separate sessions. |
+| `lcm_grep` | Search raw messages AND summaries for the active/current session. Use this for intra-session recall after compaction. For earlier separate sessions or broad cross-session history, use `session_search`. |
 | `lcm_describe` | Inspect current-session DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
 | `lcm_expand` | Recover original content from a current-session summary node, or open a stored `externalized_ref` payload directly. |
-| `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. For cross-session recall, prefer `session_search` first. |
+| `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. For cross-session recall, use `session_search` first. |
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
 
@@ -350,10 +350,9 @@ If `LCM_ENABLE_SLASH_COMMAND=true`, trusted operator contexts can use `/lcm` sla
 
 ### Retrieval contract: `session_scope` × `source`
 
-`hermes-lcm` treats `session_scope` and `source` as independent filters:
+`hermes-lcm` retrieval tools are current-session tools. `session_scope` is kept for schema compatibility and currently accepts only `current`; unsupported values are ignored and reported in the tool result. Use Hermes `session_search` for earlier separate sessions or broad cross-session recall.
 
-- **`session_scope`** decides which sessions are eligible
-- **`source`** decides which content inside those eligible sessions is allowed to match
+Within that current session, `source` decides which content is allowed to match.
 
 That contract applies across:
 
@@ -366,15 +365,11 @@ That contract applies across:
 
 - `current` + no `source` → all raw rows in the current session
 - `current` + `source='discord'` → only current-session raw rows with source `discord`
-- `all` + no `source` → all raw rows across sessions
-- `all` + `source='discord'` → all raw rows across sessions with source `discord`
 
 #### DAG summaries
 
 - `current` + no `source` → all summaries eligible in the current session
 - `current` + `source='discord'` → only current-session summaries whose descendant raw-message lineage includes `discord`
-- `all` + no `source` → all eligible summaries across sessions
-- `all` + `source='discord'` → only summaries across sessions whose descendant raw-message lineage includes `discord`
 
 Mixed-source nodes may match more than one `source` filter if their descendant lineage is mixed. Filtering is based on actual descendant lineage, not on whether the surrounding session happens to contain some message from that source.
 
@@ -401,7 +396,7 @@ When both recall paths are available to the model:
 
 - prefer **LCM tools** for recall inside the active/current conversation, especially when the relevant turns were compacted into summary nodes
 - prefer **`session_search`** when the user is asking about an earlier separate conversation, prior work from another session, or broad cross-session history
-- if you explicitly want cross-session hits from the LCM store itself, use `lcm_grep(session_scope='all')` deliberately rather than treating it as the default recall path
+- if a caller sends an unsupported `session_scope`, `lcm_grep` stays on the current session and reports the ignored value in its response
 
 That split is intentional:
 

--- a/schemas.py
+++ b/schemas.py
@@ -38,8 +38,8 @@ LCM_GREP = {
                 "type": "string",
                 "enum": ["current"],
                 "description": (
-                    "Whether to search only the current session. "
-                    "Cross-session recall should use session_search instead."
+                    "Current-session only. Cross-session recall should use session_search instead; "
+                    "unsupported values are ignored and reported in the tool result."
                 ),
                 "default": "current",
             },

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import time
+from pathlib import Path
+
 import pytest
 
 import hermes_lcm.engine as lcm_engine
@@ -262,11 +264,13 @@ class TestEngineABC:
         grep_schema = next(s for s in schemas if s["name"] == "lcm_grep")
         grep_props = grep_schema["parameters"]["properties"]
         assert "session_scope" in grep_props
+        assert grep_props["session_scope"]["enum"] == ["current"]
         assert "source" in grep_props
         assert "descendant source lineage" in grep_props["source"]["description"]
         assert "unknown" in grep_props["source"]["description"]
         assert "current session" in grep_schema["description"].lower()
         assert "session_search" in grep_schema["description"]
+        assert "session_scope='all'" not in grep_schema["description"]
         assert "session_search" in grep_props["session_scope"]["description"]
 
         describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
@@ -279,6 +283,13 @@ class TestEngineABC:
         assert "session_search" in expand_schema["description"]
         assert "current session" in expand_query_schema["description"].lower()
         assert "session_search" in expand_query_schema["description"]
+
+    def test_readme_matches_current_session_retrieval_contract(self):
+        readme = Path(__file__).resolve().parents[1].joinpath("README.md").read_text()
+        assert "session_scope='all'" not in readme
+        assert "session_scope=\"all\"" not in readme
+        assert "current-session recall" in readme
+        assert "session_search" in readme
 
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)
@@ -2814,6 +2825,23 @@ class TestEngineTools:
             )
         )
         assert result["sort"] == "relevance"
+
+    def test_handle_grep_reports_unsupported_session_scope_and_stays_current(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker rollout current session"})
+        engine._store.append("old-session", {"role": "user", "content": "docker rollout old session"})
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "limit": 10},
+            )
+        )
+
+        assert result["session_scope"] == "current"
+        assert result["ignored_session_scope"] == "all"
+        assert "session_search" in result["scope_note"]
+        assert result["total_results"] == 1
+        assert result["results"][0]["session_id"] == "test-session"
 
     def test_handle_grep_source_filter_in_current_session_includes_only_matching_summaries(self, engine):
         engine._store.append("test-session", {"role": "user", "content": "docker logs from discord"}, source="discord")

--- a/tools.py
+++ b/tools.py
@@ -331,16 +331,18 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         result.pop("_sort_rank", None)
         result.pop("_sort_directness", None)
         result.pop("_hybrid_summary_override", None)
-    return json.dumps(
-        {
-            "query": query,
-            "sort": sort,
-            "session_scope": session_scope,
-            "source": source,
-            "total_results": len(results),
-            "results": results[:limit],
-        }
-    )
+    response = {
+        "query": query,
+        "sort": sort,
+        "session_scope": session_scope,
+        "source": source,
+        "total_results": len(results),
+        "results": results[:limit],
+    }
+    if requested_session_scope != "current":
+        response["ignored_session_scope"] = requested_session_scope
+        response["scope_note"] = "lcm_grep is current-session only; use session_search for broad cross-session recall."
+    return json.dumps(response)
 
 
 def lcm_describe(args: Dict[str, Any], **kwargs) -> str:


### PR DESCRIPTION
## Summary

This tightens the retrieval contract around `lcm_grep` and the other LCM tools.

`lcm_grep` is already current-session only, but the README still mentioned `session_scope='all'`. This removes that stale guidance, keeps `session_search` visible as the cross-session recall path, and makes unsupported `session_scope` values show up in the tool result instead of being silently ignored.

## Validation

• `pytest tests/test_lcm_engine.py::TestEngineABC tests/test_lcm_engine.py::TestEngineTools -q --tb=short`
• `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
• `pytest -q`
• `python -m compileall -q .`
• `bash -n scripts/install.sh scripts/update.sh`
• `git diff --check`
• repo-shipped Hermes Agent host-load smoke for the current-only schema and ignored unsupported scope
