### PR TITLE
fix: route configured custom provider model overrides

### DIFF
--- a/model_routing.py
+++ b/model_routing.py
@@ -15,10 +15,11 @@ class ModelRoute:
 ProviderResolver = Callable[[str], bool]
 
 
-# Conservative allowlist: only split prefixes explicitly supported by LCM
-# overrides. Do not infer from arbitrary provider names, because many Hermes
-# provider IDs are also valid OpenRouter model namespaces, for example
-# ``anthropic/...``, ``deepseek/...``, ``google/...``, and ``x-ai/...``.
+# Conservative allowlist for built-in provider registry fallbacks. Named custom
+# providers from the Hermes config are always safe to split; registry-only
+# providers still need an allowlist because many provider IDs are also valid
+# OpenRouter model namespaces, for example ``anthropic/...``, ``google/...``
+# and ``x-ai/...``.
 _PROVIDER_PREFIXES = frozenset({"cerebras"})
 
 
@@ -35,7 +36,7 @@ def _provider_route_is_resolvable(provider: str) -> bool:
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY
 
-        return provider in PROVIDER_REGISTRY
+        return provider in _PROVIDER_PREFIXES and provider in PROVIDER_REGISTRY
     except Exception:
         return False
 
@@ -47,9 +48,10 @@ def parse_lcm_model_override(
 ) -> ModelRoute:
     """Parse an LCM model override into explicit provider/model routing.
 
-    Values whose first path segment is both allowlisted and resolvable by the
-    Hermes host are split into ``provider=<prefix>`` and ``model=<rest>``.
-    Other values, even when they contain ``/``, remain model-only overrides.
+    Values whose first path segment is resolvable by the Hermes host are split
+    into ``provider=<prefix>`` and ``model=<rest>``. The default resolver only
+    treats named custom providers (plus conservative registry allowlist entries)
+    as resolvable so OpenRouter-style model slugs remain model-only overrides.
     """
     model = (value or "").strip()
     if not model:
@@ -59,7 +61,7 @@ def parse_lcm_model_override(
     provider = provider.strip().lower()
     rest = rest.strip()
     can_resolve_provider = provider_resolver or _provider_route_is_resolvable
-    if sep and provider in _PROVIDER_PREFIXES and rest and can_resolve_provider(provider):
+    if sep and rest and can_resolve_provider(provider):
         return ModelRoute(provider=provider, model=rest)
 
     return ModelRoute(provider=None, model=model)

--- a/model_routing.py
+++ b/model_routing.py
@@ -15,16 +15,28 @@ class ModelRoute:
 ProviderResolver = Callable[[str], bool]
 
 
-# Conservative allowlist for built-in provider registry fallbacks. Named custom
-# providers from the Hermes config are always safe to split; registry-only
+# Conservative allowlist for built-in provider registry fallbacks. Non-canonical
+# named custom providers from the Hermes config are safe to split; registry-only
 # providers still need an allowlist because many provider IDs are also valid
 # OpenRouter model namespaces, for example ``anthropic/...``, ``google/...``
-# and ``x-ai/...``.
+# and ``x-ai/...``. ``custom:`` prefixes are intentionally not split here until
+# the Hermes auxiliary resolver supports them end-to-end.
 _PROVIDER_PREFIXES = frozenset({"cerebras"})
 
 
 def _provider_route_is_resolvable(provider: str) -> bool:
     """Return whether Hermes can route an explicit auxiliary provider."""
+    if provider.startswith("custom:"):
+        return False
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        if provider in PROVIDER_REGISTRY:
+            return provider in _PROVIDER_PREFIXES
+    except Exception:
+        pass
+
     try:
         from hermes_cli.runtime_provider import _get_named_custom_provider
 
@@ -33,12 +45,7 @@ def _provider_route_is_resolvable(provider: str) -> bool:
     except Exception:
         pass
 
-    try:
-        from hermes_cli.auth import PROVIDER_REGISTRY
-
-        return provider in _PROVIDER_PREFIXES and provider in PROVIDER_REGISTRY
-    except Exception:
-        return False
+    return False
 
 
 def parse_lcm_model_override(
@@ -50,8 +57,9 @@ def parse_lcm_model_override(
 
     Values whose first path segment is resolvable by the Hermes host are split
     into ``provider=<prefix>`` and ``model=<rest>``. The default resolver only
-    treats named custom providers (plus conservative registry allowlist entries)
-    as resolvable so OpenRouter-style model slugs remain model-only overrides.
+    treats non-canonical named custom providers (plus conservative registry
+    allowlist entries) as resolvable so OpenRouter-style model slugs and
+    canonical built-in provider names remain model-only overrides.
     """
     model = (value or "").strip()
     if not model:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -49,6 +49,17 @@ class TestModelRouting:
         assert route.provider == "cerebras"
         assert route.model == "gpt-oss-120b"
 
+    def test_custom_provider_prefixed_model_is_split_when_provider_resolves(self):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        route = parse_lcm_model_override(
+            "openai-codex/gpt-5.4-mini",
+            provider_resolver=lambda provider: provider == "openai-codex",
+        )
+
+        assert route.provider == "openai-codex"
+        assert route.model == "gpt-5.4-mini"
+
     def test_openrouter_organization_slug_stays_model_only(self):
         from hermes_lcm.model_routing import parse_lcm_model_override
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -27,6 +27,27 @@ from hermes_lcm.session_patterns import (
 
 
 class TestModelRouting:
+    def _install_fake_provider_modules(self, monkeypatch, *, named_custom=None, registry=None):
+        hermes_cli = ModuleType("hermes_cli")
+        hermes_cli.__path__ = []
+
+        runtime_provider = ModuleType("hermes_cli.runtime_provider")
+        named_custom = named_custom or {}
+
+        def fake_get_named_custom_provider(provider):
+            return named_custom.get(provider)
+
+        runtime_provider._get_named_custom_provider = fake_get_named_custom_provider
+
+        auth = ModuleType("hermes_cli.auth")
+        auth.PROVIDER_REGISTRY = registry or {}
+
+        hermes_cli.runtime_provider = runtime_provider
+        hermes_cli.auth = auth
+        monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", runtime_provider)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", auth)
+
     def test_provider_prefixed_model_stays_model_only_when_provider_unresolved(self):
         from hermes_lcm.model_routing import parse_lcm_model_override
 
@@ -53,12 +74,54 @@ class TestModelRouting:
         from hermes_lcm.model_routing import parse_lcm_model_override
 
         route = parse_lcm_model_override(
-            "openai-codex/gpt-5.4-mini",
-            provider_resolver=lambda provider: provider == "openai-codex",
+            "my-provider/model-a",
+            provider_resolver=lambda provider: provider == "my-provider",
         )
 
-        assert route.provider == "openai-codex"
-        assert route.model == "gpt-5.4-mini"
+        assert route.provider == "my-provider"
+        assert route.model == "model-a"
+
+    def test_canonical_provider_name_stays_model_only_even_if_custom_config_exists(self, monkeypatch):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        self._install_fake_provider_modules(
+            monkeypatch,
+            named_custom={"openai-codex": {"base_url": "https://example.invalid/v1"}},
+            registry={"openai-codex": object()},
+        )
+
+        route = parse_lcm_model_override("openai-codex/gpt-5.4-mini")
+
+        assert route.provider is None
+        assert route.model == "openai-codex/gpt-5.4-mini"
+
+    def test_custom_prefixed_canonical_provider_stays_model_only(self, monkeypatch):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        self._install_fake_provider_modules(
+            monkeypatch,
+            named_custom={"custom:openai-codex": {"base_url": "https://example.invalid/v1"}},
+            registry={"openai-codex": object()},
+        )
+
+        route = parse_lcm_model_override("custom:openai-codex/gpt-5.4-mini")
+
+        assert route.provider is None
+        assert route.model == "custom:openai-codex/gpt-5.4-mini"
+
+    def test_config_backed_non_canonical_custom_provider_is_split(self, monkeypatch):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        self._install_fake_provider_modules(
+            monkeypatch,
+            named_custom={"my-provider": {"base_url": "https://example.invalid/v1"}},
+            registry={"openai-codex": object()},
+        )
+
+        route = parse_lcm_model_override("my-provider/model-a")
+
+        assert route.provider == "my-provider"
+        assert route.model == "model-a"
 
     def test_openrouter_organization_slug_stays_model_only(self):
         from hermes_lcm.model_routing import parse_lcm_model_override


### PR DESCRIPTION
## Summary
- Route LCM model overrides through configured non-canonical Hermes custom providers when the prefix resolves from Hermes config
- Keep canonical/built-in provider names and OpenRouter-style slugs model-only unless they are conservative registry allowlist entries
- Add regression coverage for a non-canonical custom provider prefix such as `my-provider/model-a`
- Add negative coverage for `openai-codex/...` and `custom:openai-codex/...` until the Hermes auxiliary resolver supports those routes end-to-end

## Why
Some Hermes installations may define auxiliary/model routes as named custom providers, for example:

```env
LCM_SUMMARY_MODEL=my-provider/model-a
LCM_EXPANSION_MODEL=my-provider/model-b
```

Before this change, LCM only split allowlisted prefixes like `cerebras/...`, so non-canonical configured custom provider values stayed model-only with no explicit provider.

This keeps the OpenRouter namespace safety concern intact: registry/canonical provider names are not split just because they contain a `/`, and canonical built-ins such as `openai-codex/...` remain model-only. `custom:`-prefixed canonical names are also not treated as safe explicit custom routes here, because the current Hermes auxiliary resolver does not support that path end-to-end.

## Test plan
- `PYTHONPATH="$PWD:$HOME/.sm/hermes-agent" /Users/sbochna/.local/bin/uv run --python 3.11 --with pytest python -m pytest -q tests/test_lcm_core.py::TestModelRouting tests/test_lcm_core.py::TestProviderPrefixedAuxiliaryCalls` → `14 passed`
- `PYTHONPATH="$PWD:$HOME/.sm/hermes-agent" /Users/sbochna/.local/bin/uv run --python 3.11 --with pytest python -m pytest -q` → `411 passed`
