### PR TITLE
feat: add lossless-claw LCM importer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Default validation for code changes:
 pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
 pytest -q
 python -m compileall -q .
+python -m py_compile scripts/import_lossless_claw.py
 bash -n scripts/install.sh scripts/update.sh
 git diff --check
 ```

--- a/README.md
+++ b/README.md
@@ -299,10 +299,11 @@ The script is intentionally conservative:
 - writes create a timestamped target DB backup first when the target already exists
 - only raw messages are imported; summary DAG import is out of scope
 - imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:<source-session>`
-- the default provenance identity is the concrete source `conversations.session_id`, preserving source conversation boundaries even when many conversations share one `session_key`
+- the default provenance identity is the concrete source `conversations.session_id`, preserving source session boundaries even when many conversations share one `session_key`
 - pass `--session-identity session_key` only when you intentionally want conversations with the same source session key grouped into one imported LCM session
 - reruns are idempotent for the same `--import-id`; the default `import_id` is path-derived, so pass a stable `--import-id` if you may import the same copied DB from different paths
-- no OpenClaw secrets, config, or general memory data are imported
+- changing `--agent`, `--namespace`, or `--session-identity` under the same `--import-id` is treated as the same import and will skip already-tracked source messages; use a new `--import-id` for a different mapping
+- no OpenClaw config or separate secret tables are imported, but raw transcripts and tool payloads are imported and may contain sensitive user data
 
 This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,29 @@ be recovered in deterministic pages.
 - `lcm_expand(externalized_ref=...)` pages payload content with `content_offset`
 - `lcm_expand_query` uses `context_max_tokens` for auxiliary context and reports truncation/pagination hints when needed
 
+### lossless-claw/OpenClaw import utility
+
+`hermes-lcm` includes an opt-in operator script for backfilling raw message rows from a lossless-claw/OpenClaw LCM SQLite database into the local hermes-lcm SQLite store:
+
+```bash
+python scripts/import_lossless_claw.py \
+  --source-db ~/.openclaw/path/to/lcm.db \
+  --target-db ~/.hermes/lcm.db \
+  --agent sammy
+```
+
+The script is intentionally conservative:
+
+- dry-run is the default; pass `--apply` to write
+- run it against an explicit target DB path, preferably while Hermes is stopped for that profile
+- writes create a timestamped target DB backup first when the target already exists
+- only raw messages are imported; summary DAG import is out of scope
+- imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:telegram:direct:...`
+- reruns are idempotent for the same `--import-id`
+- no OpenClaw secrets, config, or general memory data are imported
+
+This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
+
 ## Slash Commands
 
 Slash commands are disabled by default. Enable them only in trusted operator

--- a/README.md
+++ b/README.md
@@ -298,8 +298,10 @@ The script is intentionally conservative:
 - run it against an explicit target DB path, preferably while Hermes is stopped for that profile
 - writes create a timestamped target DB backup first when the target already exists
 - only raw messages are imported; summary DAG import is out of scope
-- imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:telegram:direct:...`
-- reruns are idempotent for the same `--import-id`
+- imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:<source-session>`
+- the default provenance identity is the concrete source `conversations.session_id`, preserving source conversation boundaries even when many conversations share one `session_key`
+- pass `--session-identity session_key` only when you intentionally want conversations with the same source session key grouped into one imported LCM session
+- reruns are idempotent for the same `--import-id`; the default `import_id` is path-derived, so pass a stable `--import-id` if you may import the same copied DB from different paths
 - no OpenClaw secrets, config, or general memory data are imported
 
 This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.

--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -40,6 +40,9 @@ from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
 from hermes_lcm.tokens import count_message_tokens  # noqa: E402
 
 
+VALID_SESSION_IDENTITIES = frozenset({"session_id", "session_key"})
+
+
 @dataclass(frozen=True)
 class ImportCandidate:
     source_message_id: int
@@ -159,6 +162,29 @@ def _safe_segment(value: Any, fallback: str) -> str:
 
 def _target_source(namespace: str, agent: str, source_session: str) -> str:
     return f"{_safe_segment(namespace, 'openclaw-lcm')}:agent:{_safe_segment(agent, 'unknown')}:{source_session}"
+
+
+def _resolve_source_session(
+    row: sqlite3.Row,
+    *,
+    conversation_id: int,
+    session_identity: str,
+) -> str:
+    if session_identity not in VALID_SESSION_IDENTITIES:
+        raise ValueError(
+            "session_identity must be one of "
+            + ", ".join(sorted(VALID_SESSION_IDENTITIES))
+        )
+    fallback = f"conversation:{conversation_id}"
+    if session_identity == "session_key":
+        return _safe_segment(
+            row["conversation_session_key"] or row["conversation_session_id"],
+            fallback,
+        )
+    return _safe_segment(
+        row["conversation_session_id"] or row["conversation_session_key"],
+        fallback,
+    )
 
 
 def _load_parts(conn: sqlite3.Connection) -> dict[int, list[sqlite3.Row]]:
@@ -296,6 +322,7 @@ def _collect_candidates(
     *,
     namespace: str,
     agent: str,
+    session_identity: str = "session_id",
 ) -> tuple[list[ImportCandidate], int, int, int]:
     _require_columns(conn, "conversations", ["conversation_id", "session_id"])
     _require_columns(conn, "messages", ["message_id", "conversation_id", "seq", "role", "content"])
@@ -342,9 +369,10 @@ def _collect_candidates(
 
         conversation_id = int(row["conversation_id"])
         conversation_ids.add(conversation_id)
-        source_session = _safe_segment(
-            row["conversation_session_key"] or row["conversation_session_id"],
-            f"conversation:{conversation_id}",
+        source_session = _resolve_source_session(
+            row,
+            conversation_id=conversation_id,
+            session_identity=session_identity,
         )
         source = _target_source(namespace, agent, source_session)
         msg = {"role": role, "content": content}
@@ -444,17 +472,24 @@ def import_lossless_claw(
     namespace: str = "openclaw-lcm",
     agent: str = "unknown",
     import_id: str | None = None,
+    session_identity: str = "session_id",
     apply: bool = False,
 ) -> ImportResult:
     source_path = Path(source_db)
     target_path = Path(target_db)
     resolved_import_id = import_id or _default_import_id(source_path)
+    if session_identity not in VALID_SESSION_IDENTITIES:
+        raise ValueError(
+            "session_identity must be one of "
+            + ", ".join(sorted(VALID_SESSION_IDENTITIES))
+        )
 
     with _connect_readonly(source_path) as source_conn:
         candidates, scanned, skipped_empty, conversations = _collect_candidates(
             source_conn,
             namespace=namespace,
             agent=agent,
+            session_identity=session_identity,
         )
 
     existing_ids = _existing_source_message_ids(target_path, resolved_import_id)
@@ -564,6 +599,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--namespace", default="openclaw-lcm", help="Provenance namespace for imported rows")
     parser.add_argument("--agent", default="unknown", help="Source OpenClaw agent/profile label for provenance")
     parser.add_argument("--import-id", help="Stable idempotency key. Defaults to a hash of the source DB path")
+    parser.add_argument(
+        "--session-identity",
+        choices=sorted(VALID_SESSION_IDENTITIES),
+        default="session_id",
+        help=(
+            "Source conversation field used for imported session_id/source provenance. "
+            "Default session_id preserves concrete source conversation boundaries; "
+            "session_key intentionally groups conversations sharing the same key."
+        ),
+    )
     parser.add_argument("--apply", action="store_true", help="Write rows to the target DB. Omit for dry-run")
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON summary")
     return parser
@@ -578,6 +623,7 @@ def main(argv: list[str] | None = None) -> int:
         namespace=args.namespace,
         agent=args.agent,
         import_id=args.import_id,
+        session_identity=args.session_identity,
         apply=args.apply,
     )
     if args.json:

--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Import raw messages from a lossless-claw/OpenClaw LCM SQLite DB.
+
+This is an operator script, not an agent tool. It only writes when --apply is
+passed; dry-run is the default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+import time
+import types
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = "hermes_lcm"
+
+
+def _ensure_local_package_importable() -> None:
+    """Make local plugin modules importable when this file is run directly."""
+    if PACKAGE_NAME in sys.modules:
+        return
+    pkg = types.ModuleType(PACKAGE_NAME)
+    pkg.__path__ = [str(PLUGIN_DIR)]
+    pkg.__package__ = PACKAGE_NAME
+    sys.modules[PACKAGE_NAME] = pkg
+
+
+_ensure_local_package_importable()
+
+from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
+from hermes_lcm.tokens import count_message_tokens  # noqa: E402
+
+
+@dataclass(frozen=True)
+class ImportCandidate:
+    source_message_id: int
+    source_conversation_id: int
+    source_session: str
+    target_session_id: str
+    source: str
+    role: str
+    content: str
+    tool_call_id: str | None
+    tool_calls: list[dict[str, Any]] | None
+    tool_name: str | None
+    timestamp: float
+    token_estimate: int
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    source_db: str
+    target_db: str
+    import_id: str
+    scanned: int = 0
+    eligible: int = 0
+    would_import: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    skipped_empty: int = 0
+    conversations: int = 0
+    backup_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_db": self.source_db,
+            "target_db": self.target_db,
+            "import_id": self.import_id,
+            "scanned": self.scanned,
+            "eligible": self.eligible,
+            "would_import": self.would_import,
+            "imported": self.imported,
+            "skipped_existing": self.skipped_existing,
+            "skipped_empty": self.skipped_empty,
+            "conversations": self.conversations,
+            "backup_path": self.backup_path,
+        }
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    if not db_path.is_file():
+        raise FileNotFoundError(f"source DB not found: {db_path}")
+    uri = f"file:{db_path.resolve()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _quote_identifier(identifier: str) -> str:
+    if not identifier.replace("_", "").isalnum():
+        raise ValueError(f"unsafe SQLite identifier: {identifier!r}")
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    sql = "PRAGMA table_info(" + _quote_identifier(table) + ")"
+    return {row[1] for row in conn.execute(sql)}
+
+
+def _require_columns(conn: sqlite3.Connection, table: str, columns: Iterable[str]) -> None:
+    actual = _table_columns(conn, table)
+    missing = [column for column in columns if column not in actual]
+    if missing:
+        raise ValueError(f"source DB table {table!r} missing required columns: {', '.join(missing)}")
+
+
+def _default_import_id(source_db: Path) -> str:
+    return hashlib.sha256(str(source_db.resolve()).encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_timestamp(value: Any, fallback: float) -> float:
+    if value is None:
+        return fallback
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return fallback
+    normalized = text.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            try:
+                dt = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                dt = None
+        if dt is None:
+            return fallback
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).timestamp()
+
+
+def _safe_segment(value: Any, fallback: str) -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _target_source(namespace: str, agent: str, source_session: str) -> str:
+    return f"{_safe_segment(namespace, 'openclaw-lcm')}:agent:{_safe_segment(agent, 'unknown')}:{source_session}"
+
+
+def _load_parts(conn: sqlite3.Connection) -> dict[int, list[sqlite3.Row]]:
+    if not _table_exists(conn, "message_parts"):
+        return {}
+    columns = _table_columns(conn, "message_parts")
+    if "message_id" not in columns or "ordinal" not in columns:
+        return {}
+
+    wanted = [
+        "message_id",
+        "part_type",
+        "ordinal",
+        "text_content",
+        "is_ignored",
+        "is_synthetic",
+        "tool_call_id",
+        "tool_name",
+        "tool_input",
+        "tool_output",
+        "tool_error",
+        "metadata",
+    ]
+    select_cols = [column if column in columns else f"NULL AS {column}" for column in wanted]
+    rows = conn.execute(
+        f"SELECT {', '.join(select_cols)} FROM message_parts ORDER BY message_id, ordinal"
+    ).fetchall()
+    by_message: dict[int, list[sqlite3.Row]] = {}
+    for row in rows:
+        by_message.setdefault(int(row["message_id"]), []).append(row)
+    return by_message
+
+
+def _metadata_value(part: sqlite3.Row, *keys: str) -> Any:
+    raw = part["metadata"]
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        if key in data and data[key] is not None:
+            return data[key]
+    raw_obj = data.get("raw")
+    if isinstance(raw_obj, dict):
+        for key in keys:
+            if key in raw_obj and raw_obj[key] is not None:
+                return raw_obj[key]
+    return None
+
+
+def _part_value(part: sqlite3.Row, column: str, *metadata_keys: str) -> Any:
+    value = part[column]
+    if value not in (None, ""):
+        return value
+    return _metadata_value(part, *metadata_keys)
+
+
+def _stringify_tool_payload(value: Any) -> str:
+    if value is None:
+        return "{}"
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _message_from_parts(role: str, content: str, parts: list[sqlite3.Row]) -> tuple[str, str | None, list[dict[str, Any]] | None, str | None]:
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_result_parts: list[str] = []
+
+    for part in parts:
+        if part["is_ignored"] or part["is_synthetic"]:
+            continue
+        part_type = str(part["part_type"] or "")
+        text_content = part["text_content"]
+        if part_type == "text" and text_content:
+            text_parts.append(str(text_content))
+            continue
+        if part_type != "tool":
+            continue
+
+        candidate_tool_call_id = _part_value(
+            part,
+            "tool_call_id",
+            "toolCallId",
+            "tool_call_id",
+            "toolUseId",
+            "tool_use_id",
+            "call_id",
+            "id",
+        )
+        candidate_tool_name = _part_value(part, "tool_name", "name", "toolName", "tool_name")
+
+        if role == "assistant":
+            if candidate_tool_call_id or candidate_tool_name:
+                tool_calls.append(
+                    {
+                        "id": str(candidate_tool_call_id or f"lossless_tool_{len(tool_calls)}"),
+                        "type": "function",
+                        "function": {
+                            "name": str(candidate_tool_name or "unknown"),
+                            "arguments": _stringify_tool_payload(
+                                _part_value(part, "tool_input", "input", "arguments", "toolInput", "tool_input")
+                            ),
+                        },
+                    }
+                )
+        elif role == "tool":
+            tool_call_id = str(candidate_tool_call_id) if candidate_tool_call_id else tool_call_id
+            tool_name = str(candidate_tool_name) if candidate_tool_name else tool_name
+            output = _part_value(part, "tool_output", "output", "toolOutput", "tool_output")
+            error = _part_value(part, "tool_error", "error", "toolError", "tool_error")
+            if output not in (None, ""):
+                tool_result_parts.append(str(output))
+            elif error not in (None, ""):
+                tool_result_parts.append(str(error))
+            elif text_content:
+                tool_result_parts.append(str(text_content))
+
+    if not content and text_parts:
+        content = "\n".join(text_parts)
+    if role == "tool" and not content and tool_result_parts:
+        content = "\n".join(tool_result_parts)
+    return content, tool_call_id, tool_calls or None, tool_name
+
+
+def _collect_candidates(
+    conn: sqlite3.Connection,
+    *,
+    namespace: str,
+    agent: str,
+) -> tuple[list[ImportCandidate], int, int, int]:
+    _require_columns(conn, "conversations", ["conversation_id", "session_id"])
+    _require_columns(conn, "messages", ["message_id", "conversation_id", "seq", "role", "content"])
+
+    conversation_cols = _table_columns(conn, "conversations")
+    message_cols = _table_columns(conn, "messages")
+    session_key_expr = "c.session_key" if "session_key" in conversation_cols else "NULL"
+    conversation_created_expr = "c.created_at" if "created_at" in conversation_cols else "NULL"
+    message_created_expr = "m.created_at" if "created_at" in message_cols else "NULL"
+    token_count_expr = "m.token_count" if "token_count" in message_cols else "0"
+
+    parts_by_message = _load_parts(conn)
+    rows = conn.execute(
+        f"""
+        SELECT
+            m.message_id,
+            m.conversation_id,
+            m.seq,
+            m.role,
+            m.content,
+            {token_count_expr} AS token_count,
+            {message_created_expr} AS message_created_at,
+            c.session_id AS conversation_session_id,
+            {session_key_expr} AS conversation_session_key,
+            {conversation_created_expr} AS conversation_created_at
+        FROM messages m
+        JOIN conversations c ON c.conversation_id = m.conversation_id
+        ORDER BY m.conversation_id, m.seq
+        """
+    ).fetchall()
+
+    now = time.time()
+    candidates: list[ImportCandidate] = []
+    skipped_empty = 0
+    conversation_ids: set[int] = set()
+    for row in rows:
+        role = str(row["role"] or "unknown")
+        content = str(row["content"] or "")
+        parts = parts_by_message.get(int(row["message_id"]), [])
+        content, tool_call_id, tool_calls, tool_name = _message_from_parts(role, content, parts)
+        if not content and not tool_calls:
+            skipped_empty += 1
+            continue
+
+        conversation_id = int(row["conversation_id"])
+        conversation_ids.add(conversation_id)
+        source_session = _safe_segment(
+            row["conversation_session_key"] or row["conversation_session_id"],
+            f"conversation:{conversation_id}",
+        )
+        source = _target_source(namespace, agent, source_session)
+        msg = {"role": role, "content": content}
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        token_estimate = count_message_tokens(msg)
+        timestamp = _parse_timestamp(
+            row["message_created_at"],
+            _parse_timestamp(row["conversation_created_at"], now),
+        )
+        candidates.append(
+            ImportCandidate(
+                source_message_id=int(row["message_id"]),
+                source_conversation_id=conversation_id,
+                source_session=source_session,
+                target_session_id=source,
+                source=source,
+                role=role,
+                content=content,
+                tool_call_id=tool_call_id,
+                tool_calls=tool_calls,
+                tool_name=tool_name,
+                timestamp=timestamp,
+                token_estimate=token_estimate,
+            )
+        )
+    return candidates, len(rows), skipped_empty, len(conversation_ids)
+
+
+def _target_has_import_table(conn: sqlite3.Connection) -> bool:
+    return _table_exists(conn, "lcm_imported_messages")
+
+
+def _ensure_import_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_imported_messages (
+            import_id TEXT NOT NULL,
+            source_message_id INTEGER NOT NULL,
+            source_conversation_id INTEGER NOT NULL,
+            source_session TEXT NOT NULL,
+            target_store_id INTEGER NOT NULL,
+            imported_at REAL NOT NULL,
+            PRIMARY KEY (import_id, source_message_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_lcm_imported_messages_target
+            ON lcm_imported_messages(target_store_id)
+        """
+    )
+
+
+def _existing_source_message_ids(target_db: Path, import_id: str) -> set[int]:
+    if not target_db.exists():
+        return set()
+    conn = sqlite3.connect(target_db)
+    try:
+        if not _target_has_import_table(conn):
+            return set()
+        rows = conn.execute(
+            "SELECT source_message_id FROM lcm_imported_messages WHERE import_id = ?",
+            (import_id,),
+        ).fetchall()
+        return {int(row[0]) for row in rows}
+    finally:
+        conn.close()
+
+
+def _backup_target(target_db: Path) -> str | None:
+    if not target_db.exists():
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    backup_path = target_db.with_name(f"{target_db.name}.backup-{stamp}")
+    suffix = 1
+    while backup_path.exists():
+        backup_path = target_db.with_name(f"{target_db.name}.backup-{stamp}-{suffix}")
+        suffix += 1
+
+    source_uri = f"file:{target_db.resolve()}?mode=ro"
+    source_conn = sqlite3.connect(source_uri, uri=True)
+    backup_conn = sqlite3.connect(backup_path)
+    try:
+        source_conn.backup(backup_conn)
+    finally:
+        backup_conn.close()
+        source_conn.close()
+    return str(backup_path)
+
+
+def import_lossless_claw(
+    *,
+    source_db: str | Path,
+    target_db: str | Path,
+    namespace: str = "openclaw-lcm",
+    agent: str = "unknown",
+    import_id: str | None = None,
+    apply: bool = False,
+) -> ImportResult:
+    source_path = Path(source_db)
+    target_path = Path(target_db)
+    resolved_import_id = import_id or _default_import_id(source_path)
+
+    with _connect_readonly(source_path) as source_conn:
+        candidates, scanned, skipped_empty, conversations = _collect_candidates(
+            source_conn,
+            namespace=namespace,
+            agent=agent,
+        )
+
+    existing_ids = _existing_source_message_ids(target_path, resolved_import_id)
+    to_import = [candidate for candidate in candidates if candidate.source_message_id not in existing_ids]
+    skipped_existing = len(candidates) - len(to_import)
+
+    if not apply:
+        return ImportResult(
+            source_db=str(source_path),
+            target_db=str(target_path),
+            import_id=resolved_import_id,
+            scanned=scanned,
+            eligible=len(candidates),
+            would_import=len(to_import),
+            imported=0,
+            skipped_existing=skipped_existing,
+            skipped_empty=skipped_empty,
+            conversations=conversations,
+            backup_path=None,
+        )
+
+    if not to_import:
+        return ImportResult(
+            source_db=str(source_path),
+            target_db=str(target_path),
+            import_id=resolved_import_id,
+            scanned=scanned,
+            eligible=len(candidates),
+            would_import=0,
+            imported=0,
+            skipped_existing=skipped_existing,
+            skipped_empty=skipped_empty,
+            conversations=conversations,
+            backup_path=None,
+        )
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    backup_path = _backup_target(target_path)
+    store = MessageStore(target_path)
+    conn = store._conn
+    _ensure_import_table(conn)
+
+    imported = 0
+    try:
+        for candidate in to_import:
+            tool_calls_json = json.dumps(candidate.tool_calls) if candidate.tool_calls else None
+            cur = conn.execute(
+                """INSERT INTO messages
+                   (session_id, source, role, content, tool_call_id, tool_calls,
+                    tool_name, timestamp, token_estimate, pinned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)""",
+                (
+                    candidate.target_session_id,
+                    _normalize_source_value(candidate.source),
+                    candidate.role,
+                    candidate.content,
+                    candidate.tool_call_id,
+                    tool_calls_json,
+                    candidate.tool_name,
+                    candidate.timestamp,
+                    candidate.token_estimate,
+                ),
+            )
+            conn.execute(
+                """INSERT INTO lcm_imported_messages
+                   (import_id, source_message_id, source_conversation_id, source_session,
+                    target_store_id, imported_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    resolved_import_id,
+                    candidate.source_message_id,
+                    candidate.source_conversation_id,
+                    candidate.source_session,
+                    int(cur.lastrowid),
+                    time.time(),
+                ),
+            )
+            imported += 1
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        store.close()
+
+    return ImportResult(
+        source_db=str(source_path),
+        target_db=str(target_path),
+        import_id=resolved_import_id,
+        scanned=scanned,
+        eligible=len(candidates),
+        would_import=0,
+        imported=imported,
+        skipped_existing=skipped_existing,
+        skipped_empty=skipped_empty,
+        conversations=conversations,
+        backup_path=backup_path,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Import raw messages from a lossless-claw/OpenClaw LCM SQLite DB into hermes-lcm.",
+    )
+    parser.add_argument("--source-db", required=True, help="Path to the source lossless-claw/OpenClaw LCM SQLite DB")
+    parser.add_argument("--target-db", required=True, help="Path to the target hermes-lcm SQLite DB")
+    parser.add_argument("--namespace", default="openclaw-lcm", help="Provenance namespace for imported rows")
+    parser.add_argument("--agent", default="unknown", help="Source OpenClaw agent/profile label for provenance")
+    parser.add_argument("--import-id", help="Stable idempotency key. Defaults to a hash of the source DB path")
+    parser.add_argument("--apply", action="store_true", help="Write rows to the target DB. Omit for dry-run")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON summary")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    result = import_lossless_claw(
+        source_db=args.source_db,
+        target_db=args.target_db,
+        namespace=args.namespace,
+        agent=args.agent,
+        import_id=args.import_id,
+        apply=args.apply,
+    )
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        mode = "apply" if args.apply else "dry-run"
+        print(f"lossless-claw import {mode}")
+        print(f"  source_db: {result.source_db}")
+        print(f"  target_db: {result.target_db}")
+        print(f"  import_id: {result.import_id}")
+        print(f"  conversations: {result.conversations}")
+        print(f"  scanned: {result.scanned}")
+        print(f"  eligible: {result.eligible}")
+        print(f"  would_import: {result.would_import}")
+        print(f"  imported: {result.imported}")
+        print(f"  skipped_existing: {result.skipped_existing}")
+        print(f"  skipped_empty: {result.skipped_empty}")
+        if result.backup_path:
+            print(f"  backup_path: {result.backup_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -89,6 +89,82 @@ def create_lossless_source(db_path: Path) -> None:
     conn.close()
 
 
+def add_shared_session_key_conversation(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """INSERT INTO conversations
+           (conversation_id, session_id, session_key, title, created_at, updated_at)
+           VALUES (2, 'runtime-session-2', 'telegram:direct:503782402:conversation:88',
+                   'Second direct', '2026-04-20 12:01:00', '2026-04-20 12:01:00')"""
+    )
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (12, 2, 1, 'user', 'hello from second conversation', 5, '2026-04-20 12:01:01')"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_import_preserves_concrete_session_ids_when_session_key_is_shared(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_shared_session_key_conversation(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert result.imported == 3
+    db = sqlite3.connect(target_db)
+    imported_sessions = db.execute(
+        """SELECT DISTINCT session_id
+           FROM messages
+           WHERE source != 'existing-source'
+           ORDER BY session_id"""
+    ).fetchall()
+    db.close()
+
+    assert imported_sessions == [
+        ("openclaw-lcm:agent:sammy:runtime-session-1",),
+        ("openclaw-lcm:agent:sammy:runtime-session-2",),
+    ]
+
+
+def test_import_can_group_by_session_key_when_explicitly_requested(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_shared_session_key_conversation(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        session_identity="session_key",
+        apply=True,
+    )
+
+    assert result.imported == 3
+    db = sqlite3.connect(target_db)
+    imported_sessions = db.execute("SELECT DISTINCT session_id FROM messages").fetchall()
+    db.close()
+
+    assert imported_sessions == [
+        ("openclaw-lcm:agent:sammy:telegram:direct:503782402:conversation:88",),
+    ]
+
+
 def test_dry_run_does_not_create_target_db(tmp_path: Path):
     importer = load_importer_module()
     source_db = tmp_path / "lossless.db"
@@ -153,7 +229,7 @@ def test_apply_imports_messages_with_provenance_backup_and_search(tmp_path: Path
     ).fetchall()
     conn.close()
 
-    expected_session = "openclaw-lcm:agent:sammy:telegram:direct:503782402:conversation:88"
+    expected_session = "openclaw-lcm:agent:sammy:runtime-session-1"
     assert rows[0][0] == expected_session
     assert rows[0][1] == expected_session
     assert rows[0][2] == "user"

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -1,0 +1,304 @@
+"""Tests for the lossless-claw/OpenClaw LCM importer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.store import MessageStore
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+IMPORTER_PATH = REPO_ROOT / "scripts" / "import_lossless_claw.py"
+
+
+def load_importer_module():
+    spec = importlib.util.spec_from_file_location("import_lossless_claw", IMPORTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_lossless_source(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE conversations (
+            conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            session_key TEXT,
+            active INTEGER NOT NULL DEFAULT 1,
+            title TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE messages (
+            message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id INTEGER NOT NULL,
+            seq INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            token_count INTEGER NOT NULL DEFAULT 0,
+            identity_hash TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (conversation_id, seq)
+        );
+        CREATE TABLE message_parts (
+            part_id TEXT PRIMARY KEY,
+            message_id INTEGER NOT NULL,
+            session_id TEXT NOT NULL,
+            part_type TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            text_content TEXT,
+            is_ignored INTEGER DEFAULT 0,
+            is_synthetic INTEGER DEFAULT 0,
+            tool_call_id TEXT,
+            tool_name TEXT,
+            tool_input TEXT,
+            tool_output TEXT,
+            tool_error TEXT,
+            metadata TEXT,
+            UNIQUE (message_id, ordinal)
+        );
+        """
+    )
+    conn.execute(
+        """INSERT INTO conversations
+           (conversation_id, session_id, session_key, title, created_at, updated_at)
+           VALUES (1, 'runtime-session-1', 'telegram:direct:503782402:conversation:88',
+                   'Sammy direct', '2026-04-20 12:00:00', '2026-04-20 12:00:00')"""
+    )
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (10, 1, 1, 'user', 'hello from old OpenClaw', 7, '2026-04-20 12:00:01')"""
+    )
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (11, 1, 2, 'assistant', 'reply from old OpenClaw', 8, '2026-04-20 12:00:02')"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_dry_run_does_not_create_target_db(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=False,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.would_import == 2
+    assert result.imported == 0
+    assert result.skipped_existing == 0
+    assert result.backup_path is None
+    assert not target_db.exists()
+
+
+def test_apply_imports_messages_with_provenance_backup_and_search(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    existing_store = MessageStore(target_db)  # existing DB should be backed up before import writes
+    existing_store.append(
+        "existing-session",
+        {"role": "user", "content": "preexisting committed WAL row"},
+        token_estimate=3,
+        source="existing-source",
+    )
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.imported == 2
+    assert result.would_import == 0
+    assert result.backup_path is not None
+    assert Path(result.backup_path).exists()
+    backup_conn = sqlite3.connect(result.backup_path)
+    backup_rows = backup_conn.execute("SELECT session_id, content FROM messages").fetchall()
+    backup_conn.close()
+    existing_store.close()
+    assert backup_rows == [("existing-session", "preexisting committed WAL row")]
+
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        """SELECT session_id, source, role, content, timestamp, token_estimate
+           FROM messages WHERE source != 'existing-source' ORDER BY store_id"""
+    ).fetchall()
+    conn.close()
+
+    expected_session = "openclaw-lcm:agent:sammy:telegram:direct:503782402:conversation:88"
+    assert rows[0][0] == expected_session
+    assert rows[0][1] == expected_session
+    assert rows[0][2] == "user"
+    assert rows[0][3] == "hello from old OpenClaw"
+    assert rows[0][4] == pytest.approx(1776686401.0)
+    assert rows[0][5] > 0
+
+    searchable = MessageStore(target_db).search("old OpenClaw", session_id=None, limit=5)
+    assert [row["content"] for row in searchable] == [
+        "reply from old OpenClaw",
+        "hello from old OpenClaw",
+    ]
+
+
+def test_apply_is_idempotent_for_same_import_id(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+
+    first = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+    second = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    assert second.backup_path is None
+
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_messages").fetchone()[0] == 2
+    conn.close()
+
+
+def test_invalid_source_schema_reports_required_columns(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "invalid-lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    conn = sqlite3.connect(source_db)
+    conn.execute("CREATE TABLE conversations (conversation_id INTEGER PRIMARY KEY)")
+    conn.execute("CREATE TABLE messages (message_id INTEGER PRIMARY KEY, conversation_id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        importer.import_lossless_claw(
+            source_db=source_db,
+            target_db=target_db,
+            import_id="fixture-import",
+            apply=False,
+        )
+
+
+def test_apply_maps_tool_metadata_from_message_parts(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    conn = sqlite3.connect(source_db)
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (12, 1, 3, 'assistant', '', 3, '2026-04-20 12:00:03')"""
+    )
+    conn.execute(
+        """INSERT INTO message_parts
+           (part_id, message_id, session_id, part_type, ordinal, tool_call_id, tool_name, tool_input)
+           VALUES ('part-tool-call', 12, 'runtime-session-1', 'tool', 0,
+                   'call_123', 'lookup_memory', '{"query":"sammy"}')"""
+    )
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (13, 1, 4, 'tool', '', 4, '2026-04-20 12:00:04')"""
+    )
+    conn.execute(
+        """INSERT INTO message_parts
+           (part_id, message_id, session_id, part_type, ordinal, tool_call_id, tool_name, tool_output)
+           VALUES ('part-tool-result', 13, 'runtime-session-1', 'tool', 0,
+                   'call_123', 'lookup_memory', 'remembered fact')"""
+    )
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (14, 1, 5, 'tool', '', 5, '2026-04-20 12:00:05')"""
+    )
+    conn.execute(
+        """INSERT INTO message_parts
+           (part_id, message_id, session_id, part_type, ordinal, tool_call_id, tool_name, tool_output)
+           VALUES ('part-tool-result-a', 14, 'runtime-session-1', 'tool', 0,
+                   'call_456', 'lookup_memory', 'first chunk')"""
+    )
+    conn.execute(
+        """INSERT INTO message_parts
+           (part_id, message_id, session_id, part_type, ordinal, tool_call_id, tool_name, tool_output)
+           VALUES ('part-tool-result-b', 14, 'runtime-session-1', 'tool', 1,
+                   'call_456', 'lookup_memory', 'second chunk')"""
+    )
+    conn.commit()
+    conn.close()
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert result.imported == 5
+
+    conn = sqlite3.connect(target_db)
+    assistant = conn.execute(
+        "SELECT role, content, tool_calls FROM messages WHERE role = 'assistant' AND tool_calls IS NOT NULL"
+    ).fetchone()
+    tool = conn.execute(
+        """SELECT role, content, tool_call_id, tool_name
+           FROM messages WHERE role = 'tool' AND tool_call_id = 'call_123'"""
+    ).fetchone()
+    multipart_tool = conn.execute(
+        """SELECT role, content, tool_call_id, tool_name
+           FROM messages WHERE role = 'tool' AND tool_call_id = 'call_456'"""
+    ).fetchone()
+    conn.close()
+
+    assert assistant[0] == "assistant"
+    tool_calls = json.loads(assistant[2])
+    assert tool_calls == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "lookup_memory", "arguments": '{"query":"sammy"}'},
+        }
+    ]
+    assert tool == ("tool", "remembered fact", "call_123", "lookup_memory")
+    assert multipart_tool == ("tool", "first chunk\nsecond chunk", "call_456", "lookup_memory")


### PR DESCRIPTION
## Summary
- Add `scripts/import_lossless_claw.py`, an operator-only importer for raw message rows from lossless-claw/OpenClaw LCM SQLite databases.
- Keep dry-run as the default, require `--apply` for writes, and back up an existing target DB with SQLite's backup API before importing.
- Preserve provenance in imported `session_id` and `source`, defaulting to concrete source `conversations.session_id` so source conversation boundaries are not collapsed.
- Add explicit `--session-identity session_key` for operators who intentionally want shared-session-key grouping.
- Track idempotency in `lcm_imported_messages`, and document that path-derived default import IDs require a stable `--import-id` when importing copied DBs from different paths.
- Add importer tests for dry-run behavior, backup coverage, idempotency, schema errors, provenance/searchability, shared-session-key boundaries, explicit session-key grouping, and tool message parts.
- Document the importer as a local archive migration path, not broad memory behavior.

## Why
- Closes #105.
- Makes the lossless-claw/OpenClaw archive story explicit instead of relying on undocumented external backfills.
- Keeps import behavior outside the model-facing tools and scoped to deliberate operator action.
- Addresses review feedback that using `session_key` as the implicit default can collapse many concrete source conversations into a few imported LCM sessions.

## Validation
- RED: `python -m pytest tests/test_import_lossless_claw.py::test_import_preserves_concrete_session_ids_when_session_key_is_shared -q` failed before the fix because shared `session_key` values collapsed into one imported session.
- RED: `python -m pytest tests/test_import_lossless_claw.py::test_import_can_group_by_session_key_when_explicitly_requested -q` failed before the fix because `session_identity` was not implemented.
- `python -m pytest tests/test_import_lossless_claw.py -q` -> 7 passed
- `python -m py_compile scripts/import_lossless_claw.py` -> passed
- `python scripts/import_lossless_claw.py --help` -> passed
- First default validation slice without raised fd limit reached `290 passed` then hit local `OSError: [Errno 24] Too many open files`.
- `ulimit -n 8192 && python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_import_lossless_claw.py -q` -> 386 passed
- `ulimit -n 8192 && python -m pytest -q` -> 423 passed
- `python -m compileall -q .` -> passed
- `bash -n scripts/install.sh scripts/update.sh` -> passed
- `git diff --check` -> passed

## Notes
- The importer requires explicit `--source-db` and `--target-db` paths.
- Run against the target DB while Hermes is stopped for that profile when possible.
- Summary DAG import is intentionally out of scope for this first pass.
- `--session-identity session_id` is the default. Use `--session-identity session_key` only when grouping shared source session keys is desired.