### PR TITLE
feat: report lifecycle fragmentation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,8 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 | `lcm_describe` | Inspect current-session DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
 | `lcm_expand` | Recover original content from a current-session summary node, or open a stored `externalized_ref` payload directly. |
 | `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. For cross-session recall, use `session_search` first. |
-| `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, and active config. |
-| `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, config validation, context pressure. |
+| `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, active config, and read-only lifecycle/session fragmentation stats. |
+| `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, lifecycle/session fragmentation, config validation, context pressure. |
 
 ### Operator slash commands
 
@@ -413,7 +413,7 @@ When Hermes host support for plugin slash commands is available, `hermes-lcm` ca
 This surface is **disabled by default** and requires `LCM_ENABLE_SLASH_COMMAND=1` (or `true/yes/on`) before registration.
 
 - `/lcm` or `/lcm status` — current session/runtime status
-- `/lcm doctor` — SQLite + FTS health checks and store/node totals
+- `/lcm doctor` — SQLite + FTS health checks, store/node totals, and read-only lifecycle/session fragmentation diagnostics
 - `/lcm doctor clean` — best-effort read-only scan for obvious junk/noise sessions matched from stored session keys
 - `/lcm doctor clean apply` — backup-first cleanup for safe pattern-matched junk/noise session candidates
 - `/lcm doctor repair` — read-only SQLite/FTS diagnostics for message and summary search indexes

--- a/command.py
+++ b/command.py
@@ -13,6 +13,38 @@ from .session_patterns import build_session_match_keys, matches_session_pattern
 from .store import build_message_fts_spec
 
 
+def _state_db_path_for_engine(engine) -> Path:
+    hermes_home = getattr(engine, "_hermes_home", "") or ""
+    if hermes_home:
+        return Path(hermes_home).expanduser() / "state.db"
+    db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
+    return db_path.parent / "state.db"
+
+
+def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
+    direct_mismatch_keys = (
+        "lifecycle_current_missing_in_lcm_any",
+        "lifecycle_last_finalized_missing_in_lcm_any",
+        "lifecycle_current_missing_in_state",
+        "lifecycle_last_finalized_missing_in_state",
+        "lcm_message_sessions_missing_in_state",
+        "lcm_node_sessions_missing_in_state",
+    )
+    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
+    missing_lifecycle_reference_keys = (
+        "message_sessions_without_lifecycle_current",
+        "node_sessions_without_lifecycle_reference",
+    )
+    return (
+        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
+        or (
+            lifecycle_rows > 0
+            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
+        )
+        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
+    )
+
+
 def _fmt_bool(value: Any) -> str:
     return "yes" if bool(value) else "no"
 
@@ -714,6 +746,39 @@ def _doctor_text(engine) -> str:
         observations.append(
             "legacy blank-source rows are normalized as `source=unknown` for back-compat filters"
         )
+
+    try:
+        lifecycle_stats = engine._lifecycle.get_fragmentation_stats(
+            state_db_path=_state_db_path_for_engine(engine)
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        issues.append("lifecycle_fragmentation")
+        lifecycle_stats = {"error": str(exc)}
+    else:
+        observations.append(
+            "lifecycle_fragmentation: "
+            f"lifecycle_rows={lifecycle_stats['lifecycle_rows']} "
+            f"message_sessions={lifecycle_stats['distinct_message_sessions']} "
+            f"node_sessions={lifecycle_stats['distinct_node_sessions']} "
+            f"current_missing_in_lcm_any={lifecycle_stats['lifecycle_current_missing_in_lcm_any']} "
+            f"last_finalized_missing_in_lcm_any={lifecycle_stats['lifecycle_last_finalized_missing_in_lcm_any']} "
+            f"current_missing_in_state={lifecycle_stats['lifecycle_current_missing_in_state']} "
+            f"last_finalized_missing_in_state={lifecycle_stats['lifecycle_last_finalized_missing_in_state']} "
+            f"message_sessions_missing_in_state={lifecycle_stats['lcm_message_sessions_missing_in_state']} "
+            f"node_sessions_missing_in_state={lifecycle_stats['lcm_node_sessions_missing_in_state']} "
+            f"message_sessions_without_lifecycle_current={lifecycle_stats['message_sessions_without_lifecycle_current']} "
+            f"node_sessions_without_lifecycle_reference={lifecycle_stats['node_sessions_without_lifecycle_reference']} "
+            f"state_sessions_missing_in_lcm_any={lifecycle_stats['state_sessions_missing_in_lcm_any']}"
+        )
+        if lifecycle_stats.get("state_db_error"):
+            observations.append(f"lifecycle_fragmentation_state_db_error: {lifecycle_stats['state_db_error']}")
+        if _has_lifecycle_fragmentation(lifecycle_stats):
+            recommended_actions.append(
+                "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state"
+            )
+            recommended_actions.append(
+                "treat this as read-only evidence; do not infer every mismatch is harmful"
+            )
 
     if clean_scan.get("protected_count"):
         observations.append(

--- a/command.py
+++ b/command.py
@@ -32,7 +32,7 @@ def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
     )
     lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
     missing_lifecycle_reference_keys = (
-        "message_sessions_without_lifecycle_current",
+        "message_sessions_without_lifecycle_reference",
         "node_sessions_without_lifecycle_reference",
     )
     return (
@@ -767,6 +767,7 @@ def _doctor_text(engine) -> str:
             f"message_sessions_missing_in_state={lifecycle_stats['lcm_message_sessions_missing_in_state']} "
             f"node_sessions_missing_in_state={lifecycle_stats['lcm_node_sessions_missing_in_state']} "
             f"message_sessions_without_lifecycle_current={lifecycle_stats['message_sessions_without_lifecycle_current']} "
+            f"message_sessions_without_lifecycle_reference={lifecycle_stats['message_sessions_without_lifecycle_reference']} "
             f"node_sessions_without_lifecycle_reference={lifecycle_stats['node_sessions_without_lifecycle_reference']} "
             f"state_sessions_missing_in_lcm_any={lifecycle_stats['state_sessions_missing_in_lcm_any']}"
         )

--- a/engine.py
+++ b/engine.py
@@ -1040,6 +1040,17 @@ class LCMEngine(ContextEngine):
             status["source_lineage"] = self._store.get_source_stats(self._session_id or None)
         except Exception as exc:  # pragma: no cover - defensive
             status["source_lineage"] = {"error": str(exc)}
+        try:
+            state_db_path = (
+                Path(self._hermes_home).expanduser() / "state.db"
+                if self._hermes_home
+                else Path(self._store.db_path).parent / "state.db"
+            )
+            status["lifecycle_fragmentation"] = self._lifecycle.get_fragmentation_stats(
+                state_db_path=state_db_path
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            status["lifecycle_fragmentation"] = {"error": str(exc), "read_only": True}
         if self._session_id:
             status["store_messages"] = self._store.get_session_count(self._session_id)
             status["dag_nodes"] = len(self._dag.get_session_nodes(self._session_id))

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -352,6 +352,7 @@ class LifecycleStateStore:
         lifecycle_last_finalized_sessions = _session_ids(
             "SELECT DISTINCT last_finalized_session_id FROM lcm_lifecycle_state WHERE last_finalized_session_id IS NOT NULL"
         )
+        lifecycle_referenced_sessions = lifecycle_current_sessions | lifecycle_last_finalized_sessions
 
         stats: dict[str, Any] = {
             "read_only": True,
@@ -370,9 +371,8 @@ class LifecycleStateStore:
             "lifecycle_last_finalized_missing_in_nodes": len(lifecycle_last_finalized_sessions - node_sessions),
             "lifecycle_last_finalized_missing_in_lcm_any": len(lifecycle_last_finalized_sessions - lcm_any_sessions),
             "message_sessions_without_lifecycle_current": len(message_sessions - lifecycle_current_sessions),
-            "node_sessions_without_lifecycle_reference": len(
-                node_sessions - (lifecycle_current_sessions | lifecycle_last_finalized_sessions)
-            ),
+            "message_sessions_without_lifecycle_reference": len(message_sessions - lifecycle_referenced_sessions),
+            "node_sessions_without_lifecycle_reference": len(node_sessions - lifecycle_referenced_sessions),
             "state_db_checked": False,
             "state_db_error": "",
             "state_sessions_total": 0,

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -14,7 +14,7 @@ import sqlite3
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from .db_bootstrap import configure_connection, run_versioned_migrations
 
@@ -322,6 +322,97 @@ class LifecycleStateStore:
         updated = self.get_by_conversation(conversation_id)
         assert updated is not None
         return updated
+
+    def get_fragmentation_stats(self, state_db_path: str | Path | None = None) -> dict[str, Any]:
+        """Return read-only lifecycle/session fragmentation diagnostics.
+
+        This intentionally reports mismatches only. It does not infer that every
+        mismatch is corrupt, and it never rewrites lifecycle, message, DAG, or
+        Hermes host state. Repair/cleanup flows must stay explicit and separate.
+        """
+        conn = self._conn
+
+        def _count(query: str, params: tuple[Any, ...] = ()) -> int:
+            row = conn.execute(query, params).fetchone()
+            return int(row[0] if row else 0)
+
+        def _session_ids(query: str) -> set[str]:
+            return {
+                str(row[0])
+                for row in conn.execute(query).fetchall()
+                if row[0]
+            }
+
+        message_sessions = _session_ids("SELECT DISTINCT session_id FROM messages WHERE session_id IS NOT NULL")
+        node_sessions = _session_ids("SELECT DISTINCT session_id FROM summary_nodes WHERE session_id IS NOT NULL")
+        lcm_any_sessions = message_sessions | node_sessions
+        lifecycle_current_sessions = _session_ids(
+            "SELECT DISTINCT current_session_id FROM lcm_lifecycle_state WHERE current_session_id IS NOT NULL"
+        )
+        lifecycle_last_finalized_sessions = _session_ids(
+            "SELECT DISTINCT last_finalized_session_id FROM lcm_lifecycle_state WHERE last_finalized_session_id IS NOT NULL"
+        )
+
+        stats: dict[str, Any] = {
+            "read_only": True,
+            "lifecycle_rows": _count("SELECT COUNT(*) FROM lcm_lifecycle_state"),
+            "messages_total": _count("SELECT COUNT(*) FROM messages"),
+            "summary_nodes_total": _count("SELECT COUNT(*) FROM summary_nodes"),
+            "distinct_message_sessions": len(message_sessions),
+            "distinct_node_sessions": len(node_sessions),
+            "distinct_lcm_any_sessions": len(lcm_any_sessions),
+            "lifecycle_current_sessions": len(lifecycle_current_sessions),
+            "lifecycle_last_finalized_sessions": len(lifecycle_last_finalized_sessions),
+            "lifecycle_current_missing_in_messages": len(lifecycle_current_sessions - message_sessions),
+            "lifecycle_current_missing_in_nodes": len(lifecycle_current_sessions - node_sessions),
+            "lifecycle_current_missing_in_lcm_any": len(lifecycle_current_sessions - lcm_any_sessions),
+            "lifecycle_last_finalized_missing_in_messages": len(lifecycle_last_finalized_sessions - message_sessions),
+            "lifecycle_last_finalized_missing_in_nodes": len(lifecycle_last_finalized_sessions - node_sessions),
+            "lifecycle_last_finalized_missing_in_lcm_any": len(lifecycle_last_finalized_sessions - lcm_any_sessions),
+            "message_sessions_without_lifecycle_current": len(message_sessions - lifecycle_current_sessions),
+            "node_sessions_without_lifecycle_reference": len(
+                node_sessions - (lifecycle_current_sessions | lifecycle_last_finalized_sessions)
+            ),
+            "state_db_checked": False,
+            "state_db_error": "",
+            "state_sessions_total": 0,
+            "lifecycle_current_missing_in_state": 0,
+            "lifecycle_last_finalized_missing_in_state": 0,
+            "lcm_message_sessions_missing_in_state": 0,
+            "lcm_node_sessions_missing_in_state": 0,
+            "state_sessions_missing_in_lcm_messages": 0,
+            "state_sessions_missing_in_lcm_any": 0,
+        }
+
+        if state_db_path:
+            path = Path(state_db_path).expanduser()
+            if path.exists():
+                stats["state_db_checked"] = True
+                try:
+                    state_uri = path.resolve().as_uri() + "?mode=ro"
+                    state_conn = sqlite3.connect(state_uri, uri=True)
+                    try:
+                        state_rows = state_conn.execute("SELECT id FROM sessions WHERE id IS NOT NULL").fetchall()
+                    finally:
+                        state_conn.close()
+                    state_sessions = {str(row[0]) for row in state_rows if row[0]}
+                    stats.update({
+                        "state_sessions_total": len(state_sessions),
+                        "lifecycle_current_missing_in_state": len(lifecycle_current_sessions - state_sessions),
+                        "lifecycle_last_finalized_missing_in_state": len(
+                            lifecycle_last_finalized_sessions - state_sessions
+                        ),
+                        "lcm_message_sessions_missing_in_state": len(message_sessions - state_sessions),
+                        "lcm_node_sessions_missing_in_state": len(node_sessions - state_sessions),
+                        "state_sessions_missing_in_lcm_messages": len(state_sessions - message_sessions),
+                        "state_sessions_missing_in_lcm_any": len(state_sessions - lcm_any_sessions),
+                    })
+                except Exception as exc:  # pragma: no cover - defensive
+                    stats["state_db_error"] = str(exc)
+            else:
+                stats["state_db_error"] = f"state database not found: {path}"
+
+        return stats
 
     def record_debt(
         self,

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -331,9 +331,32 @@ def test_lcm_doctor_warns_on_lcm_sessions_without_lifecycle_references(engine):
 
     assert "status: action-recommended" in result
     assert "message_sessions_without_lifecycle_current=1" in result
+    assert "message_sessions_without_lifecycle_reference=1" in result
     assert "node_sessions_without_lifecycle_reference=1" in result
     assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" in result
 
+
+def test_lcm_doctor_does_not_warn_on_last_finalized_message_session(engine):
+    engine.on_session_start(
+        "current-session",
+        platform="cli",
+        context_length=200000,
+        conversation_id="conversation",
+    )
+    engine._store.append("previous-session", {"role": "user", "content": "previous"}, source="cli")
+    engine._store.append("current-session", {"role": "user", "content": "current"}, source="cli")
+    engine._lifecycle.record_rollover(
+        "conversation",
+        old_session_id="previous-session",
+        new_session_id="current-session",
+    )
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: ok" in result
+    assert "message_sessions_without_lifecycle_current=1" in result
+    assert "message_sessions_without_lifecycle_reference=0" in result
+    assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" not in result
 
 
 def test_lcm_help_on_unknown_subcommand(engine):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -260,6 +260,82 @@ def test_lcm_doctor_source_apply_is_backup_first_and_idempotent(tmp_path):
     assert stats_after["legacy_blank_source_messages"] == 0
 
 
+def test_lcm_doctor_reports_lifecycle_fragmentation_as_read_only_observation(engine):
+    state_db = Path(engine._hermes_home) / "state.db"
+    state_db.parent.mkdir(parents=True, exist_ok=True)
+    state_conn = sqlite3.connect(state_db)
+    state_conn.executescript(
+        """
+        CREATE TABLE sessions (id TEXT PRIMARY KEY);
+        INSERT INTO sessions(id) VALUES ('current-with-message');
+        INSERT INTO sessions(id) VALUES ('state-only');
+        """
+    )
+    state_conn.commit()
+    state_conn.close()
+    engine._store.append("current-with-message", {"role": "user", "content": "covered"}, source="cli")
+    engine._dag.add_node(SummaryNode(
+        session_id="node-missing-in-state",
+        depth=0,
+        summary="summary-only coverage",
+        token_count=5,
+        source_token_count=5,
+        source_ids=[],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._lifecycle._conn.execute(
+        """INSERT INTO lcm_lifecycle_state
+           (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("conv-current", "current-with-message", "node-missing-in-state", 0, 0, 1.0),
+    )
+    engine._lifecycle._conn.execute(
+        """INSERT INTO lcm_lifecycle_state
+           (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("conv-stale", "missing-current", "missing-final", 0, 0, 1.0),
+    )
+    engine._lifecycle._conn.commit()
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: action-recommended" in result
+    assert "lifecycle_fragmentation:" in result
+    assert "lifecycle_rows=2" in result
+    assert "current_missing_in_lcm_any=1" in result
+    assert "current_missing_in_state=1" in result
+    assert "node_sessions_missing_in_state=1" in result
+    assert "state_sessions_missing_in_lcm_any=1" in result
+    assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" in result
+    assert "read-only" in result
+    assert engine._lifecycle.row_count() == 2
+
+
+def test_lcm_doctor_warns_on_lcm_sessions_without_lifecycle_references(engine):
+    engine.on_session_start("current-session", platform="cli", context_length=200000)
+    engine._store.append("current-session", {"role": "user", "content": "covered"}, source="cli")
+    engine._store.append("message-only-session", {"role": "user", "content": "missing lifecycle"}, source="cli")
+    engine._dag.add_node(SummaryNode(
+        session_id="node-only-session",
+        depth=0,
+        summary="missing lifecycle reference",
+        token_count=5,
+        source_token_count=5,
+        source_ids=[],
+        source_type="messages",
+        created_at=1.0,
+    ))
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: action-recommended" in result
+    assert "message_sessions_without_lifecycle_current=1" in result
+    assert "node_sessions_without_lifecycle_reference=1" in result
+    assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" in result
+
+
+
 def test_lcm_help_on_unknown_subcommand(engine):
     result = handle_lcm_command("wat", engine)
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1648,6 +1648,27 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_lifecycle_fragmentation_stats_treats_last_finalized_message_session_as_referenced(self, tmp_path):
+        db_path = tmp_path / "lifecycle-finalized-message-reference.db"
+        store = MessageStore(db_path)
+        SummaryDAG(db_path)
+        state = LifecycleStateStore(db_path)
+        store.append("previous-session", {"role": "user", "content": "previous"}, source="cli")
+        store.append("current-session", {"role": "user", "content": "current"}, source="cli")
+        state.record_rollover(
+            "conversation",
+            old_session_id="previous-session",
+            new_session_id="current-session",
+        )
+
+        stats = state.get_fragmentation_stats()
+
+        assert stats["message_sessions_without_lifecycle_current"] == 1
+        assert stats["message_sessions_without_lifecycle_reference"] == 0
+        assert stats["node_sessions_without_lifecycle_reference"] == 0
+
+        state.close()
+
     def test_lifecycle_fragmentation_stats_reports_existing_malformed_state_db(self, tmp_path):
         db_path = tmp_path / "lifecycle-malformed-state.db"
         state_db = tmp_path / "state.db"

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1581,6 +1581,90 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_lifecycle_fragmentation_stats_compare_lifecycle_to_lcm_content_and_state_db(self, tmp_path):
+        db_path = tmp_path / "lifecycle-fragmentation.db"
+        state_db = tmp_path / "state.db"
+        # Initialize all shared LCM tables; fragmentation diagnostics compare
+        # lifecycle rows against raw-message and summary-DAG session coverage.
+        store = MessageStore(db_path)
+        dag = SummaryDAG(db_path)
+        state = LifecycleStateStore(db_path)
+        conn = state._conn
+        conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("message-only", "cli", "user", "message only", None, None, None, 1.0, 5, 0),
+        )
+        conn.execute(
+            """INSERT INTO summary_nodes
+               (session_id, depth, summary, token_count, source_token_count, source_ids, source_type, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("node-only", 0, "node only", 5, 5, "[]", "messages", 1.0),
+        )
+        conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-live", "message-only", "node-only", 0, 0, 1.0),
+        )
+        conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-missing", "missing-current", "missing-final", 0, 0, 1.0),
+        )
+        conn.commit()
+        state_conn = sqlite3.connect(state_db)
+        state_conn.executescript(
+            """
+            CREATE TABLE sessions (id TEXT PRIMARY KEY);
+            INSERT INTO sessions(id) VALUES ('message-only');
+            INSERT INTO sessions(id) VALUES ('state-only');
+            """
+        )
+        state_conn.commit()
+        state_conn.close()
+
+        stats = state.get_fragmentation_stats(state_db_path=state_db)
+
+        assert stats["lifecycle_rows"] == 2
+        assert stats["distinct_message_sessions"] == 1
+        assert stats["distinct_node_sessions"] == 1
+        assert stats["lifecycle_current_missing_in_messages"] == 1
+        assert stats["lifecycle_current_missing_in_lcm_any"] == 1
+        assert stats["lifecycle_last_finalized_missing_in_lcm_any"] == 1
+        assert stats["lifecycle_current_missing_in_state"] == 1
+        assert stats["lifecycle_last_finalized_missing_in_state"] == 2
+        assert stats["lcm_message_sessions_missing_in_state"] == 0
+        assert stats["lcm_node_sessions_missing_in_state"] == 1
+        assert stats["state_sessions_missing_in_lcm_any"] == 1
+        assert stats["state_db_checked"] is True
+        assert stats["state_db_error"] == ""
+
+        # Read-only diagnostic: no lifecycle rows were mutated or removed.
+        assert state.row_count() == 2
+        assert state.get_by_conversation("conv-missing").current_session_id == "missing-current"
+
+        state.close()
+
+    def test_lifecycle_fragmentation_stats_reports_existing_malformed_state_db(self, tmp_path):
+        db_path = tmp_path / "lifecycle-malformed-state.db"
+        state_db = tmp_path / "state.db"
+        MessageStore(db_path)
+        SummaryDAG(db_path)
+        state = LifecycleStateStore(db_path)
+        state_db.write_text("not sqlite")
+
+        stats = state.get_fragmentation_stats(state_db_path=state_db)
+
+        assert stats["state_db_checked"] is True
+        assert stats["state_db_error"]
+        assert stats["read_only"] is True
+        assert state.row_count() == 0
+
+        state.close()
+
     def test_record_debt_and_clear_debt(self, tmp_path):
         state = LifecycleStateStore(tmp_path / "lifecycle-debt.db")
         bound = state.bind_session("sess-1")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4558,6 +4558,31 @@ class TestEngineTools:
         lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
         assert lifecycle_check["status"] == "warn"
         assert lifecycle_check["detail"]["message_sessions_without_lifecycle_current"] == 1
+        assert lifecycle_check["detail"]["message_sessions_without_lifecycle_reference"] == 1
+        assert lifecycle_check["detail"]["read_only"] is True
+
+    def test_handle_doctor_does_not_warn_on_last_finalized_message_session(self, engine):
+        engine.on_session_start(
+            "current-session",
+            platform="cli",
+            context_length=200000,
+            conversation_id="conversation",
+        )
+        engine._store.append("previous-session", {"role": "user", "content": "previous"}, source="cli")
+        engine._store.append("current-session", {"role": "user", "content": "current"}, source="cli")
+        engine._lifecycle.record_rollover(
+            "conversation",
+            old_session_id="previous-session",
+            new_session_id="current-session",
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "healthy"
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "pass"
+        assert lifecycle_check["detail"]["message_sessions_without_lifecycle_current"] == 1
+        assert lifecycle_check["detail"]["message_sessions_without_lifecycle_reference"] == 0
         assert lifecycle_check["detail"]["read_only"] is True
 
     def test_handle_doctor_warns_on_node_session_without_lifecycle_reference(self, engine):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from pathlib import Path
+import sqlite3
 import time
 from pathlib import Path
 
@@ -29,6 +29,36 @@ def engine(tmp_path):
     e.context_length = 200000
     e.threshold_tokens = int(200000 * config.context_threshold)
     return e
+
+
+def test_lcm_tool_status_reports_lifecycle_fragmentation_summary(engine, tmp_path):
+    engine._hermes_home = str(tmp_path / "hermes_home")
+    state_db = tmp_path / "hermes_home" / "state.db"
+    state_db.parent.mkdir(parents=True, exist_ok=True)
+    state_conn = sqlite3.connect(state_db)
+    state_conn.executescript(
+        """
+        CREATE TABLE sessions (id TEXT PRIMARY KEY);
+        INSERT INTO sessions(id) VALUES ('covered-session');
+        """
+    )
+    state_conn.commit()
+    state_conn.close()
+    engine._store.append("covered-session", {"role": "user", "content": "covered"}, source="cli")
+    engine._lifecycle._conn.execute(
+        """INSERT INTO lcm_lifecycle_state
+           (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("conv-stale", "missing-current", None, 0, 0, 1.0),
+    )
+    engine._lifecycle._conn.commit()
+
+    payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+
+    assert payload["lifecycle_fragmentation"]["read_only"] is True
+    assert payload["lifecycle_fragmentation"]["lifecycle_rows"] == 1
+    assert payload["lifecycle_fragmentation"]["lifecycle_current_missing_in_lcm_any"] == 1
+    assert payload["lifecycle_fragmentation"]["lifecycle_current_missing_in_state"] == 1
 
 
 def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
@@ -4448,6 +4478,111 @@ class TestEngineTools:
         assert lineage_check["status"] == "pass"
         assert lineage_check["detail"]["legacy_blank_source_messages"] == 4
         assert lineage_check["detail"]["effective_unknown_messages"] == 4
+
+    def test_handle_doctor_reports_lifecycle_fragmentation_without_mutating(self, engine, tmp_path):
+        engine._hermes_home = str(tmp_path / "hermes_home")
+        state_db = tmp_path / "hermes_home" / "state.db"
+        state_db.parent.mkdir(parents=True, exist_ok=True)
+        state_conn = sqlite3.connect(state_db)
+        state_conn.executescript(
+            """
+            CREATE TABLE sessions (id TEXT PRIMARY KEY);
+            INSERT INTO sessions(id) VALUES ('current-with-message');
+            INSERT INTO sessions(id) VALUES ('state-only');
+            """
+        )
+        state_conn.commit()
+        state_conn.close()
+        engine._store.append("current-with-message", {"role": "user", "content": "covered"}, source="cli")
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="node-missing-in-state",
+                depth=0,
+                summary="summary-only coverage",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[],
+                source_type="messages",
+                created_at=1.0,
+            )
+        )
+        engine._lifecycle._conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-current", "current-with-message", "node-missing-in-state", 0, 0, 1.0),
+        )
+        engine._lifecycle._conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-stale", "missing-current", "missing-final", 0, 0, 1.0),
+        )
+        engine._lifecycle._conn.commit()
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["detail"]["lifecycle_rows"] == 2
+        assert lifecycle_check["detail"]["lifecycle_current_missing_in_lcm_any"] == 1
+        assert lifecycle_check["detail"]["lifecycle_current_missing_in_state"] == 1
+        assert lifecycle_check["detail"]["lcm_node_sessions_missing_in_state"] == 1
+        assert lifecycle_check["detail"]["state_sessions_missing_in_lcm_any"] == 1
+        assert lifecycle_check["detail"]["read_only"] is True
+        assert engine._lifecycle.row_count() == 2
+
+    def test_handle_doctor_warns_when_existing_state_db_is_unreadable(self, engine, tmp_path):
+        engine._hermes_home = str(tmp_path / "hermes_home")
+        state_db = tmp_path / "hermes_home" / "state.db"
+        state_db.parent.mkdir(parents=True, exist_ok=True)
+        state_db.write_text("not sqlite")
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "warnings"
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["detail"]["state_db_checked"] is True
+        assert lifecycle_check["detail"]["state_db_error"]
+        assert lifecycle_check["detail"]["read_only"] is True
+
+    def test_handle_doctor_warns_on_message_session_without_lifecycle_current(self, engine):
+        engine.on_session_start("current-session", platform="cli", context_length=200000)
+        engine._store.append("current-session", {"role": "user", "content": "covered"}, source="cli")
+        engine._store.append("message-only-session", {"role": "user", "content": "missing lifecycle"}, source="cli")
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "warnings"
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["detail"]["message_sessions_without_lifecycle_current"] == 1
+        assert lifecycle_check["detail"]["read_only"] is True
+
+    def test_handle_doctor_warns_on_node_session_without_lifecycle_reference(self, engine):
+        engine.on_session_start("current-session", platform="cli", context_length=200000)
+        engine._store.append("current-session", {"role": "user", "content": "covered"}, source="cli")
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="node-only-session",
+                depth=0,
+                summary="missing lifecycle reference",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[],
+                source_type="messages",
+                created_at=1.0,
+            )
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "warnings"
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["detail"]["node_sessions_without_lifecycle_reference"] == 1
+        assert lifecycle_check["detail"]["read_only"] is True
 
     def test_handle_doctor_warns_on_bad_config(self, tmp_path):
         config = LCMConfig(

--- a/tools.py
+++ b/tools.py
@@ -75,7 +75,7 @@ def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
     )
     lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
     missing_lifecycle_reference_keys = (
-        "message_sessions_without_lifecycle_current",
+        "message_sessions_without_lifecycle_reference",
         "node_sessions_without_lifecycle_reference",
     )
     return (

--- a/tools.py
+++ b/tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
 from .externalize import (
@@ -53,6 +54,38 @@ def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple:
     if result.get("type") == "message":
         return (-sort_timestamp, type_bias, role_bias, rank_value, 0.0, float("inf"))
     return (-sort_timestamp, type_bias, 0, rank_value, 0.0, role_bias)
+
+
+def _state_db_path_for_engine(engine: "LCMEngine") -> Path:
+    hermes_home = getattr(engine, "_hermes_home", "") or ""
+    if hermes_home:
+        return Path(hermes_home).expanduser() / "state.db"
+    db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
+    return db_path.parent / "state.db"
+
+
+def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
+    direct_mismatch_keys = (
+        "lifecycle_current_missing_in_lcm_any",
+        "lifecycle_last_finalized_missing_in_lcm_any",
+        "lifecycle_current_missing_in_state",
+        "lifecycle_last_finalized_missing_in_state",
+        "lcm_message_sessions_missing_in_state",
+        "lcm_node_sessions_missing_in_state",
+    )
+    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
+    missing_lifecycle_reference_keys = (
+        "message_sessions_without_lifecycle_current",
+        "node_sessions_without_lifecycle_reference",
+    )
+    return (
+        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
+        or (
+            lifecycle_rows > 0
+            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
+        )
+        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
+    )
 
 
 def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
@@ -615,6 +648,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     compression_ratio = round(total_source_tokens / total_dag_tokens, 1) if total_dag_tokens > 0 else 0
     full_status = engine.get_status()
     lifecycle = full_status.get("lifecycle")
+    lifecycle_fragmentation = full_status.get("lifecycle_fragmentation")
     source_lineage = full_status.get("source_lineage")
     runtime_identity = full_status.get("runtime_identity")
 
@@ -665,6 +699,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         "source_lineage": source_lineage,
         "runtime_identity": runtime_identity,
         "lifecycle": lifecycle,
+        "lifecycle_fragmentation": lifecycle_fragmentation,
     })
 
 
@@ -780,7 +815,24 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "detail": str(e),
         })
 
-    # 6. Context pressure
+    # 6. Lifecycle/session fragmentation
+    try:
+        lifecycle_fragmentation = engine._lifecycle.get_fragmentation_stats(
+            state_db_path=_state_db_path_for_engine(engine)
+        )
+        checks.append({
+            "check": "lifecycle_fragmentation",
+            "status": "warn" if _has_lifecycle_fragmentation(lifecycle_fragmentation) else "pass",
+            "detail": lifecycle_fragmentation,
+        })
+    except Exception as e:
+        checks.append({
+            "check": "lifecycle_fragmentation",
+            "status": "fail",
+            "detail": str(e),
+        })
+
+    # 7. Context pressure
     if engine.context_length > 0:
         usage_pct = round(engine.last_prompt_tokens / engine.context_length * 100, 1) if engine.context_length else 0
         threshold_pct = round(c.context_threshold * 100, 1)


### PR DESCRIPTION
## Summary

This adds a read-only lifecycle fragmentation diagnostic so operators can see when LCM lifecycle rows no longer line up cleanly with raw message coverage, summary DAG coverage, or the Hermes host session store.

The goal is visibility only. This PR does not repair, delete, rewrite, or normalize lifecycle rows.

## What changed

- Adds `LifecycleStateStore.get_fragmentation_stats(...)`.
- Compares lifecycle `current_session_id` and `last_finalized_session_id` references against:
  - LCM `messages` sessions
  - LCM `summary_nodes` sessions
  - Hermes `state.db.sessions`, when available
- Exposes the diagnostic through `lcm_status`, `lcm_doctor`, and `/lcm doctor`.
- Keeps a missing `state.db` non-warning, which matters for temp/test contexts and fresh host setups.
- Warns when an existing `state.db` is unreadable or schema-incompatible.
- Opens `state.db` using SQLite read-only URI mode.
- Documents the new status and doctor signals.

## Validation

- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_command.py -q`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
- `python -m pytest -q`
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- Temp DB smoke for `lcm_status`, `lcm_doctor`, and `/lcm doctor`
- Static diff scan for newly added destructive SQL
- Independent review pass, with follow-up fix for malformed existing `state.db` handling

## Notes

The warning should be read as diagnostic evidence, not proof that every mismatch is harmful. Cleanup and repair behavior should stay explicit and separate.