### PR TITLE
fix: isolate live auxiliary child sessions

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -600,18 +600,33 @@ class LCMEngine(ContextEngine):
         )
 
     def _thread_context_session_id(self) -> str:
-        return str(getattr(self._thread_context, "auxiliary_session_id", "") or "")
+        return str(getattr(self._thread_context, "current_auxiliary_session_id", "") or "")
+
+    def _thread_context_auxiliary_session_ids(self) -> set[str]:
+        ids = getattr(self._thread_context, "auxiliary_session_ids", None)
+        if ids is None:
+            ids = set()
+            self._thread_context.auxiliary_session_ids = ids
+        return ids
+
+    def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
+        return session_id in self._thread_context_auxiliary_session_ids()
 
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
 
     def _mark_thread_context_stateless(self, session_id: str) -> None:
-        self._thread_context.auxiliary_session_id = session_id
+        self._thread_context_auxiliary_session_ids().add(session_id)
+        self._thread_context.current_auxiliary_session_id = session_id
 
     def _clear_thread_context_stateless(self, session_id: str = "") -> None:
         current = self._thread_context_session_id()
         if current and (not session_id or current == session_id):
-            self._thread_context.auxiliary_session_id = ""
+            self._thread_context.current_auxiliary_session_id = ""
+
+    def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
+        self._thread_context_auxiliary_session_ids().discard(session_id)
+        self._clear_thread_context_stateless(session_id)
 
     def _state_db_path(self, kwargs: Dict[str, Any] | None = None) -> Path:
         kwargs = kwargs or {}
@@ -942,8 +957,8 @@ class LCMEngine(ContextEngine):
         self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
-        if self._thread_context_session_id() == session_id:
-            self._clear_thread_context_stateless(session_id)
+        if self._thread_context_has_auxiliary_session(session_id):
+            self._unmark_thread_context_auxiliary_session(session_id)
             return
         # Ensure all messages are persisted
         self._ingest_messages(messages)

--- a/engine.py
+++ b/engine.py
@@ -601,26 +601,48 @@ class LCMEngine(ContextEngine):
             self._last_compacted_store_id,
         )
 
+    def _thread_context_auxiliary_stack(self) -> list[str]:
+        stack = getattr(self._thread_context, "auxiliary_session_stack", None)
+        if stack is None:
+            current = str(getattr(self._thread_context, "current_auxiliary_session_id", "") or "")
+            stack = [current] if current else []
+            self._thread_context.auxiliary_session_stack = stack
+        return stack
+
+    def _sync_thread_context_current_auxiliary(self) -> list[str]:
+        stack = self._thread_context_auxiliary_stack()
+        with self._auxiliary_session_lock:
+            active_ids = set(self._auxiliary_session_ids)
+        stack[:] = [session_id for session_id in stack if session_id in active_ids]
+        self._thread_context.current_auxiliary_session_id = stack[-1] if stack else ""
+        return stack
+
     def _thread_context_session_id(self) -> str:
-        return str(getattr(self._thread_context, "current_auxiliary_session_id", "") or "")
+        stack = self._sync_thread_context_current_auxiliary()
+        return stack[-1] if stack else ""
 
     def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_session_ids
 
     def _thread_context_stateless(self) -> bool:
-        session_id = self._thread_context_session_id()
-        return bool(session_id and self._thread_context_has_auxiliary_session(session_id))
+        return bool(self._thread_context_session_id())
 
     def _mark_thread_context_stateless(self, session_id: str) -> None:
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.add(session_id)
+        stack = self._thread_context_auxiliary_stack()
+        stack[:] = [existing for existing in stack if existing != session_id]
+        stack.append(session_id)
         self._thread_context.current_auxiliary_session_id = session_id
 
     def _clear_thread_context_stateless(self, session_id: str = "") -> None:
-        current = self._thread_context_session_id()
-        if current and (not session_id or current == session_id):
-            self._thread_context.current_auxiliary_session_id = ""
+        stack = self._thread_context_auxiliary_stack()
+        if session_id:
+            stack[:] = [existing for existing in stack if existing != session_id]
+        else:
+            stack.clear()
+        self._sync_thread_context_current_auxiliary()
 
     def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
         with self._auxiliary_session_lock:

--- a/engine.py
+++ b/engine.py
@@ -615,9 +615,8 @@ class LCMEngine(ContextEngine):
 
     def _sync_thread_context_current_auxiliary(self) -> list[str]:
         stack = self._thread_context_auxiliary_stack()
-        with self._auxiliary_session_lock:
-            lineage_ids = set(self._auxiliary_lineage_session_ids)
-        stack[:] = [session_id for session_id in stack if session_id in lineage_ids]
+        active_ids = self._active_auxiliary_session_ids()
+        stack[:] = [session_id for session_id in stack if session_id in active_ids]
         self._thread_context.current_auxiliary_session_id = stack[-1] if stack else ""
         return stack
 
@@ -654,6 +653,12 @@ class LCMEngine(ContextEngine):
             self._auxiliary_session_ids.add(session_id)
             self._auxiliary_lineage_session_ids.add(session_id)
 
+    def _deactivate_auxiliary_session(self, session_id: str) -> None:
+        if not session_id:
+            return
+        with self._auxiliary_session_lock:
+            self._auxiliary_session_ids.discard(session_id)
+
     def _mark_thread_context_stateless(self, session_id: str) -> None:
         self._register_auxiliary_session(session_id)
         stack = self._thread_context_auxiliary_stack()
@@ -664,12 +669,28 @@ class LCMEngine(ContextEngine):
     def _clear_thread_context_stateless(self, session_id: str = "") -> None:
         stack = self._thread_context_auxiliary_stack()
         if session_id:
-            had_session = session_id in stack
             stack[:] = [existing for existing in stack if existing != session_id]
-            if had_session and not stack and self._has_auxiliary_lineage_session(session_id):
-                stack.append(session_id)
         else:
             stack.clear()
+        self._sync_thread_context_current_auxiliary()
+
+    def _handoff_auxiliary_session(self, old_session_id: str, new_session_id: str) -> None:
+        with self._auxiliary_session_lock:
+            if old_session_id:
+                self._auxiliary_session_ids.discard(old_session_id)
+                self._auxiliary_lineage_session_ids.add(old_session_id)
+            if new_session_id:
+                self._auxiliary_session_ids.add(new_session_id)
+                self._auxiliary_lineage_session_ids.add(new_session_id)
+        stack = self._thread_context_auxiliary_stack()
+        had_thread_marker = old_session_id in stack or new_session_id in stack
+        stack[:] = [
+            existing
+            for existing in stack
+            if existing not in {old_session_id, new_session_id}
+        ]
+        if had_thread_marker and new_session_id:
+            stack.append(new_session_id)
         self._sync_thread_context_current_auxiliary()
 
     def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
@@ -683,40 +704,6 @@ class LCMEngine(ContextEngine):
         if hermes_home:
             return Path(hermes_home).expanduser() / "state.db"
         return Path(self._store.db_path).parent / "state.db"
-
-    def _state_db_has_live_child_row(
-        self,
-        session_id: str,
-        parent_session_id: str,
-        kwargs: Dict[str, Any],
-    ) -> bool:
-        if not session_id or not parent_session_id:
-            return False
-        path = self._state_db_path(kwargs)
-        if not path.exists():
-            return False
-        try:
-            uri = path.resolve().as_uri() + "?mode=ro"
-            conn = sqlite3.connect(uri, uri=True)
-            try:
-                row = conn.execute(
-                    """
-                    SELECT parent_session_id, ended_at
-                    FROM sessions
-                    WHERE id = ?
-                    LIMIT 1
-                    """,
-                    (session_id,),
-                ).fetchone()
-            finally:
-                conn.close()
-        except Exception as exc:  # pragma: no cover - defensive against host DB drift
-            logger.debug("LCM state.db live child probe failed: %s", exc)
-            return False
-        if not row:
-            return False
-        child_parent_id, child_ended_at = row
-        return child_parent_id == parent_session_id and child_ended_at is None
 
     def _caller_is_auxiliary_agent_frame(self, caller_self: Any) -> bool:
         if caller_self is None:
@@ -818,10 +805,11 @@ class LCMEngine(ContextEngine):
         """Return True when a same-process child agent should not rebind LCM.
 
         Detect Hermes auxiliary/background child sessions without treating real
-        foreground branches as stateless. Explicit or in-process parent metadata
-        wins even when this engine is fresh and has no bound foreground yet; the
-        state.db fallback is only used for descendants of an auxiliary lineage
-        already observed in this process.
+        foreground branches as stateless. In-process auxiliary agent frames are
+        trusted even when this engine is fresh and has no bound foreground yet.
+        Explicit parent metadata by itself is not enough, because legitimate
+        foreground branches can also carry parent ids before their state.db row
+        is visible to the plugin.
         """
         if not session_id or session_id == parent_session_id:
             return False
@@ -838,13 +826,11 @@ class LCMEngine(ContextEngine):
             if in_process_parent_id in known_auxiliary_ids:
                 return True
         if explicit_parent_id:
-            if (
-                explicit_parent_id not in known_auxiliary_ids
-                and not self._thread_context_has_auxiliary_session(explicit_parent_id)
-                and self._state_db_has_live_child_row(session_id, explicit_parent_id, kwargs)
-            ):
-                return False
-            return True
+            if self._thread_context_has_auxiliary_session(explicit_parent_id):
+                return True
+            if explicit_parent_id in known_auxiliary_ids and explicit_parent_id != self._session_id:
+                return True
+            return False
         if not parent_session_id:
             return False
 
@@ -884,7 +870,9 @@ class LCMEngine(ContextEngine):
 
         active_auxiliary_ids = self._active_auxiliary_session_ids()
         known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
-        if child_parent_id in active_auxiliary_ids or child_parent_id in known_auxiliary_ids:
+        if child_parent_id in active_auxiliary_ids:
+            return True
+        if child_parent_id in known_auxiliary_ids and child_parent_id != self._session_id:
             return True
         if child_parent_id != parent_session_id:
             return self._session_has_auxiliary_ancestor(
@@ -1167,7 +1155,7 @@ class LCMEngine(ContextEngine):
                 self._has_auxiliary_lineage_session(old_session_id)
                 and old_session_id != self._session_id
             ):
-                self._register_auxiliary_session(session_id)
+                self._handoff_auxiliary_session(old_session_id, session_id)
                 logger.info(
                     "LCM auxiliary session %s compressed to %s — keeping boundary stateless",
                     old_session_id,
@@ -1186,6 +1174,7 @@ class LCMEngine(ContextEngine):
                 previous_session_id,
             )
             return
+        self._deactivate_auxiliary_session(session_id)
         self._clear_thread_context_stateless()
         if previous_session_id and previous_session_id != session_id:
             self._finalize_pending_reset_boundary(previous_session_id)

--- a/engine.py
+++ b/engine.py
@@ -923,7 +923,7 @@ class LCMEngine(ContextEngine):
                 previous_session_id,
             )
             return
-        self._clear_thread_context_stateless(session_id)
+        self._clear_thread_context_stateless()
         if previous_session_id and previous_session_id != session_id:
             self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()

--- a/engine.py
+++ b/engine.py
@@ -609,7 +609,8 @@ class LCMEngine(ContextEngine):
             return session_id in self._auxiliary_session_ids
 
     def _thread_context_stateless(self) -> bool:
-        return bool(self._thread_context_session_id())
+        session_id = self._thread_context_session_id()
+        return bool(session_id and self._thread_context_has_auxiliary_session(session_id))
 
     def _mark_thread_context_stateless(self, session_id: str) -> None:
         with self._auxiliary_session_lock:

--- a/engine.py
+++ b/engine.py
@@ -910,11 +910,12 @@ class LCMEngine(ContextEngine):
     def on_session_start(self, session_id: str, **kwargs) -> None:
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")
+        previous_session_id = self._session_id
         if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
+            self._clear_thread_context_stateless()
             self._continue_compression_boundary(session_id, old_session_id, kwargs)
             return
 
-        previous_session_id = self._session_id
         if self._is_live_auxiliary_child_session(session_id, previous_session_id, kwargs):
             self._mark_thread_context_stateless(session_id)
             logger.info(

--- a/engine.py
+++ b/engine.py
@@ -211,6 +211,8 @@ class LCMEngine(ContextEngine):
         self._pending_reset_conversation_id: str = ""
         self._pending_reset_frontier_store_id: int = 0
         self._thread_context = threading.local()
+        self._auxiliary_session_ids: set[str] = set()
+        self._auxiliary_session_lock = threading.RLock()
 
     @property
     def name(self) -> str:
@@ -602,21 +604,16 @@ class LCMEngine(ContextEngine):
     def _thread_context_session_id(self) -> str:
         return str(getattr(self._thread_context, "current_auxiliary_session_id", "") or "")
 
-    def _thread_context_auxiliary_session_ids(self) -> set[str]:
-        ids = getattr(self._thread_context, "auxiliary_session_ids", None)
-        if ids is None:
-            ids = set()
-            self._thread_context.auxiliary_session_ids = ids
-        return ids
-
     def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
-        return session_id in self._thread_context_auxiliary_session_ids()
+        with self._auxiliary_session_lock:
+            return session_id in self._auxiliary_session_ids
 
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
 
     def _mark_thread_context_stateless(self, session_id: str) -> None:
-        self._thread_context_auxiliary_session_ids().add(session_id)
+        with self._auxiliary_session_lock:
+            self._auxiliary_session_ids.add(session_id)
         self._thread_context.current_auxiliary_session_id = session_id
 
     def _clear_thread_context_stateless(self, session_id: str = "") -> None:
@@ -625,7 +622,8 @@ class LCMEngine(ContextEngine):
             self._thread_context.current_auxiliary_session_id = ""
 
     def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
-        self._thread_context_auxiliary_session_ids().discard(session_id)
+        with self._auxiliary_session_lock:
+            self._auxiliary_session_ids.discard(session_id)
         self._clear_thread_context_stateless(session_id)
 
     def _state_db_path(self, kwargs: Dict[str, Any] | None = None) -> Path:
@@ -665,6 +663,7 @@ class LCMEngine(ContextEngine):
                     SELECT
                         child.parent_session_id,
                         child.started_at,
+                        child.ended_at,
                         parent.id,
                         parent.ended_at
                     FROM sessions AS child
@@ -682,8 +681,10 @@ class LCMEngine(ContextEngine):
             return False
         if not row:
             return False
-        child_parent_id, child_started_at, actual_parent_id, parent_ended_at = row
+        child_parent_id, child_started_at, child_ended_at, actual_parent_id, parent_ended_at = row
         if child_parent_id != parent_session_id or actual_parent_id != parent_session_id:
+            return False
+        if child_ended_at is not None:
             return False
         if parent_ended_at is None:
             return True

--- a/engine.py
+++ b/engine.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 import re
+import sqlite3
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -208,6 +210,7 @@ class LCMEngine(ContextEngine):
         self._pending_reset_session_id: str = ""
         self._pending_reset_conversation_id: str = ""
         self._pending_reset_frontier_store_id: int = 0
+        self._thread_context = threading.local()
 
     @property
     def name(self) -> str:
@@ -237,7 +240,7 @@ class LCMEngine(ContextEngine):
         return self.last_cache_read_tokens / self.last_prompt_tokens
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
-        if self._session_ignored or self._session_stateless:
+        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if self._should_force_overflow_recovery(observed_tokens=tokens):
@@ -248,7 +251,7 @@ class LCMEngine(ContextEngine):
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
-        if self._session_ignored or self._session_stateless:
+        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
             return False
         if self._session_id and messages:
             try:
@@ -392,11 +395,11 @@ class LCMEngine(ContextEngine):
         if not messages:
             return messages
 
-        if self._session_ignored or self._session_stateless:
+        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
             logger.debug(
                 "LCM compress bypassed for %s session %s",
-                "ignored" if self._session_ignored else "stateless",
-                self._session_id or "(unknown)",
+                "auxiliary" if self._thread_context_stateless() else "ignored" if self._session_ignored else "stateless",
+                self._thread_context_session_id() or self._session_id or "(unknown)",
             )
             return messages
 
@@ -595,6 +598,84 @@ class LCMEngine(ContextEngine):
             self._session_id,
             self._last_compacted_store_id,
         )
+
+    def _thread_context_session_id(self) -> str:
+        return str(getattr(self._thread_context, "auxiliary_session_id", "") or "")
+
+    def _thread_context_stateless(self) -> bool:
+        return bool(self._thread_context_session_id())
+
+    def _mark_thread_context_stateless(self, session_id: str) -> None:
+        self._thread_context.auxiliary_session_id = session_id
+
+    def _clear_thread_context_stateless(self, session_id: str = "") -> None:
+        current = self._thread_context_session_id()
+        if current and (not session_id or current == session_id):
+            self._thread_context.auxiliary_session_id = ""
+
+    def _state_db_path(self, kwargs: Dict[str, Any] | None = None) -> Path:
+        kwargs = kwargs or {}
+        hermes_home = str(kwargs.get("hermes_home") or self._hermes_home or "")
+        if hermes_home:
+            return Path(hermes_home).expanduser() / "state.db"
+        return Path(self._store.db_path).parent / "state.db"
+
+    def _is_live_auxiliary_child_session(
+        self,
+        session_id: str,
+        parent_session_id: str,
+        kwargs: Dict[str, Any],
+    ) -> bool:
+        """Return True when a same-process child agent should not rebind LCM.
+
+        Hermes background review and other auxiliary agents can be recorded in
+        state.db as children of the foreground session while that parent is
+        still live. When Hermes shares one mutable plugin context-engine
+        instance across those agents, rebinding to the live child would steal
+        the foreground session's LCM state. Compression continuations are not
+        live children: the parent is ended before the continuation is created
+        and newer hosts also pass boundary_reason="compression".
+        """
+        if not session_id or not parent_session_id or session_id == parent_session_id:
+            return False
+        path = self._state_db_path(kwargs)
+        if not path.exists():
+            return False
+        try:
+            uri = path.resolve().as_uri() + "?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+            try:
+                row = conn.execute(
+                    """
+                    SELECT
+                        child.parent_session_id,
+                        child.started_at,
+                        parent.id,
+                        parent.ended_at
+                    FROM sessions AS child
+                    LEFT JOIN sessions AS parent
+                        ON parent.id = child.parent_session_id
+                    WHERE child.id = ?
+                    LIMIT 1
+                    """,
+                    (session_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+        except Exception as exc:  # pragma: no cover - defensive against host DB drift
+            logger.debug("LCM auxiliary child session probe failed: %s", exc)
+            return False
+        if not row:
+            return False
+        child_parent_id, child_started_at, actual_parent_id, parent_ended_at = row
+        if child_parent_id != parent_session_id or actual_parent_id != parent_session_id:
+            return False
+        if parent_ended_at is None:
+            return True
+        try:
+            return float(child_started_at or 0) < float(parent_ended_at)
+        except (TypeError, ValueError):
+            return False
 
     def _clear_pending_reset_boundary(self) -> None:
         self._pending_reset_session_id = ""
@@ -834,6 +915,15 @@ class LCMEngine(ContextEngine):
             return
 
         previous_session_id = self._session_id
+        if self._is_live_auxiliary_child_session(session_id, previous_session_id, kwargs):
+            self._mark_thread_context_stateless(session_id)
+            logger.info(
+                "LCM session %s is a live child of bound session %s — treating it as auxiliary/stateless in this thread",
+                session_id,
+                previous_session_id,
+            )
+            return
+        self._clear_thread_context_stateless(session_id)
         if previous_session_id and previous_session_id != session_id:
             self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
@@ -851,6 +941,9 @@ class LCMEngine(ContextEngine):
         self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        if self._thread_context_session_id() == session_id:
+            self._clear_thread_context_stateless(session_id)
+            return
         # Ensure all messages are persisted
         self._ingest_messages(messages)
         self._lifecycle.finalize_session(
@@ -971,7 +1064,9 @@ class LCMEngine(ContextEngine):
         # Ingest live messages if passed (enables current-turn search)
         messages = kwargs.get("messages")
 
-        if messages and self._session_id and not (self._session_ignored or self._session_stateless):
+        if messages and self._session_id and not (
+            self._session_ignored or self._session_stateless or self._thread_context_stateless()
+        ):
             try:
                 self._ingest_messages(messages)
             except Exception as e:

--- a/engine.py
+++ b/engine.py
@@ -625,6 +625,10 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_session_ids
 
+    def _active_auxiliary_session_ids(self) -> set[str]:
+        with self._auxiliary_session_lock:
+            return set(self._auxiliary_session_ids)
+
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
 
@@ -705,16 +709,58 @@ class LCMEngine(ContextEngine):
         if not row:
             return False
         child_parent_id, child_started_at, child_ended_at, actual_parent_id, parent_ended_at = row
-        if child_parent_id != parent_session_id or actual_parent_id != parent_session_id:
+        if child_ended_at is not None or actual_parent_id is None:
             return False
-        if child_ended_at is not None:
-            return False
+
+        active_auxiliary_ids = self._active_auxiliary_session_ids()
+        if child_parent_id in active_auxiliary_ids:
+            return True
+        if child_parent_id != parent_session_id:
+            return self._session_has_active_auxiliary_ancestor(
+                str(child_parent_id or ""),
+                active_auxiliary_ids,
+                path,
+            )
         if parent_ended_at is None:
             return True
         try:
             return float(child_started_at or 0) < float(parent_ended_at)
         except (TypeError, ValueError):
             return False
+
+    def _session_has_active_auxiliary_ancestor(
+        self,
+        session_id: str,
+        active_auxiliary_ids: set[str],
+        state_db_path: Path,
+    ) -> bool:
+        if not session_id or not active_auxiliary_ids or not state_db_path.exists():
+            return False
+        visited: set[str] = set()
+        current = session_id
+        try:
+            uri = state_db_path.resolve().as_uri() + "?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+            try:
+                for _ in range(32):
+                    if not current or current in visited:
+                        return False
+                    if current in active_auxiliary_ids:
+                        return True
+                    visited.add(current)
+                    row = conn.execute(
+                        "SELECT parent_session_id FROM sessions WHERE id = ? LIMIT 1",
+                        (current,),
+                    ).fetchone()
+                    if not row:
+                        return False
+                    current = str(row[0] or "")
+            finally:
+                conn.close()
+        except Exception as exc:  # pragma: no cover - defensive against host DB drift
+            logger.debug("LCM auxiliary ancestor probe failed: %s", exc)
+            return False
+        return False
 
     def _clear_pending_reset_boundary(self) -> None:
         self._pending_reset_session_id = ""

--- a/engine.py
+++ b/engine.py
@@ -929,6 +929,14 @@ class LCMEngine(ContextEngine):
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id
         if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
+            if self._thread_context_has_auxiliary_session(old_session_id):
+                self._mark_thread_context_stateless(session_id)
+                logger.info(
+                    "LCM auxiliary session %s compressed to %s — keeping boundary stateless",
+                    old_session_id,
+                    session_id,
+                )
+                return
             self._clear_thread_context_stateless()
             self._continue_compression_boundary(session_id, old_session_id, kwargs)
             return

--- a/engine.py
+++ b/engine.py
@@ -4,6 +4,7 @@ Implements the ContextEngine ABC. Replaces the built-in ContextCompressor
 with a DAG-based summarization system that preserves every message.
 """
 
+import inspect
 import json
 import logging
 import os
@@ -212,6 +213,7 @@ class LCMEngine(ContextEngine):
         self._pending_reset_frontier_store_id: int = 0
         self._thread_context = threading.local()
         self._auxiliary_session_ids: set[str] = set()
+        self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
 
     @property
@@ -221,6 +223,8 @@ class LCMEngine(ContextEngine):
     # -- ContextEngine required methods ------------------------------------
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
+        if self._thread_context_stateless():
+            return
         self.last_prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
         self.last_completion_tokens = int(usage.get("completion_tokens", 0) or 0)
         self.last_total_tokens = int(usage.get("total_tokens", 0) or 0)
@@ -612,14 +616,19 @@ class LCMEngine(ContextEngine):
     def _sync_thread_context_current_auxiliary(self) -> list[str]:
         stack = self._thread_context_auxiliary_stack()
         with self._auxiliary_session_lock:
-            active_ids = set(self._auxiliary_session_ids)
-        stack[:] = [session_id for session_id in stack if session_id in active_ids]
+            lineage_ids = set(self._auxiliary_lineage_session_ids)
+        stack[:] = [session_id for session_id in stack if session_id in lineage_ids]
         self._thread_context.current_auxiliary_session_id = stack[-1] if stack else ""
         return stack
 
     def _thread_context_session_id(self) -> str:
         stack = self._sync_thread_context_current_auxiliary()
-        return stack[-1] if stack else ""
+        stack_session_id = self._in_process_auxiliary_session_id_from_stack()
+        if stack_session_id:
+            return stack_session_id
+        if stack:
+            return stack[-1]
+        return ""
 
     def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
@@ -629,12 +638,24 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             return set(self._auxiliary_session_ids)
 
+    def _known_auxiliary_lineage_session_ids(self) -> set[str]:
+        with self._auxiliary_session_lock:
+            return set(self._auxiliary_lineage_session_ids)
+
+    def _has_auxiliary_lineage_session(self, session_id: str) -> bool:
+        with self._auxiliary_session_lock:
+            return session_id in self._auxiliary_lineage_session_ids
+
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
 
-    def _mark_thread_context_stateless(self, session_id: str) -> None:
+    def _register_auxiliary_session(self, session_id: str) -> None:
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.add(session_id)
+            self._auxiliary_lineage_session_ids.add(session_id)
+
+    def _mark_thread_context_stateless(self, session_id: str) -> None:
+        self._register_auxiliary_session(session_id)
         stack = self._thread_context_auxiliary_stack()
         stack[:] = [existing for existing in stack if existing != session_id]
         stack.append(session_id)
@@ -643,7 +664,10 @@ class LCMEngine(ContextEngine):
     def _clear_thread_context_stateless(self, session_id: str = "") -> None:
         stack = self._thread_context_auxiliary_stack()
         if session_id:
+            had_session = session_id in stack
             stack[:] = [existing for existing in stack if existing != session_id]
+            if had_session and not stack and self._has_auxiliary_lineage_session(session_id):
+                stack.append(session_id)
         else:
             stack.clear()
         self._sync_thread_context_current_auxiliary()
@@ -660,6 +684,131 @@ class LCMEngine(ContextEngine):
             return Path(hermes_home).expanduser() / "state.db"
         return Path(self._store.db_path).parent / "state.db"
 
+    def _state_db_has_live_child_row(
+        self,
+        session_id: str,
+        parent_session_id: str,
+        kwargs: Dict[str, Any],
+    ) -> bool:
+        if not session_id or not parent_session_id:
+            return False
+        path = self._state_db_path(kwargs)
+        if not path.exists():
+            return False
+        try:
+            uri = path.resolve().as_uri() + "?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+            try:
+                row = conn.execute(
+                    """
+                    SELECT parent_session_id, ended_at
+                    FROM sessions
+                    WHERE id = ?
+                    LIMIT 1
+                    """,
+                    (session_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+        except Exception as exc:  # pragma: no cover - defensive against host DB drift
+            logger.debug("LCM state.db live child probe failed: %s", exc)
+            return False
+        if not row:
+            return False
+        child_parent_id, child_ended_at = row
+        return child_parent_id == parent_session_id and child_ended_at is None
+
+    def _caller_is_auxiliary_agent_frame(self, caller_self: Any) -> bool:
+        if caller_self is None:
+            return False
+        if getattr(caller_self, "_subagent_id", None):
+            return True
+        if getattr(caller_self, "_parent_subagent_id", None):
+            return True
+        try:
+            if int(getattr(caller_self, "_delegate_depth", 0) or 0) > 0:
+                return True
+        except (TypeError, ValueError):
+            pass
+        memory_origin = str(getattr(caller_self, "_memory_write_origin", "") or "")
+        memory_context = str(getattr(caller_self, "_memory_write_context", "") or "")
+        if memory_origin == "background_review" or memory_context == "background_review":
+            return True
+        log_prefix = str(getattr(caller_self, "log_prefix", "") or "").strip()
+        if log_prefix.startswith("[subagent-"):
+            return True
+        enabled_toolsets = getattr(caller_self, "enabled_toolsets", None)
+        if enabled_toolsets is not None:
+            try:
+                toolsets = {str(toolset) for toolset in enabled_toolsets}
+            except TypeError:
+                toolsets = set()
+            if toolsets and toolsets <= {"memory", "skills"}:
+                return True
+        if getattr(caller_self, "ephemeral_system_prompt", None) and log_prefix.startswith("[subagent-"):
+            return True
+        return False
+
+    def _in_process_parent_session_id(
+        self,
+        kwargs: Dict[str, Any],
+        session_id: str = "",
+        include_explicit: bool = True,
+    ) -> str:
+        explicit = str(kwargs.get("parent_session_id") or "")
+        if include_explicit and explicit:
+            return explicit
+        target_session_id = str(session_id or kwargs.get("session_id") or "")
+        frame = inspect.currentframe()
+        try:
+            frame = frame.f_back if frame is not None else None
+            for _ in range(32):
+                if frame is None:
+                    return ""
+                caller_self = frame.f_locals.get("self")
+                if not self._caller_is_auxiliary_agent_frame(caller_self):
+                    frame = frame.f_back
+                    continue
+                parent = str(getattr(caller_self, "_parent_session_id", "") or "")
+                caller_session = str(getattr(caller_self, "session_id", "") or "")
+                if parent and caller_session and (
+                    not target_session_id or caller_session == target_session_id
+                ):
+                    return parent
+                frame = frame.f_back
+        finally:
+            del frame
+        return ""
+
+    def _in_process_auxiliary_session_id_from_stack(self) -> str:
+        active_ids = self._active_auxiliary_session_ids()
+        lineage_ids = self._known_auxiliary_lineage_session_ids()
+        if not active_ids and not lineage_ids and not self._session_id:
+            return ""
+        frame = inspect.currentframe()
+        try:
+            frame = frame.f_back if frame is not None else None
+            for _ in range(32):
+                if frame is None:
+                    return ""
+                caller_self = frame.f_locals.get("self")
+                if not self._caller_is_auxiliary_agent_frame(caller_self):
+                    frame = frame.f_back
+                    continue
+                session_id = str(getattr(caller_self, "session_id", "") or "")
+                parent_id = str(getattr(caller_self, "_parent_session_id", "") or "")
+                if session_id and parent_id and (
+                    session_id in active_ids
+                    or session_id in lineage_ids
+                    or parent_id == self._session_id
+                    or parent_id in lineage_ids
+                ):
+                    return session_id
+                frame = frame.f_back
+        finally:
+            del frame
+        return ""
+
     def _is_live_auxiliary_child_session(
         self,
         session_id: str,
@@ -668,16 +817,37 @@ class LCMEngine(ContextEngine):
     ) -> bool:
         """Return True when a same-process child agent should not rebind LCM.
 
-        Hermes background review and other auxiliary agents can be recorded in
-        state.db as children of the foreground session while that parent is
-        still live. When Hermes shares one mutable plugin context-engine
-        instance across those agents, rebinding to the live child would steal
-        the foreground session's LCM state. Compression continuations are not
-        live children: the parent is ended before the continuation is created
-        and newer hosts also pass boundary_reason="compression".
+        Detect Hermes auxiliary/background child sessions without treating real
+        foreground branches as stateless. Explicit or in-process parent metadata
+        wins even when this engine is fresh and has no bound foreground yet; the
+        state.db fallback is only used for descendants of an auxiliary lineage
+        already observed in this process.
         """
-        if not session_id or not parent_session_id or session_id == parent_session_id:
+        if not session_id or session_id == parent_session_id:
             return False
+        known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
+        explicit_parent_id = str(kwargs.get("parent_session_id") or "")
+        in_process_parent_id = self._in_process_parent_session_id(
+            kwargs,
+            session_id,
+            include_explicit=False,
+        )
+        if in_process_parent_id:
+            if not parent_session_id or in_process_parent_id == parent_session_id:
+                return True
+            if in_process_parent_id in known_auxiliary_ids:
+                return True
+        if explicit_parent_id:
+            if (
+                explicit_parent_id not in known_auxiliary_ids
+                and not self._thread_context_has_auxiliary_session(explicit_parent_id)
+                and self._state_db_has_live_child_row(session_id, explicit_parent_id, kwargs)
+            ):
+                return False
+            return True
+        if not parent_session_id:
+            return False
+
         path = self._state_db_path(kwargs)
         if not path.exists():
             return False
@@ -713,28 +883,24 @@ class LCMEngine(ContextEngine):
             return False
 
         active_auxiliary_ids = self._active_auxiliary_session_ids()
-        if child_parent_id in active_auxiliary_ids:
+        known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
+        if child_parent_id in active_auxiliary_ids or child_parent_id in known_auxiliary_ids:
             return True
         if child_parent_id != parent_session_id:
-            return self._session_has_active_auxiliary_ancestor(
+            return self._session_has_auxiliary_ancestor(
                 str(child_parent_id or ""),
-                active_auxiliary_ids,
+                known_auxiliary_ids | active_auxiliary_ids,
                 path,
             )
-        if parent_ended_at is None:
-            return True
-        try:
-            return float(child_started_at or 0) < float(parent_ended_at)
-        except (TypeError, ValueError):
-            return False
+        return False
 
-    def _session_has_active_auxiliary_ancestor(
+    def _session_has_auxiliary_ancestor(
         self,
         session_id: str,
-        active_auxiliary_ids: set[str],
+        auxiliary_lineage_ids: set[str],
         state_db_path: Path,
     ) -> bool:
-        if not session_id or not active_auxiliary_ids or not state_db_path.exists():
+        if not session_id or not auxiliary_lineage_ids or not state_db_path.exists():
             return False
         visited: set[str] = set()
         current = session_id
@@ -745,7 +911,7 @@ class LCMEngine(ContextEngine):
                 for _ in range(32):
                     if not current or current in visited:
                         return False
-                    if current in active_auxiliary_ids:
+                    if current in auxiliary_lineage_ids:
                         return True
                     visited.add(current)
                     row = conn.execute(
@@ -997,8 +1163,11 @@ class LCMEngine(ContextEngine):
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id
         if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
-            if self._thread_context_has_auxiliary_session(old_session_id):
-                self._mark_thread_context_stateless(session_id)
+            if (
+                self._has_auxiliary_lineage_session(old_session_id)
+                and old_session_id != self._session_id
+            ):
+                self._register_auxiliary_session(session_id)
                 logger.info(
                     "LCM auxiliary session %s compressed to %s — keeping boundary stateless",
                     old_session_id,
@@ -1010,9 +1179,9 @@ class LCMEngine(ContextEngine):
             return
 
         if self._is_live_auxiliary_child_session(session_id, previous_session_id, kwargs):
-            self._mark_thread_context_stateless(session_id)
+            self._register_auxiliary_session(session_id)
             logger.info(
-                "LCM session %s is a live child of bound session %s — treating it as auxiliary/stateless in this thread",
+                "LCM session %s is a live child of bound session %s — treating it as auxiliary/stateless",
                 session_id,
                 previous_session_id,
             )
@@ -1035,8 +1204,12 @@ class LCMEngine(ContextEngine):
         self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
-        if self._thread_context_has_auxiliary_session(session_id):
-            self._unmark_thread_context_auxiliary_session(session_id)
+        if self._has_auxiliary_lineage_session(session_id) and session_id != self._session_id:
+            current_thread_session_id = self._thread_context_session_id()
+            with self._auxiliary_session_lock:
+                self._auxiliary_session_ids.discard(session_id)
+            if current_thread_session_id == session_id:
+                self._clear_thread_context_stateless(session_id)
             return
         # Ensure all messages are persisted
         self._ingest_messages(messages)
@@ -1293,6 +1466,13 @@ class LCMEngine(ContextEngine):
                      base_url: str = "", api_key: str = "",
                      provider: str = "",
                      api_mode: str = "") -> None:
+        parent_session_id = self._in_process_parent_session_id({})
+        if parent_session_id:
+            logger.debug(
+                "LCM model update ignored for auxiliary child of %s",
+                parent_session_id,
+            )
+            return
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self._config.context_threshold)
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1954,6 +1954,7 @@ class TestSessionRollover:
         )
 
         assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._session_id == "foreground-continuation"
         assert engine._conversation_id == foreground_conversation_id
         assert [
@@ -1965,8 +1966,85 @@ class TestSessionRollover:
         ]
         engine.should_compress_preflight(messages)
 
+        background_messages = [
+            {"role": "user", "content": "late background review must still not persist"},
+        ]
+        engine.on_session_end("background-review-session", background_messages)
+
         assert engine._store.get_session_count("foreground-continuation") == 2
         assert engine._store.get_session_count("background-review-session") == 0
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+
+    def test_multiple_auxiliary_child_sessions_are_tracked_independently(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-a', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-b', 'foreground-session', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_multiple_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-a",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-b",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == "background-review-b"
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert engine._thread_context_has_auxiliary_session("background-review-b")
+
+        engine.on_session_end(
+            "background-review-a",
+            [{"role": "user", "content": "first background review must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == "background-review-b"
+        assert not engine._thread_context_has_auxiliary_session("background-review-a")
+        assert engine._thread_context_has_auxiliary_session("background-review-b")
+        assert engine._store.get_session_count("background-review-a") == 0
+
+        engine.on_session_end(
+            "background-review-b",
+            [{"role": "user", "content": "second background review must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("background-review-b")
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-b") == 0
+        assert engine._store.get_session_count("foreground-session") == 0
 
     def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
         engine.on_session_start("old-session", platform="telegram", context_length=200000)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1976,6 +1976,101 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-session") == 0
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
 
+    def test_auxiliary_compression_boundary_does_not_reassign_foreground_state(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-continuation', 'background-review-session', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        foreground_store_id = engine._store.append(
+            "foreground-session",
+            {"role": "user", "content": "foreground must not move into child continuation"},
+            token_estimate=13,
+            source="telegram",
+        )
+        foreground_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-session",
+            depth=0,
+            summary="foreground must stay foreground",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[foreground_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = foreground_store_id
+        foreground_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+
+        engine.on_session_start(
+            "background-review-continuation",
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._conversation_id == foreground_conversation_id
+        assert engine._thread_context_session_id() == "background-review-continuation"
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-continuation") == 0
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("foreground-session")
+        ] == [foreground_node_id]
+        assert engine._dag.get_session_nodes("background-review-continuation") == []
+
+        engine.on_session_end(
+            "background-review-session",
+            [{"role": "user", "content": "old child end must not persist"}],
+        )
+        engine.on_session_end(
+            "background-review-continuation",
+            [{"role": "user", "content": "new child end must not persist"}],
+        )
+
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
     def test_multiple_auxiliary_child_sessions_are_tracked_independently(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1886,6 +1886,88 @@ class TestSessionRollover:
         assert engine._store.get_session_count("next-normal-session") == 1
         assert engine._store.get_session_count("background-review-session") == 0
 
+    def test_stale_auxiliary_thread_marker_clears_before_compression_boundary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_aux_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        foreground_store_id = engine._store.append(
+            "foreground-session",
+            {"role": "user", "content": "foreground context crosses boundary"},
+            token_estimate=17,
+            source="telegram",
+        )
+        foreground_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-session",
+            depth=0,
+            summary="foreground boundary summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[foreground_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = foreground_store_id
+        foreground_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._session_id == "foreground-session"
+
+        engine.on_session_start(
+            "foreground-continuation",
+            boundary_reason="compression",
+            old_session_id="foreground-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert engine._session_id == "foreground-continuation"
+        assert engine._conversation_id == foreground_conversation_id
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
+        ] == [foreground_node_id]
+
+        messages = [
+            {"role": "user", "content": "post-boundary foreground ingestion returns"},
+        ]
+        engine.should_compress_preflight(messages)
+
+        assert engine._store.get_session_count("foreground-continuation") == 2
+        assert engine._store.get_session_count("background-review-session") == 0
+
     def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
         engine.on_session_start("old-session", platform="telegram", context_length=200000)
         store_id = engine._store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2142,6 +2142,83 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-b") == 0
         assert engine._store.get_session_count("foreground-session") == 0
 
+    def test_nested_auxiliary_child_end_restores_previous_thread_marker(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-a', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-b', 'foreground-session', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_nested_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-a",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-b",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == "background-review-b"
+        assert engine._thread_context_stateless()
+
+        engine.on_session_end(
+            "background-review-b",
+            [{"role": "user", "content": "nested child b must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == "background-review-a"
+        assert engine._thread_context_stateless()
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert not engine._thread_context_has_auxiliary_session("background-review-b")
+
+        engine.should_compress_preflight([
+            {"role": "user", "content": "continuing child a must still be stateless"},
+        ])
+
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-b") == 0
+
+        engine.on_session_end(
+            "background-review-a",
+            [{"role": "user", "content": "nested child a must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-b") == 0
+
     def test_auxiliary_child_end_is_ignored_across_threads(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -2257,7 +2334,7 @@ class TestSessionRollover:
 
         assert not thread.is_alive()
         assert errors == []
-        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert not engine._thread_context_stateless()
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2085,6 +2085,7 @@ class TestSessionRollover:
         )
 
         assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_stateless()
 
         errors = []
 
@@ -2104,8 +2105,72 @@ class TestSessionRollover:
         assert not thread.is_alive()
         assert errors == []
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_stateless()
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._session_id == "foreground-session"
+
+    def test_inactive_auxiliary_marker_does_not_keep_thread_stateless(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_inactive_marker.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._thread_context_stateless()
+
+        errors = []
+
+        def end_auxiliary_child():
+            try:
+                engine.on_session_end("background-review-session", [])
+            except Exception as exc:  # pragma: no cover - assertion helper
+                errors.append(exc)
+
+        thread = threading.Thread(target=end_auxiliary_child)
+        thread.start()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert engine._thread_context_session_id() == "background-review-session"
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_stateless()
+
+        messages = [{"role": "user", "content": "foreground must persist after child ended"}]
+        engine.should_compress_preflight(messages)
+
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
 
     def test_historical_child_session_is_not_treated_as_live_auxiliary(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1735,6 +1735,98 @@ class TestSessionRollover:
         assert engine._dag.get_session_nodes("attacker-new") == []
         assert engine._session_id == "attacker-new"
 
+    def test_live_auxiliary_child_session_does_not_rebind_shared_engine(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_auxiliary_child.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        foreground_store_id = engine._store.append(
+            "foreground-session",
+            {"role": "user", "content": "foreground context must stay bound"},
+            token_estimate=17,
+            source="telegram",
+        )
+        foreground_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-session",
+            depth=0,
+            summary="foreground summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[foreground_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = foreground_store_id
+        foreground_conversation_id = engine._conversation_id
+
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._conversation_id == foreground_conversation_id
+        assert engine._lifecycle.get_by_conversation(
+            foreground_conversation_id
+        ).current_session_id == "foreground-session"
+
+        background_messages = [
+            {"role": "user", "content": "background review must not enter LCM"},
+            {"role": "assistant", "content": "Nothing to save."},
+        ]
+        assert engine.should_compress_preflight(background_messages) is False
+        assert engine.compress(background_messages) == background_messages
+        engine.on_session_end("background-review-session", background_messages)
+
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("foreground-session")
+        ] == [foreground_node_id]
+
+        engine.on_session_start(
+            "foreground-continuation",
+            boundary_reason="compression",
+            old_session_id="foreground-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-continuation"
+        assert engine._conversation_id == foreground_conversation_id
+        assert engine._store.get_session_count("foreground-continuation") == 1
+        assert engine._dag.get_session_nodes("foreground-session") == []
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
+        ] == [foreground_node_id]
+
     def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
         engine.on_session_start("old-session", platform="telegram", context_length=200000)
         store_id = engine._store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1884,7 +1884,7 @@ class TestSessionRollover:
             node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
         ] == [foreground_node_id]
 
-    def test_auxiliary_child_with_explicit_parent_id_does_not_need_state_db_row(self, tmp_path):
+    def test_auxiliary_child_with_explicit_parent_id_and_aux_frame_does_not_need_state_db_row(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
         state_db = hermes_home / "state.db"
@@ -1904,6 +1904,22 @@ class TestSessionRollover:
         conn.commit()
         conn.close()
 
+        class ExplicitParentAuxFrame:
+            def __init__(self, session_id: str, parent_session_id: str):
+                self.session_id = session_id
+                self._parent_session_id = parent_session_id
+                self.enabled_toolsets = ["memory", "skills"]
+                self.log_prefix = ""
+
+            def on_session_start(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.on_session_start(
+                    self.session_id,
+                    hermes_home=str(hermes_home),
+                    platform="telegram",
+                    context_length=200000,
+                    parent_session_id=self._parent_session_id,
+                )
+
         config = LCMConfig(database_path=str(tmp_path / "lcm_aux_explicit_parent.db"))
         engine = LCMEngine(config=config, hermes_home=str(hermes_home))
         engine.on_session_start(
@@ -1912,20 +1928,14 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
-            "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
-            parent_session_id="foreground-session",
-        )
+        child = ExplicitParentAuxFrame("background-review-session", "foreground-session")
+        child.on_session_start(engine)
 
         assert engine._session_id == "foreground-session"
         assert engine._thread_context_session_id() == ""
         assert engine._thread_context_has_auxiliary_session("background-review-session")
-        child = self.HostAgentFrame("background-review-session", "foreground-session", hermes_home)
-        child.should_compress_preflight(engine, [
-            {"role": "user", "content": "explicit parent child must stay stateless"},
+        self.HostAgentFrame("background-review-session", "foreground-session", hermes_home).should_compress_preflight(engine, [
+            {"role": "user", "content": "explicit parent aux-frame child must stay stateless"},
         ])
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-session") == 0
@@ -2285,6 +2295,51 @@ class TestSessionRollover:
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("foreground-branch-session") == 1
 
+    def test_explicit_parent_id_without_aux_frame_or_live_row_rebinds_foreground_branch(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_explicit_missing_row_branch.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "foreground-branch-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+            parent_session_id="foreground-session",
+        )
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "explicit parent missing row branch should persist"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("foreground-branch-session") == 1
+
     def test_auxiliary_lineage_does_not_poison_reused_root_session_id(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -2382,6 +2437,91 @@ class TestSessionRollover:
         messages.append({"role": "assistant", "content": "reused root frame final"})
         frame.on_session_end(engine, messages)
         assert engine._store.get_session_count("reused-session") == 2
+
+    def test_auxiliary_lineage_does_not_poison_reused_root_parent_branches(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('reused-parent', NULL, 10.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('reused-child-state', 'reused-parent', 11.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_parent_branch.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-parent",
+            "foreground-session",
+        )
+        assert engine._has_auxiliary_lineage_session("reused-parent")
+        assert engine._thread_context_has_auxiliary_session("reused-parent")
+
+        # If that id later becomes a real foreground/root session, the old
+        # auxiliary lineage must not poison real child branches under it.
+        engine.on_session_start(
+            "reused-parent",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+        assert engine._session_id == "reused-parent"
+        assert not engine._thread_context_has_auxiliary_session("reused-parent")
+
+        engine.on_session_start(
+            "reused-child-state",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+        )
+        assert engine._session_id == "reused-child-state"
+        assert not engine._thread_context_has_auxiliary_session("reused-child-state")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "state-db child of reused parent persists"},
+        ])
+        assert engine._store.get_session_count("reused-child-state") == 1
+
+        engine.on_session_start(
+            "reused-parent",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "reused-child-explicit",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+            parent_session_id="reused-parent",
+        )
+        assert engine._session_id == "reused-child-explicit"
+        assert not engine._thread_context_has_auxiliary_session("reused-child-explicit")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "explicit child of reused parent persists"},
+        ])
+        assert engine._store.get_session_count("reused-child-explicit") == 1
 
     def test_auxiliary_lineage_does_not_block_reused_root_compression_boundary(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
@@ -2894,7 +3034,7 @@ class TestSessionRollover:
         assert engine._session_id == "foreground-session"
         assert engine._conversation_id == foreground_conversation_id
         assert engine._thread_context_session_id() == ""
-        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._thread_context_has_auxiliary_session("background-review-continuation")
         assert engine._store.get_session_count("foreground-session") == 1
         assert engine._store.get_session_count("background-review-continuation") == 0
@@ -2917,6 +3057,87 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-continuation") == 0
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+    def test_auxiliary_compression_boundary_retires_old_child_if_old_end_is_missing(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-continuation', 'background-review-session', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_missing_old_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "old child work must stay stateless"},
+        ])
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+
+        engine.on_session_start(
+            "background-review-continuation",
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        continuation.should_compress_preflight(engine, [
+            {"role": "user", "content": "new child work must stay stateless"},
+        ])
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+        continuation.on_session_end(engine, [
+            {"role": "user", "content": "new child end must not persist"},
+        ])
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground persists after child compression handoff"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
 
     def test_auxiliary_compression_boundary_after_child_end_stays_auxiliary(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import sqlite3
+import threading
 import time
 from pathlib import Path
 
@@ -2045,6 +2046,113 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-b") == 0
         assert engine._store.get_session_count("foreground-session") == 0
+
+    def test_auxiliary_child_end_is_ignored_across_threads(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_cross_thread_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+
+        errors = []
+
+        def end_auxiliary_child():
+            try:
+                engine.on_session_end(
+                    "background-review-session",
+                    [{"role": "user", "content": "cross-thread child end must not persist"}],
+                )
+            except Exception as exc:  # pragma: no cover - assertion helper
+                errors.append(exc)
+
+        thread = threading.Thread(target=end_auxiliary_child)
+        thread.start()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._session_id == "foreground-session"
+
+    def test_historical_child_session_is_not_treated_as_live_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, 10.0);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('historical-child-session', 'foreground-session', 2.0, 3.0);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_historical_child.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "historical-child-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("historical-child-session")
+        assert engine._session_id == "historical-child-session"
+        messages = [
+            {"role": "user", "content": "historical child resume should persist normally"},
+        ]
+        engine.should_compress_preflight(messages)
+
+        assert engine._store.get_session_count("historical-child-session") == 1
 
     def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
         engine.on_session_start("old-session", platform="telegram", context_length=200000)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1827,6 +1827,65 @@ class TestSessionRollover:
             node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
         ] == [foreground_node_id]
 
+    def test_stale_auxiliary_thread_marker_clears_on_next_normal_session_start(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('next-normal-session', NULL, 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_aux_marker.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._session_id == "foreground-session"
+
+        engine.on_session_start(
+            "next-normal-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert engine._session_id == "next-normal-session"
+        messages = [
+            {"role": "user", "content": "normal foreground ingestion returns"},
+        ]
+        engine.should_compress_preflight(messages)
+
+        assert engine._store.get_session_count("next-normal-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
+
     def test_compression_boundary_continues_logical_session_without_resetting_state(self, engine):
         engine.on_session_start("old-session", platform="telegram", context_length=200000)
         store_id = engine._store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2219,6 +2219,90 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-b") == 0
 
+    def test_auxiliary_descendant_session_does_not_rebind_shared_engine(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-a', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-followup', 'background-review-a', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_descendant.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-a",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == "background-review-a"
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+
+        engine.on_session_start(
+            "background-review-followup",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == "background-review-followup"
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert engine._thread_context_has_auxiliary_session("background-review-followup")
+        assert engine._thread_context_stateless()
+
+        engine.should_compress_preflight([
+            {"role": "user", "content": "descendant auxiliary must stay stateless"},
+        ])
+
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-followup") == 0
+
+        engine.on_session_end(
+            "background-review-followup",
+            [{"role": "user", "content": "followup end must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == "background-review-a"
+        assert engine._thread_context_stateless()
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert not engine._thread_context_has_auxiliary_session("background-review-followup")
+
+        engine.on_session_end(
+            "background-review-a",
+            [{"role": "user", "content": "parent auxiliary end must not persist"}],
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-followup") == 0
+
     def test_auxiliary_child_end_is_ignored_across_threads(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1485,6 +1485,61 @@ class TestSessionRetainDepth:
 
 
 class TestSessionRollover:
+    class HostAgentFrame:
+        def __init__(self, session_id: str, parent_session_id: str, hermes_home: Path):
+            self.session_id = session_id
+            self._parent_session_id = parent_session_id
+            self._hermes_home = hermes_home
+            self.enabled_toolsets = ["memory", "skills"]
+            self.log_prefix = "[subagent-test] "
+            self._subagent_id = session_id
+            self._delegate_depth = 1
+
+        def on_session_start(self, engine: LCMEngine, **kwargs) -> None:
+            engine.on_session_start(
+                self.session_id,
+                hermes_home=str(self._hermes_home),
+                platform=kwargs.pop("platform", "telegram"),
+                context_length=kwargs.pop("context_length", 200000),
+                **kwargs,
+            )
+
+        def update_model(self, engine: LCMEngine, context_length: int) -> None:
+            engine.update_model("child-model", context_length)
+
+        def should_compress_preflight(self, engine: LCMEngine, messages):
+            return engine.should_compress_preflight(messages)
+
+        def compress(self, engine: LCMEngine, messages):
+            return engine.compress(messages)
+
+        def update_from_response(self, engine: LCMEngine, usage: dict) -> None:
+            engine.update_from_response(usage)
+
+        def thread_context_session_id(self, engine: LCMEngine) -> str:
+            return engine._thread_context_session_id()
+
+        def thread_context_stateless(self, engine: LCMEngine) -> bool:
+            return engine._thread_context_stateless()
+
+        def on_session_end(self, engine: LCMEngine, messages) -> None:
+            engine.on_session_end(self.session_id, messages)
+
+    def _start_host_child(
+        self,
+        engine: LCMEngine,
+        hermes_home: Path,
+        session_id: str,
+        parent_session_id: str,
+        **kwargs,
+    ) -> HostAgentFrame:
+        frame = self.HostAgentFrame(session_id, parent_session_id, hermes_home)
+        frame.on_session_start(
+            engine,
+            **kwargs,
+        )
+        return frame
+
     def test_rollover_session_rebinds_engine_and_carries_retained_nodes(self, engine):
         engine._config.new_session_retain_depth = 2
         from hermes_lcm.dag import SummaryNode
@@ -1785,14 +1840,15 @@ class TestSessionRollover:
         engine._last_compacted_store_id = foreground_store_id
         foreground_conversation_id = engine._conversation_id
 
-        engine.on_session_start(
+        child = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
-
         assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._conversation_id == foreground_conversation_id
         assert engine._lifecycle.get_by_conversation(
             foreground_conversation_id
@@ -1802,9 +1858,9 @@ class TestSessionRollover:
             {"role": "user", "content": "background review must not enter LCM"},
             {"role": "assistant", "content": "Nothing to save."},
         ]
-        assert engine.should_compress_preflight(background_messages) is False
-        assert engine.compress(background_messages) == background_messages
-        engine.on_session_end("background-review-session", background_messages)
+        assert child.should_compress_preflight(engine, background_messages) is False
+        assert child.compress(engine, background_messages) == background_messages
+        child.on_session_end(engine, background_messages)
 
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._store.get_session_count("foreground-session") == 1
@@ -1827,6 +1883,795 @@ class TestSessionRollover:
         assert [
             node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
         ] == [foreground_node_id]
+
+    def test_auxiliary_child_with_explicit_parent_id_does_not_need_state_db_row(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_explicit_parent.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+            parent_session_id="foreground-session",
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        child = self.HostAgentFrame("background-review-session", "foreground-session", hermes_home)
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "explicit parent child must stay stateless"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_child_parent_id_can_be_inferred_from_host_agent_frame(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        class HostAgentFrame:
+            def __init__(self, session_id: str, parent_session_id: str):
+                self.session_id = session_id
+                self._parent_session_id = parent_session_id
+                self.enabled_toolsets = ["memory", "skills"]
+                self.log_prefix = ""
+
+            def notify_context_engine(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.on_session_start(
+                    self.session_id,
+                    hermes_home=str(hermes_home),
+                    platform="telegram",
+                    context_length=200000,
+                )
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_frame_parent.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = HostAgentFrame(
+            session_id="background-review-session",
+            parent_session_id="foreground-session",
+        )
+        child.notify_context_engine(engine)
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        self.HostAgentFrame(
+            "background-review-session",
+            "foreground-session",
+            hermes_home,
+        ).should_compress_preflight(engine, [
+            {"role": "user", "content": "frame parent child must stay stateless"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_child_parent_frame_is_honored_even_on_fresh_engine(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_fresh_engine.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        assert engine._session_id == ""
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "fresh-engine child must stay stateless"},
+        ])
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_delegate_depth_only_parent_frame_is_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        class DelegateDepthOnlyFrame:
+            def __init__(self, session_id: str, parent_session_id: str):
+                self.session_id = session_id
+                self._parent_session_id = parent_session_id
+                self.enabled_toolsets = ["terminal", "file"]
+                self.log_prefix = ""
+                self._delegate_depth = 1
+
+            def on_session_start(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.on_session_start(
+                    self.session_id,
+                    hermes_home=str(hermes_home),
+                    platform="telegram",
+                    context_length=200000,
+                )
+
+            def should_compress_preflight(self, lcm_engine: LCMEngine, messages):
+                return lcm_engine.should_compress_preflight(messages)
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_delegate_depth_only.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = DelegateDepthOnlyFrame("delegate-child-session", "foreground-session")
+        child.on_session_start(engine)
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_has_auxiliary_session("delegate-child-session")
+        assert child.should_compress_preflight(engine, [
+            {"role": "user", "content": "delegate-depth child must stay stateless"},
+        ]) is False
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("delegate-child-session") == 0
+
+    def test_auxiliary_frame_detection_survives_wrapper_depth(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        class DeepWrappedChildFrame:
+            def __init__(self, session_id: str, parent_session_id: str):
+                self.session_id = session_id
+                self._parent_session_id = parent_session_id
+                self.enabled_toolsets = ["terminal", "file"]
+                self.log_prefix = "[subagent-deep] "
+                self._delegate_depth = 0
+
+            def on_session_start(self, lcm_engine: LCMEngine) -> None:
+                def wrapped(depth: int) -> None:
+                    if depth <= 0:
+                        lcm_engine.on_session_start(
+                            self.session_id,
+                            hermes_home=str(hermes_home),
+                            platform="telegram",
+                            context_length=200000,
+                        )
+                        return
+                    wrapped(depth - 1)
+
+                wrapped(20)
+
+            def should_compress_preflight(self, lcm_engine: LCMEngine, messages):
+                def wrapped(depth: int):
+                    if depth <= 0:
+                        return lcm_engine.should_compress_preflight(messages)
+                    return wrapped(depth - 1)
+
+                return wrapped(20)
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_deep_wrapper_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = DeepWrappedChildFrame("deep-child-session", "foreground-session")
+        child.on_session_start(engine)
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_has_auxiliary_session("deep-child-session")
+        assert child.should_compress_preflight(engine, [
+            {"role": "user", "content": "deep wrapper child must stay stateless"},
+        ]) is False
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("deep-child-session") == 0
+
+    def test_unrelated_parent_frame_does_not_make_foreground_branch_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-branch-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        class UnrelatedFrame:
+            session_id = "some-other-session"
+            _parent_session_id = "foreground-session"
+
+            def notify_context_engine(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.on_session_start(
+                    "foreground-branch-session",
+                    hermes_home=str(hermes_home),
+                    platform="tui",
+                    context_length=200000,
+                )
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_unrelated_frame.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+        )
+        UnrelatedFrame().notify_context_engine(engine)
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+
+    def test_auxiliary_child_model_update_does_not_mutate_foreground_threshold(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        class HostAgentFrame:
+            def __init__(self, session_id: str, parent_session_id: str):
+                self.session_id = session_id
+                self._parent_session_id = parent_session_id
+                self.enabled_toolsets = ["memory", "skills"]
+                self.log_prefix = ""
+
+            def update_context_engine(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.update_model("tiny-child-model", 1000)
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_update_model.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.update_model("foreground-model", 200000)
+        assert engine.context_length == 200000
+        assert engine.threshold_tokens == int(200000 * config.context_threshold)
+
+        HostAgentFrame(
+            session_id="background-review-session",
+            parent_session_id="foreground-session",
+        ).update_context_engine(engine)
+
+        assert engine.context_length == 200000
+        assert engine.threshold_tokens == int(200000 * config.context_threshold)
+
+    def test_state_db_only_child_session_can_rebind_as_foreground_branch(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-branch-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_foreground_branch.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "foreground-branch-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground branch should persist normally"},
+        ])
+
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("foreground-branch-session") == 1
+
+    def test_explicit_parent_id_state_db_child_can_rebind_as_foreground_branch(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-branch-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_explicit_foreground_branch.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "foreground-branch-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+            parent_session_id="foreground-session",
+        )
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "explicit parent foreground branch should persist"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("foreground-branch-session") == 1
+
+    def test_auxiliary_lineage_does_not_poison_reused_root_session_id(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_id.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        engine.on_session_end("reused-session", [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "reused-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("reused-session")
+        messages = [
+            {"role": "user", "content": "reused root session should persist normally"},
+        ]
+        engine.should_compress_preflight(messages)
+        assert engine._store.get_session_count("reused-session") == 1
+
+        messages.append({"role": "assistant", "content": "reused root session final message"})
+        engine.on_session_end(
+            "reused-session",
+            messages,
+        )
+        assert engine._store.get_session_count("reused-session") == 2
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state.last_finalized_session_id == "reused-session"
+
+    def test_auxiliary_lineage_does_not_poison_reused_root_inside_non_aux_parent_frame(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_id_frame.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        engine.on_session_end("reused-session", [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        class ForegroundFrame:
+            def __init__(self):
+                self.session_id = "reused-session"
+                self._parent_session_id = "foreground-session"
+                self.enabled_toolsets = ["terminal", "file"]
+                self.log_prefix = ""
+                self._delegate_depth = 0
+
+            def should_compress_preflight(self, lcm_engine: LCMEngine, messages):
+                return lcm_engine.should_compress_preflight(messages)
+
+            def on_session_end(self, lcm_engine: LCMEngine, messages) -> None:
+                lcm_engine.on_session_end(self.session_id, messages)
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+        frame = ForegroundFrame()
+        messages = [
+            {"role": "user", "content": "reused root frame should persist normally"},
+        ]
+        frame.should_compress_preflight(engine, messages)
+        assert engine._thread_context_session_id() == ""
+        assert engine._store.get_session_count("reused-session") == 1
+        messages.append({"role": "assistant", "content": "reused root frame final"})
+        frame.on_session_end(engine, messages)
+        assert engine._store.get_session_count("reused-session") == 2
+
+    def test_auxiliary_lineage_does_not_block_reused_root_compression_boundary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        engine.on_session_end("reused-session", [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+        store_id = engine._store.append(
+            "reused-session",
+            {"role": "user", "content": "reused root compression source"},
+            token_estimate=5,
+            source="cli",
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="reused-session",
+            depth=0,
+            summary="reused root node should move",
+            token_count=4,
+            source_token_count=5,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        conversation_id = engine._conversation_id
+        engine._last_compacted_store_id = store_id
+
+        engine.on_session_start(
+            "reused-continuation",
+            boundary_reason="compression",
+            old_session_id="reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "reused-continuation"
+        assert engine._conversation_id == conversation_id
+        assert engine._thread_context_session_id() == ""
+        assert engine._store.get_session_count("reused-continuation") == 1
+        assert engine._dag.get_session_nodes("reused-session") == []
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("reused-continuation")
+        ] == [node_id]
+
+    def test_auxiliary_child_worker_thread_stays_stateless_without_parent_thread_leak(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_worker_thread.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "delegate-child-session",
+            "foreground-session",
+        )
+
+        assert engine._thread_context_session_id() == ""
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground parent thread must still persist"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("delegate-child-session") == 0
+
+        errors = []
+
+        def run_child_worker():
+            try:
+                assert child.should_compress_preflight(engine, [
+                    {"role": "user", "content": "delegate child worker must stay stateless"},
+                ]) is False
+                assert child.compress(engine, [
+                    {"role": "user", "content": "delegate child compression must bypass"},
+                ]) == [
+                    {"role": "user", "content": "delegate child compression must bypass"},
+                ]
+                child.update_from_response(engine, {
+                    "prompt_tokens": 999,
+                    "completion_tokens": 1,
+                    "total_tokens": 1000,
+                })
+                child.on_session_end(engine, [
+                    {"role": "assistant", "content": "delegate child end must not persist"},
+                ])
+            except Exception as exc:  # pragma: no cover - assertion helper
+                errors.append(exc)
+
+        worker = threading.Thread(target=run_child_worker)
+        worker.start()
+        worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert errors == []
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("delegate-child-session") == 0
+        assert engine.last_prompt_tokens == 0
+        assert not engine._thread_context_stateless()
+
+    def test_auxiliary_child_end_on_clean_parent_thread_does_not_poison_foreground(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_clean_parent_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+
+        engine.on_session_end(
+            "background-review-session",
+            [{"role": "assistant", "content": "background child end from parent thread"}],
+        )
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground must persist after child end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_matching_parent_frame_foreground_branch_rebinds_normally(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-branch-session', 'foreground-session', 2.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        class ForegroundBranchFrame:
+            def __init__(self):
+                self.session_id = "foreground-branch-session"
+                self._parent_session_id = "foreground-session"
+                self.enabled_toolsets = ["terminal", "file"]
+                self.log_prefix = ""
+                self._delegate_depth = 0
+
+            def on_session_start(self, lcm_engine: LCMEngine) -> None:
+                lcm_engine.on_session_start(
+                    self.session_id,
+                    hermes_home=str(hermes_home),
+                    platform="tui",
+                    context_length=200000,
+                )
+
+            def should_compress_preflight(self, lcm_engine: LCMEngine, messages):
+                return lcm_engine.should_compress_preflight(messages)
+
+            def update_model(self, lcm_engine: LCMEngine, context_length: int) -> None:
+                lcm_engine.update_model("foreground-branch-model", context_length)
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_matching_foreground_branch.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        branch = ForegroundBranchFrame()
+        branch.on_session_start(engine)
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+        branch.update_model(engine, 300000)
+        assert engine.context_length == 300000
+        assert engine.threshold_tokens == int(300000 * config.context_threshold)
+        branch.should_compress_preflight(engine, [
+            {"role": "user", "content": "foreground branch must persist"},
+        ])
+        assert engine._store.get_session_count("foreground-branch-session") == 1
+        assert engine._store.get_session_count("foreground-session") == 0
+
+    def test_auxiliary_child_update_from_response_does_not_mutate_foreground_metrics(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_usage.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        foreground_usage = {
+            "prompt_tokens": 12345,
+            "completion_tokens": 10,
+            "total_tokens": 12355,
+            "input_tokens": 12000,
+            "output_tokens": 355,
+            "cache_read_tokens": 6000,
+            "cache_write_tokens": 500,
+            "reasoning_tokens": 42,
+        }
+        engine.update_from_response(foreground_usage)
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+            "input_tokens": 3,
+            "output_tokens": 4,
+            "cache_read_tokens": 5,
+            "cache_write_tokens": 6,
+            "reasoning_tokens": 7,
+        })
+
+        assert engine.last_prompt_tokens == 12345
+        assert engine.last_completion_tokens == 10
+        assert engine.last_total_tokens == 12355
+        assert engine.last_input_tokens == 12000
+        assert engine.last_output_tokens == 355
+        assert engine.last_cache_read_tokens == 6000
+        assert engine.last_cache_write_tokens == 500
+        assert engine.last_reasoning_tokens == 42
+        assert engine.cache_metrics_available is True
+
+        engine.update_from_response({
+            "prompt_tokens": 222,
+            "completion_tokens": 3,
+            "total_tokens": 225,
+            "cache_read_tokens": 11,
+            "cache_write_tokens": 12,
+        })
+        assert engine.last_prompt_tokens == 222
+        assert engine.last_total_tokens == 225
+        assert engine.last_cache_read_tokens == 11
+        assert engine.last_cache_write_tokens == 12
 
     def test_stale_auxiliary_thread_marker_clears_on_next_normal_session_start(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
@@ -1860,14 +2705,15 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
 
-        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._session_id == "foreground-session"
 
         engine.on_session_start(
@@ -1936,14 +2782,15 @@ class TestSessionRollover:
         engine._last_compacted_store_id = foreground_store_id
         foreground_conversation_id = engine._conversation_id
 
-        engine.on_session_start(
+        self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
 
-        assert engine._thread_context_session_id() == "background-review-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._session_id == "foreground-session"
 
         engine.on_session_start(
@@ -2027,11 +2874,11 @@ class TestSessionRollover:
         engine._last_compacted_store_id = foreground_store_id
         foreground_conversation_id = engine._conversation_id
 
-        engine.on_session_start(
+        self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
         assert engine._session_id == "foreground-session"
         assert engine._thread_context_has_auxiliary_session("background-review-session")
@@ -2046,7 +2893,7 @@ class TestSessionRollover:
 
         assert engine._session_id == "foreground-session"
         assert engine._conversation_id == foreground_conversation_id
-        assert engine._thread_context_session_id() == "background-review-continuation"
+        assert engine._thread_context_session_id() == ""
         assert engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._thread_context_has_auxiliary_session("background-review-continuation")
         assert engine._store.get_session_count("foreground-session") == 1
@@ -2070,6 +2917,103 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-continuation") == 0
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+    def test_auxiliary_compression_boundary_after_child_end_stays_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-session', 'foreground-session', 2.0, 3.0);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-continuation', 'background-review-session', 4.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_late_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        foreground_store_id = engine._store.append(
+            "foreground-session",
+            {"role": "user", "content": "foreground must survive late auxiliary boundary"},
+            token_estimate=13,
+            source="telegram",
+        )
+        foreground_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-session",
+            depth=0,
+            summary="foreground must not move after child end",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[foreground_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = foreground_store_id
+        foreground_conversation_id = engine._conversation_id
+
+        # The child was seen as auxiliary while live, then ended before its
+        # compression continuation starts. A clean foreground thread must stay
+        # clean; the continuation is stateless only when executed through the
+        # auxiliary child frame/lineage.
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.on_session_end(engine, [
+            {"role": "user", "content": "ended child must not persist"},
+        ])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+
+        engine.on_session_start(
+            "background-review-continuation",
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._conversation_id == foreground_conversation_id
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        continuation.should_compress_preflight(engine, [
+            {"role": "user", "content": "continuation child must not persist"},
+        ])
+        assert engine._thread_context_session_id() == ""
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("foreground-session")
+        ] == [foreground_node_id]
+        assert engine._dag.get_session_nodes("background-review-continuation") == []
 
     def test_multiple_auxiliary_child_sessions_are_tracked_independently(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
@@ -2103,44 +3047,52 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        a = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-a",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
-        engine.on_session_start(
+        b = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-b",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
 
         assert engine._session_id == "foreground-session"
-        assert engine._thread_context_session_id() == "background-review-b"
+        assert engine._thread_context_session_id() == ""
         assert engine._thread_context_has_auxiliary_session("background-review-a")
         assert engine._thread_context_has_auxiliary_session("background-review-b")
+        assert b.thread_context_session_id(engine) == "background-review-b"
+        b.should_compress_preflight(engine, [
+            {"role": "user", "content": "child b worker must be stateless"},
+        ])
+        assert engine._thread_context_session_id() == ""
 
         engine.on_session_end(
             "background-review-a",
             [{"role": "user", "content": "first background review must not persist"}],
         )
 
-        assert engine._thread_context_session_id() == "background-review-b"
+        assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_has_auxiliary_session("background-review-a")
         assert engine._thread_context_has_auxiliary_session("background-review-b")
         assert engine._store.get_session_count("background-review-a") == 0
 
-        engine.on_session_end(
-            "background-review-b",
-            [{"role": "user", "content": "second background review must not persist"}],
-        )
+        b.on_session_end(engine, [
+            {"role": "user", "content": "second background review must not persist"},
+        ])
 
         assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
         assert not engine._thread_context_has_auxiliary_session("background-review-b")
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-b") == 0
-        assert engine._store.get_session_count("foreground-session") == 0
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground persists after auxiliary children end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
 
     def test_nested_auxiliary_child_end_restores_previous_thread_marker(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
@@ -2174,33 +3126,40 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        a = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-a",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
-        engine.on_session_start(
+        b = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-b",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
+        assert a.thread_context_session_id(engine) == "background-review-a"
+        a.should_compress_preflight(engine, [
+            {"role": "user", "content": "child a worker must be stateless"},
+        ])
+        assert b.thread_context_session_id(engine) == "background-review-b"
+        b.should_compress_preflight(engine, [
+            {"role": "user", "content": "child b worker must be stateless"},
+        ])
 
-        assert engine._thread_context_session_id() == "background-review-b"
-        assert engine._thread_context_stateless()
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
 
-        engine.on_session_end(
-            "background-review-b",
-            [{"role": "user", "content": "nested child b must not persist"}],
-        )
+        b.on_session_end(engine, [
+            {"role": "user", "content": "nested child b must not persist"},
+        ])
 
-        assert engine._thread_context_session_id() == "background-review-a"
-        assert engine._thread_context_stateless()
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
         assert engine._thread_context_has_auxiliary_session("background-review-a")
         assert not engine._thread_context_has_auxiliary_session("background-review-b")
 
-        engine.should_compress_preflight([
+        a.should_compress_preflight(engine, [
             {"role": "user", "content": "continuing child a must still be stateless"},
         ])
 
@@ -2208,14 +3167,17 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-b") == 0
 
-        engine.on_session_end(
-            "background-review-a",
-            [{"role": "user", "content": "nested child a must not persist"}],
-        )
+        a.on_session_end(engine, [
+            {"role": "user", "content": "nested child a must not persist"},
+        ])
 
         assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_stateless()
-        assert engine._store.get_session_count("foreground-session") == 0
+        assert not engine._thread_context_has_auxiliary_session("background-review-a")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground persists after nested children end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-b") == 0
 
@@ -2251,15 +3213,20 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        parent = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-a",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
         assert engine._session_id == "foreground-session"
-        assert engine._thread_context_session_id() == "background-review-a"
+        assert engine._thread_context_session_id() == ""
         assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert parent.thread_context_session_id(engine) == "background-review-a"
+        parent.should_compress_preflight(engine, [
+            {"role": "user", "content": "parent auxiliary must be stateless"},
+        ])
+        assert engine._thread_context_session_id() == ""
 
         engine.on_session_start(
             "background-review-followup",
@@ -2269,36 +3236,120 @@ class TestSessionRollover:
         )
 
         assert engine._session_id == "foreground-session"
-        assert engine._thread_context_session_id() == "background-review-followup"
+        assert engine._thread_context_session_id() == ""
         assert engine._thread_context_has_auxiliary_session("background-review-a")
         assert engine._thread_context_has_auxiliary_session("background-review-followup")
-        assert engine._thread_context_stateless()
-
-        engine.should_compress_preflight([
+        followup = self.HostAgentFrame(
+            "background-review-followup",
+            "background-review-a",
+            hermes_home,
+        )
+        followup.should_compress_preflight(engine, [
             {"role": "user", "content": "descendant auxiliary must stay stateless"},
         ])
+        assert followup.thread_context_session_id(engine) == "background-review-followup"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
 
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-followup") == 0
 
-        engine.on_session_end(
-            "background-review-followup",
-            [{"role": "user", "content": "followup end must not persist"}],
-        )
-
-        assert engine._thread_context_session_id() == "background-review-a"
-        assert engine._thread_context_stateless()
-        assert engine._thread_context_has_auxiliary_session("background-review-a")
-        assert not engine._thread_context_has_auxiliary_session("background-review-followup")
-
-        engine.on_session_end(
-            "background-review-a",
-            [{"role": "user", "content": "parent auxiliary end must not persist"}],
-        )
+        followup.on_session_end(engine, [
+            {"role": "user", "content": "followup end must not persist"},
+        ])
 
         assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_stateless()
+        assert engine._thread_context_has_auxiliary_session("background-review-a")
+        assert not engine._thread_context_has_auxiliary_session("background-review-followup")
+
+        parent.on_session_end(engine, [
+            {"role": "user", "content": "parent auxiliary end must not persist"},
+        ])
+
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+        assert not engine._thread_context_has_auxiliary_session("background-review-a")
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-a") == 0
+        assert engine._store.get_session_count("background-review-followup") == 0
+
+    def test_auxiliary_descendant_after_parent_end_stays_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-a', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('background-review-followup', 'background-review-a', 4.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_descendant_late.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-a",
+            "foreground-session",
+        )
+        engine.on_session_end(
+            "background-review-a",
+            [{"role": "user", "content": "parent auxiliary ended first"}],
+        )
+        conn = sqlite3.connect(state_db)
+        conn.execute(
+            "UPDATE sessions SET ended_at = 3.0 WHERE id = 'background-review-a'"
+        )
+        conn.commit()
+        conn.close()
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-a")
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+
+        engine.on_session_start(
+            "background-review-followup",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-session"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("background-review-followup")
+        followup = self.HostAgentFrame(
+            "background-review-followup",
+            "background-review-a",
+            hermes_home,
+        )
+        followup.should_compress_preflight(engine, [
+            {"role": "user", "content": "late descendant auxiliary must stay stateless"},
+        ])
+        assert followup.thread_context_session_id(engine) == "background-review-followup"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-a") == 0
         assert engine._store.get_session_count("background-review-followup") == 0
@@ -2333,15 +3384,19 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        child = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "child worker must be stateless before cross-thread end"},
+        ])
 
         assert engine._thread_context_has_auxiliary_session("background-review-session")
-        assert engine._thread_context_stateless()
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
 
         errors = []
 
@@ -2361,11 +3416,69 @@ class TestSessionRollover:
         assert not thread.is_alive()
         assert errors == []
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_stateless()
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._session_id == "foreground-session"
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground persists after cross-thread auxiliary end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
 
-    def test_inactive_auxiliary_marker_does_not_keep_thread_stateless(self, tmp_path):
+    def test_same_thread_late_auxiliary_callback_after_end_stays_stateless(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_same_thread_late_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "child worker must become stateless"},
+        ])
+        assert child.thread_context_session_id(engine) == "background-review-session"
+        assert child.thread_context_stateless(engine)
+        assert engine._thread_context_session_id() == ""
+
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "same-thread late child callback must not persist"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+        engine.should_compress_preflight([
+            {"role": "user", "content": "bare foreground callback persists after child end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
+
+        engine.on_session_start(
+            "foreground-followup-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        assert engine._thread_context_session_id() == ""
+        engine.should_compress_preflight([
+            {"role": "user", "content": "foreground followup persists after marker clear"},
+        ])
+        assert engine._store.get_session_count("foreground-followup-session") == 1
+
+    def test_ended_auxiliary_marker_stays_stateless_until_next_normal_session_start(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
         state_db = hermes_home / "state.db"
@@ -2395,14 +3508,19 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        engine.on_session_start(
+        child = self._start_host_child(
+            engine,
+            hermes_home,
             "background-review-session",
-            hermes_home=str(hermes_home),
-            platform="telegram",
-            context_length=200000,
+            "foreground-session",
         )
-        assert engine._thread_context_session_id() == "background-review-session"
-        assert engine._thread_context_stateless()
+        child.should_compress_preflight(engine, [
+            {"role": "user", "content": "child worker must become stateless"},
+        ])
+        assert child.thread_context_session_id(engine) == "background-review-session"
+        assert child.thread_context_stateless(engine)
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
 
         errors = []
 
@@ -2418,13 +3536,36 @@ class TestSessionRollover:
 
         assert not thread.is_alive()
         assert errors == []
-        assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._thread_context_session_id() == ""
         assert not engine._thread_context_stateless()
 
-        messages = [{"role": "user", "content": "foreground must persist after child ended"}]
+        late_child_messages = [
+            {"role": "user", "content": "late child callback must stay stateless after cross-thread end"},
+        ]
+        child.should_compress_preflight(engine, late_child_messages)
+
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+        engine.should_compress_preflight([
+            {"role": "user", "content": "bare foreground callback persists after cross-thread child end"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 1
+
+        engine.on_session_start(
+            "foreground-followup-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_stateless()
+
+        messages = [{"role": "user", "content": "foreground must persist after normal start"}]
         engine.should_compress_preflight(messages)
 
+        assert engine._store.get_session_count("foreground-followup-session") == 1
         assert engine._store.get_session_count("foreground-session") == 1
         assert engine._store.get_session_count("background-review-session") == 0
 


### PR DESCRIPTION
## Summary

This keeps Hermes child agents from stealing the foreground LCM binding when they share the same plugin engine instance.

The fix is intentionally plugin side. Hermes can start background review or delegated child `AIAgent` instances in the same process, and those children can call the context engine lifecycle hooks while the foreground agent is still active. LCM treats those child calls as auxiliary and stateless without rebinding `_session_id`, `_conversation_id`, lifecycle state, cursors, or foreground DAG ownership.

## What changed

Auxiliary detection is per call, not a sticky parent-thread state. Child construction can happen on the foreground thread without poisoning it. Actual child work is skipped when the call stack shows an auxiliary agent frame, including background review, delegate/subagent, memory/skills review, and deeper wrapper paths.

Auxiliary compression handoffs now retire the old active child id and activate the continuation, so a missing `on_session_end(old_child)` cannot strand stale auxiliary state. Thread-local markers are synced only against active auxiliary ids, while historical lineage is still kept for late child-frame callbacks and descendant detection.

Explicit `parent_session_id` alone is no longer enough to classify a session as auxiliary. That avoids dropping legitimate foreground branch/TUI sessions when the state DB row is delayed or unavailable. Known auxiliary lineage is also ignored when that id has been rebound as the current foreground session, so reused ids do not poison later foreground branches.

Child `update_model`, preflight, compression, usage updates, and session end callbacks no longer mutate foreground LCM state.

Refs #78.

## Validation

```text
python3 -m pytest tests/test_lcm_engine.py::TestSessionRollover -q
52 passed

python3 -m pytest tests/test_lcm_engine.py::TestSessionRollover tests/test_lcm_engine.py::TestSessionFiltering -q
58 passed

python3 -m pytest -q
383 passed

python3 -m compileall -q .
bash -n scripts/install.sh scripts/update.sh
git diff --check
all clean
```

I also ran runtime-shaped smokes through the active plugin path at `/home/nabu/.hermes/plugins/hermes-lcm`, covering the issue #78 foreground carry-over path, auxiliary compression handoff, explicit-parent foreground branches, reused-parent foreground branches, and delegate worker execution.