### PR TITLE
fix: reconcile ingest cursor after session restart

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -259,7 +259,11 @@ class LCMEngine(ContextEngine):
         # messages have been persisted.  After compress() shortens the
         # list, the cursor resets to len(compressed) so that only
         # genuinely new messages (appended after compaction) get ingested.
+        # The cursor is process-local; existing sessions rebound after a
+        # gateway restart reconcile it against the durable store on the
+        # next ingest.
         self._ingest_cursor: int = 0
+        self._ingest_cursor_needs_reconcile = False
 
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
@@ -650,6 +654,7 @@ class LCMEngine(ContextEngine):
         # Reset cursor to the length of the compressed context so that
         # only messages appended *after* this point get ingested next time.
         self._ingest_cursor = len(compressed)
+        self._ingest_cursor_needs_reconcile = False
 
         logger.info(
             "LCM compaction #%d: %d messages → %d (%d leaf pass%s, %d→%d tokens, %d DAG nodes%s)",
@@ -1086,6 +1091,7 @@ class LCMEngine(ContextEngine):
         self.cache_metrics_available = False
         self._last_compacted_store_id = 0
         self._ingest_cursor = 0
+        self._ingest_cursor_needs_reconcile = False
         self._context_probed = False
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False
@@ -1272,6 +1278,7 @@ class LCMEngine(ContextEngine):
             session_id,
             conversation_id=kwargs.get("conversation_id"),
         )
+        self._schedule_ingest_cursor_reconciliation()
         self._log_session_filter_diagnostics()
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
@@ -1635,6 +1642,122 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: message ingestion ---------------------------------------
 
+    def _schedule_ingest_cursor_reconciliation(self) -> None:
+        """Mark existing-session rebinds for cursor repair on next ingest."""
+        self._ingest_cursor_needs_reconcile = False
+        if not self._session_id or self._session_ignored or self._session_stateless:
+            return
+        try:
+            self._ingest_cursor_needs_reconcile = self._store.get_session_count(self._session_id) > 0
+        except Exception as exc:  # pragma: no cover - defensive only
+            logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
+            self._ingest_cursor_needs_reconcile = False
+
+    def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
+        """Return true for active-context scaffolding that should not be re-ingested."""
+        role = str(msg.get("role") or "")
+        content = normalize_content_value(msg.get("content")) or ""
+        if role == "system" and "Lossless Context Management (LCM)" in content:
+            return True
+        if "[Expand for details:" not in content:
+            return False
+        return bool(
+            re.search(
+                r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary \(d\d+, node \d+\)\]",
+                content,
+            )
+        )
+
+    @staticmethod
+    def _stable_tool_calls_identity(tool_calls: Any) -> str:
+        if not tool_calls:
+            return ""
+        try:
+            return json.dumps(tool_calls, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(tool_calls)
+
+    def _message_replay_identity(self, msg: Dict[str, Any]) -> tuple[str, str, str, str]:
+        return (
+            str(msg.get("role") or "unknown"),
+            normalize_content_value(msg.get("content")) or "",
+            str(msg.get("tool_call_id") or ""),
+            self._stable_tool_calls_identity(msg.get("tool_calls")),
+        )
+
+    @staticmethod
+    def _matches_store_tail_suffix(
+        stored_tail: list[tuple[str, str, str, str]],
+        candidate_prefix: list[tuple[str, str, str, str]],
+    ) -> bool:
+        if not candidate_prefix:
+            return True
+        if len(candidate_prefix) > len(stored_tail):
+            return False
+        return stored_tail[-len(candidate_prefix) :] == candidate_prefix
+
+    def _find_reconciled_cursor_for_store_tail(
+        self,
+        messages: List[Dict[str, Any]],
+        stored_tail: list[tuple[str, str, str, str]],
+        *,
+        allow_empty_prefix: bool,
+    ) -> int | None:
+        empty_prefix_cursor: int | None = None
+        for cursor in range(len(messages), -1, -1):
+            candidate_prefix = [
+                self._message_replay_identity(msg)
+                for msg in messages[:cursor]
+                if not self._is_replayed_context_scaffold_message(msg)
+            ]
+            if not candidate_prefix:
+                empty_prefix_cursor = cursor
+                if allow_empty_prefix:
+                    return cursor
+                continue
+            if len(candidate_prefix) > len(stored_tail):
+                continue
+            if self._matches_store_tail_suffix(stored_tail, candidate_prefix):
+                return cursor
+        return empty_prefix_cursor if allow_empty_prefix else None
+
+    def _reconcile_ingest_cursor_from_store(self, messages: List[Dict[str, Any]]) -> int:
+        """Infer the in-memory cursor for an existing session after process restart."""
+        if not self._session_id or not messages:
+            return 0
+
+        try:
+            session_count = self._store.get_session_count(self._session_id)
+        except Exception as exc:  # pragma: no cover - defensive only
+            logger.debug("LCM ingest cursor reconciliation count failed: %s", exc)
+            return 0
+        if session_count <= 0:
+            return 0
+
+        tail_limit = min(max(len(messages) * 4, 64), session_count)
+        stored_tail = [
+            self._message_replay_identity(row)
+            for row in self._store.get_session_tail(self._session_id, limit=tail_limit)
+        ]
+        if not stored_tail:
+            return 0
+        cursor = self._find_reconciled_cursor_for_store_tail(
+            messages,
+            stored_tail,
+            allow_empty_prefix=True,
+        )
+        if cursor is not None:
+            logger.debug(
+                "LCM reconciled ingest cursor after existing-session bind: session=%s cursor=%d incoming=%d stored_tail=%d session_count=%d",
+                self._session_id,
+                cursor,
+                len(messages),
+                len(stored_tail),
+                session_count,
+            )
+            return cursor
+        return 0
+
     def _ingest_messages(self, messages: List[Dict[str, Any]]) -> None:
         """Persist new messages to the store.
 
@@ -1657,6 +1780,9 @@ class LCMEngine(ContextEngine):
             return
 
         n = len(messages)
+        if self._ingest_cursor_needs_reconcile:
+            self._ingest_cursor = self._reconcile_ingest_cursor_from_store(messages)
+            self._ingest_cursor_needs_reconcile = False
         cursor = self._ingest_cursor
         logger.debug(
             "Ingest: session=%s cursor=%d incoming=%d",
@@ -2049,6 +2175,7 @@ class LCMEngine(ContextEngine):
     ) -> List[Dict[str, Any]]:
         if compressed != original_messages:
             self._ingest_cursor = len(compressed)
+            self._ingest_cursor_needs_reconcile = False
             logger.info(
                 "LCM assembly guardrail recovery: %d messages → %d (no new summary node)",
                 len(original_messages),

--- a/engine.py
+++ b/engine.py
@@ -1657,8 +1657,11 @@ class LCMEngine(ContextEngine):
         """Return true for active-context scaffolding that should not be re-ingested."""
         role = str(msg.get("role") or "")
         content = normalize_content_value(msg.get("content")) or ""
-        if role == "system" and "Lossless Context Management (LCM)" in content:
-            return True
+        if role == "system":
+            return (
+                "[Note: This conversation uses Lossless Context Management (LCM)." in content
+                and "Earlier turns have been compacted into hierarchical summaries below." in content
+            )
         if "[Expand for details:" not in content:
             return False
         return bool(

--- a/store.py
+++ b/store.py
@@ -430,6 +430,24 @@ class MessageStore:
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    def get_session_tail(self, session_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
+        """Get the latest messages for a session, returned in store order."""
+        if limit <= 0:
+            return []
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+               FROM (
+                   SELECT {_MESSAGE_SELECT_COLUMNS}
+                   FROM messages
+                   WHERE session_id = ?
+                   ORDER BY store_id DESC
+                   LIMIT ?
+               )
+               ORDER BY store_id""",
+            (session_id, limit),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def get_session_count(self, session_id: str) -> int:
         """Count messages in a session."""
         row = self._conn.execute(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -746,6 +746,88 @@ class TestEngineABC:
         assert rows[-1]["content"] == "new user after restart"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_existing_session_restart_persists_new_system_message_that_mentions_lcm(self, tmp_path):
+        db_path = tmp_path / "restart-new-system-lcm-phrase.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "system-lcm-phrase-session",
+            platform="cli",
+            conversation_id="system-lcm-phrase-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "tail before restart"},
+            {"role": "assistant", "content": "answer before restart"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "system-lcm-phrase-session",
+            platform="cli",
+            conversation_id="system-lcm-phrase-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "Policy update: Lossless Context Management (LCM) must be audited during this run.",
+            },
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "system-lcm-phrase-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages) + 1
+        assert rows[-1]["role"] == "system"
+        assert rows[-1]["content"] == "Policy update: Lossless Context Management (LCM) must be audited during this run."
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_skips_exact_lcm_system_scaffold(self, tmp_path):
+        db_path = tmp_path / "restart-system-scaffold.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "system-scaffold-session",
+            platform="cli",
+            conversation_id="system-scaffold-conversation",
+            context_length=200000,
+        )
+        before_restart._ingest_messages([
+            {"role": "user", "content": "tail before restart"},
+        ])
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "system-scaffold-session",
+            platform="cli",
+            conversation_id="system-scaffold-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages("system-scaffold-session")
+        assert len(rows) == 1
+        assert rows[0]["content"] == "tail before restart"
+        assert after_restart._ingest_cursor == len(active_context)
+
     def test_get_status(self, engine):
         status = engine.get_status()
         assert status["engine"] == "lcm"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -499,6 +499,253 @@ class TestEngineABC:
         assert engine._context_probed is False
         assert engine._context_probe_persistable is False
 
+    def test_existing_session_restart_reconciles_cursor_before_ingest(self, tmp_path):
+        db_path = tmp_path / "restart-reconcile.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "restart-session",
+            platform="cli",
+            conversation_id="restart-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "question before restart"},
+            {"role": "assistant", "content": "answer before restart"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._lifecycle.advance_frontier(
+            "restart-conversation",
+            "restart-session",
+            before_restart._store.get_session_count("restart-session"),
+        )
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "restart-session",
+            platform="cli",
+            conversation_id="restart-conversation",
+            context_length=200000,
+        )
+        active_context = persisted_messages + [
+            {"role": "assistant", "content": "calling terminal", "tool_calls": [{"id": "call_1", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "terminal output after restart"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages("restart-session")
+        assert [row["role"] for row in rows] == [
+            "system",
+            "user",
+            "assistant",
+            "assistant",
+            "tool",
+        ]
+        assert rows[-1]["content"] == "terminal output after restart"
+        assert rows[-1]["tool_call_id"] == "call_1"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_compacted_session_restart_skips_synthetic_context_but_persists_new_tool(self, tmp_path):
+        db_path = tmp_path / "restart-compacted.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "compacted-session",
+            platform="cli",
+            conversation_id="compacted-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "fresh user tail"},
+            {"role": "assistant", "content": "fresh assistant tail"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "compacted-session",
+            platform="cli",
+            conversation_id="compacted-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {
+                "role": "assistant",
+                "content": "[Recent Summary (d0, node 12)]\nEarlier details.\n[Expand for details: hint-12]",
+            },
+            {"role": "user", "content": "fresh user tail"},
+            {"role": "assistant", "content": "fresh assistant tail"},
+            {"role": "assistant", "content": "calling terminal", "tool_calls": [{"id": "call_2", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_2", "content": "tool output after compacted restart"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages("compacted-session")
+        assert [row["role"] for row in rows] == [
+            "system",
+            "user",
+            "assistant",
+            "assistant",
+            "tool",
+        ]
+        assert rows[-1]["content"] == "tool output after compacted restart"
+        assert rows[-1]["tool_call_id"] == "call_2"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_large_session_restart_reconciles_beyond_short_tail_window(self, tmp_path):
+        db_path = tmp_path / "restart-large.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "large-restart-session",
+            platform="cli",
+            conversation_id="large-restart-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"message before restart {i}"}
+            for i in range(5000)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "large-restart-session",
+            platform="cli",
+            conversation_id="large-restart-conversation",
+            context_length=200000,
+        )
+        active_context = persisted_messages + [
+            {"role": "assistant", "content": "calling terminal", "tool_calls": [{"id": "call_large", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_large", "content": "large-session tool output after restart"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "large-restart-session",
+            limit=len(active_context) + 1,
+        )
+        assert len(rows) == len(active_context)
+        assert rows[-1]["role"] == "tool"
+        assert rows[-1]["tool_call_id"] == "call_large"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_does_not_skip_repeated_non_tail_messages(self, tmp_path):
+        db_path = tmp_path / "restart-repeated-non-tail.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "repeat-restart-session",
+            platform="cli",
+            conversation_id="repeat-restart-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "repeatable request"},
+            {"role": "assistant", "content": "repeatable answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"tail message before restart {i}"}
+            for i in range(120)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "repeat-restart-session",
+            platform="cli",
+            conversation_id="repeat-restart-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {"role": "user", "content": "repeatable request"},
+            {"role": "assistant", "content": "repeatable answer"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "repeat-restart-session",
+            limit=len(persisted_messages) + 3,
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert rows[-2]["role"] == "user"
+        assert rows[-2]["content"] == "repeatable request"
+        assert rows[-1]["role"] == "assistant"
+        assert rows[-1]["content"] == "repeatable answer"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_new_system_message(self, tmp_path):
+        db_path = tmp_path / "restart-new-system.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "system-restart-session",
+            platform="cli",
+            conversation_id="system-restart-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "tail before restart"},
+            {"role": "assistant", "content": "answer before restart"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "system-restart-session",
+            platform="cli",
+            conversation_id="system-restart-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {"role": "system", "content": "new policy injected after restart"},
+            {"role": "user", "content": "new user after restart"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "system-restart-session",
+            limit=len(persisted_messages) + 2,
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert rows[-2]["role"] == "system"
+        assert rows[-2]["content"] == "new policy injected after restart"
+        assert rows[-1]["role"] == "user"
+        assert rows[-1]["content"] == "new user after restart"
+        assert after_restart._ingest_cursor == len(active_context)
+
     def test_get_status(self, engine):
         status = engine.get_status()
         assert status["engine"] == "lcm"


### PR DESCRIPTION
## Summary
- Reconcile the process-local ingest cursor when an existing session is rebound after a gateway restart.
- Match replayed active-context rows against a contiguous durable-store suffix before advancing the cursor.
- Skip explicit LCM scaffold messages, but preserve legitimate new system rows.
- Add restart regressions for normal, compacted, large, repeated non-tail, and new-system cases.

## Why
- Fixes #109.
- `_ingest_cursor` is process-local, but gateway restarts can rebind the same session with an existing durable message store.
- Reconstructing the cursor from the durable store prevents duplicate replay of old tail rows while preserving post-restart tool result rows.
- Suffix-only matching avoids silently dropping a new turn whose content repeats older non-tail history.

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_reconciles_cursor_before_ingest tests/test_lcm_engine.py::TestEngineABC::test_existing_compacted_session_restart_skips_synthetic_context_but_persists_new_tool tests/test_lcm_engine.py::TestEngineABC::test_existing_large_session_restart_reconciles_beyond_short_tail_window tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_does_not_skip_repeated_non_tail_messages tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_persists_new_system_message -q` -> 5 passed
- `ulimit -n 8192 && python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 384 passed, 38 warnings
- `ulimit -n 8192 && python -m pytest -q` -> 421 passed, 38 warnings
- `python -m compileall -q .`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- Static scan clean for hardcoded secrets, shell injection, eval/exec, pickle, and obvious SQL formatting.
- Independent review passed after addressing Codex feedback.

## Notes
- Addressed Codex P1 by replacing arbitrary subsequence matching with durable-tail suffix matching.
- Addressed Codex P2 by narrowing scaffold detection so non-LCM system messages still persist.
- The default validation slice hit local `OSError: [Errno 24] Too many open files` under the default fd limit before rerunning. The same suite passed with `ulimit -n 8192`.
