### PR TITLE
fix: treat empty session ids as scoped search filters

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -335,6 +335,8 @@ class SummaryDAG:
 
         Retrieval contract:
         - ``session_id`` limits which sessions are eligible
+        - ``session_id=None`` means all sessions; an empty string is treated as
+          a literal session id
         - ``source`` filters summaries by descendant raw-message lineage, not by
           session-level source presence
         - mixed-source nodes may match more than one ``source`` filter
@@ -356,7 +358,7 @@ class SummaryDAG:
         source_match_cache: dict[int, bool] = {}
         while True:
             try:
-                if session_id:
+                if session_id is not None:
                     rows = self._conn.execute(
                         f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
                            JOIN summary_nodes n ON n.node_id = fts.rowid
@@ -420,7 +422,7 @@ class SummaryDAG:
 
         where: list[str] = ["summary IS NOT NULL"]
         args: list[Any] = []
-        if session_id:
+        if session_id is not None:
             where.append("session_id = ?")
             args.append(session_id)
         like_clauses = []

--- a/store.py
+++ b/store.py
@@ -538,6 +538,8 @@ class MessageStore:
 
         Retrieval contract:
         - ``session_id`` limits which sessions are eligible
+        - ``session_id=None`` means all sessions; an empty string is treated as
+          a literal session id
         - ``source`` limits which raw rows inside those sessions are eligible
         - ``source='unknown'`` means the explicit unknown-source bucket, with
           legacy blank-source rows treated as equivalent for back-compat
@@ -565,7 +567,7 @@ class MessageStore:
             try:
                 where = ["messages_fts MATCH ?"]
                 args: list[Any] = [safe_query]
-                if session_id:
+                if session_id is not None:
                     where.append("m.session_id = ?")
                     args.append(session_id)
                 if source_clause:
@@ -632,7 +634,7 @@ class MessageStore:
 
         where: list[str] = ["content IS NOT NULL"]
         args: list[Any] = []
-        if session_id:
+        if session_id is not None:
             where.append("session_id = ?")
             args.append(session_id)
         source_clause, source_args = _source_filter_clause("source", source)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -504,6 +504,27 @@ class TestMessageStore:
         results = store.search("docker", session_id="sess1")
         assert len(results) >= 1
 
+    def test_search_empty_session_id_does_not_search_all_sessions(self, store):
+        store.append("sess1", {"role": "user", "content": "deploy docker from session one"})
+        store.append("sess2", {"role": "user", "content": "deploy docker from session two"})
+
+        scoped_results = store.search("docker", session_id="")
+        all_results = store.search("docker", session_id=None, limit=10)
+
+        assert scoped_results == []
+        assert {result["session_id"] for result in all_results} == {"sess1", "sess2"}
+
+    def test_search_like_fallback_empty_session_id_does_not_search_all_sessions(self, store):
+        store.append("sess1", {"role": "user", "content": "foo bar baz session one"})
+        store.append("sess2", {"role": "user", "content": "foo bar baz session two"})
+        store._conn.execute("DROP TABLE messages_fts")
+
+        scoped_results = store.search('foo"bar', session_id="")
+        all_results = store.search('foo"bar', session_id=None, limit=10)
+
+        assert scoped_results == []
+        assert {result["session_id"] for result in all_results} == {"sess1", "sess2"}
+
     def test_source_stored_and_filterable(self, store):
         store.append("sess1", {"role": "user", "content": "docker in cli"}, source="cli")
         store.append("sess2", {"role": "user", "content": "docker in discord"}, source="discord")
@@ -1917,6 +1938,43 @@ class TestSummaryDAG:
         ))
         results = dag.search("Docker", session_id="s1")
         assert len(results) >= 1
+
+    def test_search_empty_session_id_does_not_search_all_sessions(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="Docker containers for session one",
+            token_count=10, source_ids=[1], source_type="messages",
+        ))
+        dag.add_node(SummaryNode(
+            session_id="s2", depth=0,
+            summary="Docker containers for session two",
+            token_count=10, source_ids=[2], source_type="messages",
+        ))
+
+        scoped_results = dag.search("Docker", session_id="")
+        all_results = dag.search("Docker", session_id=None, limit=10)
+
+        assert scoped_results == []
+        assert {node.session_id for node in all_results} == {"s1", "s2"}
+
+    def test_search_like_fallback_empty_session_id_does_not_search_all_sessions(self, dag):
+        dag.add_node(SummaryNode(
+            session_id="s1", depth=0,
+            summary="foo bar baz session one",
+            token_count=10, source_ids=[1], source_type="messages",
+        ))
+        dag.add_node(SummaryNode(
+            session_id="s2", depth=0,
+            summary="foo bar baz session two",
+            token_count=10, source_ids=[2], source_type="messages",
+        ))
+        dag._conn.execute("DROP TABLE nodes_fts")
+
+        scoped_results = dag.search('foo"bar', session_id="")
+        all_results = dag.search('foo"bar', session_id=None, limit=10)
+
+        assert scoped_results == []
+        assert {node.session_id for node in all_results} == {"s1", "s2"}
 
     def test_init_repairs_malformed_nodes_fts_and_sets_schema_version(self, tmp_path):
         db_path = tmp_path / "legacy-dag.db"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5240,6 +5240,19 @@ class TestEngineTools:
         result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
         assert "results" in result
 
+    def test_handle_grep_unbound_current_session_does_not_search_all_sessions(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "unbound-current-session.db"))
+        instance = LCMEngine(config=config)
+        assert instance._session_id == ""
+        instance._store.append("session-a", {"role": "user", "content": "docker from session a"})
+        instance._store.append("session-b", {"role": "user", "content": "docker from session b"})
+
+        result = json.loads(instance.handle_tool_call("lcm_grep", {"query": "docker", "limit": 10}))
+
+        assert result["session_scope"] == "current"
+        assert result["total_results"] == 0
+        assert result["results"] == []
+
     def test_handle_grep_reports_sort_mode(self, engine):
         engine._store.append(
             "test-session",


### PR DESCRIPTION
## Summary
- Treat `session_id=""` as a literal scoped session filter in `MessageStore.search` and `SummaryDAG.search`.
- Keep `session_id=None` as the explicit all-sessions sentinel.
- Add regression coverage for FTS, LIKE fallback, and unbound `lcm_grep` current-session behavior.

## Why
- `LCMEngine` starts with `_session_id = ""` before a real session is bound.
- The old truthiness checks treated that empty value like no filter, so current-session search could return rows from other sessions.
- The fix makes the data-layer contract explicit: only `None` means all sessions.

Fixes #103

## Validation
- RED: `python -m pytest tests/test_lcm_core.py::TestMessageStore::test_search_empty_session_id_does_not_search_all_sessions tests/test_lcm_core.py::TestMessageStore::test_search_like_fallback_empty_session_id_does_not_search_all_sessions tests/test_lcm_core.py::TestSummaryDAG::test_search_empty_session_id_does_not_search_all_sessions tests/test_lcm_core.py::TestSummaryDAG::test_search_like_fallback_empty_session_id_does_not_search_all_sessions tests/test_lcm_engine.py::TestEngineTools::test_handle_grep_unbound_current_session_does_not_search_all_sessions -q` failed before the fix with 5 failures.
- GREEN: same focused command passed after the fix, 5 passed.
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` hit local fd exhaustion after 349 passed.
- `ulimit -n 8192; python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` passed, 379 passed, 38 warnings.
- `ulimit -n 8192; python -m pytest -q -o addopts=` passed, 416 passed, 38 warnings.
- `python -m compileall -q .` passed.
- `bash -n scripts/install.sh scripts/update.sh` passed.
- `git diff --check` passed.

## Notes
- Independent delegate review approved the diff before commit.
- No user-facing command schema changes.