### PR TITLE
fix: report FTS integrity failures separately

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -221,14 +221,49 @@ def _fts_needs_rebuild_structural(conn: sqlite3.Connection, spec: ExternalConten
 def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
     if _fts_needs_rebuild_structural(conn, spec):
         return True
+    return check_external_content_fts_integrity(conn, spec)["status"] == "fail"
+
+
+def check_external_content_fts_integrity(
+    conn: sqlite3.Connection,
+    spec: ExternalContentFtsSpec,
+) -> dict[str, str]:
+    """Run SQLite's FTS5 integrity-check for an external-content table.
+
+    FTS5 exposes this as a special INSERT command. Wrap it in a savepoint and
+    roll it back so diagnostics can verify the index without leaving any state
+    behind on the shared connection.
+    """
+
+    if _fts_needs_rebuild_structural(conn, spec):
+        return {"status": "fail", "detail": "structural repair needed"}
+
+    savepoint = f"lcm_fts_integrity_{spec.table_name}"
+    savepoint_sql = quote_sql_identifier(savepoint)
     try:
+        conn.execute(f"SAVEPOINT {savepoint_sql}")
         conn.execute(
             f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}, rank) VALUES('integrity-check', 1)"
         )
-    except sqlite3.DatabaseError:
-        return True
+    except sqlite3.DatabaseError as exc:
+        try:
+            conn.execute(f"ROLLBACK TO {savepoint_sql}")
+            conn.execute(f"RELEASE {savepoint_sql}")
+        except sqlite3.DatabaseError:
+            pass
+        detail = str(exc)
+        lowered = detail.lower()
+        if "readonly" in lowered or "read-only" in lowered:
+            return {"status": "unchecked", "detail": detail}
+        return {"status": "fail", "detail": detail}
 
-    return False
+    try:
+        conn.execute(f"ROLLBACK TO {savepoint_sql}")
+        conn.execute(f"RELEASE {savepoint_sql}")
+    except sqlite3.DatabaseError as exc:
+        return {"status": "fail", "detail": str(exc)}
+
+    return {"status": "pass", "detail": "ok"}
 
 
 def _drop_fts_table(conn: sqlite3.Connection, table_name: str) -> None:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7634,10 +7634,35 @@ class TestEngineTools:
         assert result["overall"] == "healthy"
         check_names = [c["check"] for c in result["checks"]]
         assert "database_integrity" in check_names
+        assert "messages_fts_integrity" in check_names
+        assert "nodes_fts_integrity" in check_names
         assert "fts_index_sync" in check_names
         assert "orphaned_dag_nodes" in check_names
         assert "config_validation" in check_names
         assert all(c["status"] == "pass" for c in result["checks"])
+
+    def test_handle_doctor_reports_fts_integrity_failures_separately(self, engine, monkeypatch):
+        def fake_fts_integrity(_conn, spec):
+            if spec.table_name == "nodes_fts":
+                return {
+                    "status": "fail",
+                    "detail": "malformed inverted index for FTS5 table main.nodes_fts",
+                }
+            return {"status": "pass", "detail": "ok"}
+
+        monkeypatch.setattr(lcm_tools, "check_external_content_fts_integrity", fake_fts_integrity)
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        checks = {check["check"]: check for check in result["checks"]}
+        assert result["overall"] == "unhealthy"
+        assert checks["database_integrity"]["status"] == "pass"
+        assert checks["messages_fts_integrity"]["status"] == "pass"
+        assert checks["nodes_fts_integrity"] == {
+            "check": "nodes_fts_integrity",
+            "status": "fail",
+            "detail": "malformed inverted index for FTS5 table main.nodes_fts",
+        }
 
     def test_handle_doctor_treats_legacy_blank_source_rows_as_healthy(self, engine):
         for source in (None, "", "   ", "\t\n"):

--- a/tools.py
+++ b/tools.py
@@ -13,9 +13,12 @@ from .externalize import (
     find_externalized_payload_for_message,
     load_externalized_payload,
 )
+from .dag import build_nodes_fts_spec
+from .db_bootstrap import check_external_content_fts_integrity
 from .extraction import sanitize_pre_compaction_content
 from .model_routing import apply_lcm_model_route
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
+from .store import build_message_fts_spec
 
 if TYPE_CHECKING:
     from .engine import LCMEngine
@@ -1105,6 +1108,27 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "status": "fail",
             "detail": str(e),
         })
+
+    # 1b. FTS5 integrity, separated from generic SQLite integrity so malformed
+    # inverted indexes point at the exact table and repair path.
+    for check_name, conn, spec in (
+        ("messages_fts_integrity", engine._store._conn, build_message_fts_spec()),
+        ("nodes_fts_integrity", engine._dag._conn, build_nodes_fts_spec()),
+    ):
+        try:
+            fts_integrity = check_external_content_fts_integrity(conn, spec)
+            status = fts_integrity["status"]
+            checks.append({
+                "check": check_name,
+                "status": "warn" if status == "unchecked" else status,
+                "detail": fts_integrity["detail"],
+            })
+        except Exception as e:
+            checks.append({
+                "check": check_name,
+                "status": "fail",
+                "detail": str(e),
+            })
 
     # 2. FTS index sync
     try:


### PR DESCRIPTION
## Summary

- Adds explicit `messages_fts_integrity` and `nodes_fts_integrity` checks to `lcm_doctor`.
- Reuses SQLite's FTS5 `integrity-check` through a savepoint so diagnostics can verify the inverted index without leaving state behind.
- Adds regression coverage for a malformed `nodes_fts` report staying separate from generic database integrity.

## Why

A malformed FTS5 inverted index should point operators at the exact FTS table and repair path. Generic `database_integrity` alone makes the failure look broader than it may be, especially when row counts and basic `MATCH` probes still work.

## Validation

```bash
PYTHONPATH=. /home/nabu/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_returns_healthy tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_reports_fts_integrity_failures_separately tests/test_lcm_command.py::test_lcm_doctor_repair_reports_fts_drift_without_mutating tests/test_lcm_command.py::test_lcm_doctor_repair_dry_run_works_with_read_only_database tests/test_lcm_command.py::test_lcm_doctor_repair_apply_is_backup_first_and_rebuilds_fts -q -o addopts=
PYTHONPATH=. /home/nabu/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_lcm_command.py tests/test_lcm_engine.py -q -k 'doctor or fts or malformed' -o addopts=
PYTHONPATH=. /home/nabu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts=
PYTHONPATH=. /home/nabu/.hermes/hermes-agent/venv/bin/python -m compileall -q .
git diff --check origin/main...HEAD
```

Results:

```text
5 passed
35 passed, 220 deselected
407 passed
compileall ok
git diff --check ok
```
