### PR TITLE
fix: fail open on session-end sqlite locks

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -117,6 +117,19 @@ def _git_runtime_identity(root: Path) -> dict[str, Any]:
     }
 
 
+def _is_sqlite_locked_error(exc: BaseException) -> bool:
+    """Return True when an exception chain represents SQLite lock contention."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if isinstance(current, sqlite3.Error) and "locked" in message:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 _SYNTHETIC_ASSISTANT_NOISE = {
     "ack",
     "acknowledged",
@@ -1241,13 +1254,22 @@ class LCMEngine(ContextEngine):
             if current_thread_session_id == session_id:
                 self._clear_thread_context_stateless(session_id)
             return
-        # Ensure all messages are persisted
-        self._ingest_messages(messages)
-        self._lifecycle.finalize_session(
-            self._conversation_id,
-            session_id,
-            frontier_store_id=self._last_compacted_store_id,
-        )
+        try:
+            # Ensure all messages are persisted
+            self._ingest_messages(messages)
+            self._lifecycle.finalize_session(
+                self._conversation_id,
+                session_id,
+                frontier_store_id=self._last_compacted_store_id,
+            )
+        except Exception as exc:
+            if _is_sqlite_locked_error(exc):
+                logger.warning(
+                    "LCM session-end ingest/finalize skipped due to SQLite lock: %s",
+                    exc,
+                )
+                return
+            raise
 
     def on_session_reset(self) -> None:
         self._pending_reset_session_id = self._session_id

--- a/engine.py
+++ b/engine.py
@@ -13,8 +13,9 @@ import sqlite3
 import subprocess
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from agent.context_engine import ContextEngine
 
@@ -48,6 +49,7 @@ logger = logging.getLogger(__name__)
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
+_SESSION_END_BUSY_TIMEOUT_MS = 50
 
 
 def _strip_metadata_scalar(value: str) -> str:
@@ -128,6 +130,32 @@ def _is_sqlite_locked_error(exc: BaseException) -> bool:
             return True
         current = current.__cause__ or current.__context__
     return False
+
+
+def _sqlite_busy_timeout_ms(conn: sqlite3.Connection) -> int:
+    row = conn.execute("PRAGMA busy_timeout").fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+@contextmanager
+def _temporary_sqlite_busy_timeout(
+    connections: List[sqlite3.Connection | None],
+    timeout_ms: int,
+) -> Iterator[None]:
+    """Temporarily bound SQLite lock waits for gateway-critical paths."""
+    bounded_timeout = max(0, int(timeout_ms))
+    originals: list[tuple[sqlite3.Connection, int]] = []
+    for conn in connections:
+        if conn is None:
+            continue
+        original = _sqlite_busy_timeout_ms(conn)
+        conn.execute(f"PRAGMA busy_timeout={bounded_timeout}")
+        originals.append((conn, original))
+    try:
+        yield
+    finally:
+        for conn, original in reversed(originals):
+            conn.execute(f"PRAGMA busy_timeout={original}")
 
 
 _SYNTHETIC_ASSISTANT_NOISE = {
@@ -1255,17 +1283,47 @@ class LCMEngine(ContextEngine):
                 self._clear_thread_context_stateless(session_id)
             return
         try:
-            # Ensure all messages are persisted
-            self._ingest_messages(messages)
-            self._lifecycle.finalize_session(
-                self._conversation_id,
-                session_id,
-                frontier_store_id=self._last_compacted_store_id,
-            )
+            with _temporary_sqlite_busy_timeout(
+                [
+                    getattr(self._store, "_conn", None),
+                    getattr(self._lifecycle, "_conn", None),
+                ],
+                _SESSION_END_BUSY_TIMEOUT_MS,
+            ):
+                try:
+                    # Best-effort final flush. Keep this path bounded because
+                    # host gateways call session-end hooks from lifecycle paths
+                    # that must not wait through SQLite's normal busy timeout.
+                    self._ingest_messages(messages)
+                except Exception as exc:
+                    if _is_sqlite_locked_error(exc):
+                        logger.warning(
+                            "LCM session-end raw-message ingest skipped due to SQLite lock after short wait; "
+                            "final messages may be absent from the plugin-local store: %s",
+                            exc,
+                        )
+                        return
+                    raise
+
+                try:
+                    self._lifecycle.finalize_session(
+                        self._conversation_id,
+                        session_id,
+                        frontier_store_id=self._last_compacted_store_id,
+                    )
+                except Exception as exc:
+                    if _is_sqlite_locked_error(exc):
+                        logger.warning(
+                            "LCM session-end lifecycle finalization skipped due to SQLite lock after short wait; "
+                            "raw messages were ingested but lifecycle state may be finalized later: %s",
+                            exc,
+                        )
+                        return
+                    raise
         except Exception as exc:
             if _is_sqlite_locked_error(exc):
                 logger.warning(
-                    "LCM session-end ingest/finalize skipped due to SQLite lock: %s",
+                    "LCM session-end ingest/finalize skipped due to SQLite lock before bounded flush: %s",
                     exc,
                 )
                 return

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1560,7 +1560,7 @@ class TestSessionRollover:
         with caplog.at_level(logging.WARNING):
             engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
 
-        assert "LCM session-end ingest/finalize skipped due to SQLite lock" in caplog.text
+        assert "LCM session-end raw-message ingest skipped due to SQLite lock" in caplog.text
 
     def test_on_session_end_fails_open_when_finalize_store_is_locked(self, engine, monkeypatch, caplog):
         engine.on_session_start("test-session", platform="discord")
@@ -1573,7 +1573,29 @@ class TestSessionRollover:
         with caplog.at_level(logging.WARNING):
             engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
 
-        assert "LCM session-end ingest/finalize skipped due to SQLite lock" in caplog.text
+        assert "LCM session-end lifecycle finalization skipped due to SQLite lock" in caplog.text
+
+    def test_on_session_end_returns_quickly_under_real_sqlite_writer_lock(self, engine, caplog):
+        engine.on_session_start("test-session", platform="discord")
+        engine._store._conn.execute("PRAGMA busy_timeout=750")
+        engine._lifecycle._conn.execute("PRAGMA busy_timeout=750")
+
+        locker = sqlite3.connect(str(engine._store.db_path), timeout=1.0, isolation_level=None)
+        locker.execute("PRAGMA journal_mode=WAL")
+        locker.execute("BEGIN IMMEDIATE")
+        try:
+            started = time.monotonic()
+            with caplog.at_level(logging.WARNING):
+                engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
+            elapsed = time.monotonic() - started
+        finally:
+            locker.execute("ROLLBACK")
+            locker.close()
+
+        assert elapsed < 0.3
+        assert engine._store._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 750
+        assert engine._lifecycle._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 750
+        assert "LCM session-end raw-message ingest skipped due to SQLite lock" in caplog.text
 
     def test_on_session_end_reraises_non_lock_errors(self, engine, monkeypatch):
         engine.on_session_start("test-session", platform="discord")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1549,6 +1549,43 @@ class TestSessionRollover:
         )
         return frame
 
+    def test_on_session_end_fails_open_when_ingest_store_is_locked(self, engine, monkeypatch, caplog):
+        engine.on_session_start("test-session", platform="discord")
+
+        def locked_ingest(messages):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(engine, "_ingest_messages", locked_ingest)
+
+        with caplog.at_level(logging.WARNING):
+            engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
+
+        assert "LCM session-end ingest/finalize skipped due to SQLite lock" in caplog.text
+
+    def test_on_session_end_fails_open_when_finalize_store_is_locked(self, engine, monkeypatch, caplog):
+        engine.on_session_start("test-session", platform="discord")
+
+        def locked_finalize(*args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(engine._lifecycle, "finalize_session", locked_finalize)
+
+        with caplog.at_level(logging.WARNING):
+            engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
+
+        assert "LCM session-end ingest/finalize skipped due to SQLite lock" in caplog.text
+
+    def test_on_session_end_reraises_non_lock_errors(self, engine, monkeypatch):
+        engine.on_session_start("test-session", platform="discord")
+
+        def broken_ingest(messages):
+            raise RuntimeError("not a lock")
+
+        monkeypatch.setattr(engine, "_ingest_messages", broken_ingest)
+
+        with pytest.raises(RuntimeError, match="not a lock"):
+            engine.on_session_end("test-session", [{"role": "user", "content": "hello"}])
+
     def test_rollover_session_rebinds_engine_and_carries_retained_nodes(self, engine):
         engine._config.new_session_retain_depth = 2
         from hermes_lcm.dag import SummaryNode


### PR DESCRIPTION
## Summary
- Bound `on_session_end()` SQLite writes to a short busy timeout so real writer-lock contention returns quickly instead of waiting through the normal 30 second timeout.
- Split raw-message ingest and lifecycle-finalization lock handling so logs make the persistence tradeoff explicit.
- Added a real held-writer-lock regression that proves `on_session_end()` returns within a small bound.

## Why
- #95 is about gateway availability, not just swallowing the final SQLite exception.
- A normal SQLite locked write waits through `PRAGMA busy_timeout` before raising, so catching the exception after the wait still blocks heartbeat-critical lifecycle paths.
- The final raw-message flush is best effort. If it cannot acquire the DB quickly, availability wins and the warning states that final messages may be absent from the plugin-local store.

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_returns_quickly_under_real_sqlite_writer_lock tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_fails_open_when_ingest_store_is_locked tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_fails_open_when_finalize_store_is_locked tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_reraises_non_lock_errors -q` -> 4 passed
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover -q` -> 57 passed
- `ulimit -n 4096 && python -m pytest -q` -> 406 passed
- `python -m compileall -q .` -> passed
- `bash -n scripts/install.sh scripts/update.sh` -> passed
- `git diff --check` -> passed

## Notes
- Full local pytest needed `ulimit -n 4096` on this Arch/Python 3.14 machine to avoid pytest tempdir cleanup hitting the default 1024 file-descriptor ceiling.

Fixes #95
