### PR TITLE
fix: make raw LCM expansion pageable

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Environment variables (all optional):
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. Slash-bearing aggregator model slugs such as `meta-llama/...`, `anthropic/...`, and unresolved `cerebras/...` stay model-only. |
 | `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Uses the same routing rules as `LCM_SUMMARY_MODEL`. |
-| `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Raw/source context budget fed to the auxiliary LLM for `lcm_expand_query` before returning a bounded answer |
+| `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Summary/raw/source context budget fed to the auxiliary LLM for `lcm_expand_query` before returning a bounded answer |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
@@ -367,7 +367,7 @@ For `lcm_expand(externalized_ref=...)`:
 For `lcm_expand_query`:
 
 - `max_tokens` is the bounded answer budget returned to the main agent
-- `context_max_tokens` is the larger fresh context budget used to expand raw/source material for the auxiliary LLM before synthesis
+- `context_max_tokens` is the larger fresh context budget used to expand summaries and raw/source material for the auxiliary LLM before synthesis
 - default `context_max_tokens` comes from `LCM_EXPANSION_CONTEXT_TOKENS`, currently `32000`
 - if the auxiliary context still cannot cover all raw sources, the response reports `context_truncated` and `context_pagination` so the main agent can fall back to explicit `lcm_expand` pages
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Environment variables (all optional):
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Opt-in rewrite of already-externalized summarized tool-result transcript rows to compact GC placeholders |
 | `LCM_SUMMARY_MODEL` | *(auxiliary)* | Override model for summarization. Slash-bearing aggregator model slugs such as `meta-llama/...`, `anthropic/...`, and unresolved `cerebras/...` stay model-only. |
 | `LCM_EXPANSION_MODEL` | *(summary model / auxiliary)* | Override model for `lcm_expand_query` synthesis. Uses the same routing rules as `LCM_SUMMARY_MODEL`. |
+| `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Raw/source context budget fed to the auxiliary LLM for `lcm_expand_query` before returning a bounded answer |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for a single model-backed summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for `lcm_expand_query` answer synthesis |
 | `LCM_DATABASE_PATH` | `~/.hermes/lcm.db` | SQLite database path (auto profile-scoped) |
@@ -338,10 +339,39 @@ That means patterns like `cron:*` can catch Hermes cron sessions today, while pl
 |------|-------------|
 | `lcm_grep` | Search raw messages AND summaries for the active/current session. Use this for intra-session recall after compaction. For earlier separate sessions or broad cross-session history, use `session_search`. |
 | `lcm_describe` | Inspect current-session DAG structure or an `externalized_ref` payload preview without loading full payload content. No node_id/externalized_ref = session overview. |
-| `lcm_expand` | Recover original content from a current-session summary node, or open a stored `externalized_ref` payload directly. |
-| `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. For cross-session recall, use `session_search` first. |
+| `lcm_expand` | Recover original content from a current-session summary node, or open a stored `externalized_ref` payload directly. Bounded by default, pageable via source/content cursors. |
+| `lcm_expand_query` | Answer a question from expanded LCM context for the active/current session using either a query or explicit node_ids. It can use a larger fresh auxiliary context budget while still returning a bounded answer. For cross-session recall, use `session_search` first. |
 | `lcm_status` | Quick health overview — compression count, store size, DAG depth distribution, context usage, active config, and read-only lifecycle/session fragmentation stats. |
 | `lcm_doctor` | Run diagnostics — database integrity, FTS index sync, orphaned nodes, lifecycle/session fragmentation, config validation, context pressure. |
+
+### Lossless raw recovery contract
+
+`lcm_expand` and `lcm_expand_query` are intentionally bounded at the tool-response boundary so one retrieval call cannot flood the main agent context. “Lossless” therefore means two things together:
+
+1. raw content is stored with stable source lineage
+2. raw content can be recovered in deterministic bounded spans
+
+For `lcm_expand(node_id=...)`:
+
+- `source_offset` selects the first immediate source to return from the summary node's source list
+- `source_limit` limits how many immediate sources are returned in that page
+- `content_offset` continues inside one oversized raw message when the previous response could not fit the whole item under `max_tokens`
+- responses include `pagination.has_more`, `pagination.next_source_offset`, and `pagination.next_content_offset`
+- child-node expansion uses the same source cursor shape, so an agent can page lower-level summaries before drilling further
+
+For `lcm_expand(externalized_ref=...)`:
+
+- `content_offset` continues inside the externalized payload
+- responses include `has_more` and `next_content_offset`
+
+For `lcm_expand_query`:
+
+- `max_tokens` is the bounded answer budget returned to the main agent
+- `context_max_tokens` is the larger fresh context budget used to expand raw/source material for the auxiliary LLM before synthesis
+- default `context_max_tokens` comes from `LCM_EXPANSION_CONTEXT_TOKENS`, currently `32000`
+- if the auxiliary context still cannot cover all raw sources, the response reports `context_truncated` and `context_pagination` so the main agent can fall back to explicit `lcm_expand` pages
+
+This keeps normal retrieval safe while making larger raw spans practically recoverable instead of silently disappearing behind a cap.
 
 ### Operator slash commands
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ For `lcm_expand(externalized_ref=...)`:
 For `lcm_expand_query`:
 
 - `max_tokens` is the bounded answer budget returned to the main agent
-- `context_max_tokens` is the larger fresh context budget used to expand summaries, raw messages, child summaries, and externalized payload content for the auxiliary LLM before synthesis
+- `context_max_tokens` is the larger fresh context budget used to expand summaries, raw messages, child summaries, externalized transcript markers, and externalized payload content for the auxiliary LLM before synthesis
 - default `context_max_tokens` comes from `LCM_EXPANSION_CONTEXT_TOKENS`, currently `32000`, but never below the requested answer `max_tokens`
 - if the auxiliary context still cannot cover all summary/raw/child-source context, the response reports `context_truncated` and `context_pagination` so the main agent can fall back to explicit pages or deeper expansion
 - `context_pagination` entries include `expand_args` for the intended follow-up: node/source cursors use `lcm_expand(node_id=...)`, externalized payload truncation uses `lcm_expand(externalized_ref=...)`, and truncated child summaries point at the child `node_id` to expand next

--- a/README.md
+++ b/README.md
@@ -367,9 +367,10 @@ For `lcm_expand(externalized_ref=...)`:
 For `lcm_expand_query`:
 
 - `max_tokens` is the bounded answer budget returned to the main agent
-- `context_max_tokens` is the larger fresh context budget used to expand summaries and raw/source material for the auxiliary LLM before synthesis
-- default `context_max_tokens` comes from `LCM_EXPANSION_CONTEXT_TOKENS`, currently `32000`
-- if the auxiliary context still cannot cover all raw sources, the response reports `context_truncated` and `context_pagination` so the main agent can fall back to explicit `lcm_expand` pages
+- `context_max_tokens` is the larger fresh context budget used to expand summaries, raw messages, child summaries, and externalized payload content for the auxiliary LLM before synthesis
+- default `context_max_tokens` comes from `LCM_EXPANSION_CONTEXT_TOKENS`, currently `32000`, but never below the requested answer `max_tokens`
+- if the auxiliary context still cannot cover all summary/raw/child-source context, the response reports `context_truncated` and `context_pagination` so the main agent can fall back to explicit pages or deeper expansion
+- `context_pagination` entries include `expand_args` for the intended follow-up: node/source cursors use `lcm_expand(node_id=...)`, externalized payload truncation uses `lcm_expand(externalized_ref=...)`, and truncated child summaries point at the child `node_id` to expand next
 
 This keeps normal retrieval safe while making larger raw spans practically recoverable instead of silently disappearing behind a cap.
 

--- a/config.py
+++ b/config.py
@@ -121,7 +121,7 @@ class LCMConfig:
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
-    # Summary/raw/source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
+    # Summary/raw/child-source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
     expansion_context_tokens: int = 32_000
 
     # -- Timeouts ---

--- a/config.py
+++ b/config.py
@@ -121,7 +121,7 @@ class LCMConfig:
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
-    # Summary/raw/child-source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
+    # Serialized summary/raw/child-source/externalized context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
     expansion_context_tokens: int = 32_000
 
     # -- Timeouts ---

--- a/config.py
+++ b/config.py
@@ -121,7 +121,7 @@ class LCMConfig:
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
-    # Raw/source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
+    # Summary/raw/source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
     expansion_context_tokens: int = 32_000
 
     # -- Timeouts ---

--- a/config.py
+++ b/config.py
@@ -121,6 +121,8 @@ class LCMConfig:
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
+    # Raw/source context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
+    expansion_context_tokens: int = 32_000
 
     # -- Timeouts ---
     summary_timeout_ms: int = 60_000
@@ -194,6 +196,7 @@ class LCMConfig:
         )
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
+        c.expansion_context_tokens = _int("LCM_EXPANSION_CONTEXT_TOKENS", c.expansion_context_tokens)
         c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)
         c.expansion_timeout_ms = _int("LCM_EXPANSION_TIMEOUT_MS", c.expansion_timeout_ms)
         c.database_path = _str("LCM_DATABASE_PATH", c.database_path)

--- a/schemas.py
+++ b/schemas.py
@@ -90,9 +90,11 @@ LCM_EXPAND = {
         "Recover the original detail behind a current session summary node, or open an "
         "externalized payload ref directly. Given a node_id, returns the "
         "source messages or lower-depth summaries that were compacted into "
-        "that node. Given externalized_ref, returns the stored payload "
-        "content plus metadata. Use after lcm_describe to drill into "
-        "specific parts of the active conversation or large externalized "
+        "that node. Output is bounded by default, but raw recovery is pageable: "
+        "use source_offset/source_limit to page immediate sources and content_offset "
+        "to continue an oversized message or externalized payload. Given externalized_ref, "
+        "returns the stored payload content plus cursor metadata. Use after lcm_describe "
+        "to drill into specific parts of the active conversation or large externalized "
         "tool output. For cross-session recall, prefer session_search first."
     ),
     "parameters": {
@@ -110,6 +112,20 @@ LCM_EXPAND = {
                 "type": "integer",
                 "description": "Token budget for returned content (default 4000)",
                 "default": 4000,
+            },
+            "source_offset": {
+                "type": "integer",
+                "description": "Zero-based pagination offset into the node's immediate source list (messages or child nodes). Use pagination.next_source_offset to continue.",
+                "default": 0,
+            },
+            "source_limit": {
+                "type": "integer",
+                "description": "Maximum number of immediate sources to return from source_offset. Output still respects max_tokens.",
+            },
+            "content_offset": {
+                "type": "integer",
+                "description": "Character offset used to continue an oversized raw message or externalized payload. Use next_content_offset from the previous response.",
+                "default": 0,
             },
         },
         "required": [],
@@ -177,8 +193,13 @@ LCM_EXPAND_QUERY = {
             },
             "max_tokens": {
                 "type": "integer",
-                "description": "Max answer tokens for synthesis (default 2000)",
+                "description": "Max answer tokens for bounded synthesis returned to the main agent (default 2000)",
                 "default": 2000,
+            },
+            "context_max_tokens": {
+                "type": "integer",
+                "description": "Expanded raw/source fresh context budget for the auxiliary LLM before it returns the bounded answer (default 32000 or LCM_EXPANSION_CONTEXT_TOKENS)",
+                "default": 32000,
             },
         },
         "required": ["prompt"],

--- a/schemas.py
+++ b/schemas.py
@@ -198,7 +198,7 @@ LCM_EXPAND_QUERY = {
             },
             "context_max_tokens": {
                 "type": "integer",
-                "description": "Expanded summary/raw/child-source fresh context budget for the auxiliary LLM before it returns the bounded answer (default max(answer max_tokens, 32000 or LCM_EXPANSION_CONTEXT_TOKENS))",
+                "description": "Expanded serialized summary/raw/child-source/externalized fresh context budget for the auxiliary LLM before it returns the bounded answer (default max(answer max_tokens, 32000 or LCM_EXPANSION_CONTEXT_TOKENS))",
                 "default": 32000,
             },
         },

--- a/schemas.py
+++ b/schemas.py
@@ -198,7 +198,7 @@ LCM_EXPAND_QUERY = {
             },
             "context_max_tokens": {
                 "type": "integer",
-                "description": "Expanded raw/source fresh context budget for the auxiliary LLM before it returns the bounded answer (default 32000 or LCM_EXPANSION_CONTEXT_TOKENS)",
+                "description": "Expanded summary/raw/source fresh context budget for the auxiliary LLM before it returns the bounded answer (default 32000 or LCM_EXPANSION_CONTEXT_TOKENS)",
                 "default": 32000,
             },
         },

--- a/schemas.py
+++ b/schemas.py
@@ -198,7 +198,7 @@ LCM_EXPAND_QUERY = {
             },
             "context_max_tokens": {
                 "type": "integer",
-                "description": "Expanded summary/raw/source fresh context budget for the auxiliary LLM before it returns the bounded answer (default 32000 or LCM_EXPANSION_CONTEXT_TOKENS)",
+                "description": "Expanded summary/raw/child-source fresh context budget for the auxiliary LLM before it returns the bounded answer (default max(answer max_tokens, 32000 or LCM_EXPANSION_CONTEXT_TOKENS))",
                 "default": 32000,
             },
         },

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -228,6 +228,7 @@ class TestConfig:
         assert c.stateless_session_patterns_source == "default"
         assert c.summary_model == ""
         assert c.expansion_model == ""
+        assert c.expansion_context_tokens == 32_000
         assert c.summary_timeout_ms == 60_000
         assert c.expansion_timeout_ms == 120_000
 
@@ -237,6 +238,7 @@ class TestConfig:
         monkeypatch.setenv("LCM_IGNORE_SESSION_PATTERNS", "cron:*,subagent:**")
         monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "telegram:*, cli:debug")
         monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
+        monkeypatch.setenv("LCM_EXPANSION_CONTEXT_TOKENS", "64000")
         monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
         monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
         monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_ENABLED", "1")
@@ -259,6 +261,7 @@ class TestConfig:
         assert c.ignore_session_patterns_source == "env"
         assert c.stateless_session_patterns_source == "env"
         assert c.expansion_model == "openai/gpt-5.4-mini"
+        assert c.expansion_context_tokens == 64_000
         assert c.summary_timeout_ms == 45_000
         assert c.expansion_timeout_ms == 90_000
         assert c.dynamic_leaf_chunk_enabled is True
@@ -280,6 +283,7 @@ class TestConfig:
         monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "bad-float")
         monkeypatch.setenv("LCM_MAX_ASSEMBLY_TOKENS", "nope")
         monkeypatch.setenv("LCM_RESERVE_TOKENS_FLOOR", "still-nope")
+        monkeypatch.setenv("LCM_EXPANSION_CONTEXT_TOKENS", "nah")
 
         c = LCMConfig.from_env()
 
@@ -288,6 +292,7 @@ class TestConfig:
         assert c.context_threshold == 0.75
         assert c.max_assembly_tokens == 0
         assert c.reserve_tokens_floor == 0
+        assert c.expansion_context_tokens == 32_000
 
 
 class TestSessionPatterns:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -6739,6 +6739,132 @@ class TestEngineTools:
             for item in result["context_pagination"]
         )
 
+    def test_handle_expand_query_reports_last_child_summary_truncation_in_context_pagination(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        child_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary=("child summary detail " * 80) + "CHILD SUMMARY TAIL",
+                token_count=200,
+                source_token_count=200,
+                source_ids=[],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+        parent_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="",
+                token_count=0,
+                source_token_count=200,
+                source_ids=[child_id],
+                source_type="nodes",
+                created_at=1,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What child details fit?",
+                    "node_ids": [parent_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 5,
+                },
+            )
+        )
+
+        context_json = json.dumps(captured["context_blocks"])
+        assert "CHILD SUMMARY TAIL" not in context_json
+        child_block = next(block for block in captured["context_blocks"] if block["type"] == "child_nodes")
+        assert child_block["children"][0]["summary_truncated"] is True
+        assert result["context_truncated"] is True
+        assert any(
+            item["type"] == "child_summary"
+            and item["node_id"] == parent_id
+            and item["child_node_id"] == child_id
+            and item["summary_truncated"] is True
+            and item["expand_args"] == {"node_id": child_id}
+            for item in result["context_pagination"]
+        )
+
+    def test_handle_expand_query_externalized_truncation_returns_ref_in_context_pagination(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_expand_query_externalized_truncated.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        content = "EXTERNALIZED RAW DETAIL " + ("abcdef" * 1000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_ext", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+        placeholder = f"[GC'd externalized tool output: tool_call_id=call_ext; chars={len(content)}; ref={ref}]"
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_ext", "content": placeholder},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="externalized payload summary",
+                token_count=10,
+                source_token_count=200,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What externalized detail exists?",
+                    "node_ids": [node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 20,
+                },
+            )
+        )
+
+        message_block = next(block for block in captured["context_blocks"] if block["type"] == "messages")
+        assert message_block["messages"][0]["content_source"] == "externalized_payload"
+        assert message_block["messages"][0]["content_truncated"] is True
+        assert result["context_truncated"] is True
+        assert any(
+            item["type"] == "messages"
+            and item["node_id"] == node_id
+            and item["content_source"] == "externalized_payload"
+            and item["externalized_ref"] == ref
+            and item["pagination"]["has_more"] is True
+            and item["expand_args"] == {
+                "externalized_ref": ref,
+                "content_offset": item["pagination"]["next_content_offset"],
+            }
+            for item in result["context_pagination"]
+        )
+
     def test_handle_expand_query_hydrates_externalized_payload_content_for_auxiliary_context(self, tmp_path, monkeypatch):
         captured = {}
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -368,8 +368,16 @@ class TestEngineABC:
         assert "session_search" in describe_schema["description"]
         assert "current session" in expand_schema["description"].lower()
         assert "session_search" in expand_schema["description"]
+        expand_props = expand_schema["parameters"]["properties"]
+        assert "source_offset" in expand_props
+        assert "source_limit" in expand_props
+        assert "content_offset" in expand_props
+        assert "pagination" in expand_props["source_offset"]["description"].lower()
         assert "current session" in expand_query_schema["description"].lower()
         assert "session_search" in expand_query_schema["description"]
+        expand_query_props = expand_query_schema["parameters"]["properties"]
+        assert "context_max_tokens" in expand_query_props
+        assert "fresh context budget" in expand_query_props["context_max_tokens"]["description"]
 
     def test_readme_matches_current_session_retrieval_contract(self):
         readme = Path(__file__).resolve().parents[1].joinpath("README.md").read_text()
@@ -377,6 +385,10 @@ class TestEngineABC:
         assert "session_scope=\"all\"" not in readme
         assert "current-session recall" in readme
         assert "session_search" in readme
+        assert "Lossless raw recovery contract" in readme
+        assert "source_offset" in readme
+        assert "content_offset" in readme
+        assert "LCM_EXPANSION_CONTEXT_TOKENS" in readme
 
     def test_should_compress(self, engine):
         assert not engine.should_compress(1000)
@@ -5979,6 +5991,232 @@ class TestEngineTools:
         assert "session_id" in result
         assert "store_message_count" in result
 
+    def test_handle_expand_paginates_message_sources_with_cursor_metadata(self, engine):
+        store_ids = [
+            engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"raw page message {idx}"},
+            )
+            for idx in range(5)
+        ]
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Paged raw source summary",
+                token_count=10,
+                source_token_count=50,
+                source_ids=store_ids,
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": node_id, "source_offset": 1, "source_limit": 2, "max_tokens": 1000},
+            )
+        )
+
+        assert [item["store_id"] for item in result["expanded"]] == store_ids[1:3]
+        assert [item["source_index"] for item in result["expanded"]] == [1, 2]
+        assert result["pagination"] == {
+            "source_offset": 1,
+            "content_offset": 0,
+            "source_limit": 2,
+            "returned_sources": 2,
+            "total_sources": 5,
+            "next_source_offset": 3,
+            "next_content_offset": 0,
+            "has_more": True,
+            "remaining_sources": 2,
+        }
+
+    def test_handle_expand_paginates_oversized_message_content_without_losing_raw_tail(self, engine):
+        from hermes_lcm.tokens import count_tokens
+
+        content = "alpha " * 400
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": content},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Oversized raw message summary",
+                token_count=10,
+                source_token_count=count_tokens(content),
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        first = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": node_id, "max_tokens": 20},
+            )
+        )
+
+        first_item = first["expanded"][0]
+        assert first_item["store_id"] == store_id
+        assert first_item["content_offset"] == 0
+        assert first_item["content_truncated"] is True
+        assert count_tokens(first_item["content"]) <= 20
+        assert first["pagination"]["has_more"] is True
+        assert first["pagination"]["next_source_offset"] == 0
+        assert first["pagination"]["next_content_offset"] > 0
+
+        second = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {
+                    "node_id": node_id,
+                    "source_offset": first["pagination"]["next_source_offset"],
+                    "content_offset": first["pagination"]["next_content_offset"],
+                    "max_tokens": 20,
+                },
+            )
+        )
+
+        assert second["expanded"][0]["content_offset"] == first["pagination"]["next_content_offset"]
+        assert second["expanded"][0]["content"] == content[first["pagination"]["next_content_offset"]:][:len(second["expanded"][0]["content"])]
+
+    def test_handle_expand_paginates_child_node_sources(self, engine):
+        child_ids = []
+        for idx in range(3):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"child node raw {idx}"},
+            )
+            child_ids.append(
+                engine._dag.add_node(
+                    SummaryNode(
+                        session_id="test-session",
+                        depth=0,
+                        summary=f"child summary {idx}",
+                        token_count=10,
+                        source_token_count=10,
+                        source_ids=[store_id],
+                        source_type="messages",
+                        created_at=idx,
+                    )
+                )
+            )
+        parent_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="parent summary",
+                token_count=10,
+                source_token_count=30,
+                source_ids=child_ids,
+                source_type="nodes",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": parent_id, "source_offset": 1, "source_limit": 1},
+            )
+        )
+
+        assert result["source_type"] == "nodes"
+        assert [item["node_id"] for item in result["expanded"]] == [child_ids[1]]
+        assert result["expanded"][0]["source_index"] == 1
+        assert result["pagination"]["has_more"] is True
+        assert result["pagination"]["next_source_offset"] == 2
+
+    def test_handle_expand_child_node_pagination_preserves_source_id_order(self, engine):
+        newer_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="newer child in source order first",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[],
+                source_type="messages",
+                created_at=2,
+            )
+        )
+        older_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="older child in source order second",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        parent_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="parent summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[newer_id, older_id],
+                source_type="nodes",
+                created_at=3,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": parent_id, "source_offset": 0, "source_limit": 1},
+            )
+        )
+
+        assert [item["node_id"] for item in result["expanded"]] == [newer_id]
+        assert result["expanded"][0]["source_index"] == 0
+
+    def test_handle_expand_child_node_sources_respect_max_tokens(self, engine):
+        child_ids = []
+        for idx in range(2):
+            child_ids.append(
+                engine._dag.add_node(
+                    SummaryNode(
+                        session_id="test-session",
+                        depth=0,
+                        summary=(f"child {idx} " * 80),
+                        token_count=160,
+                        source_token_count=160,
+                        source_ids=[],
+                        source_type="messages",
+                        created_at=idx,
+                    )
+                )
+            )
+        parent_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="parent summary",
+                token_count=10,
+                source_token_count=320,
+                source_ids=child_ids,
+                source_type="nodes",
+                created_at=3,
+            )
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": parent_id, "max_tokens": 5}))
+
+        assert len(result["expanded"]) == 1
+        assert result["expanded"][0]["summary_truncated"] is True
+        assert result["pagination"]["has_more"] is True
+        assert result["pagination"]["next_source_offset"] == 1
+
     def test_handle_expand_includes_externalized_metadata_for_large_tool_result_sources(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_externalized_expand.db"),
@@ -6166,6 +6404,202 @@ class TestEngineTools:
         assert result["content_truncated"] is True
         assert count_tokens(result["content"]) <= 10
         assert result["tool_call_id"] == "call_big"
+
+    def test_handle_expand_externalized_ref_uses_content_offset_cursor(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_payload_cursor.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "RESULT:\n" + ("abcdef" * 2000)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_big", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+
+        first = json.loads(engine.handle_tool_call("lcm_expand", {"externalized_ref": ref, "max_tokens": 10}))
+        assert first["has_more"] is True
+        assert first["next_content_offset"] > 0
+
+        second = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {
+                    "externalized_ref": ref,
+                    "content_offset": first["next_content_offset"],
+                    "max_tokens": 10,
+                },
+            )
+        )
+
+        assert second["content_offset"] == first["next_content_offset"]
+        assert second["content"] == content[first["next_content_offset"]:][:len(second["content"])]
+
+    def test_handle_expand_query_uses_independent_context_budget_for_auxiliary_retrieval(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            captured["max_tokens"] = max_tokens
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        first_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "first filler " * 80},
+        )
+        second_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "SECOND RAW DETAIL survives auxiliary context expansion"},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Summary mentioning second raw detail",
+                token_count=10,
+                source_token_count=200,
+                source_ids=[first_store_id, second_store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What detail survived?",
+                    "node_ids": [node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 500,
+                },
+            )
+        )
+
+        assert result["answer"] == "bounded answer"
+        assert captured["max_tokens"] == 5
+        context_json = json.dumps(captured["context_blocks"])
+        assert "SECOND RAW DETAIL" in context_json
+
+    def test_handle_expand_query_applies_context_budget_globally_across_nodes(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        first_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "first filler " * 80},
+        )
+        first_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="first summary",
+                token_count=10,
+                source_token_count=200,
+                source_ids=[first_store_id],
+                source_type="messages",
+                created_at=2,
+            )
+        )
+        second_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "SECOND NODE RAW DETAIL should require another page"},
+        )
+        second_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="second summary without raw detail",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[second_store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw details exist?",
+                    "node_ids": [first_node_id, second_node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        context_json = json.dumps(captured["context_blocks"])
+        assert "SECOND NODE RAW DETAIL" not in context_json
+        assert result["context_truncated"] is True
+        assert any(
+            item["node_id"] == second_node_id and item["pagination"]["has_more"]
+            for item in result["context_pagination"]
+        )
+
+    def test_handle_expand_query_hydrates_externalized_payload_content_for_auxiliary_context(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_expand_query_externalized.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        content = "EXTERNALIZED RAW DETAIL survives for auxiliary retrieval " + ("abcdef" * 100)
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_ext", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+        placeholder = f"[GC'd externalized tool output: tool_call_id=call_ext; chars={len(content)}; ref={ref}]"
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_ext", "content": placeholder},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="externalized payload summary",
+                token_count=10,
+                source_token_count=200,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What externalized detail exists?",
+                    "node_ids": [node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 500,
+                },
+            )
+        )
+
+        context_json = json.dumps(captured["context_blocks"])
+        assert "EXTERNALIZED RAW DETAIL" in context_json
+        assert "externalized_payload" in context_json
+        assert result["context_truncated"] is False
 
     def test_compress_gc_rewrites_summarized_externalized_tool_results(self, tmp_path, monkeypatch):
         config = LCMConfig(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -6542,7 +6542,54 @@ class TestEngineTools:
         assert "SECOND NODE RAW DETAIL" not in context_json
         assert result["context_truncated"] is True
         assert any(
-            item["node_id"] == second_node_id and item["pagination"]["has_more"]
+            item["node_id"] == second_node_id and item.get("pagination", {}).get("has_more")
+            for item in result["context_pagination"]
+        )
+
+    def test_handle_expand_query_counts_summary_blocks_against_context_budget(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "raw detail should wait behind summary budget"},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary=("long summary filler " * 80) + "UNBUDGETED SUMMARY TAIL",
+                token_count=200,
+                source_token_count=20,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What fits?",
+                    "node_ids": [node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 5,
+                },
+            )
+        )
+
+        context_json = json.dumps(captured["context_blocks"])
+        assert "UNBUDGETED SUMMARY TAIL" not in context_json
+        assert "raw detail should wait" not in context_json
+        assert captured["context_blocks"][0]["summary_truncated"] is True
+        assert result["context_truncated"] is True
+        assert any(
+            item["node_id"] == node_id and item["type"] == "summary"
             for item in result["context_pagination"]
         )
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -6865,6 +6865,93 @@ class TestEngineTools:
             for item in result["context_pagination"]
         )
 
+    def test_handle_expand_query_counts_externalized_transcript_content_against_context_budget(self, tmp_path, monkeypatch):
+        import hermes_lcm.tokens as token_utils
+
+        captured = {}
+
+        def fake_count_tokens(text):
+            return len(str(text or ""))
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(token_utils, "count_tokens", fake_count_tokens)
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_expand_query_externalized_transcript_budget.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=2,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+        content = "PAYLOAD"
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_ext", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+        transcript_content = (
+            f"[GC'd externalized tool output: tool_call_id=call_ext; chars={len(content)}; ref={ref}]"
+            + (" transcript filler" * 20)
+        )
+        first_store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_ext", "content": transcript_content},
+        )
+        first_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="",
+                token_count=0,
+                source_token_count=200,
+                source_ids=[first_store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        second_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "SECOND_RAW_DETAIL"},
+        )
+        second_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="",
+                token_count=0,
+                source_token_count=20,
+                source_ids=[second_store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What details fit?",
+                    "node_ids": [first_node_id, second_node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 30,
+                },
+            )
+        )
+
+        context_json = json.dumps(captured["context_blocks"])
+        assert "transcript_content" in context_json
+        assert "SECOND_RAW_DETAIL" not in context_json
+        assert result["context_truncated"] is True
+        assert any(
+            item["node_id"] == second_node_id
+            and item["type"] == "messages"
+            and item.get("pagination", {}).get("has_more") is True
+            and item.get("expand_args") == {"node_id": second_node_id, "source_offset": 0, "content_offset": 0}
+            for item in result["context_pagination"]
+        )
+
     def test_handle_expand_query_hydrates_externalized_payload_content_for_auxiliary_context(self, tmp_path, monkeypatch):
         captured = {}
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -6085,6 +6085,109 @@ class TestEngineTools:
         assert second["expanded"][0]["content_offset"] == first["pagination"]["next_content_offset"]
         assert second["expanded"][0]["content"] == content[first["pagination"]["next_content_offset"]:][:len(second["expanded"][0]["content"])]
 
+    def test_handle_expand_advances_content_cursor_when_budget_cannot_fit_character(self, engine, monkeypatch):
+        import hermes_lcm.tokens as token_utils
+
+        def fake_count_tokens(text):
+            return 0 if not text else len(text) + 1
+
+        monkeypatch.setattr(token_utils, "count_tokens", fake_count_tokens)
+        content = "abcdef"
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": content},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Tiny budget raw message summary",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        first = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id, "max_tokens": 1}))
+
+        assert first["expanded"][0]["content"] == "a"
+        assert first["expanded"][0]["content_offset"] == 0
+        assert first["expanded"][0]["next_content_offset"] == 1
+        assert first["pagination"]["has_more"] is True
+        assert first["pagination"]["next_source_offset"] == 0
+        assert first["pagination"]["next_content_offset"] == 1
+
+        second = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {
+                    "node_id": node_id,
+                    "source_offset": first["pagination"]["next_source_offset"],
+                    "content_offset": first["pagination"]["next_content_offset"],
+                    "max_tokens": 1,
+                },
+            )
+        )
+
+        assert second["expanded"][0]["content"] == "b"
+        assert second["expanded"][0]["content_offset"] == 1
+        assert second["pagination"]["next_content_offset"] == 2
+
+    def test_handle_expand_query_advances_content_cursor_when_context_budget_cannot_fit_character(self, engine, monkeypatch):
+        import hermes_lcm.tokens as token_utils
+
+        captured = {}
+
+        def fake_count_tokens(text):
+            return 0 if not text else len(text) + 1
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "bounded answer"
+
+        monkeypatch.setattr(token_utils, "count_tokens", fake_count_tokens)
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "abcdef"},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="",
+                token_count=0,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw detail?",
+                    "node_ids": [node_id],
+                    "max_tokens": 5,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        message_block = next(block for block in captured["context_blocks"] if block["type"] == "messages")
+        assert message_block["messages"][0]["content"] == "a"
+        assert message_block["messages"][0]["next_content_offset"] == 1
+        assert result["context_truncated"] is True
+        assert any(
+            item["node_id"] == node_id
+            and item.get("pagination", {}).get("next_content_offset") == 1
+            for item in result["context_pagination"]
+        )
+
     def test_handle_expand_paginates_child_node_sources(self, engine):
         child_ids = []
         for idx in range(3):
@@ -6437,6 +6540,49 @@ class TestEngineTools:
 
         assert second["content_offset"] == first["next_content_offset"]
         assert second["content"] == content[first["next_content_offset"]:][:len(second["content"])]
+
+    def test_handle_expand_externalized_ref_advances_content_cursor_when_budget_cannot_fit_character(self, tmp_path, monkeypatch):
+        import hermes_lcm.tokens as token_utils
+
+        def fake_count_tokens(text):
+            return 0 if not text else len(text) + 1
+
+        monkeypatch.setattr(token_utils, "count_tokens", fake_count_tokens)
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_externalized_payload_tiny_cursor.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=2,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        content = "abcdef"
+        engine._serialize_messages([
+            {"role": "tool", "tool_call_id": "call_tiny", "content": content}
+        ])
+        ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
+
+        first = json.loads(engine.handle_tool_call("lcm_expand", {"externalized_ref": ref, "max_tokens": 1}))
+
+        assert first["content"] == "a"
+        assert first["content_offset"] == 0
+        assert first["next_content_offset"] == 1
+        assert first["has_more"] is True
+
+        second = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {
+                    "externalized_ref": ref,
+                    "content_offset": first["next_content_offset"],
+                    "max_tokens": 1,
+                },
+            )
+        )
+
+        assert second["content"] == "b"
+        assert second["content_offset"] == 1
+        assert second["next_content_offset"] == 2
 
     def test_handle_expand_query_uses_independent_context_budget_for_auxiliary_retrieval(self, engine, monkeypatch):
         captured = {}

--- a/tools.py
+++ b/tools.py
@@ -478,7 +478,9 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
         if block.get("type") == "summary":
             total += count_tokens(str(block.get("summary") or ""))
         elif block.get("type") == "messages":
-            total += sum(count_tokens(str(message.get("content") or "")) for message in block.get("messages", []))
+            for message in block.get("messages", []):
+                total += count_tokens(str(message.get("content") or ""))
+                total += count_tokens(str(message.get("transcript_content") or ""))
         elif block.get("type") == "child_nodes":
             total += sum(count_tokens(str(child.get("summary") or "")) for child in block.get("children", []))
     return total

--- a/tools.py
+++ b/tools.py
@@ -847,23 +847,79 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     for block in context_blocks:
         if not isinstance(block, dict):
             continue
-        if block.get("type") == "summary" and block.get("summary_truncated"):
+        block_type = block.get("type")
+        if block_type == "summary" and block.get("summary_truncated"):
             context_pagination.append(
                 {
                     "node_id": block.get("node_id"),
                     "type": "summary",
                     "summary_truncated": True,
+                    "expand_args": {"node_id": block.get("node_id")},
                 }
             )
+            continue
+
+        if block_type == "child_nodes":
+            for child in block.get("children", []):
+                if child.get("summary_truncated"):
+                    child_node_id = child.get("node_id")
+                    context_pagination.append(
+                        {
+                            "node_id": block.get("node_id"),
+                            "type": "child_summary",
+                            "child_node_id": child_node_id,
+                            "source_index": child.get("source_index"),
+                            "summary_truncated": True,
+                            "expand_args": {"node_id": child_node_id},
+                        }
+                    )
+
         pagination = block.get("pagination")
-        if pagination:
-            context_pagination.append(
-                {
-                    "node_id": block.get("node_id"),
-                    "type": block.get("type"),
-                    "pagination": pagination,
-                }
+        if not pagination or not pagination.get("has_more"):
+            continue
+
+        item = {
+            "node_id": block.get("node_id"),
+            "type": block_type,
+            "pagination": pagination,
+        }
+        if block_type == "messages":
+            truncated_message = next(
+                (message for message in block.get("messages", []) if message.get("content_truncated")),
+                None,
             )
+            if truncated_message:
+                item["source_index"] = truncated_message.get("source_index")
+                item["content_source"] = truncated_message.get("content_source")
+                externalized = truncated_message.get("externalized") or {}
+                externalized_ref = externalized.get("ref")
+                if externalized_ref:
+                    item["externalized_ref"] = externalized_ref
+                    item["tool_call_id"] = externalized.get("tool_call_id")
+                if truncated_message.get("content_source") == "externalized_payload" and externalized_ref:
+                    item["expand_args"] = {
+                        "externalized_ref": externalized_ref,
+                        "content_offset": pagination.get("next_content_offset") or 0,
+                    }
+                else:
+                    item["expand_args"] = {
+                        "node_id": block.get("node_id"),
+                        "source_offset": pagination.get("next_source_offset") or 0,
+                        "content_offset": pagination.get("next_content_offset") or 0,
+                    }
+            else:
+                item["expand_args"] = {
+                    "node_id": block.get("node_id"),
+                    "source_offset": pagination.get("next_source_offset") or 0,
+                    "content_offset": pagination.get("next_content_offset") or 0,
+                }
+        elif block_type == "child_nodes":
+            item["expand_args"] = {
+                "node_id": block.get("node_id"),
+                "source_offset": pagination.get("next_source_offset") or 0,
+            }
+        context_pagination.append(item)
+
     context_truncated = any(
         bool(item.get("summary_truncated")) or bool(item.get("pagination", {}).get("has_more"))
         for item in context_pagination

--- a/tools.py
+++ b/tools.py
@@ -152,6 +152,11 @@ def _slice_content_for_response(content: str, max_tokens: int, content_offset: i
     content = content or ""
     content_offset = min(max(0, content_offset), len(content))
     sliced, _ = _truncate_text_to_token_budget(content[content_offset:], max_tokens)
+    if not sliced and content_offset < len(content):
+        # A tiny token budget can fail to fit even the next character. Return one
+        # character anyway so callers make deterministic, lossless cursor progress
+        # instead of receiving has_more=true with the same content_offset forever.
+        sliced = content[content_offset:content_offset + 1]
     next_content_offset = content_offset + len(sliced)
     has_more = next_content_offset < len(content)
     return {

--- a/tools.py
+++ b/tools.py
@@ -419,22 +419,27 @@ def _collect_context_blocks_for_node(
     *,
     hydrate_externalized_content: bool = False,
 ) -> list[dict[str, Any]]:
+    from .tokens import count_tokens
+
+    summary, summary_truncated = _truncate_text_to_token_budget(node.summary, max_tokens)
     blocks: list[dict[str, Any]] = [
         {
             "type": "summary",
             "node_id": node.node_id,
             "depth": node.depth,
-            "summary": node.summary,
+            "summary": summary,
+            "summary_truncated": summary_truncated,
             "expand_hint": node.expand_hint,
             "token_count": node.token_count,
         }
     ]
+    remaining_tokens = max(0, max_tokens - count_tokens(summary))
 
     if node.source_type == "messages":
         messages, pagination = _expand_message_sources(
             engine,
             node,
-            max_tokens=max_tokens,
+            max_tokens=remaining_tokens,
             hydrate_externalized_content=hydrate_externalized_content,
         )
         if messages or pagination.get("has_more"):
@@ -446,7 +451,7 @@ def _collect_context_blocks_for_node(
             }
             blocks.append(block)
     elif node.source_type == "nodes":
-        children, pagination = _expand_child_nodes(engine, node, max_tokens=max_tokens)
+        children, pagination = _expand_child_nodes(engine, node, max_tokens=remaining_tokens)
         if children or pagination.get("has_more"):
             blocks.append(
                 {
@@ -465,7 +470,9 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
 
     total = 0
     for block in blocks:
-        if block.get("type") == "messages":
+        if block.get("type") == "summary":
+            total += count_tokens(str(block.get("summary") or ""))
+        elif block.get("type") == "messages":
             total += sum(count_tokens(str(message.get("content") or "")) for message in block.get("messages", []))
         elif block.get("type") == "child_nodes":
             total += sum(count_tokens(str(child.get("summary") or "")) for child in block.get("children", []))
@@ -833,7 +840,17 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
 
     context_pagination = []
     for block in context_blocks:
-        pagination = block.get("pagination") if isinstance(block, dict) else None
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "summary" and block.get("summary_truncated"):
+            context_pagination.append(
+                {
+                    "node_id": block.get("node_id"),
+                    "type": "summary",
+                    "summary_truncated": True,
+                }
+            )
+        pagination = block.get("pagination")
         if pagination:
             context_pagination.append(
                 {
@@ -843,7 +860,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                 }
             )
     context_truncated = any(
-        bool(item.get("pagination", {}).get("has_more"))
+        bool(item.get("summary_truncated")) or bool(item.get("pagination", {}).get("has_more"))
         for item in context_pagination
     )
 

--- a/tools.py
+++ b/tools.py
@@ -133,42 +133,172 @@ def _truncate_text_to_token_budget(text: str, max_tokens: int) -> tuple[str, boo
     return best, True
 
 
-def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
+def _parse_int_value(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_non_negative_int(value: Any, default: int) -> int:
+    return max(0, _parse_int_value(value, default))
+
+
+def _parse_positive_int(value: Any, default: int) -> int:
+    return max(1, _parse_int_value(value, default))
+
+
+def _slice_content_for_response(content: str, max_tokens: int, content_offset: int = 0) -> dict[str, Any]:
+    content = content or ""
+    content_offset = min(max(0, content_offset), len(content))
+    sliced, _ = _truncate_text_to_token_budget(content[content_offset:], max_tokens)
+    next_content_offset = content_offset + len(sliced)
+    has_more = next_content_offset < len(content)
+    return {
+        "content": sliced,
+        "content_chars": len(content),
+        "content_offset": content_offset,
+        "content_returned_chars": len(sliced),
+        "content_truncated": has_more,
+        "next_content_offset": next_content_offset if has_more else 0,
+        "has_more": has_more,
+    }
+
+
+def _full_content_slice(content: str, content_offset: int = 0) -> dict[str, Any]:
+    content = content or ""
+    content_offset = min(max(0, content_offset), len(content))
+    sliced = content[content_offset:]
+    return {
+        "content": sliced,
+        "content_chars": len(content),
+        "content_offset": content_offset,
+        "content_returned_chars": len(sliced),
+        "content_truncated": False,
+        "next_content_offset": 0,
+        "has_more": False,
+    }
+
+
+def _is_compact_externalized_marker(content: str, ref: str | None) -> bool:
+    if not ref or not content:
+        return False
+    if len(content) > 512:
+        return False
+    return content.startswith("[Externalized tool output:") or content.startswith("[GC'd externalized tool output:")
+
+
+def _pagination_payload(
+    *,
+    total_sources: int,
+    source_offset: int,
+    content_offset: int,
+    source_limit: int,
+    returned_sources: int,
+    next_source_offset: int | None,
+    next_content_offset: int,
+    has_more: bool,
+) -> dict[str, Any]:
+    if not has_more:
+        next_source_offset = None
+        next_content_offset = 0
+    remaining_sources = 0
+    if has_more and next_source_offset is not None:
+        remaining_sources = max(0, total_sources - next_source_offset)
+    return {
+        "source_offset": source_offset,
+        "content_offset": content_offset,
+        "source_limit": source_limit,
+        "returned_sources": returned_sources,
+        "total_sources": total_sources,
+        "next_source_offset": next_source_offset,
+        "next_content_offset": next_content_offset,
+        "has_more": has_more,
+        "remaining_sources": remaining_sources,
+    }
+
+
+def _expand_message_sources(
+    engine: "LCMEngine",
+    node,
+    max_tokens: int,
+    *,
+    source_offset: int = 0,
+    source_limit: int | None = None,
+    content_offset: int = 0,
+    hydrate_externalized_content: bool = False,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     from .tokens import count_tokens
 
-    stored_by_id = engine._store.get_batch(node.source_ids)
+    total_sources = len(node.source_ids)
+    source_offset = min(max(0, source_offset), total_sources)
+    remaining_source_count = max(0, total_sources - source_offset)
+    if source_limit is None:
+        source_limit = remaining_source_count
+    else:
+        source_limit = min(max(0, source_limit), remaining_source_count)
+    content_offset = max(0, content_offset)
+    source_ids = node.source_ids[source_offset:source_offset + source_limit]
+    stored_by_id = engine._store.get_batch(source_ids)
 
-    messages = []
+    messages: list[dict[str, Any]] = []
     budget_used = 0
-    for store_id in node.source_ids:
+    next_source_offset: int | None = source_offset
+    next_content_offset = content_offset
+    has_more = source_offset < total_sources
+
+    for relative_index, store_id in enumerate(source_ids):
+        source_index = source_offset + relative_index
+        remaining_tokens = max_tokens - budget_used
+        if remaining_tokens <= 0:
+            next_source_offset = source_index
+            next_content_offset = 0
+            has_more = True
+            break
         stored = stored_by_id.get(store_id)
         if not stored or stored.get("session_id") != engine._session_id:
+            next_source_offset = source_index + 1
+            next_content_offset = 0
+            has_more = next_source_offset < total_sources
             continue
-        content = stored.get("content", "")
-        msg_tokens = count_tokens(content)
-        if budget_used + msg_tokens > max_tokens and messages:
-            messages.append(
-                {
-                    "note": f"Truncated — {len(node.source_ids) - len(messages)} more messages available",
-                }
-            )
-            break
+        transcript_content = stored.get("content", "")
+        content = transcript_content
+        content_source = "message"
+        externalized = None
+        ref = extract_externalized_ref(transcript_content)
+        if ref:
+            externalized = _get_externalized_payload(engine, ref)
+        if hydrate_externalized_content and externalized is not None:
+            content = externalized.get("content", "")
+            content_source = "externalized_payload"
+        effective_content_offset = content_offset if source_index == source_offset else 0
+        if not hydrate_externalized_content and _is_compact_externalized_marker(content, ref):
+            sliced = _full_content_slice(content, effective_content_offset)
+        else:
+            sliced = _slice_content_for_response(content, remaining_tokens, effective_content_offset)
         expanded = {
             "store_id": stored["store_id"],
+            "source_index": source_index,
             "role": stored["role"],
-            "content": content[:2000] if len(content) > 2000 else content,
+            "content": sliced["content"],
+            "content_chars": sliced["content_chars"],
+            "content_offset": sliced["content_offset"],
+            "content_returned_chars": sliced["content_returned_chars"],
+            "content_truncated": sliced["content_truncated"],
+            "next_content_offset": sliced["next_content_offset"],
+            "content_source": content_source,
         }
+        if content_source == "externalized_payload":
+            expanded["transcript_content"] = transcript_content
         if stored.get("role") == "tool":
-            ref = extract_externalized_ref(content)
-            if ref:
-                externalized = _get_externalized_payload(engine, ref)
-                if externalized is not None:
-                    externalized.pop("content", None)
-                    expanded["externalized"] = externalized
+            if externalized is not None:
+                externalized_summary = dict(externalized)
+                externalized_summary.pop("content", None)
+                expanded["externalized"] = externalized_summary
             if "externalized" not in expanded:
-                lookup_candidates = [content]
-                sanitized_content = sanitize_pre_compaction_content(content)
-                if sanitized_content != content:
+                lookup_candidates = [transcript_content]
+                sanitized_content = sanitize_pre_compaction_content(transcript_content)
+                if sanitized_content != transcript_content:
                     lookup_candidates.insert(0, sanitized_content)
                 for candidate in lookup_candidates:
                     externalized = find_externalized_payload_for_message(
@@ -182,25 +312,113 @@ def _expand_message_sources(engine: "LCMEngine", node, max_tokens: int) -> list[
                         expanded["externalized"] = externalized
                         break
         messages.append(expanded)
-        budget_used += msg_tokens
-    return messages
+        budget_used += count_tokens(sliced["content"])
+        if sliced["has_more"]:
+            next_source_offset = source_index
+            next_content_offset = sliced["next_content_offset"]
+            has_more = True
+            break
+        next_source_offset = source_index + 1
+        next_content_offset = 0
+        has_more = next_source_offset < total_sources
+    else:
+        has_more = (source_offset + source_limit) < total_sources
+        next_source_offset = source_offset + source_limit if has_more else None
+        next_content_offset = 0
+
+    pagination = _pagination_payload(
+        total_sources=total_sources,
+        source_offset=source_offset,
+        content_offset=content_offset,
+        source_limit=source_limit,
+        returned_sources=len(messages),
+        next_source_offset=next_source_offset,
+        next_content_offset=next_content_offset,
+        has_more=has_more,
+    )
+    return messages, pagination
 
 
-def _expand_child_nodes(engine: "LCMEngine", node) -> list[dict[str, Any]]:
-    children = [child for child in engine._dag.get_source_nodes(node) if child.session_id == engine._session_id]
-    return [
-        {
-            "node_id": child.node_id,
-            "depth": child.depth,
-            "summary": child.summary[:1000],
-            "token_count": child.token_count,
-            "expand_hint": child.expand_hint,
-        }
-        for child in children
-    ]
+def _expand_child_nodes(
+    engine: "LCMEngine",
+    node,
+    max_tokens: int | None = None,
+    *,
+    source_offset: int = 0,
+    source_limit: int | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    from .tokens import count_tokens
+
+    total_sources = len(node.source_ids)
+    source_offset = min(max(0, source_offset), total_sources)
+    remaining_source_count = max(0, total_sources - source_offset)
+    if source_limit is None:
+        source_limit = remaining_source_count
+    else:
+        source_limit = min(max(0, source_limit), remaining_source_count)
+    selected_source_ids = node.source_ids[source_offset:source_offset + source_limit]
+    children: list[tuple[int, Any]] = []
+    for relative_index, child_id in enumerate(selected_source_ids):
+        child = engine._dag.get_node(child_id)
+        if child is None or child.session_id != engine._session_id:
+            continue
+        children.append((source_offset + relative_index, child))
+
+    expanded: list[dict[str, Any]] = []
+    budget_used = 0
+    next_source_offset: int | None = None
+    has_more = (source_offset + source_limit) < total_sources
+    for source_index, child in children:
+        summary = child.summary
+        summary_truncated = False
+        if max_tokens is not None:
+            remaining_tokens = max_tokens - budget_used
+            if remaining_tokens <= 0:
+                next_source_offset = source_index
+                has_more = True
+                break
+            summary, summary_truncated = _truncate_text_to_token_budget(summary, remaining_tokens)
+        expanded.append(
+            {
+                "node_id": child.node_id,
+                "source_index": source_index,
+                "depth": child.depth,
+                "summary": summary[:1000] if max_tokens is None else summary,
+                "summary_truncated": summary_truncated or (max_tokens is None and len(child.summary) > 1000),
+                "token_count": child.token_count,
+                "source_token_count": child.source_token_count,
+                "expand_hint": child.expand_hint,
+            }
+        )
+        budget_used += count_tokens(summary)
+        if summary_truncated:
+            next_source_offset = source_index + 1
+            has_more = next_source_offset < total_sources
+            break
+        next_source_offset = source_index + 1
+
+    if has_more and next_source_offset is None:
+        next_source_offset = source_offset + source_limit
+
+    return expanded, _pagination_payload(
+        total_sources=total_sources,
+        source_offset=source_offset,
+        content_offset=0,
+        source_limit=source_limit,
+        returned_sources=len(expanded),
+        next_source_offset=next_source_offset,
+        next_content_offset=0,
+        has_more=has_more,
+    )
 
 
-def _collect_context_blocks_for_node(engine: "LCMEngine", node, max_tokens: int) -> list[dict[str, Any]]:
+def _collect_context_blocks_for_node(
+    engine: "LCMEngine",
+    node,
+    max_tokens: int,
+    *,
+    hydrate_externalized_content: bool = False,
+) -> list[dict[str, Any]]:
     blocks: list[dict[str, Any]] = [
         {
             "type": "summary",
@@ -213,27 +431,45 @@ def _collect_context_blocks_for_node(engine: "LCMEngine", node, max_tokens: int)
     ]
 
     if node.source_type == "messages":
-        messages = _expand_message_sources(engine, node, max_tokens=max_tokens)
-        if messages:
-            blocks.append(
-                {
-                    "type": "messages",
-                    "node_id": node.node_id,
-                    "messages": messages,
-                }
-            )
+        messages, pagination = _expand_message_sources(
+            engine,
+            node,
+            max_tokens=max_tokens,
+            hydrate_externalized_content=hydrate_externalized_content,
+        )
+        if messages or pagination.get("has_more"):
+            block = {
+                "type": "messages",
+                "node_id": node.node_id,
+                "messages": messages,
+                "pagination": pagination,
+            }
+            blocks.append(block)
     elif node.source_type == "nodes":
-        children = _expand_child_nodes(engine, node)
-        if children:
+        children, pagination = _expand_child_nodes(engine, node, max_tokens=max_tokens)
+        if children or pagination.get("has_more"):
             blocks.append(
                 {
                     "type": "child_nodes",
                     "node_id": node.node_id,
                     "children": children,
+                    "pagination": pagination,
                 }
             )
 
     return blocks
+
+
+def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
+    from .tokens import count_tokens
+
+    total = 0
+    for block in blocks:
+        if block.get("type") == "messages":
+            total += sum(count_tokens(str(message.get("content") or "")) for message in block.get("messages", []))
+        elif block.get("type") == "child_nodes":
+            total += sum(count_tokens(str(child.get("summary") or "")) for child in block.get("children", []))
+    return total
 
 
 def _synthesize_expansion_answer(
@@ -445,13 +681,17 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": "LCM engine not initialized"})
 
     externalized_ref = str(args.get("externalized_ref") or "").strip()
-    max_tokens = int(args.get("max_tokens", 4000))
+    max_tokens = _parse_positive_int(args.get("max_tokens", 4000), 4000)
+    source_offset = _parse_non_negative_int(args.get("source_offset", 0), 0)
+    source_limit_arg = args.get("source_limit")
+    source_limit = _parse_positive_int(source_limit_arg, 0) if source_limit_arg is not None else None
+    content_offset = _parse_non_negative_int(args.get("content_offset", 0), 0)
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
         if payload is None:
             return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
         content = payload.get("content", "")
-        truncated_content, content_truncated = _truncate_text_to_token_budget(content, max_tokens)
+        sliced = _slice_content_for_response(content, max_tokens, content_offset)
         return json.dumps(
             {
                 "externalized_ref": externalized_ref,
@@ -459,10 +699,14 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
                 "kind": payload.get("kind", "tool_result"),
                 "tool_call_id": payload.get("tool_call_id", ""),
                 "session_id": payload.get("session_id", ""),
-                "content_chars": payload.get("content_chars", 0),
+                "content_chars": payload.get("content_chars", len(content)),
                 "content_bytes": payload.get("content_bytes", 0),
-                "content": truncated_content,
-                "content_truncated": content_truncated,
+                "content": sliced["content"],
+                "content_offset": sliced["content_offset"],
+                "content_returned_chars": sliced["content_returned_chars"],
+                "content_truncated": sliced["content_truncated"],
+                "next_content_offset": sliced["next_content_offset"],
+                "has_more": sliced["has_more"],
             }
         )
 
@@ -475,24 +719,39 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": f"Node {node_id} not found in current session"})
 
     if node.source_type == "messages":
-        messages = _expand_message_sources(engine, node, max_tokens=max_tokens)
+        messages, pagination = _expand_message_sources(
+            engine,
+            node,
+            max_tokens=max_tokens,
+            source_offset=source_offset,
+            source_limit=source_limit,
+            content_offset=content_offset,
+        )
         return json.dumps(
             {
                 "node_id": node_id,
                 "depth": node.depth,
                 "source_type": "messages",
                 "expanded": messages,
+                "pagination": pagination,
             }
         )
 
     if node.source_type == "nodes":
-        children = _expand_child_nodes(engine, node)
+        children, pagination = _expand_child_nodes(
+            engine,
+            node,
+            max_tokens=max_tokens,
+            source_offset=source_offset,
+            source_limit=source_limit,
+        )
         return json.dumps(
             {
                 "node_id": node_id,
                 "depth": node.depth,
                 "source_type": "nodes",
                 "expanded": children,
+                "pagination": pagination,
             }
         )
 
@@ -519,6 +778,12 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     max_tokens, max_tokens_error = _parse_int_arg("max_tokens", 2000)
     if max_tokens_error:
         return json.dumps({"error": max_tokens_error})
+    max_tokens = max(1, max_tokens)
+    context_default = max(max_tokens, int(getattr(engine._config, "expansion_context_tokens", 32_000) or 32_000))
+    context_max_tokens, context_max_tokens_error = _parse_int_arg("context_max_tokens", context_default)
+    if context_max_tokens_error:
+        return json.dumps({"error": context_max_tokens_error})
+    context_max_tokens = max(1, context_max_tokens)
 
     max_results, max_results_error = _parse_int_arg("max_results", 5)
     if max_results_error:
@@ -554,8 +819,33 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
         )
 
     context_blocks = []
+    context_budget_used = 0
     for node in nodes[:max_results]:
-        context_blocks.extend(_collect_context_blocks_for_node(engine, node, max_tokens=max_tokens))
+        remaining_context_tokens = max(0, context_max_tokens - context_budget_used)
+        node_blocks = _collect_context_blocks_for_node(
+            engine,
+            node,
+            max_tokens=remaining_context_tokens,
+            hydrate_externalized_content=True,
+        )
+        context_blocks.extend(node_blocks)
+        context_budget_used += _context_content_token_count(node_blocks)
+
+    context_pagination = []
+    for block in context_blocks:
+        pagination = block.get("pagination") if isinstance(block, dict) else None
+        if pagination:
+            context_pagination.append(
+                {
+                    "node_id": block.get("node_id"),
+                    "type": block.get("type"),
+                    "pagination": pagination,
+                }
+            )
+    context_truncated = any(
+        bool(item.get("pagination", {}).get("has_more"))
+        for item in context_pagination
+    )
 
     selected_nodes = nodes[:max_results]
     matches = [
@@ -576,6 +866,10 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "error": reason,
             "degraded": True,
             "model": model,
+            "max_tokens": max_tokens,
+            "context_max_tokens": context_max_tokens,
+            "context_truncated": context_truncated,
+            "context_pagination": context_pagination,
             "node_ids": node_ids,
             "matches": matches,
         }
@@ -611,6 +905,10 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "query": query,
             "answer": answer,
             "model": model,
+            "max_tokens": max_tokens,
+            "context_max_tokens": context_max_tokens,
+            "context_truncated": context_truncated,
+            "context_pagination": context_pagination,
             "node_ids": node_ids,
             "matches": matches,
         }


### PR DESCRIPTION
## Summary

This implements the two retrieval contracts from #93.

Main-agent recovery stays bounded by default, but `lcm_expand` now has explicit source and content cursors. `source_offset` and `source_limit` page immediate message or child-node sources. `content_offset` continues inside oversized raw messages and externalized payloads. Responses include cursor metadata so the agent can keep walking the raw span instead of losing it behind one capped response. If a tiny token budget cannot fit even the next character, the cursor still makes one-character progress rather than returning the same offset forever.

`lcm_expand_query` now separates the bounded answer budget from the auxiliary context budget. `max_tokens` still bounds the answer returned to the main agent. `context_max_tokens` controls the larger serialized summary, raw, child-summary, externalized transcript marker, and externalized payload context sent to the auxiliary LLM, defaulting through `LCM_EXPANSION_CONTEXT_TOKENS`. Truncated auxiliary context reports actionable follow-up hints: normal source cursors, externalized payload refs, or child node IDs for deeper expansion.

Refs #93.

## Validation

`python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q` passed with 358 tests.

`python3 -m pytest -q` passed with 402 tests.

`python3 -m compileall -q .`, `bash -n scripts/install.sh scripts/update.sh`, and `git diff --check` passed.

I also ran a runtime-shaped smoke through `engine.handle_tool_call` for source pagination, content cursors, child source ordering, externalized payload cursors, externalized payload hydration in `lcm_expand_query`, summary-budget enforcement, tiny-budget cursor progress, child-summary truncation signaling, externalized-ref pagination actionability, and transcript marker budget accounting.