### PR TITLE
fix: normalize legacy blank source lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ If `LCM_ENABLE_SLASH_COMMAND=true`, trusted operator contexts can use `/lcm` sla
 
 - `/lcm doctor repair` — read-only SQLite/FTS diagnostics for message and summary search indexes. Reports whether `messages_fts` or `nodes_fts` need repair without rebuilding anything.
 - `/lcm doctor repair apply` — backup-first SQLite/FTS repair. Creates a timestamped database backup, then rebuilds/repairs the message and summary FTS indexes without deleting source `messages` or `summary_nodes` rows.
+- `/lcm doctor source` — read-only source-lineage scan. Reports legacy `NULL`, blank, or whitespace-only message sources that are treated as `unknown` for backward-compatible retrieval.
+- `/lcm doctor source apply` — backup-first source-lineage normalization. Creates a timestamped database backup, then rewrites only legacy blank-source message rows to explicit `unknown`. The operation is idempotent and does not delete rows.
 
 ### Retrieval contract: `session_scope` × `source`
 
@@ -419,9 +421,14 @@ This surface is **disabled by default** and requires `LCM_ENABLE_SLASH_COMMAND=1
 - `/lcm doctor` — SQLite + FTS health checks and store/node totals
 - `/lcm doctor clean` — best-effort read-only scan for obvious junk/noise sessions matched from stored session keys
 - `/lcm doctor clean apply` — backup-first cleanup for safe pattern-matched junk/noise session candidates
+- `/lcm doctor repair` — read-only SQLite/FTS diagnostics for message and summary search indexes
+- `/lcm doctor repair apply` — backup-first SQLite/FTS repair for message and summary search indexes
+- `/lcm doctor source` — read-only scan for legacy blank-source message rows
+- `/lcm doctor source apply` — backup-first normalization of legacy blank-source message rows to explicit `unknown`
+- `/lcm doctor retention` — read-only retention analysis for stored session footprint and age
 - `/lcm backup` — create a timestamped SQLite backup before any future cleanup workflow
 
-The cleanup path stays intentionally narrow and backup-first; broader retention/prune workflows should still start with diagnostics before any apply/delete step.
+The cleanup and source-normalization apply paths stay intentionally narrow and backup-first; broader retention/prune workflows should still start with diagnostics before any apply/delete step.
 
 ## How It Works
 

--- a/command.py
+++ b/command.py
@@ -43,6 +43,8 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm doctor clean apply: backup-first cleanup for safe pattern-matched candidates only",
         "- /lcm doctor repair: read-only scan for SQLite/FTS index repair needs",
         "- /lcm doctor repair apply: backup-first repair/rebuild of message and summary FTS indexes",
+        "- /lcm doctor source: read-only scan for legacy blank-source rows",
+        "- /lcm doctor source apply: backup-first normalization of legacy blank-source rows to unknown",
         "- /lcm doctor retention: read-only retention analysis for stored session footprint and age",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
         "- /lcm help: show this help",
@@ -485,6 +487,105 @@ def _doctor_repair_apply_text(engine) -> str:
     ])
 
 
+def _doctor_source_text(engine) -> str:
+    try:
+        plan = engine._store.get_source_normalization_plan()
+    except Exception as exc:  # pragma: no cover - defensive
+        return "\n".join([
+            "LCM doctor source",
+            "status: error",
+            f"error: source-lineage scan failed: {exc}",
+            "note: read-only scan only — no source rows were updated",
+        ])
+
+    stats = plan["stats_before"]
+    would_update = int(plan["would_update_messages"])
+    lines = [
+        "LCM doctor source",
+        f"status: {'normalization-needed' if would_update else 'ok'}",
+        f"messages_total: {stats['messages_total']}",
+        f"attributed_messages: {stats['attributed_messages']}",
+        f"unknown_messages: {stats['normalized_unknown_messages']}",
+        f"legacy_blank_messages: {stats['legacy_blank_source_messages']}",
+        f"effective_unknown_messages: {stats['effective_unknown_messages']}",
+        f"target_source: {plan['target_source']}",
+        f"would_update_messages: {would_update}",
+        f"affected_sessions: {plan['affected_sessions']}",
+        "note: read-only scan only — no source rows were updated",
+    ]
+    if would_update:
+        lines.append(
+            "note: use `/lcm doctor source apply` to create a backup and normalize legacy blank-source rows"
+        )
+    else:
+        lines.append("note: no legacy blank-source rows need normalization")
+    return "\n".join(lines)
+
+
+def _doctor_source_apply_text(engine) -> str:
+    try:
+        plan = engine._store.get_source_normalization_plan()
+    except Exception as exc:  # pragma: no cover - defensive
+        return "\n".join([
+            "LCM doctor source apply",
+            "status: error",
+            f"error: source-lineage scan failed: {exc}",
+            "note: source normalization apply aborted before any rows were updated",
+        ])
+
+    if int(plan["would_update_messages"]) == 0:
+        stats = plan["stats_before"]
+        return "\n".join([
+            "LCM doctor source apply",
+            "status: ok",
+            f"target_source: {plan['target_source']}",
+            "updated_messages: 0",
+            f"legacy_blank_before: {stats['legacy_blank_source_messages']}",
+            f"legacy_blank_after: {stats['legacy_blank_source_messages']}",
+            "note: no legacy blank-source rows needed normalization",
+        ])
+
+    backup = _backup_database(engine)
+    if not backup["ok"]:
+        return "\n".join([
+            "LCM doctor source apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"error: backup failed: {backup['error']}",
+            "note: source normalization apply aborted before any rows were updated",
+        ])
+
+    try:
+        result = engine._store.normalize_legacy_blank_sources()
+    except sqlite3.Error as exc:
+        return "\n".join([
+            "LCM doctor source apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"backup_path: {backup['backup_path']}",
+            f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+            f"error: source normalization failed: {exc}",
+            "note: backup was created before source normalization apply",
+        ])
+
+    before = result["stats_before"]
+    after = result["stats_after"]
+    return "\n".join([
+        "LCM doctor source apply",
+        "status: ok",
+        f"database_path: {backup['db_path']}",
+        f"backup_path: {backup['backup_path']}",
+        f"backup_size: {_fmt_size(int(backup['backup_size']))}",
+        f"target_source: {result['target_source']}",
+        f"updated_messages: {result['updated_messages']}",
+        f"legacy_blank_before: {before['legacy_blank_source_messages']}",
+        f"legacy_blank_after: {after['legacy_blank_source_messages']}",
+        f"unknown_before: {before['normalized_unknown_messages']}",
+        f"unknown_after: {after['normalized_unknown_messages']}",
+        "note: backup created before source normalization apply",
+    ])
+
+
 def _doctor_text(engine) -> str:
     db_path = Path(engine._store.db_path)
     store_conn = engine._store._conn
@@ -908,13 +1009,17 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
             return _doctor_clean_text(engine)
         if len(rest) == 1 and rest[0].lower() == "repair":
             return _doctor_repair_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "source":
+            return _doctor_source_text(engine)
         if len(rest) == 1 and rest[0].lower() == "retention":
             return _doctor_retention_text(engine)
         if len(rest) == 2 and rest[0].lower() == "clean" and rest[1].lower() == "apply":
             return _doctor_clean_apply_text(engine)
         if len(rest) == 2 and rest[0].lower() == "repair" and rest[1].lower() == "apply":
             return _doctor_repair_apply_text(engine)
-        return _help_text("`/lcm doctor` currently supports `clean`, `clean apply`, `repair`, `repair apply`, and `retention` as extra subcommands.")
+        if len(rest) == 2 and rest[0].lower() == "source" and rest[1].lower() == "apply":
+            return _doctor_source_apply_text(engine)
+        return _help_text("`/lcm doctor` currently supports `clean`, `clean apply`, `repair`, `repair apply`, `source`, `source apply`, and `retention` as extra subcommands.")
 
     if head == "backup":
         if rest:

--- a/dag.py
+++ b/dag.py
@@ -42,7 +42,7 @@ from .search_query import (
     sanitize_fts5_query,
     should_apply_directness_rank_adjustment,
 )
-from .store import _normalize_source_value, _UNKNOWN_SOURCE
+from .store import _normalize_source_value, _UNKNOWN_SOURCE, _legacy_blank_source_clause
 
 
 logger = logging.getLogger(__name__)
@@ -484,8 +484,9 @@ class SummaryDAG:
         normalized_source = _normalize_source_value(source)
         if cache is not None and node_id in cache:
             return cache[node_id]
+        legacy_blank_clause = _legacy_blank_source_clause("m.source")
         row = self._conn.execute(
-            """
+            f"""
             WITH RECURSIVE source_walk(source_type, source_id) AS (
                 SELECT n.source_type, CAST(j.value AS INTEGER)
                 FROM summary_nodes n, json_each(n.source_ids) j
@@ -506,7 +507,7 @@ class SummaryDAG:
               ON walk.source_type = 'messages'
              AND m.store_id = walk.source_id
             WHERE CASE
-                    WHEN ? = ? THEN (m.source = ? OR m.source = '')
+                    WHEN ? = ? THEN (m.source = ? OR {legacy_blank_clause})
                     ELSE m.source = ?
                   END
             LIMIT 1

--- a/store.py
+++ b/store.py
@@ -52,6 +52,14 @@ _MESSAGE_SELECT_COLUMNS = (
 _UNKNOWN_SOURCE = "unknown"
 
 
+def _legacy_blank_source_clause(column: str) -> str:
+    # SQLite TRIM() only strips spaces unless given an explicit character set.
+    # Match Python's write-time `str.strip()` behavior for common ASCII whitespace
+    # so legacy tabs/newlines do not become a fake attributed source bucket.
+    whitespace_chars = "char(9) || char(10) || char(11) || char(12) || char(13) || char(32)"
+    return f"({column} IS NULL OR TRIM({column}, {whitespace_chars}) = '')"
+
+
 def _normalize_source_value(source: str | None) -> str:
     normalized = (source or "").strip()
     return normalized or _UNKNOWN_SOURCE
@@ -62,7 +70,7 @@ def _source_filter_clause(column: str, source: str | None) -> tuple[str | None, 
     if not normalized:
         return None, []
     if normalized == _UNKNOWN_SOURCE:
-        return f"({column} = ? OR {column} = '')", [_UNKNOWN_SOURCE]
+        return f"({column} = ? OR {_legacy_blank_source_clause(column)})", [_UNKNOWN_SOURCE]
     return f"{column} = ?", [normalized]
 
 
@@ -446,18 +454,17 @@ class MessageStore:
             where = "WHERE session_id = ?"
             args.append(session_id)
 
+        legacy_blank_clause = _legacy_blank_source_clause("source")
         query = f"""
             SELECT COUNT(*) AS messages_total,
-                   COALESCE(SUM(CASE WHEN source = '{_UNKNOWN_SOURCE}' THEN 1 ELSE 0 END), 0) AS normalized_unknown_messages,
-                   COALESCE(SUM(CASE WHEN source = '' THEN 1 ELSE 0 END), 0) AS legacy_blank_source_messages,
-                   COALESCE(SUM(CASE WHEN source != '' AND source != '{_UNKNOWN_SOURCE}' THEN 1 ELSE 0 END), 0) AS attributed_messages
+                   COALESCE(SUM(CASE WHEN source = ? THEN 1 ELSE 0 END), 0) AS normalized_unknown_messages,
+                   COALESCE(SUM(CASE WHEN {legacy_blank_clause} THEN 1 ELSE 0 END), 0) AS legacy_blank_source_messages,
+                   COALESCE(SUM(CASE WHEN NOT {legacy_blank_clause} AND source != ? THEN 1 ELSE 0 END), 0) AS attributed_messages
             FROM messages
             {where}
             """
-        if args:
-            row = self._conn.execute(query, args).fetchone()
-        else:
-            row = self._conn.execute(query).fetchone()
+        query_args: list[Any] = [_UNKNOWN_SOURCE, _UNKNOWN_SOURCE, *args]
+        row = self._conn.execute(query, query_args).fetchone()
 
         messages_total = int(row[0] or 0) if row else 0
         normalized_unknown = int(row[1] or 0) if row else 0
@@ -469,6 +476,45 @@ class MessageStore:
             "normalized_unknown_messages": normalized_unknown,
             "legacy_blank_source_messages": legacy_blank,
             "effective_unknown_messages": normalized_unknown + legacy_blank,
+        }
+
+    def get_source_normalization_plan(self) -> Dict[str, Any]:
+        """Return a dry-run plan for normalizing legacy blank source values."""
+        stats_before = self.get_source_stats()
+        blank_clause = _legacy_blank_source_clause("source")
+        row = self._conn.execute(
+            f"""
+            SELECT COUNT(*) AS would_update_messages,
+                   COUNT(DISTINCT session_id) AS affected_sessions
+            FROM messages
+            WHERE {blank_clause}
+            """
+        ).fetchone()
+        would_update = int(row[0] or 0) if row else 0
+        affected_sessions = int(row[1] or 0) if row else 0
+        return {
+            "target_source": _UNKNOWN_SOURCE,
+            "would_update_messages": would_update,
+            "affected_sessions": affected_sessions,
+            "stats_before": stats_before,
+        }
+
+    def normalize_legacy_blank_sources(self) -> Dict[str, Any]:
+        """Normalize legacy NULL/blank source rows to the explicit unknown bucket."""
+        stats_before = self.get_source_stats()
+        blank_clause = _legacy_blank_source_clause("source")
+        with self._conn:
+            cur = self._conn.execute(
+                f"UPDATE messages SET source = ? WHERE {blank_clause}",
+                (_UNKNOWN_SOURCE,),
+            )
+        updated = cur.rowcount if cur.rowcount is not None else 0
+        stats_after = self.get_source_stats()
+        return {
+            "target_source": _UNKNOWN_SOURCE,
+            "updated_messages": int(updated),
+            "stats_before": stats_before,
+            "stats_after": stats_after,
         }
 
     def get_time_bounds(self, store_ids: List[int]) -> tuple[float | None, float | None]:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -187,6 +187,66 @@ def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(e
     assert "review legacy blank-source rows before any destructive cleanup" not in result
 
 
+def test_lcm_doctor_source_reports_dry_run_without_mutating(engine):
+    engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+    for source in (None, "", "   ", "\t\n"):
+        engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("legacy-session", source, "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+        )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor source", engine)
+    stats_after = engine._store.get_source_stats()
+
+    assert "LCM doctor source" in result
+    assert "status: normalization-needed" in result
+    assert "legacy_blank_messages: 4" in result
+    assert "would_update_messages: 4" in result
+    assert "affected_sessions: 1" in result
+    assert "target_source: unknown" in result
+    assert "note: read-only scan only — no source rows were updated" in result
+    assert "note: use `/lcm doctor source apply` to create a backup and normalize legacy blank-source rows" in result
+    assert stats_after["legacy_blank_source_messages"] == 4
+
+
+def test_lcm_doctor_source_apply_is_backup_first_and_idempotent(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_source_apply.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+    for source in (None, "", "   ", "\t\n"):
+        engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("legacy-session", source, "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+        )
+    engine._store._conn.commit()
+
+    first = handle_lcm_command("doctor source apply", engine)
+    second = handle_lcm_command("doctor source apply", engine)
+    stats_after = engine._store.get_source_stats()
+
+    assert "LCM doctor source apply" in first
+    assert "status: ok" in first
+    assert "updated_messages: 4" in first
+    assert "legacy_blank_before: 4" in first
+    assert "legacy_blank_after: 0" in first
+    assert "note: backup created before source normalization apply" in first
+    backup_line = next(line for line in first.splitlines() if line.startswith("backup_path: "))
+    assert Path(backup_line.split(": ", 1)[1]).exists()
+    assert "updated_messages: 0" in second
+    assert stats_after["messages_total"] == 5
+    assert stats_after["attributed_messages"] == 1
+    assert stats_after["normalized_unknown_messages"] == 4
+    assert stats_after["legacy_blank_source_messages"] == 0
+
+
 def test_lcm_help_on_unknown_subcommand(engine):
     result = handle_lcm_command("wat", engine)
 
@@ -198,10 +258,12 @@ def test_lcm_help_on_unknown_subcommand(engine):
 def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
     result = handle_lcm_command("doctor clean foo", engine)
 
-    assert "currently supports `clean`, `clean apply`, `repair`, `repair apply`, and `retention`" in result
+    assert "currently supports `clean`, `clean apply`, `repair`, `repair apply`, `source`, `source apply`, and `retention`" in result
     assert "/lcm doctor clean apply" in result
     assert "/lcm doctor repair" in result
     assert "/lcm doctor repair apply" in result
+    assert "/lcm doctor source" in result
+    assert "/lcm doctor source apply" in result
     assert "/lcm doctor retention" in result
 
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -495,6 +495,87 @@ class TestMessageStore:
 
         store.close()
 
+    def test_source_unknown_filter_matches_null_and_whitespace_legacy_source_rows(self, tmp_path):
+        db_path = tmp_path / "legacy-null-whitespace-source.db"
+        store = MessageStore(db_path)
+        for source in (None, "", "   ", "\t\n"):
+            store._conn.execute(
+                """INSERT INTO messages
+                   (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ("legacy-session", source, "user", f"docker with {source!r} source", None, None, None, 1.0, 5, 0),
+            )
+        store._conn.commit()
+
+        results = store.search("docker", source="unknown")
+        fetched = [store.get(result["store_id"]) for result in results]
+
+        assert len(results) == 4
+        assert {result["source"] for result in results} == {"unknown"}
+        assert {item["source"] for item in fetched} == {"unknown"}
+
+        store.close()
+
+    def test_get_source_stats_treats_null_and_whitespace_as_legacy_blank(self, tmp_path):
+        db_path = tmp_path / "source-stats-legacy-shapes.db"
+        store = MessageStore(db_path)
+        store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+        store.append("sess-unknown", {"role": "user", "content": "unknown message"})
+        for source in (None, "", "   ", "\t\n"):
+            store._conn.execute(
+                """INSERT INTO messages
+                   (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ("legacy-session", source, "user", "legacy source shape", None, None, None, 1.0, 5, 0),
+            )
+        store._conn.commit()
+
+        stats = store.get_source_stats()
+
+        assert stats["messages_total"] == 6
+        assert stats["attributed_messages"] == 1
+        assert stats["normalized_unknown_messages"] == 1
+        assert stats["legacy_blank_source_messages"] == 4
+        assert stats["effective_unknown_messages"] == 5
+
+        store.close()
+
+    def test_source_normalization_plan_and_apply_are_idempotent(self, tmp_path):
+        db_path = tmp_path / "source-normalization.db"
+        store = MessageStore(db_path)
+        store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
+        store.append("sess-unknown", {"role": "user", "content": "unknown message"})
+        for session_id, source in (("legacy-a", None), ("legacy-a", ""), ("legacy-b", "   "), ("legacy-b", "\t\n")):
+            store._conn.execute(
+                """INSERT INTO messages
+                   (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (session_id, source, "user", "legacy source shape", None, None, None, 1.0, 5, 0),
+            )
+        store._conn.commit()
+
+        plan = store.get_source_normalization_plan()
+
+        assert plan["target_source"] == "unknown"
+        assert plan["would_update_messages"] == 4
+        assert plan["affected_sessions"] == 2
+        assert plan["stats_before"]["legacy_blank_source_messages"] == 4
+
+        first = store.normalize_legacy_blank_sources()
+        second = store.normalize_legacy_blank_sources()
+        stats = store.get_source_stats()
+
+        assert first["updated_messages"] == 4
+        assert first["stats_before"]["legacy_blank_source_messages"] == 4
+        assert first["stats_after"]["legacy_blank_source_messages"] == 0
+        assert second["updated_messages"] == 0
+        assert stats["messages_total"] == 6
+        assert stats["attributed_messages"] == 1
+        assert stats["normalized_unknown_messages"] == 5
+        assert stats["effective_unknown_messages"] == 5
+
+        store.close()
+
     def test_gc_externalized_tool_result_rewrites_content_and_updates_fts(self, store):
         placeholder = "[GC'd externalized tool output: tool_call_id=call_gc; ref=payload.json]"
         store_id = store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2951,6 +2951,45 @@ class TestEngineTools:
             if item["type"] == "summary"
         )
 
+    def test_handle_grep_unknown_source_filter_matches_whitespace_legacy_summary_lineage(self, engine):
+        cursor = engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("test-session", "\t\n", "user", "docker logs from whitespace legacy source", None, None, None, 1.0, 5, 0),
+        )
+        legacy_store_id = cursor.lastrowid
+        engine._store._conn.commit()
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="whitespace legacy summary about docker logs",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[legacy_store_id],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "current", "source": "unknown", "limit": 10},
+            )
+        )
+
+        assert result["source"] == "unknown"
+        assert any(
+            item["type"] == "message" and item.get("source") == "unknown"
+            for item in result["results"]
+        )
+        assert any(
+            item["type"] == "summary" and "whitespace legacy summary" in item.get("snippet", "")
+            for item in result["results"]
+        )
+
     def test_handle_grep_prefers_conversational_hits_over_tool_output_noise(self, engine):
         engine._store.append(
             "test-session",
@@ -4194,12 +4233,13 @@ class TestEngineTools:
         assert all(c["status"] == "pass" for c in result["checks"])
 
     def test_handle_doctor_treats_legacy_blank_source_rows_as_healthy(self, engine):
-        engine._store._conn.execute(
-            """INSERT INTO messages
-               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            ("legacy-session", "", "user", "legacy blank source", None, None, None, 1.0, 5, 0),
-        )
+        for source in (None, "", "   ", "\t\n"):
+            engine._store._conn.execute(
+                """INSERT INTO messages
+                   (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ("legacy-session", source, "user", "legacy blank source", None, None, None, 1.0, 5, 0),
+            )
         engine._store._conn.commit()
 
         result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
@@ -4207,7 +4247,8 @@ class TestEngineTools:
         assert result["overall"] == "healthy"
         lineage_check = next(c for c in result["checks"] if c["check"] == "source_lineage_hygiene")
         assert lineage_check["status"] == "pass"
-        assert lineage_check["detail"]["legacy_blank_source_messages"] == 1
+        assert lineage_check["detail"]["legacy_blank_source_messages"] == 4
+        assert lineage_check["detail"]["effective_unknown_messages"] == 4
 
     def test_handle_doctor_warns_on_bad_config(self, tmp_path):
         config = LCMConfig(


### PR DESCRIPTION
## Summary

This makes legacy blank source rows safe and explicit without rewriting them by default.

The change does four things:

- treats legacy `NULL`, blank, and whitespace-only message sources as `unknown` in raw message filtering
- applies the same `unknown` back-compat semantics to summary/DAG source lineage filtering
- adds `/lcm doctor source` for a read-only normalization scan
- adds `/lcm doctor source apply` for backup-first, idempotent normalization to explicit `unknown`

The apply path only updates legacy blank-source message rows. It does not delete messages, rewrite content, or touch summaries.

## Why

Older databases can contain many persisted rows with an empty source. New writes already normalize missing sources to `unknown`, but old rows still need to be visible and explainable so source filtering does not behave differently depending on whether content is still raw or has been summarized.

This keeps the runtime behavior backward-compatible while giving operators a clear dry-run and a backup-first cleanup path if they want to physically normalize the old rows.

## Validation

```bash
pytest tests/test_lcm_core.py::TestMessageStore::test_source_unknown_filter_matches_null_and_whitespace_legacy_source_rows tests/test_lcm_core.py::TestMessageStore::test_get_source_stats_treats_null_and_whitespace_as_legacy_blank tests/test_lcm_core.py::TestMessageStore::test_source_normalization_plan_and_apply_are_idempotent tests/test_lcm_command.py::test_lcm_doctor_source_reports_dry_run_without_mutating tests/test_lcm_command.py::test_lcm_doctor_source_apply_is_backup_first_and_idempotent tests/test_lcm_engine.py::TestEngineTools::test_handle_grep_unknown_source_filter_matches_whitespace_legacy_summary_lineage tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_treats_legacy_blank_source_rows_as_healthy -q --tb=short
```

Result: `7 passed`

```bash
pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_command.py -q
```

Result: `323 passed`

```bash
pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
```

Result: `295 passed`

```bash
pytest -q
```

Result: `328 passed`

```bash
python -m compileall -q .
bash -n scripts/install.sh scripts/update.sh
git diff --check
```

All passed.

I also ran a temp-database smoke test covering dry-run, backup-first apply, idempotent second apply, raw `source='unknown'` search before and after apply, and summary lineage matching for a whitespace-only legacy source.