### PR TITLE
feat: surface LCM runtime identity

### DIFF
--- a/command.py
+++ b/command.py
@@ -57,6 +57,7 @@ def _status_text(engine) -> str:
     db_size = db_path.stat().st_size if db_exists else 0
     session_bound = bool(engine._session_id)
     source_stats = status.get("source_lineage") or {}
+    runtime_identity = status.get("runtime_identity") or {}
     source_stats = {
         "messages_total": int(source_stats.get("messages_total", 0) or 0),
         "attributed_messages": int(source_stats.get("attributed_messages", 0) or 0),
@@ -70,9 +71,15 @@ def _status_text(engine) -> str:
     lines = [
         "LCM status",
         f"engine: {status.get('engine', engine.name)}",
+        f"plugin_name: {runtime_identity.get('plugin_name', '(unknown)')}",
+        f"plugin_version: {runtime_identity.get('plugin_version', '(unknown)')}",
+        f"plugin_path: {runtime_identity.get('plugin_path', '(unknown)')}",
+        f"module_path: {runtime_identity.get('module_path', '(unknown)')}",
+        f"hermes_home: {runtime_identity.get('hermes_home', '') or '(unset)'}",
         f"session_id: {engine._session_id or '(unbound)'}",
         f"session_platform: {status.get('session_platform') or ('(unbound)' if not session_bound else '(unknown)')}",
         f"database_path: {db_path}",
+        f"database_path_source: {runtime_identity.get('database_path_source', '(unknown)')}",
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"compression_count: {engine.compression_count}",
@@ -86,6 +93,9 @@ def _status_text(engine) -> str:
         f"cache_read_ratio: {float(status.get('cache_read_ratio', 0.0) or 0.0) * 100:.1f}%",
         f"session_ignored: {_fmt_bool(status.get('session_ignored'))}",
         f"session_stateless: {_fmt_bool(status.get('session_stateless'))}",
+        f"conversation_id: {runtime_identity.get('conversation_id', '') or '(unbound)'}",
+        f"lifecycle_current_session_id: {runtime_identity.get('lifecycle_current_session_id', '') or '(none)'}",
+        f"lifecycle_last_finalized_session_id: {runtime_identity.get('lifecycle_last_finalized_session_id', '') or '(none)'}",
         f"source_messages_total: {source_stats['messages_total']}",
         f"source_attributed_messages: {source_stats['attributed_messages']}",
         f"source_unknown_messages: {source_stats['normalized_unknown_messages']}",

--- a/engine.py
+++ b/engine.py
@@ -42,6 +42,37 @@ from . import tools as lcm_tools
 
 logger = logging.getLogger(__name__)
 
+_PLUGIN_ROOT = Path(__file__).resolve().parent
+_PLUGIN_METADATA: dict[str, str] | None = None
+
+
+def _strip_metadata_scalar(value: str) -> str:
+    return value.strip().strip('"').strip("'")
+
+
+def _plugin_metadata() -> dict[str, str]:
+    """Return plugin identity from the loaded code tree."""
+    global _PLUGIN_METADATA
+    if _PLUGIN_METADATA is not None:
+        return dict(_PLUGIN_METADATA)
+
+    metadata = {"name": "hermes-lcm", "version": "unknown"}
+    manifest = _PLUGIN_ROOT / "plugin.yaml"
+    try:
+        for line in manifest.read_text(encoding="utf-8").splitlines():
+            key, sep, raw_value = line.partition(":")
+            if not sep:
+                continue
+            key = key.strip()
+            if key in {"name", "version"}:
+                metadata[key] = _strip_metadata_scalar(raw_value)
+    except OSError:
+        logger.debug("LCM plugin manifest not readable at %s", manifest)
+
+    _PLUGIN_METADATA = metadata
+    return dict(metadata)
+
+
 _SYNTHETIC_ASSISTANT_NOISE = {
     "ack",
     "acknowledged",
@@ -942,6 +973,49 @@ class LCMEngine(ContextEngine):
             return handler(args, engine=self)
         return json.dumps({"error": f"Unknown LCM tool: {name}"})
 
+    def _database_path_source(self) -> str:
+        if self._config.database_path:
+            return "config.database_path"
+        if self._hermes_home:
+            return "hermes_home"
+        return "default_home"
+
+    def get_runtime_identity(self) -> Dict[str, Any]:
+        """Return operator-facing identity for the loaded LCM runtime."""
+        metadata = _plugin_metadata()
+        lifecycle_state = None
+        lifecycle_error = ""
+        if self._conversation_id:
+            try:
+                lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                lifecycle_error = str(exc)
+
+        identity: Dict[str, Any] = {
+            "engine": self.name,
+            "plugin_name": metadata.get("name", "hermes-lcm"),
+            "plugin_version": metadata.get("version", "unknown"),
+            "plugin_path": str(_PLUGIN_ROOT),
+            "module_path": str(Path(__file__).resolve()),
+            "hermes_home": str(self._hermes_home or ""),
+            "database_path": str(self._store.db_path),
+            "database_path_source": self._database_path_source(),
+            "session_id": self._session_id,
+            "session_platform": self._session_platform,
+            "session_bound": bool(self._session_id),
+            "conversation_id": self._conversation_id,
+            "lifecycle_current_session_id": "",
+            "lifecycle_last_finalized_session_id": "",
+        }
+        if lifecycle_state is not None:
+            identity.update({
+                "lifecycle_current_session_id": lifecycle_state.current_session_id or "",
+                "lifecycle_last_finalized_session_id": lifecycle_state.last_finalized_session_id or "",
+            })
+        if lifecycle_error:
+            identity["lifecycle_error"] = lifecycle_error
+        return identity
+
     def get_status(self) -> Dict[str, Any]:
         status = super().get_status()
         status.update({
@@ -961,6 +1035,7 @@ class LCMEngine(ContextEngine):
         })
         lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
         status["engine"] = "lcm"
+        status["runtime_identity"] = self.get_runtime_identity()
         try:
             status["source_lineage"] = self._store.get_source_stats(self._session_id or None)
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -114,6 +114,19 @@ def test_lcm_status_explains_unbound_runtime_before_first_session(tmp_path):
     assert "note: no active Hermes session has initialized LCM in this process yet" in result
 
 
+def test_lcm_status_reports_runtime_identity(engine):
+    result = handle_lcm_command("status", engine)
+    repo_root = Path(__file__).resolve().parent.parent
+
+    assert "plugin_name: hermes-lcm" in result
+    assert "plugin_version: 0.7.1" in result
+    assert f"plugin_path: {repo_root}" in result
+    assert "module_path:" in result
+    assert "database_path_source: config.database_path" in result
+    assert f"hermes_home: {engine._hermes_home}" in result
+    assert "conversation_id:" in result
+
+
 def test_lcm_status_reports_source_lineage_breakdown(engine):
     engine._store.append("test-session", {"role": "user", "content": "cli message"}, source="cli")
     engine._store.append("test-session", {"role": "user", "content": "unknown message"})

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 import time
 import pytest
 
@@ -49,6 +50,52 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["last_cache_write_tokens"] == 50
     assert payload["last_reasoning_tokens"] == 30
     assert payload["cache_read_ratio"] == 0.381
+    assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
+    assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
+
+
+def test_lcm_tool_status_reports_runtime_identity_before_session_binding(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "unbound-tool-status.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))
+
+    payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+
+    assert payload["error"] == "No active session"
+    assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
+    assert payload["runtime_identity"]["session_bound"] is False
+    assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
+
+
+
+def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
+    db_path = tmp_path / "identity.db"
+    hermes_home = tmp_path / "hermes-home"
+    config = LCMConfig(database_path=str(db_path))
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        context_length=200000,
+        conversation_id="telegram:chat-1",
+    )
+
+    status = engine.get_status()
+    identity = status["runtime_identity"]
+    repo_root = Path(__file__).resolve().parent.parent
+
+    assert identity["engine"] == "lcm"
+    assert identity["plugin_name"] == "hermes-lcm"
+    assert identity["plugin_version"] == "0.7.1"
+    assert Path(identity["plugin_path"]) == repo_root
+    assert Path(identity["module_path"]).name == "engine.py"
+    assert Path(identity["database_path"]) == db_path
+    assert identity["database_path_source"] == "config.database_path"
+    assert identity["hermes_home"] == str(hermes_home)
+    assert identity["session_id"] == "telegram:chat-1:session-1"
+    assert identity["session_platform"] == "telegram"
+    assert identity["conversation_id"] == "telegram:chat-1"
+    assert identity["lifecycle_current_session_id"] == "telegram:chat-1:session-1"
+    assert identity["lifecycle_last_finalized_session_id"] == ""
 
 
 class TestEscalationStripReasoning:

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -103,6 +103,12 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
 
     assert engine is not None
     assert engine.name == "lcm"
+    identity = engine.get_status()["runtime_identity"]
+    repo_root = Path(__file__).resolve().parent.parent
+    assert identity["plugin_name"] == "hermes-lcm"
+    assert identity["plugin_version"] == "0.7.1"
+    assert Path(identity["plugin_path"]) == repo_root
+    assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
 
     tool_names = {schema["name"] for schema in engine.get_tool_schemas()}
     assert {

--- a/tools.py
+++ b/tools.py
@@ -560,7 +560,10 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
 
     session_id = engine._session_id
     if not session_id:
-        return json.dumps({"error": "No active session"})
+        return json.dumps({
+            "error": "No active session",
+            "runtime_identity": engine.get_runtime_identity(),
+        })
 
     # Store stats
     store_messages = engine._store.get_session_count(session_id)
@@ -581,6 +584,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     full_status = engine.get_status()
     lifecycle = full_status.get("lifecycle")
     source_lineage = full_status.get("source_lineage")
+    runtime_identity = full_status.get("runtime_identity")
 
     return json.dumps({
         "session_id": session_id,
@@ -627,6 +631,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "stateless": engine._session_stateless,
         },
         "source_lineage": source_lineage,
+        "runtime_identity": runtime_identity,
         "lifecycle": lifecycle,
     })
 


### PR DESCRIPTION
## Summary

This makes the loaded LCM runtime easier to identify from the normal status surfaces.

The main problem this addresses is install-path drift: when dogfooding or switching between a dev checkout and a live plugin install, it should be obvious which code tree is actually loaded and which database it is using.

This adds runtime identity to `engine.get_status()`, `lcm_status`, and `/lcm status`, including the plugin version, plugin path, module path, Hermes home, database path/source, session id, conversation id, and lifecycle session binding. The unbound `lcm_status` response now also includes runtime identity, so the loaded tree is visible even before a session has been started.

## Validation

* `pytest tests/test_lcm_command.py tests/test_packaging_install.py -q`
* `pytest tests/test_lcm_engine.py::TestEngineABC tests/test_lcm_engine.py::TestEngineTools -q --tb=short`
* `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
* `pytest -q`
* `python -m compileall -q .`
* `bash -n scripts/install.sh scripts/update.sh`
* `git diff --check`
* repo-shipped Hermes Agent host-load smoke for bound and unbound runtime identity
