### PR TITLE
fix: carry over finalized compression source

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -709,6 +709,7 @@ class LCMEngine(ContextEngine):
         kwargs: Dict[str, Any],
     ) -> None:
         previous_session_id = self._session_id
+        requested_conversation_id = kwargs.get("conversation_id")
         old_state = self._lifecycle.get_by_session(old_session_id)
         source_session_id = old_session_id
         source_state = old_state
@@ -718,6 +719,10 @@ class LCMEngine(ContextEngine):
             bound_conversation_matches = bool(
                 bound_state
                 and (not self._conversation_id or bound_state.conversation_id == self._conversation_id)
+                and (
+                    not requested_conversation_id
+                    or bound_state.conversation_id == requested_conversation_id
+                )
             )
             bound_is_active_source = bool(
                 bound_state and bound_state.current_session_id == previous_session_id

--- a/engine.py
+++ b/engine.py
@@ -715,13 +715,24 @@ class LCMEngine(ContextEngine):
 
         if previous_session_id and previous_session_id != old_session_id:
             bound_state = self._lifecycle.get_by_session(previous_session_id)
-            bound_is_current_conversation = bool(
+            bound_conversation_matches = bool(
                 bound_state
-                and bound_state.current_session_id == previous_session_id
                 and (not self._conversation_id or bound_state.conversation_id == self._conversation_id)
             )
+            bound_is_active_source = bool(
+                bound_state and bound_state.current_session_id == previous_session_id
+            )
+            bound_is_finalized_source = bool(
+                bound_state
+                and bound_state.current_session_id is None
+                and bound_state.last_finalized_session_id == previous_session_id
+            )
             bound_has_summary_nodes = bool(self._dag.get_session_nodes(previous_session_id))
-            if bound_is_current_conversation and bound_has_summary_nodes:
+            if (
+                bound_conversation_matches
+                and (bound_is_active_source or bound_is_finalized_source)
+                and bound_has_summary_nodes
+            ):
                 source_session_id = previous_session_id
                 source_state = bound_state
                 logger.warning(
@@ -744,6 +755,7 @@ class LCMEngine(ContextEngine):
         frontier = max(
             int(self._last_compacted_store_id or 0),
             int(source_state.current_frontier_store_id if source_state else 0),
+            int(source_state.last_finalized_frontier_store_id if source_state else 0),
             int(
                 self._pending_reset_frontier_store_id
                 if self._pending_reset_session_id

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1922,6 +1922,9 @@ class TestSessionRollover:
         assert finalized is not None
         assert finalized.current_session_id is None
         assert finalized.last_finalized_session_id == "lcm-source"
+        # Prove the rollover restores the finalized lifecycle frontier, not only
+        # the engine's in-memory compacted marker.
+        engine._last_compacted_store_id = 0
 
         engine.on_session_start(
             "new-hermes-session",
@@ -1949,8 +1952,93 @@ class TestSessionRollover:
         stale_host_node = engine._dag.get_node(stale_host_node_id)
         assert stale_host_node is not None
         assert stale_host_node.session_id == "old-hermes-session"
+        lifecycle = engine._lifecycle.get_by_conversation(old_conversation_id)
+        assert lifecycle is not None
+        assert lifecycle.current_session_id == "new-hermes-session"
+        assert lifecycle.last_finalized_session_id == "lcm-source"
+        assert lifecycle.current_frontier_store_id == source_store_id
+        assert lifecycle.last_finalized_frontier_store_id == source_store_id
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
         assert expanded["expanded"][0]["content"] == "finalized LCM-bound context"
+
+    def test_compression_boundary_rejects_bound_source_for_explicit_conversation_mismatch(self, engine):
+        engine.on_session_start(
+            "lcm-source",
+            platform="telegram",
+            context_length=200000,
+            conversation_id="conversation-a",
+        )
+        source_store_id = engine._store.append(
+            "lcm-source",
+            {"role": "user", "content": "conversation A context"},
+            token_estimate=17,
+            source="telegram",
+        )
+        stale_host_store_id = engine._store.append(
+            "old-hermes-session",
+            {"role": "user", "content": "unrelated stale host context"},
+            token_estimate=11,
+            source="telegram",
+        )
+        source_node_id = engine._dag.add_node(SummaryNode(
+            session_id="lcm-source",
+            depth=0,
+            summary="conversation A summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[source_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        stale_host_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-hermes-session",
+            depth=0,
+            summary="stale host summary should not move",
+            token_count=5,
+            source_token_count=11,
+            source_ids=[stale_host_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine.compression_count = 2
+        engine._last_compacted_store_id = source_store_id
+        engine._ingest_cursor = 2
+        engine._lifecycle.finalize_session(
+            "conversation-a",
+            "lcm-source",
+            frontier_store_id=source_store_id,
+        )
+
+        engine.on_session_start(
+            "new-hermes-session",
+            boundary_reason="compression",
+            old_session_id="old-hermes-session",
+            conversation_id="conversation-b",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-hermes-session"
+        assert engine._conversation_id == "conversation-b"
+        assert engine.compression_count == 0
+        assert engine._last_compacted_store_id == 0
+        assert engine._ingest_cursor == 0
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
+        assert engine._store.get_session_count("old-hermes-session") == 1
+        source_node = engine._dag.get_node(source_node_id)
+        assert source_node is not None
+        assert source_node.session_id == "lcm-source"
+        stale_host_node = engine._dag.get_node(stale_host_node_id)
+        assert stale_host_node is not None
+        assert stale_host_node.session_id == "old-hermes-session"
+        conversation_a = engine._lifecycle.get_by_conversation("conversation-a")
+        assert conversation_a is not None
+        assert conversation_a.current_session_id is None
+        assert conversation_a.last_finalized_session_id == "lcm-source"
+        conversation_b = engine._lifecycle.get_by_conversation("conversation-b")
+        assert conversation_b is not None
+        assert conversation_b.current_session_id == "new-hermes-session"
 
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1872,6 +1872,86 @@ class TestSessionRollover:
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
         assert expanded["expanded"][0]["content"] == "important LCM-bound context"
 
+    def test_compression_boundary_uses_finalized_bound_lcm_source_when_host_old_session_differs(self, engine):
+        engine.on_session_start("lcm-source", platform="telegram", context_length=200000)
+        source_store_id = engine._store.append(
+            "lcm-source",
+            {"role": "user", "content": "finalized LCM-bound context"},
+            token_estimate=17,
+            source="telegram",
+        )
+        stale_host_store_id = engine._store.append(
+            "old-hermes-session",
+            {"role": "user", "content": "unrelated stale host context"},
+            token_estimate=11,
+            source="telegram",
+        )
+        source_node_id = engine._dag.add_node(SummaryNode(
+            session_id="lcm-source",
+            depth=0,
+            summary="finalized LCM-bound summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[source_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        stale_host_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-hermes-session",
+            depth=0,
+            summary="stale host summary should not move",
+            token_count=5,
+            source_token_count=11,
+            source_ids=[stale_host_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine.compression_count = 2
+        engine.last_prompt_tokens = 1000
+        engine.last_completion_tokens = 50
+        engine.last_total_tokens = 1050
+        engine._last_compacted_store_id = source_store_id
+        engine._ingest_cursor = 2
+        old_conversation_id = engine._conversation_id
+        engine._lifecycle.finalize_session(
+            old_conversation_id,
+            "lcm-source",
+            frontier_store_id=source_store_id,
+        )
+        finalized = engine._lifecycle.get_by_conversation(old_conversation_id)
+        assert finalized is not None
+        assert finalized.current_session_id is None
+        assert finalized.last_finalized_session_id == "lcm-source"
+
+        engine.on_session_start(
+            "new-hermes-session",
+            boundary_reason="compression",
+            old_session_id="old-hermes-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-hermes-session"
+        assert engine._conversation_id == old_conversation_id
+        assert engine.compression_count == 2
+        assert engine.last_prompt_tokens == 1000
+        assert engine.last_completion_tokens == 50
+        assert engine.last_total_tokens == 1050
+        assert engine._last_compacted_store_id == source_store_id
+        assert engine._ingest_cursor == 2
+        assert engine._store.get_session_count("lcm-source") == 0
+        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("old-hermes-session") == 1
+        assert engine._dag.get_session_nodes("lcm-source") == []
+        new_nodes = engine._dag.get_session_nodes("new-hermes-session")
+        assert len(new_nodes) == 1
+        assert new_nodes[0].node_id == source_node_id
+        stale_host_node = engine._dag.get_node(stale_host_node_id)
+        assert stale_host_node is not None
+        assert stale_host_node.session_id == "old-hermes-session"
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
+        assert expanded["expanded"][0]["content"] == "finalized LCM-bound context"
+
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)
         engine.compression_count = 3


### PR DESCRIPTION
## Summary
- Allows compression-boundary recovery when the LCM-bound source was just finalized before the host rollover signal arrives
- Preserves the finalized frontier marker during that recovery path
- Keeps unrelated stale host-session rows and nodes untouched
- Rejects bound-source carry-over when an explicit target conversation id differs from the bound lifecycle conversation

## Why
#79 handled the mismatch case where the LCM-bound source was still current. The reopened #78 report showed a second valid shape: the bound source owns the summary DAG but lifecycle has already finalized it, so the previous guard rejected the carry-over and recreated the split-brain state.

This keeps that safe recovery path, while avoiding cross-conversation carry-over when callers pass an explicit `conversation_id` that does not match the bound lifecycle state.

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover -q`
- `python -m pytest tests/test_lcm_engine.py -q`
- `python -m pytest -q`
- `python -m compileall -q .`
- `git diff --check`

Refs #78
