### PR TITLE
feat: add bounded cross-session search to lcm_grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,19 +248,20 @@ for earlier separate sessions or broad cross-session history.
 
 | Tool | Use |
 |------|-----|
-| `lcm_grep` | Search current-session raw messages and summaries. Use `session_search` for earlier separate sessions or broad cross-session recall. |
+| `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Use `session_search` for earlier separate sessions or broad cross-session recall. |
 | `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
-| `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. |
+| `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
 | `lcm_expand_query` | Answer a question using expanded current-session LCM context while returning a bounded answer. |
 | `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
 | `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
 
 ### Retrieval contract
 
-LCM retrieval tools are current-session tools. `session_scope` is kept for
-schema compatibility and currently accepts only `current`; unsupported values
-are ignored and reported in the tool result. Use Hermes `session_search` for
-earlier sessions.
+LCM retrieval tools default to current-session scope. `lcm_grep` accepts
+`session_scope='all'` or `session_scope='session'` as an explicit opt-in for
+bounded archive search over rows already present in `lcm.db` (raw-message hits
+only); use Hermes `session_search` for broad cross-session history outside the
+LCM database.
 
 Within the current session, `source` filters raw rows directly and filters
 summary nodes by descendant raw-message source lineage. `unknown` is a real

--- a/schemas.py
+++ b/schemas.py
@@ -3,11 +3,13 @@
 LCM_GREP = {
     "name": "lcm_grep",
     "description": (
-        "Search the current session's conversation history — raw messages AND summaries across all depths — "
-        "to recover details from earlier in the active conversation, even if those turns were compacted. "
-        "Prefer this for intra-session recall. If the user is asking about an earlier separate conversation "
-        "or broad cross-session history, prefer session_search instead. Returns matches with depth labels "
-        "showing where each result lives."
+        "Search the LCM database for past conversation content (raw messages AND summaries across all depths) "
+        "to recover details from the active session or, when explicitly scoped, from other sessions in the "
+        "plugin-local LCM database (including history imported from OpenClaw or lossless-claw). "
+        "Default scope is current-session only; broader scopes must be requested explicitly. "
+        "Cross-session summary hits are returned as snippets but cannot be expanded by node_id in this version "
+        "(they carry cross_session_expand_supported=false); use lcm_expand with the result's store_id for raw-message "
+        "expansion across sessions. For Hermes-tracked session history outside the LCM database, use session_search."
     ),
     "parameters": {
         "type": "object",
@@ -22,7 +24,10 @@ LCM_GREP = {
             },
             "limit": {
                 "type": "integer",
-                "description": "Max results to return (default 10)",
+                "description": (
+                    "Max results to return (default 10, hard upper bound 200). "
+                    "Values above the cap are clamped and reported via limit_clamped_from in the response."
+                ),
                 "default": 10,
             },
             "sort": {
@@ -36,12 +41,23 @@ LCM_GREP = {
             },
             "session_scope": {
                 "type": "string",
-                "enum": ["current"],
+                "enum": ["current", "all", "session"],
                 "description": (
-                    "Current-session only. Cross-session recall should use session_search instead; "
-                    "unsupported values are ignored and reported in the tool result."
+                    "Scope of the search across the plugin-local LCM database. "
+                    "'current' (default) restricts to the active session and preserves historical behavior. "
+                    "'all' searches every session in the local LCM database. "
+                    "'session' restricts to the session_id supplied via the session_id parameter. "
+                    "Cross-session search returns snippets and message store_ids; cross-session summary node expansion is deferred. "
+                    "For Hermes-tracked session history outside the LCM database, use session_search."
                 ),
                 "default": "current",
+            },
+            "session_id": {
+                "type": "string",
+                "description": (
+                    "When session_scope='session', the explicit session id to restrict the search to. "
+                    "Must not be supplied with session_scope='current' or session_scope='all'."
+                ),
             },
             "source": {
                 "type": "string",
@@ -49,6 +65,27 @@ LCM_GREP = {
                     "Optional source/platform filter (for example cli, discord, telegram). "
                     "Applies directly to raw messages and to summaries via descendant source lineage. "
                     "Use 'unknown' for explicit unknown-source content."
+                ),
+            },
+            "role": {
+                "type": "string",
+                "enum": ["user", "assistant", "tool"],
+                "description": (
+                    "Optional role filter. Applies to message hits only; summary hits are returned unfiltered "
+                    "(role does not exist on summary nodes). The response echoes role_filter_applies='messages_only' when this is set."
+                ),
+            },
+            "time_from": {
+                "type": "string",
+                "description": (
+                    "Optional inclusive ISO 8601 lower bound for message timestamps and summary latest_at. "
+                    "Examples: '2026-01-01T00:00:00Z' or '2026-01-01T00:00:00+00:00'."
+                ),
+            },
+            "time_to": {
+                "type": "string",
+                "description": (
+                    "Optional inclusive ISO 8601 upper bound for message timestamps and summary latest_at."
                 ),
             },
         },

--- a/schemas.py
+++ b/schemas.py
@@ -124,26 +124,37 @@ LCM_DESCRIBE = {
 LCM_EXPAND = {
     "name": "lcm_expand",
     "description": (
-        "Recover the original detail behind a current session summary node, or open an "
-        "externalized payload ref directly. Given a node_id, returns the "
-        "source messages or lower-depth summaries that were compacted into "
-        "that node. Output is bounded by default, but raw recovery is pageable: "
-        "use source_offset/source_limit to page immediate sources and content_offset "
-        "to continue an oversized message or externalized payload. Given externalized_ref, "
-        "returns the stored payload content plus cursor metadata. Use after lcm_describe "
-        "to drill into specific parts of the active conversation or large externalized "
-        "tool output. For cross-session recall, prefer session_search first."
+        "Recover the original detail behind a summary node, externalized payload, or raw message. "
+        "Mode selection (exactly one): node_id (current session only) returns the source messages "
+        "or lower-depth summaries that were compacted into a summary node; externalized_ref "
+        "(current session only) returns a stored externalized payload's content; store_id returns "
+        "a single raw message by store_id and works across sessions, suitable for drilling into "
+        "cross-session lcm_grep results. Output is bounded by max_tokens; raw recovery is pageable "
+        "via content_offset (and source_offset/source_limit for node_id mode). For Hermes-tracked "
+        "session history outside the LCM database, prefer session_search."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "node_id": {
                 "type": "integer",
-                "description": "Summary node ID to expand",
+                "description": (
+                    "Summary node ID to expand. Current-session only — cross-session DAG expansion "
+                    "is not supported in this version."
+                ),
             },
             "externalized_ref": {
                 "type": "string",
-                "description": "Optional externalized payload ref filename to expand instead of a summary node.",
+                "description": "Externalized payload ref filename to expand instead of a summary node. Current-session only.",
+            },
+            "store_id": {
+                "type": "integer",
+                "description": (
+                    "Raw message store_id to fetch. Works across sessions, so a store_id surfaced by "
+                    "a cross-session lcm_grep result can be expanded directly. Returns the message's "
+                    "content paged by content_offset; if the row references an externalized payload, "
+                    "the ref is surfaced but content is not hydrated."
+                ),
             },
             "max_tokens": {
                 "type": "integer",
@@ -152,16 +163,16 @@ LCM_EXPAND = {
             },
             "source_offset": {
                 "type": "integer",
-                "description": "Zero-based pagination offset into the node's immediate source list (messages or child nodes). Use pagination.next_source_offset to continue.",
+                "description": "Zero-based pagination offset into the node's immediate source list (node_id mode only).",
                 "default": 0,
             },
             "source_limit": {
                 "type": "integer",
-                "description": "Maximum number of immediate sources to return from source_offset. Output still respects max_tokens.",
+                "description": "Maximum number of immediate sources to return from source_offset (node_id mode only). Output still respects max_tokens.",
             },
             "content_offset": {
                 "type": "integer",
-                "description": "Character offset used to continue an oversized raw message or externalized payload. Use next_content_offset from the previous response.",
+                "description": "Character offset used to continue an oversized raw message, externalized payload, or store_id-mode message. Use next_content_offset from the previous response.",
                 "default": 0,
             },
         },

--- a/schemas.py
+++ b/schemas.py
@@ -3,13 +3,13 @@
 LCM_GREP = {
     "name": "lcm_grep",
     "description": (
-        "Search the LCM database for past conversation content (raw messages AND summaries across all depths) "
-        "to recover details from the active session or, when explicitly scoped, from other sessions in the "
-        "plugin-local LCM database (including history imported from OpenClaw or lossless-claw). "
-        "Default scope is current-session only; broader scopes must be requested explicitly. "
-        "Cross-session summary hits are returned as snippets but cannot be expanded by node_id in this version "
-        "(they carry cross_session_expand_supported=false); use lcm_expand with the result's store_id for raw-message "
-        "expansion across sessions. For Hermes-tracked session history outside the LCM database, use session_search."
+        "Search the plugin-local LCM database for past conversation content. "
+        "Default scope is the active session and returns both raw messages and summary nodes across all depths. "
+        "Broader scopes ('all' or 'session') must be requested explicitly and exist for bounded archive recovery "
+        "over rows already present in lcm.db, including externally backfilled rows that may carry source strings "
+        "such as openclaw-lcm:* . In broader scopes only raw-message hits are returned; cross-session summary "
+        "node expansion is intentionally deferred. Use lcm_expand(store_id=...) on a cross-session message hit "
+        "to drill into its full content. For Hermes-tracked session history outside the LCM database, use session_search."
     ),
     "parameters": {
         "type": "object",
@@ -65,27 +65,6 @@ LCM_GREP = {
                     "Optional source/platform filter (for example cli, discord, telegram). "
                     "Applies directly to raw messages and to summaries via descendant source lineage. "
                     "Use 'unknown' for explicit unknown-source content."
-                ),
-            },
-            "role": {
-                "type": "string",
-                "enum": ["user", "assistant", "tool"],
-                "description": (
-                    "Optional role filter. Applies to message hits only; summary hits are returned unfiltered "
-                    "(role does not exist on summary nodes). The response echoes role_filter_applies='messages_only' when this is set."
-                ),
-            },
-            "time_from": {
-                "type": "string",
-                "description": (
-                    "Optional inclusive ISO 8601 lower bound for message timestamps and summary latest_at. "
-                    "Examples: '2026-01-01T00:00:00Z' or '2026-01-01T00:00:00+00:00'."
-                ),
-            },
-            "time_to": {
-                "type": "string",
-                "description": (
-                    "Optional inclusive ISO 8601 upper bound for message timestamps and summary latest_at."
                 ),
             },
         },

--- a/schemas.py
+++ b/schemas.py
@@ -152,8 +152,10 @@ LCM_EXPAND = {
                 "description": (
                     "Raw message store_id to fetch. Works across sessions, so a store_id surfaced by "
                     "a cross-session lcm_grep result can be expanded directly. Returns the message's "
-                    "content paged by content_offset; if the row references an externalized payload, "
-                    "the ref is surfaced but content is not hydrated."
+                    "content paged by content_offset. If the row references an externalized payload, "
+                    "the ref is surfaced via 'externalized_ref'; payload metadata and content are "
+                    "session-scoped, so a cross-session row also includes 'externalized_note' "
+                    "explaining that the ref is for traceability only and cannot be expanded in this version."
                 ),
             },
             "max_tokens": {

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5,7 +5,6 @@ import logging
 import sqlite3
 import threading
 import time
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -355,23 +354,30 @@ class TestEngineABC:
         assert grep_props["session_scope"]["enum"] == ["current", "all", "session"]
         assert "session_id" in grep_props
         assert "session_scope='session'" in grep_props["session_id"]["description"]
-        assert "role" in grep_props
-        assert grep_props["role"]["enum"] == ["user", "assistant", "tool"]
-        assert "time_from" in grep_props
-        assert "ISO 8601" in grep_props["time_from"]["description"]
-        assert "time_to" in grep_props
+        # role/time_from/time_to filters are intentionally absent in this
+        # version; they need to be pushed into the search layer before being
+        # exposed again. See follow-up issue tracking that work.
+        assert "role" not in grep_props
+        assert "time_from" not in grep_props
+        assert "time_to" not in grep_props
         assert "source" in grep_props
         assert "descendant source lineage" in grep_props["source"]["description"]
         assert "unknown" in grep_props["source"]["description"]
-        assert "current-session" in grep_schema["description"].lower() or "current session" in grep_schema["description"].lower()
+        # The default scope still steers callers to the active session.
+        description_lower = grep_schema["description"].lower()
+        assert (
+            "current-session" in description_lower
+            or "current session" in description_lower
+            or "active session" in description_lower
+        )
         assert "session_search" in grep_schema["description"]
         # The schema now documents the broader scopes — assert by enumerating them in the
         # session_scope description rather than enforcing the legacy current-only wording.
         scope_description = grep_props["session_scope"]["description"]
         assert "all" in scope_description and "session" in scope_description and "current" in scope_description
         assert "session_search" in scope_description
-        # cross-session summary expansion is intentionally deferred — top-level description should mention it.
-        assert "cross_session_expand_supported" in grep_schema["description"]
+        # Cross-session search is positioned as plugin-local archive recovery, not memory.
+        assert "archive" in grep_schema["description"].lower() or "plugin-local" in grep_schema["description"].lower()
 
         describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
         expand_schema = next(s for s in schemas if s["name"] == "lcm_expand")
@@ -397,12 +403,18 @@ class TestEngineABC:
 
     def test_readme_documents_session_scope_contract(self):
         readme = Path(__file__).resolve().parents[1].joinpath("README.md").read_text()
-        # cross-session opt-in is now documented explicitly
+        # cross-session opt-in is now documented as bounded archive recovery
         assert "session_scope='all'" in readme
         assert "session_scope='session'" in readme
         assert "current-session recall" in readme
         assert "session_search" in readme
-        assert "cross_session_expand_supported" in readme
+        # The reframed positioning steers callers away from a memory-system
+        # reading and toward bounded archive recovery over rows already in lcm.db.
+        assert "archive" in readme.lower() or "externally backfilled" in readme.lower()
+        # No implied importer language: anchor the use case on rows already in
+        # lcm.db, not on an official OpenClaw/lossless-claw importer.
+        assert "imported from OpenClaw" not in readme
+        assert "imported from lossless-claw" not in readme
         assert "Lossless raw recovery contract" in readme
         assert "source_offset" in readme
         assert "content_offset" in readme
@@ -7988,53 +8000,6 @@ class TestHandleGrepCrossSession:
         assert result["limit"] == 200
         assert result["limit_clamped_from"] == 5000
 
-    def test_time_from_in_future_excludes_all(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
-        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
-        result = json.loads(
-            engine.handle_tool_call(
-                "lcm_grep",
-                {"query": "docker", "time_from": future},
-            )
-        )
-        assert result["total_results"] == 0
-        # time_from is echoed back as the original input string, not as a float
-        assert result["time_from"] == future
-
-    def test_time_to_in_past_excludes_all(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
-        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-        result = json.loads(
-            engine.handle_tool_call("lcm_grep", {"query": "docker", "time_to": past})
-        )
-        assert result["total_results"] == 0
-        assert result["time_to"] == past
-
-    def test_inverted_time_range_returns_error(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
-        now = datetime.now(timezone.utc)
-        time_from = (now + timedelta(hours=1)).isoformat()
-        time_to = (now - timedelta(hours=1)).isoformat()
-        result = json.loads(
-            engine.handle_tool_call(
-                "lcm_grep",
-                {"query": "docker", "time_from": time_from, "time_to": time_to},
-            )
-        )
-        assert "error" in result
-        assert "time_from" in result["error"] and "time_to" in result["error"]
-
-    def test_naive_iso8601_time_is_rejected(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
-        result = json.loads(
-            engine.handle_tool_call(
-                "lcm_grep",
-                {"query": "docker", "time_from": "2026-01-01T00:00:00"},
-            )
-        )
-        assert "error" in result
-        assert "timezone" in result["error"].lower() or "naive" in result["error"].lower()
-
     def test_limit_zero_returns_error(self, engine):
         engine._store.append("test-session", {"role": "user", "content": "docker plan"})
         result = json.loads(
@@ -8050,77 +8015,31 @@ class TestHandleGrepCrossSession:
         )
         assert "error" in result
 
-    def test_empty_engine_session_under_current_scope_returns_error(self, engine):
+    def test_empty_engine_session_with_unknown_scope_does_not_leak(self, engine):
+        # Regression: unknown session_scope previously fell through to engine._session_id
+        # and returned multi-session rows when the engine was unbound. The fix in #104
+        # makes empty session_id a literal scoped filter at the data layer; the unknown-
+        # scope fallback now routes through current-session and naturally returns zero
+        # results instead of leaking. Mirrors the maintainer's repro from PR #102 review.
         engine._session_id = ""
-        engine._store.append("some-session", {"role": "user", "content": "docker plan"})
-        result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
-        assert "error" in result
-        assert "no active session" in result["error"].lower() or "session_scope" in result["error"]
-
-    def test_invalid_time_from_returns_error(self, engine):
-        result = json.loads(
-            engine.handle_tool_call(
-                "lcm_grep", {"query": "docker", "time_from": "not-a-real-timestamp"}
-            )
-        )
-        assert "error" in result
-        assert "time_from" in result["error"]
-
-    def test_time_zulu_suffix_accepted(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        engine._store.append("session-a", {"role": "user", "content": "docker from a"})
+        engine._store.append("session-b", {"role": "user", "content": "docker from b"})
         result = json.loads(
             engine.handle_tool_call(
                 "lcm_grep",
-                {"query": "docker", "time_from": "2000-01-01T00:00:00Z"},
+                {"query": "docker", "session_scope": "bogus", "limit": 10},
             )
         )
-        assert "error" not in result
-        assert result["total_results"] >= 1
+        assert result["session_scope"] == "current"
+        assert result["ignored_session_scope"] == "bogus"
+        assert result["total_results"] == 0
+        assert result["results"] == []
 
-    def test_role_filter_keeps_only_matching_role(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker user line"})
-        engine._store.append("test-session", {"role": "assistant", "content": "docker assistant line"})
-
-        result = json.loads(
-            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "assistant"})
-        )
-        assert result["role"] == "assistant"
-        assert result["role_filter_applies"] == "messages_only"
-        roles_seen = {hit["role"] for hit in result["results"] if hit["type"] == "message"}
-        assert roles_seen == {"assistant"}
-
-    def test_role_filter_does_not_drop_summary_hits(self, engine):
-        engine._store.append("test-session", {"role": "user", "content": "docker user only"})
-        engine._dag.add_node(
-            SummaryNode(
-                session_id="test-session",
-                depth=0,
-                summary="summary about docker",
-                token_count=5,
-                source_token_count=5,
-                source_ids=[1],
-                source_type="messages",
-                created_at=time.time(),
-            )
-        )
-        result = json.loads(
-            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "tool"})
-        )
-        # No tool-role messages, so all message hits are filtered out, but the
-        # summary hit (which has no role) remains.
-        types_seen = {hit["type"] for hit in result["results"]}
-        assert "summary" in types_seen
-        assert "message" not in types_seen
-
-    def test_invalid_role_returns_error(self, engine):
-        result = json.loads(
-            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "moderator"})
-        )
-        assert "error" in result
-        assert "role" in result["error"]
-
-    def test_cross_session_summary_hit_marked_non_expandable(self, engine):
-        engine._store.append("old-session", {"role": "user", "content": "docker old"})
+    def test_cross_session_scope_returns_only_message_hits(self, engine):
+        # Cross-session scope intentionally restricts to raw-message hits.
+        # Summary nodes from foreign sessions are excluded entirely (deferred
+        # until a real cross-session DAG-expansion contract exists).
+        engine._store.append("old-session", {"role": "user", "content": "docker old message"})
         engine._dag.add_node(
             SummaryNode(
                 session_id="old-session",
@@ -8136,13 +8055,16 @@ class TestHandleGrepCrossSession:
         result = json.loads(
             engine.handle_tool_call("lcm_grep", {"query": "docker", "session_scope": "all"})
         )
-        summary_hits = [hit for hit in result["results"] if hit["type"] == "summary"]
-        assert summary_hits, "expected at least one summary hit"
-        for hit in summary_hits:
-            if hit["session_id"] != "test-session":
-                assert hit.get("cross_session_expand_supported") is False
+        types_seen = {hit["type"] for hit in result["results"]}
+        assert "message" in types_seen
+        assert "summary" not in types_seen
+        # No summary hits means no cross_session_expand_supported marker is needed.
+        for hit in result["results"]:
+            assert "cross_session_expand_supported" not in hit
 
-    def test_current_session_summary_hit_does_not_carry_non_expandable_marker(self, engine):
+    def test_current_scope_still_returns_summary_hits(self, engine):
+        # Regression: removing cross-session summary hits must not affect
+        # current-session DAG search behavior.
         engine._store.append("test-session", {"role": "user", "content": "docker current"})
         engine._dag.add_node(
             SummaryNode(
@@ -8156,16 +8078,9 @@ class TestHandleGrepCrossSession:
                 created_at=time.time(),
             )
         )
-        result = json.loads(
-            engine.handle_tool_call("lcm_grep", {"query": "docker", "session_scope": "all"})
-        )
-        summary_hits = [
-            hit for hit in result["results"]
-            if hit["type"] == "summary" and hit["session_id"] == "test-session"
-        ]
-        assert summary_hits
-        for hit in summary_hits:
-            assert "cross_session_expand_supported" not in hit
+        result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
+        types_seen = {hit["type"] for hit in result["results"]}
+        assert "summary" in types_seen
 
     def test_source_filter_combined_with_scope_all(self, engine):
         engine._store.append("test-session", {"role": "user", "content": "docker via cli"}, source="cli")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5,6 +5,7 @@ import logging
 import sqlite3
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -7988,8 +7989,6 @@ class TestHandleGrepCrossSession:
         assert result["limit_clamped_from"] == 5000
 
     def test_time_from_in_future_excludes_all(self, engine):
-        from datetime import datetime, timezone, timedelta
-
         engine._store.append("test-session", {"role": "user", "content": "docker plan"})
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         result = json.loads(
@@ -7999,18 +7998,64 @@ class TestHandleGrepCrossSession:
             )
         )
         assert result["total_results"] == 0
-        assert "time_from" in result
+        # time_from is echoed back as the original input string, not as a float
+        assert result["time_from"] == future
 
     def test_time_to_in_past_excludes_all(self, engine):
-        from datetime import datetime, timezone, timedelta
-
         engine._store.append("test-session", {"role": "user", "content": "docker plan"})
         past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
         result = json.loads(
             engine.handle_tool_call("lcm_grep", {"query": "docker", "time_to": past})
         )
         assert result["total_results"] == 0
-        assert "time_to" in result
+        assert result["time_to"] == past
+
+    def test_inverted_time_range_returns_error(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        now = datetime.now(timezone.utc)
+        time_from = (now + timedelta(hours=1)).isoformat()
+        time_to = (now - timedelta(hours=1)).isoformat()
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "time_from": time_from, "time_to": time_to},
+            )
+        )
+        assert "error" in result
+        assert "time_from" in result["error"] and "time_to" in result["error"]
+
+    def test_naive_iso8601_time_is_rejected(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "time_from": "2026-01-01T00:00:00"},
+            )
+        )
+        assert "error" in result
+        assert "timezone" in result["error"].lower() or "naive" in result["error"].lower()
+
+    def test_limit_zero_returns_error(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "limit": 0})
+        )
+        assert "error" in result
+        assert "limit" in result["error"]
+
+    def test_limit_negative_returns_error(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "limit": -5})
+        )
+        assert "error" in result
+
+    def test_empty_engine_session_under_current_scope_returns_error(self, engine):
+        engine._session_id = ""
+        engine._store.append("some-session", {"role": "user", "content": "docker plan"})
+        result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
+        assert "error" in result
+        assert "no active session" in result["error"].lower() or "session_scope" in result["error"]
 
     def test_invalid_time_from_returns_error(self, engine):
         result = json.loads(
@@ -8243,6 +8288,28 @@ class TestHandleExpandStoreId:
         )
         assert "error" in result
         assert "current session" in result["error"].lower()
+
+    def test_store_id_cross_session_externalized_ref_surfaced_with_note(self, engine):
+        # Seed a foreign-session tool message that references an externalized
+        # payload. The ref string follows the produced-placeholder shape so
+        # extract_externalized_ref will pick it up.
+        placeholder = (
+            "[Externalized tool output: tool_call_id=call_abc; "
+            "chars=1234; bytes=5678; ref=foreign_payload_ref.json]"
+        )
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "tool", "content": placeholder, "tool_call_id": "call_abc"},
+        )
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"store_id": store_id}))
+        assert result["source_type"] == "raw_message"
+        assert result["from_current_session"] is False
+        assert result["externalized_ref"] == "foreign_payload_ref.json"
+        # Cross-session payload metadata is intentionally omitted; an explanatory
+        # note is surfaced so callers don't treat the bare ref as expandable.
+        assert "externalized" not in result
+        assert "externalized_note" in result
+        assert "session-scoped" in result["externalized_note"].lower()
 
     def test_grep_then_expand_round_trip_cross_session(self, engine):
         store_id = engine._store.append(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -351,14 +351,26 @@ class TestEngineABC:
         grep_schema = next(s for s in schemas if s["name"] == "lcm_grep")
         grep_props = grep_schema["parameters"]["properties"]
         assert "session_scope" in grep_props
-        assert grep_props["session_scope"]["enum"] == ["current"]
+        assert grep_props["session_scope"]["enum"] == ["current", "all", "session"]
+        assert "session_id" in grep_props
+        assert "session_scope='session'" in grep_props["session_id"]["description"]
+        assert "role" in grep_props
+        assert grep_props["role"]["enum"] == ["user", "assistant", "tool"]
+        assert "time_from" in grep_props
+        assert "ISO 8601" in grep_props["time_from"]["description"]
+        assert "time_to" in grep_props
         assert "source" in grep_props
         assert "descendant source lineage" in grep_props["source"]["description"]
         assert "unknown" in grep_props["source"]["description"]
-        assert "current session" in grep_schema["description"].lower()
+        assert "current-session" in grep_schema["description"].lower() or "current session" in grep_schema["description"].lower()
         assert "session_search" in grep_schema["description"]
-        assert "session_scope='all'" not in grep_schema["description"]
-        assert "session_search" in grep_props["session_scope"]["description"]
+        # The schema now documents the broader scopes — assert by enumerating them in the
+        # session_scope description rather than enforcing the legacy current-only wording.
+        scope_description = grep_props["session_scope"]["description"]
+        assert "all" in scope_description and "session" in scope_description and "current" in scope_description
+        assert "session_search" in scope_description
+        # cross-session summary expansion is intentionally deferred — top-level description should mention it.
+        assert "cross_session_expand_supported" in grep_schema["description"]
 
         describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
         expand_schema = next(s for s in schemas if s["name"] == "lcm_expand")
@@ -366,12 +378,15 @@ class TestEngineABC:
 
         assert "current session" in describe_schema["description"].lower()
         assert "session_search" in describe_schema["description"]
-        assert "current session" in expand_schema["description"].lower()
+        # lcm_expand picked up a third mode (store_id); its description must surface that.
+        assert "store_id" in expand_schema["description"]
         assert "session_search" in expand_schema["description"]
         expand_props = expand_schema["parameters"]["properties"]
         assert "source_offset" in expand_props
         assert "source_limit" in expand_props
         assert "content_offset" in expand_props
+        assert "store_id" in expand_props
+        assert "across sessions" in expand_props["store_id"]["description"].lower() or "cross-session" in expand_props["store_id"]["description"].lower()
         assert "pagination" in expand_props["source_offset"]["description"].lower()
         assert "current session" in expand_query_schema["description"].lower()
         assert "session_search" in expand_query_schema["description"]
@@ -379,12 +394,14 @@ class TestEngineABC:
         assert "context_max_tokens" in expand_query_props
         assert "fresh context budget" in expand_query_props["context_max_tokens"]["description"]
 
-    def test_readme_matches_current_session_retrieval_contract(self):
+    def test_readme_documents_session_scope_contract(self):
         readme = Path(__file__).resolve().parents[1].joinpath("README.md").read_text()
-        assert "session_scope='all'" not in readme
-        assert "session_scope=\"all\"" not in readme
+        # cross-session opt-in is now documented explicitly
+        assert "session_scope='all'" in readme
+        assert "session_scope='session'" in readme
         assert "current-session recall" in readme
         assert "session_search" in readme
+        assert "cross_session_expand_supported" in readme
         assert "Lossless raw recovery contract" in readme
         assert "source_offset" in readme
         assert "content_offset" in readme
@@ -1750,6 +1767,7 @@ class TestSessionRollover:
                 "expand_hint": "",
                 "earliest_at": None,
                 "latest_at": None,
+                "from_current_session": True,
             }
         ]
         assert engine._dag.get_node(pruned_node_id) is None
@@ -5266,7 +5284,7 @@ class TestEngineTools:
         )
         assert result["sort"] == "relevance"
 
-    def test_handle_grep_reports_unsupported_session_scope_and_stays_current(self, engine):
+    def test_handle_grep_session_scope_all_returns_cross_session_hits(self, engine):
         engine._store.append("test-session", {"role": "user", "content": "docker rollout current session"})
         engine._store.append("old-session", {"role": "user", "content": "docker rollout old session"})
 
@@ -5277,9 +5295,31 @@ class TestEngineTools:
             )
         )
 
+        assert result["session_scope"] == "all"
+        assert result["total_results"] == 2
+        session_ids = {hit["session_id"] for hit in result["results"]}
+        assert session_ids == {"test-session", "old-session"}
+        from_current_flags = {
+            hit["session_id"]: hit["from_current_session"] for hit in result["results"]
+        }
+        assert from_current_flags == {"test-session": True, "old-session": False}
+        # No ignored_session_scope key when the requested scope is now supported.
+        assert "ignored_session_scope" not in result
+
+    def test_handle_grep_truly_unknown_session_scope_stays_current_and_reports(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker rollout current session"})
+        engine._store.append("old-session", {"role": "user", "content": "docker rollout old session"})
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "everything", "limit": 10},
+            )
+        )
+
         assert result["session_scope"] == "current"
-        assert result["ignored_session_scope"] == "all"
-        assert "session_search" in result["scope_note"]
+        assert result["ignored_session_scope"] == "everything"
+        assert "current" in result["scope_note"]
         assert result["total_results"] == 1
         assert result["results"][0]["session_id"] == "test-session"
 
@@ -7872,6 +7912,362 @@ class TestEngineTools:
         fts_check = next(c for c in result["checks"] if c["check"] == "fts_index_sync")
         assert fts_check["status"] == "pass"
         assert fts_check["detail"] == "1 session FTS rows, 1 session messages"
+
+
+class TestHandleGrepCrossSession:
+    """Cross-session search via session_scope=all|session and the new filters."""
+
+    def _seed_two_sessions(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan current"})
+        engine._store.append("test-session", {"role": "assistant", "content": "docker plan current reply"})
+        engine._store.append("old-session", {"role": "user", "content": "docker plan old"}, source="discord")
+
+    def test_session_scope_all_returns_cross_session_messages(self, engine):
+        self._seed_two_sessions(engine)
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "session_scope": "all"})
+        )
+        assert result["session_scope"] == "all"
+        sessions_seen = {hit["session_id"] for hit in result["results"]}
+        assert sessions_seen == {"test-session", "old-session"}
+        for hit in result["results"]:
+            assert "from_current_session" in hit
+            assert hit["from_current_session"] == (hit["session_id"] == "test-session")
+            assert "timestamp" in hit
+            assert hit["timestamp"] >= 0
+
+    def test_session_scope_session_restricts_to_explicit_id(self, engine):
+        self._seed_two_sessions(engine)
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "session", "session_id": "old-session"},
+            )
+        )
+        assert result["session_scope"] == "session"
+        assert result["session_id"] == "old-session"
+        assert result["total_results"] == 1
+        assert result["results"][0]["session_id"] == "old-session"
+        assert result["results"][0]["from_current_session"] is False
+
+    def test_session_scope_session_without_session_id_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "session"},
+            )
+        )
+        assert "error" in result
+        assert "session_id" in result["error"]
+
+    def test_session_scope_current_with_session_id_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "current", "session_id": "old-session"},
+            )
+        )
+        assert "error" in result
+        assert "session_id is only valid with session_scope=session" in result["error"]
+
+    def test_session_scope_all_with_session_id_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "session_id": "old-session"},
+            )
+        )
+        assert "error" in result
+
+    def test_limit_clamped_at_hard_cap(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker once"})
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "limit": 5000})
+        )
+        assert result["limit"] == 200
+        assert result["limit_clamped_from"] == 5000
+
+    def test_time_from_in_future_excludes_all(self, engine):
+        from datetime import datetime, timezone, timedelta
+
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "time_from": future},
+            )
+        )
+        assert result["total_results"] == 0
+        assert "time_from" in result
+
+    def test_time_to_in_past_excludes_all(self, engine):
+        from datetime import datetime, timezone, timedelta
+
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "time_to": past})
+        )
+        assert result["total_results"] == 0
+        assert "time_to" in result
+
+    def test_invalid_time_from_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep", {"query": "docker", "time_from": "not-a-real-timestamp"}
+            )
+        )
+        assert "error" in result
+        assert "time_from" in result["error"]
+
+    def test_time_zulu_suffix_accepted(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker plan"})
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "time_from": "2000-01-01T00:00:00Z"},
+            )
+        )
+        assert "error" not in result
+        assert result["total_results"] >= 1
+
+    def test_role_filter_keeps_only_matching_role(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker user line"})
+        engine._store.append("test-session", {"role": "assistant", "content": "docker assistant line"})
+
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "assistant"})
+        )
+        assert result["role"] == "assistant"
+        assert result["role_filter_applies"] == "messages_only"
+        roles_seen = {hit["role"] for hit in result["results"] if hit["type"] == "message"}
+        assert roles_seen == {"assistant"}
+
+    def test_role_filter_does_not_drop_summary_hits(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker user only"})
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="summary about docker",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "tool"})
+        )
+        # No tool-role messages, so all message hits are filtered out, but the
+        # summary hit (which has no role) remains.
+        types_seen = {hit["type"] for hit in result["results"]}
+        assert "summary" in types_seen
+        assert "message" not in types_seen
+
+    def test_invalid_role_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "role": "moderator"})
+        )
+        assert "error" in result
+        assert "role" in result["error"]
+
+    def test_cross_session_summary_hit_marked_non_expandable(self, engine):
+        engine._store.append("old-session", {"role": "user", "content": "docker old"})
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="docker old summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "session_scope": "all"})
+        )
+        summary_hits = [hit for hit in result["results"] if hit["type"] == "summary"]
+        assert summary_hits, "expected at least one summary hit"
+        for hit in summary_hits:
+            if hit["session_id"] != "test-session":
+                assert hit.get("cross_session_expand_supported") is False
+
+    def test_current_session_summary_hit_does_not_carry_non_expandable_marker(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker current"})
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="docker current summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        result = json.loads(
+            engine.handle_tool_call("lcm_grep", {"query": "docker", "session_scope": "all"})
+        )
+        summary_hits = [
+            hit for hit in result["results"]
+            if hit["type"] == "summary" and hit["session_id"] == "test-session"
+        ]
+        assert summary_hits
+        for hit in summary_hits:
+            assert "cross_session_expand_supported" not in hit
+
+    def test_source_filter_combined_with_scope_all(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "docker via cli"}, source="cli")
+        engine._store.append("old-session", {"role": "user", "content": "docker via discord"}, source="discord")
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "all", "source": "discord"},
+            )
+        )
+        assert result["session_scope"] == "all"
+        assert result["source"] == "discord"
+        assert result["total_results"] == 1
+        assert result["results"][0]["session_id"] == "old-session"
+        assert result["results"][0]["source"] == "discord"
+
+    def test_default_scope_preserves_historical_behavior(self, engine):
+        # Omitting session_scope must behave identically to current.
+        engine._store.append("test-session", {"role": "user", "content": "docker default"})
+        engine._store.append("old-session", {"role": "user", "content": "docker old"})
+        result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
+        assert result["session_scope"] == "current"
+        sessions_seen = {hit["session_id"] for hit in result["results"]}
+        assert sessions_seen == {"test-session"}
+
+
+class TestHandleExpandStoreId:
+    """lcm_expand store_id mode for cross-session raw expansion."""
+
+    def test_store_id_returns_raw_message_cross_session(self, engine):
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "cross session content body"},
+            source="cli",
+        )
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"store_id": store_id}))
+        assert result["source_type"] == "raw_message"
+        assert result["store_id"] == store_id
+        assert result["session_id"] == "old-session"
+        assert result["from_current_session"] is False
+        assert result["role"] == "user"
+        assert result["source"] == "cli"
+        assert result["content"].startswith("cross session content")
+
+    def test_store_id_paging_via_content_offset(self, engine):
+        big_content = "x" * 10000
+        store_id = engine._store.append(
+            "old-session", {"role": "user", "content": big_content}
+        )
+        first = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand", {"store_id": store_id, "max_tokens": 50}
+            )
+        )
+        assert first["content_truncated"] is True
+        assert first["next_content_offset"] > 0
+        second = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {
+                    "store_id": store_id,
+                    "max_tokens": 50,
+                    "content_offset": first["next_content_offset"],
+                },
+            )
+        )
+        assert second["content_offset"] == first["next_content_offset"]
+        assert second["content"]
+        # Combined slices should not exceed total content length.
+        assert first["content_chars"] == second["content_chars"]
+
+    def test_store_id_not_found_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call("lcm_expand", {"store_id": 999_999_999})
+        )
+        assert "error" in result
+        assert "store_id" in result["error"]
+
+    def test_store_id_not_an_integer_returns_error(self, engine):
+        result = json.loads(
+            engine.handle_tool_call("lcm_expand", {"store_id": "not-an-int"})
+        )
+        assert "error" in result
+        assert "integer" in result["error"]
+
+    def test_multiple_modes_returns_error(self, engine):
+        store_id = engine._store.append(
+            "test-session", {"role": "user", "content": "x"}
+        )
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand", {"store_id": store_id, "node_id": 1}
+            )
+        )
+        assert "error" in result
+        assert "Provide only one" in result["error"]
+
+    def test_no_modes_returns_error(self, engine):
+        result = json.loads(engine.handle_tool_call("lcm_expand", {}))
+        assert "error" in result
+        assert "node_id" in result["error"] and "store_id" in result["error"]
+
+    def test_node_id_remains_session_scoped(self, engine):
+        # Node belongs to a different session — must not be expandable via node_id.
+        engine._store.append("old-session", {"role": "user", "content": "old content"})
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="old summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+        result = json.loads(
+            engine.handle_tool_call("lcm_expand", {"node_id": node_id})
+        )
+        assert "error" in result
+        assert "current session" in result["error"].lower()
+
+    def test_grep_then_expand_round_trip_cross_session(self, engine):
+        store_id = engine._store.append(
+            "old-session", {"role": "user", "content": "phoenix payload across session"}
+        )
+        grep_result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "phoenix", "session_scope": "all"},
+            )
+        )
+        cross_hits = [
+            hit for hit in grep_result["results"]
+            if hit["type"] == "message" and hit["session_id"] == "old-session"
+        ]
+        assert cross_hits, "cross-session grep should surface the seeded message"
+        assert cross_hits[0]["store_id"] == store_id
+
+        expand_result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand", {"store_id": cross_hits[0]["store_id"]}
+            )
+        )
+        assert expand_result["source_type"] == "raw_message"
+        assert "phoenix payload" in expand_result["content"]
 
 
 class TestExtractionDuringCompress:

--- a/tools.py
+++ b/tools.py
@@ -820,17 +820,51 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
 
 
 def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
-    """Expand a summary node to its source content."""
+    """Expand a summary node, externalized payload, or raw message to its content.
+
+    Mode selection (exactly one is required):
+    - ``externalized_ref``: open a stored externalized payload by ref filename (current session only)
+    - ``store_id``: fetch a single raw message by store_id; works across sessions
+    - ``node_id``: expand a summary node to its source content (current session only)
+
+    Only ``store_id`` mode is cross-session in this version. Cross-session DAG
+    expansion via ``node_id`` is intentionally not supported (it would require
+    descending session-bound source ids).
+    """
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
     externalized_ref = str(args.get("externalized_ref") or "").strip()
+    raw_store_id_arg = args.get("store_id")
+    raw_node_id_arg = args.get("node_id")
+
+    modes_provided: list[str] = []
+    if externalized_ref:
+        modes_provided.append("externalized_ref")
+    if raw_store_id_arg is not None:
+        modes_provided.append("store_id")
+    if raw_node_id_arg is not None:
+        modes_provided.append("node_id")
+
+    if len(modes_provided) > 1:
+        return json.dumps({
+            "error": (
+                "Provide only one of node_id, externalized_ref, store_id "
+                f"(got {', '.join(modes_provided)})"
+            ),
+        })
+    if not modes_provided:
+        return json.dumps({
+            "error": "node_id, externalized_ref, or store_id is required",
+        })
+
     max_tokens = _parse_positive_int(args.get("max_tokens", 4000), 4000)
     source_offset = _parse_non_negative_int(args.get("source_offset", 0), 0)
     source_limit_arg = args.get("source_limit")
     source_limit = _parse_positive_int(source_limit_arg, 0) if source_limit_arg is not None else None
     content_offset = _parse_non_negative_int(args.get("content_offset", 0), 0)
+
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
         if payload is None:
@@ -855,9 +889,49 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             }
         )
 
-    node_id = args.get("node_id")
-    if node_id is None:
-        return json.dumps({"error": "node_id or externalized_ref is required"})
+    if raw_store_id_arg is not None:
+        try:
+            store_id = int(raw_store_id_arg)
+        except (TypeError, ValueError):
+            return json.dumps({"error": "store_id must be an integer"})
+        stored = engine._store.get(store_id)
+        if stored is None:
+            return json.dumps({"error": f"Message store_id {store_id} not found"})
+        transcript_content = stored.get("content", "") or ""
+        sliced = _slice_content_for_response(transcript_content, max_tokens, content_offset)
+        result: Dict[str, Any] = {
+            "store_id": store_id,
+            "source_type": "raw_message",
+            "session_id": stored.get("session_id", ""),
+            "source": stored.get("source") or "",
+            "role": stored.get("role"),
+            "timestamp": stored.get("timestamp", 0),
+            "tool_call_id": stored.get("tool_call_id") or "",
+            "from_current_session": stored.get("session_id") == engine._session_id,
+            "content": sliced["content"],
+            "content_chars": sliced["content_chars"],
+            "content_offset": sliced["content_offset"],
+            "content_returned_chars": sliced["content_returned_chars"],
+            "content_truncated": sliced["content_truncated"],
+            "next_content_offset": sliced["next_content_offset"],
+            "has_more": sliced["has_more"],
+        }
+        # Surface externalized-payload metadata when the row references one. Content
+        # is not hydrated by default, mirroring the existing _expand_message_sources
+        # default. Externalized lookup remains session-scoped (per the existing
+        # _get_externalized_payload contract).
+        ref = extract_externalized_ref(transcript_content)
+        if ref:
+            result["externalized_ref"] = ref
+            if stored.get("session_id") == engine._session_id:
+                payload = _get_externalized_payload(engine, ref)
+                if payload is not None:
+                    payload_summary = dict(payload)
+                    payload_summary.pop("content", None)
+                    result["externalized"] = payload_summary
+        return json.dumps(result)
+
+    node_id = raw_node_id_arg
 
     node = _get_session_node(engine, node_id)
     if node is None:

--- a/tools.py
+++ b/tools.py
@@ -151,6 +151,37 @@ def _parse_positive_int(value: Any, default: int) -> int:
     return max(1, _parse_int_value(value, default))
 
 
+_LCM_GREP_VALID_SCOPES = ("current", "all", "session")
+_LCM_GREP_VALID_ROLES = ("user", "assistant", "tool")
+_LCM_GREP_HARD_LIMIT_CAP = 200
+
+
+def _parse_iso8601_arg(name: str, value: Any) -> tuple[float | None, str | None]:
+    """Parse an ISO 8601 string (or numeric Unix timestamp) into Unix seconds.
+
+    Returns ``(timestamp_or_none, error_or_none)``. ``None`` for ``value``
+    means the caller did not supply the argument and is not an error.
+    """
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, f"{name} must be an ISO 8601 string"
+    if isinstance(value, (int, float)):
+        return float(value), None
+    if not isinstance(value, str):
+        return None, f"{name} must be an ISO 8601 string"
+    text = value.strip()
+    if not text:
+        return None, None
+    from datetime import datetime
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None, f"{name} is not a valid ISO 8601 timestamp"
+    return parsed.timestamp(), None
+
+
 def _slice_content_for_response(content: str, max_tokens: int, content_offset: int = 0) -> dict[str, Any]:
     content = content or ""
     content_offset = min(max(0, content_offset), len(content))
@@ -528,7 +559,14 @@ def _synthesize_expansion_answer(
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
-    """Search raw messages + summaries in the active session with optional source filtering."""
+    """Search raw messages + summaries with optional cross-session scoping and filters.
+
+    Default scope is the current session, preserving historical behavior. Callers may
+    explicitly request ``session_scope='all'`` (every session in the local LCM
+    database) or ``session_scope='session'`` (a single ``session_id``). Optional
+    ``role`` and ``time_from``/``time_to`` filters narrow results further. ``limit``
+    is clamped to ``_LCM_GREP_HARD_LIMIT_CAP`` regardless of input.
+    """
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
@@ -537,26 +575,77 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     if not query:
         return json.dumps({"error": "No query provided"})
 
-    limit = args.get("limit", 10)
+    requested_limit = _parse_positive_int(args.get("limit", 10), 10)
+    limit = min(requested_limit, _LCM_GREP_HARD_LIMIT_CAP)
     sort = normalize_search_sort(args.get("sort"))
     source_limit = max(limit * 4, limit, 20)
+
     requested_session_scope = str(args.get("session_scope", "current")).lower()
-    session_scope = "current"
+    raw_session_id_arg = args.get("session_id")
+    explicit_session_id = (
+        str(raw_session_id_arg).strip() if raw_session_id_arg is not None else ""
+    )
     source = str(args.get("source") or "").strip() or None
-    if requested_session_scope != "current":
-        logger.warning("Ignoring unsupported session_scope=%s for lcm_grep", requested_session_scope)
-    session_id = engine._session_id
-    results = []
+
+    raw_role_arg = args.get("role")
+    role_filter = (
+        str(raw_role_arg).strip().lower() if raw_role_arg is not None else ""
+    ) or None
+    if role_filter is not None and role_filter not in _LCM_GREP_VALID_ROLES:
+        return json.dumps({
+            "error": f"role must be one of {list(_LCM_GREP_VALID_ROLES)}",
+        })
+
+    time_from, time_from_error = _parse_iso8601_arg("time_from", args.get("time_from"))
+    if time_from_error:
+        return json.dumps({"error": time_from_error})
+    time_to, time_to_error = _parse_iso8601_arg("time_to", args.get("time_to"))
+    if time_to_error:
+        return json.dumps({"error": time_to_error})
+
+    if requested_session_scope == "current":
+        if explicit_session_id:
+            return json.dumps({
+                "error": "session_id is only valid with session_scope=session",
+            })
+        search_session_id: str | None = engine._session_id
+        session_scope = "current"
+    elif requested_session_scope == "all":
+        if explicit_session_id:
+            return json.dumps({
+                "error": "session_id is not used with session_scope=all",
+            })
+        search_session_id = None
+        session_scope = "all"
+    elif requested_session_scope == "session":
+        if not explicit_session_id:
+            return json.dumps({
+                "error": "session_scope=session requires session_id",
+            })
+        search_session_id = explicit_session_id
+        session_scope = "session"
+    else:
+        # Preserve historical behavior for unknown scopes: stay current and report.
+        search_session_id = engine._session_id
+        session_scope = "current"
+        logger.warning(
+            "Ignoring unsupported session_scope=%s for lcm_grep",
+            requested_session_scope,
+        )
+
+    current_session_id = engine._session_id
+    results: list[Dict[str, Any]] = []
 
     try:
         msg_hits = engine._store.search(
             query,
-            session_id=session_id,
+            session_id=search_session_id,
             limit=source_limit,
             sort=sort,
             source=source,
         )
         for hit in msg_hits:
+            timestamp_value = hit.get("timestamp", 0) or 0
             results.append(
                 {
                     "type": "message",
@@ -565,8 +654,10 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "session_id": hit["session_id"],
                     "source": hit.get("source") or "",
                     "role": hit["role"],
+                    "timestamp": timestamp_value,
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
-                    "_sort_ts": hit.get("timestamp", 0),
+                    "from_current_session": hit["session_id"] == current_session_id,
+                    "_sort_ts": timestamp_value,
                     "_sort_rank": hit.get("search_rank"),
                     "_sort_directness": hit.get("_directness_score") or 0.0,
                 }
@@ -577,30 +668,51 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     try:
         node_hits = engine._dag.search(
             query,
-            session_id=session_id,
+            session_id=search_session_id,
             limit=source_limit,
             sort=sort,
             source=source,
         )
         for node in node_hits:
-            results.append(
-                {
-                    "type": "summary",
-                    "depth": f"d{node.depth}",
-                    "node_id": node.node_id,
-                    "session_id": node.session_id,
-                    "snippet": node.summary[:300],
-                    "token_count": node.token_count,
-                    "expand_hint": node.expand_hint,
-                    "earliest_at": node.earliest_at,
-                    "latest_at": node.latest_at,
-                    "_sort_ts": node.latest_at or node.created_at,
-                    "_sort_rank": node.search_rank,
-                    "_sort_directness": node.search_directness or 0.0,
-                }
-            )
+            entry: Dict[str, Any] = {
+                "type": "summary",
+                "depth": f"d{node.depth}",
+                "node_id": node.node_id,
+                "session_id": node.session_id,
+                "snippet": node.summary[:300],
+                "token_count": node.token_count,
+                "expand_hint": node.expand_hint,
+                "earliest_at": node.earliest_at,
+                "latest_at": node.latest_at,
+                "from_current_session": node.session_id == current_session_id,
+                "_sort_ts": node.latest_at or node.created_at,
+                "_sort_rank": node.search_rank,
+                "_sort_directness": node.search_directness or 0.0,
+            }
+            if session_scope != "current" and node.session_id != current_session_id:
+                # Cross-session DAG expansion is intentionally deferred. Mark
+                # these hits so callers do not attempt node_id-based expansion.
+                entry["cross_session_expand_supported"] = False
+            results.append(entry)
     except Exception as exc:
         logger.warning("Node search failed: %s", exc)
+
+    if role_filter is not None:
+        # Role applies to message hits; summary hits have no role field.
+        results = [
+            result for result in results
+            if result.get("type") != "message" or result.get("role") == role_filter
+        ]
+
+    if time_from is not None or time_to is not None:
+        def _within_window(result: Dict[str, Any]) -> bool:
+            ts = float(result.get("_sort_ts") or 0)
+            if time_from is not None and ts < time_from:
+                return False
+            if time_to is not None and ts > time_to:
+                return False
+            return True
+        results = [result for result in results if _within_window(result)]
 
     if sort == "hybrid":
         max_message_directness = max(
@@ -617,17 +729,33 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         result.pop("_sort_rank", None)
         result.pop("_sort_directness", None)
         result.pop("_hybrid_summary_override", None)
-    response = {
+
+    response: Dict[str, Any] = {
         "query": query,
         "sort": sort,
         "session_scope": session_scope,
         "source": source,
+        "limit": limit,
         "total_results": len(results),
         "results": results[:limit],
     }
-    if requested_session_scope != "current":
+    if session_scope == "session":
+        response["session_id"] = explicit_session_id
+    if role_filter is not None:
+        response["role"] = role_filter
+        response["role_filter_applies"] = "messages_only"
+    if time_from is not None:
+        response["time_from"] = time_from
+    if time_to is not None:
+        response["time_to"] = time_to
+    if requested_limit > _LCM_GREP_HARD_LIMIT_CAP:
+        response["limit_clamped_from"] = requested_limit
+    if requested_session_scope not in _LCM_GREP_VALID_SCOPES:
         response["ignored_session_scope"] = requested_session_scope
-        response["scope_note"] = "lcm_grep is current-session only; use session_search for broad cross-session recall."
+        response["scope_note"] = (
+            "Unsupported session_scope; stayed on current. "
+            "Valid values: current, all, session."
+        )
     return json.dumps(response)
 
 

--- a/tools.py
+++ b/tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -151,13 +152,16 @@ def _parse_positive_int(value: Any, default: int) -> int:
     return max(1, _parse_int_value(value, default))
 
 
-_LCM_GREP_VALID_SCOPES = ("current", "all", "session")
-_LCM_GREP_VALID_ROLES = ("user", "assistant", "tool")
+_LCM_GREP_VALID_SCOPES = frozenset({"current", "all", "session"})
+_LCM_GREP_VALID_ROLES = frozenset({"user", "assistant", "tool"})
 _LCM_GREP_HARD_LIMIT_CAP = 200
 
 
 def _parse_iso8601_arg(name: str, value: Any) -> tuple[float | None, str | None]:
     """Parse an ISO 8601 string (or numeric Unix timestamp) into Unix seconds.
+
+    Naive datetimes (no ``Z`` and no offset) are rejected so cross-machine
+    time-window filters stay reproducible regardless of host timezone.
 
     Returns ``(timestamp_or_none, error_or_none)``. ``None`` for ``value``
     means the caller did not supply the argument and is not an error.
@@ -173,12 +177,16 @@ def _parse_iso8601_arg(name: str, value: Any) -> tuple[float | None, str | None]
     text = value.strip()
     if not text:
         return None, None
-    from datetime import datetime
     normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return None, f"{name} is not a valid ISO 8601 timestamp"
+    if parsed.tzinfo is None:
+        return None, (
+            f"{name} must include a timezone (Z or +HH:MM); "
+            "naive datetimes are rejected to keep filters reproducible across machines"
+        )
     return parsed.timestamp(), None
 
 
@@ -575,7 +583,11 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     if not query:
         return json.dumps({"error": "No query provided"})
 
-    requested_limit = _parse_positive_int(args.get("limit", 10), 10)
+    raw_limit_arg = args.get("limit", 10)
+    parsed_limit = _parse_int_value(raw_limit_arg, 10)
+    if parsed_limit <= 0:
+        return json.dumps({"error": "limit must be a positive integer"})
+    requested_limit = parsed_limit
     limit = min(requested_limit, _LCM_GREP_HARD_LIMIT_CAP)
     sort = normalize_search_sort(args.get("sort"))
     source_limit = max(limit * 4, limit, 20)
@@ -596,17 +608,35 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
             "error": f"role must be one of {list(_LCM_GREP_VALID_ROLES)}",
         })
 
-    time_from, time_from_error = _parse_iso8601_arg("time_from", args.get("time_from"))
+    raw_time_from_arg = args.get("time_from")
+    raw_time_to_arg = args.get("time_to")
+    time_from, time_from_error = _parse_iso8601_arg("time_from", raw_time_from_arg)
     if time_from_error:
         return json.dumps({"error": time_from_error})
-    time_to, time_to_error = _parse_iso8601_arg("time_to", args.get("time_to"))
+    time_to, time_to_error = _parse_iso8601_arg("time_to", raw_time_to_arg)
     if time_to_error:
         return json.dumps({"error": time_to_error})
+    if time_from is not None and time_to is not None and time_from > time_to:
+        return json.dumps({
+            "error": "time_from must be less than or equal to time_to",
+        })
 
     if requested_session_scope == "current":
         if explicit_session_id:
             return json.dumps({
                 "error": "session_id is only valid with session_scope=session",
+            })
+        # Defensive guard: when no current session is bound, the underlying
+        # truthiness-based filter in MessageStore.search/SummaryDAG.search
+        # would silently widen to all sessions. That is a pre-existing data-
+        # layer bug; here we explicitly refuse to leak cross-session results
+        # under the documented current-session contract.
+        if not engine._session_id:
+            return json.dumps({
+                "error": (
+                    "session_scope=current has no active session bound; "
+                    "use session_scope=all or session_scope=session with an explicit session_id"
+                ),
             })
         search_session_id: str | None = engine._session_id
         session_scope = "current"
@@ -634,6 +664,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         )
 
     current_session_id = engine._session_id
+    has_current_session = bool(current_session_id)
     results: list[Dict[str, Any]] = []
 
     try:
@@ -656,7 +687,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "role": hit["role"],
                     "timestamp": timestamp_value,
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
-                    "from_current_session": hit["session_id"] == current_session_id,
+                    "from_current_session": has_current_session and hit["session_id"] == current_session_id,
                     "_sort_ts": timestamp_value,
                     "_sort_rank": hit.get("search_rank"),
                     "_sort_directness": hit.get("_directness_score") or 0.0,
@@ -684,7 +715,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                 "expand_hint": node.expand_hint,
                 "earliest_at": node.earliest_at,
                 "latest_at": node.latest_at,
-                "from_current_session": node.session_id == current_session_id,
+                "from_current_session": has_current_session and node.session_id == current_session_id,
                 "_sort_ts": node.latest_at or node.created_at,
                 "_sort_rank": node.search_rank,
                 "_sort_directness": node.search_directness or 0.0,
@@ -745,9 +776,12 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         response["role"] = role_filter
         response["role_filter_applies"] = "messages_only"
     if time_from is not None:
-        response["time_from"] = time_from
+        # Echo the caller's original argument so the response shape matches the
+        # schema-declared input type (ISO 8601 string when given as a string;
+        # numeric Unix seconds when given numerically).
+        response["time_from"] = raw_time_from_arg if not isinstance(raw_time_from_arg, str) else raw_time_from_arg.strip()
     if time_to is not None:
-        response["time_to"] = time_to
+        response["time_to"] = raw_time_to_arg if not isinstance(raw_time_to_arg, str) else raw_time_to_arg.strip()
     if requested_limit > _LCM_GREP_HARD_LIMIT_CAP:
         response["limit_clamped_from"] = requested_limit
     if requested_session_scope not in _LCM_GREP_VALID_SCOPES:
@@ -892,22 +926,24 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     if raw_store_id_arg is not None:
         try:
             store_id = int(raw_store_id_arg)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return json.dumps({"error": "store_id must be an integer"})
         stored = engine._store.get(store_id)
         if stored is None:
             return json.dumps({"error": f"Message store_id {store_id} not found"})
         transcript_content = stored.get("content", "") or ""
         sliced = _slice_content_for_response(transcript_content, max_tokens, content_offset)
+        engine_session_id = engine._session_id
+        stored_session_id = stored.get("session_id", "")
         result: Dict[str, Any] = {
             "store_id": store_id,
             "source_type": "raw_message",
-            "session_id": stored.get("session_id", ""),
+            "session_id": stored_session_id,
             "source": stored.get("source") or "",
             "role": stored.get("role"),
             "timestamp": stored.get("timestamp", 0),
             "tool_call_id": stored.get("tool_call_id") or "",
-            "from_current_session": stored.get("session_id") == engine._session_id,
+            "from_current_session": bool(engine_session_id) and stored_session_id == engine_session_id,
             "content": sliced["content"],
             "content_chars": sliced["content_chars"],
             "content_offset": sliced["content_offset"],
@@ -919,16 +955,22 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         # Surface externalized-payload metadata when the row references one. Content
         # is not hydrated by default, mirroring the existing _expand_message_sources
         # default. Externalized lookup remains session-scoped (per the existing
-        # _get_externalized_payload contract).
+        # _get_externalized_payload contract); cross-session rows surface only the
+        # ref string, with a hint pointing at the same-session expansion path.
         ref = extract_externalized_ref(transcript_content)
         if ref:
             result["externalized_ref"] = ref
-            if stored.get("session_id") == engine._session_id:
+            if bool(engine_session_id) and stored_session_id == engine_session_id:
                 payload = _get_externalized_payload(engine, ref)
                 if payload is not None:
                     payload_summary = dict(payload)
                     payload_summary.pop("content", None)
                     result["externalized"] = payload_summary
+            else:
+                result["externalized_note"] = (
+                    "Externalized payload metadata is session-scoped; "
+                    "cross-session ref is surfaced for traceability only and cannot be expanded in this version."
+                )
         return json.dumps(result)
 
     node_id = raw_node_id_arg

--- a/tools.py
+++ b/tools.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -153,41 +152,7 @@ def _parse_positive_int(value: Any, default: int) -> int:
 
 
 _LCM_GREP_VALID_SCOPES = frozenset({"current", "all", "session"})
-_LCM_GREP_VALID_ROLES = frozenset({"user", "assistant", "tool"})
 _LCM_GREP_HARD_LIMIT_CAP = 200
-
-
-def _parse_iso8601_arg(name: str, value: Any) -> tuple[float | None, str | None]:
-    """Parse an ISO 8601 string (or numeric Unix timestamp) into Unix seconds.
-
-    Naive datetimes (no ``Z`` and no offset) are rejected so cross-machine
-    time-window filters stay reproducible regardless of host timezone.
-
-    Returns ``(timestamp_or_none, error_or_none)``. ``None`` for ``value``
-    means the caller did not supply the argument and is not an error.
-    """
-    if value is None:
-        return None, None
-    if isinstance(value, bool):
-        return None, f"{name} must be an ISO 8601 string"
-    if isinstance(value, (int, float)):
-        return float(value), None
-    if not isinstance(value, str):
-        return None, f"{name} must be an ISO 8601 string"
-    text = value.strip()
-    if not text:
-        return None, None
-    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None, f"{name} is not a valid ISO 8601 timestamp"
-    if parsed.tzinfo is None:
-        return None, (
-            f"{name} must include a timezone (Z or +HH:MM); "
-            "naive datetimes are rejected to keep filters reproducible across machines"
-        )
-    return parsed.timestamp(), None
 
 
 def _slice_content_for_response(content: str, max_tokens: int, content_offset: int = 0) -> dict[str, Any]:
@@ -567,13 +532,15 @@ def _synthesize_expansion_answer(
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
-    """Search raw messages + summaries with optional cross-session scoping and filters.
+    """Search raw messages + summaries with optional cross-session scoping.
 
-    Default scope is the current session, preserving historical behavior. Callers may
-    explicitly request ``session_scope='all'`` (every session in the local LCM
-    database) or ``session_scope='session'`` (a single ``session_id``). Optional
-    ``role`` and ``time_from``/``time_to`` filters narrow results further. ``limit``
-    is clamped to ``_LCM_GREP_HARD_LIMIT_CAP`` regardless of input.
+    Default scope is the current session, preserving historical behavior and returning
+    both raw-message and summary-node hits. Callers may explicitly request
+    ``session_scope='all'`` (every session in the local LCM database) or
+    ``session_scope='session'`` (a single ``session_id``); broader scopes return
+    raw-message hits only and exist for bounded archive recovery over rows already
+    present in ``lcm.db``. ``limit`` is clamped to ``_LCM_GREP_HARD_LIMIT_CAP``
+    regardless of input.
     """
     engine = _require_engine(kwargs)
     if engine is None:
@@ -599,45 +566,14 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     )
     source = str(args.get("source") or "").strip() or None
 
-    raw_role_arg = args.get("role")
-    role_filter = (
-        str(raw_role_arg).strip().lower() if raw_role_arg is not None else ""
-    ) or None
-    if role_filter is not None and role_filter not in _LCM_GREP_VALID_ROLES:
-        return json.dumps({
-            "error": f"role must be one of {list(_LCM_GREP_VALID_ROLES)}",
-        })
-
-    raw_time_from_arg = args.get("time_from")
-    raw_time_to_arg = args.get("time_to")
-    time_from, time_from_error = _parse_iso8601_arg("time_from", raw_time_from_arg)
-    if time_from_error:
-        return json.dumps({"error": time_from_error})
-    time_to, time_to_error = _parse_iso8601_arg("time_to", raw_time_to_arg)
-    if time_to_error:
-        return json.dumps({"error": time_to_error})
-    if time_from is not None and time_to is not None and time_from > time_to:
-        return json.dumps({
-            "error": "time_from must be less than or equal to time_to",
-        })
-
     if requested_session_scope == "current":
         if explicit_session_id:
             return json.dumps({
                 "error": "session_id is only valid with session_scope=session",
             })
-        # Defensive guard: when no current session is bound, the underlying
-        # truthiness-based filter in MessageStore.search/SummaryDAG.search
-        # would silently widen to all sessions. That is a pre-existing data-
-        # layer bug; here we explicitly refuse to leak cross-session results
-        # under the documented current-session contract.
-        if not engine._session_id:
-            return json.dumps({
-                "error": (
-                    "session_scope=current has no active session bound; "
-                    "use session_scope=all or session_scope=session with an explicit session_id"
-                ),
-            })
+        # MessageStore.search and SummaryDAG.search treat session_id="" as a
+        # literal scoped filter, so an unbound engine searching scope=current
+        # returns zero results rather than leaking cross-session matches.
         search_session_id: str | None = engine._session_id
         session_scope = "current"
     elif requested_session_scope == "all":
@@ -655,7 +591,10 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         search_session_id = explicit_session_id
         session_scope = "session"
     else:
-        # Preserve historical behavior for unknown scopes: stay current and report.
+        # Preserve historical behavior for unknown scopes: route through the
+        # current-session path and report. The data-layer empty-string scoping
+        # contract keeps an unbound engine from leaking cross-session matches
+        # here too.
         search_session_id = engine._session_id
         session_scope = "current"
         logger.warning(
@@ -696,54 +635,40 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     except Exception as exc:
         logger.warning("Message search failed: %s", exc)
 
-    try:
-        node_hits = engine._dag.search(
-            query,
-            session_id=search_session_id,
-            limit=source_limit,
-            sort=sort,
-            source=source,
-        )
-        for node in node_hits:
-            entry: Dict[str, Any] = {
-                "type": "summary",
-                "depth": f"d{node.depth}",
-                "node_id": node.node_id,
-                "session_id": node.session_id,
-                "snippet": node.summary[:300],
-                "token_count": node.token_count,
-                "expand_hint": node.expand_hint,
-                "earliest_at": node.earliest_at,
-                "latest_at": node.latest_at,
-                "from_current_session": has_current_session and node.session_id == current_session_id,
-                "_sort_ts": node.latest_at or node.created_at,
-                "_sort_rank": node.search_rank,
-                "_sort_directness": node.search_directness or 0.0,
-            }
-            if session_scope != "current" and node.session_id != current_session_id:
-                # Cross-session DAG expansion is intentionally deferred. Mark
-                # these hits so callers do not attempt node_id-based expansion.
-                entry["cross_session_expand_supported"] = False
-            results.append(entry)
-    except Exception as exc:
-        logger.warning("Node search failed: %s", exc)
-
-    if role_filter is not None:
-        # Role applies to message hits; summary hits have no role field.
-        results = [
-            result for result in results
-            if result.get("type") != "message" or result.get("role") == role_filter
-        ]
-
-    if time_from is not None or time_to is not None:
-        def _within_window(result: Dict[str, Any]) -> bool:
-            ts = float(result.get("_sort_ts") or 0)
-            if time_from is not None and ts < time_from:
-                return False
-            if time_to is not None and ts > time_to:
-                return False
-            return True
-        results = [result for result in results if _within_window(result)]
+    # Summary-node search is intentionally current-session only. Cross-session
+    # DAG expansion is deferred; returning summary hits without an expansion
+    # contract would push this tool toward a memory-system shape rather than
+    # a plugin-local archive search. Raw-message hits remain expandable across
+    # sessions via lcm_expand(store_id=...).
+    if session_scope == "current":
+        try:
+            node_hits = engine._dag.search(
+                query,
+                session_id=search_session_id,
+                limit=source_limit,
+                sort=sort,
+                source=source,
+            )
+            for node in node_hits:
+                results.append(
+                    {
+                        "type": "summary",
+                        "depth": f"d{node.depth}",
+                        "node_id": node.node_id,
+                        "session_id": node.session_id,
+                        "snippet": node.summary[:300],
+                        "token_count": node.token_count,
+                        "expand_hint": node.expand_hint,
+                        "earliest_at": node.earliest_at,
+                        "latest_at": node.latest_at,
+                        "from_current_session": True,
+                        "_sort_ts": node.latest_at or node.created_at,
+                        "_sort_rank": node.search_rank,
+                        "_sort_directness": node.search_directness or 0.0,
+                    }
+                )
+        except Exception as exc:
+            logger.warning("Node search failed: %s", exc)
 
     if sort == "hybrid":
         max_message_directness = max(
@@ -772,16 +697,6 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     }
     if session_scope == "session":
         response["session_id"] = explicit_session_id
-    if role_filter is not None:
-        response["role"] = role_filter
-        response["role_filter_applies"] = "messages_only"
-    if time_from is not None:
-        # Echo the caller's original argument so the response shape matches the
-        # schema-declared input type (ISO 8601 string when given as a string;
-        # numeric Unix seconds when given numerically).
-        response["time_from"] = raw_time_from_arg if not isinstance(raw_time_from_arg, str) else raw_time_from_arg.strip()
-    if time_to is not None:
-        response["time_to"] = raw_time_to_arg if not isinstance(raw_time_to_arg, str) else raw_time_to_arg.strip()
     if requested_limit > _LCM_GREP_HARD_LIMIT_CAP:
         response["limit_clamped_from"] = requested_limit
     if requested_session_scope not in _LCM_GREP_VALID_SCOPES:


### PR DESCRIPTION
## Summary
- `lcm_grep` gains explicit opt-in `session_scope='all'` and `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`. Default `session_scope='current'` is preserved byte-for-byte.
- Cross-session scopes return raw-message hits only. Cross-session DAG/summary expansion is intentionally deferred.
- `lcm_expand` gains a `store_id` mode that fetches a single raw message regardless of session, paged via `content_offset`. `node_id` and `externalized_ref` modes remain current-session.
- `limit` is clamped to 200 with `limit_clamped_from` echoed when the input exceeds the cap.
- Each result carries `from_current_session` so callers can prefer in-session expansion paths when both are available.

## Why
- Closes the gap that `lcm_grep` is unreachable for rows already present in the plugin-local LCM database, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`.
- The narrowing positions this as **bounded archive recovery**, not a memory-system expansion. Tool descriptions continue to direct normal cross-session recall to `session_search`.
- No claim of an official OpenClaw/lossless-claw importer; the feature stands on rows-already-present.
- Refs #101.

## Validation
- `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> **402 passed**
- `pytest -q` -> **439 passed**
- `python3 -m compileall -q .` -> clean
- `bash -n scripts/install.sh scripts/update.sh` -> clean
- `git diff --check origin/main` -> clean

## Notes
- **Rebased** onto current `main` (past #104 and #106). Branch history was rewritten and force-pushed accordingly. GitHub Actions check runs on a fork PR from a non-collaborator require maintainer approval to run; the empty checks on the head are a permissions thing, not a CI failure.
- **Defers to follow-up issue #108**: pushing `role`/`time_from`/`time_to` filters into the search layer. The maintainer's Bug 2 reproduction is captured as the regression contract on that issue.
- **Cross-session DAG/summary expansion** stays deferred. Sessions remain bound on source-id provenance; returning non-expandable summary hits would push this tool toward a broader memory-system shape than the maintainer's scope direction allows.
- **`lcm_expand` store_id mode** is the only cross-session drilldown path in this PR.
- Empty-engine-session safety relies on the data-layer fix from #104 (empty `session_id` is now a literal scoped filter); the unknown-scope fallback routes through current-session and naturally returns zero results rather than leaking.