### PR TITLE
fix: require replay evidence for restart cursor reconciliation

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1929,7 +1929,7 @@ class LCMEngine(ContextEngine):
             messages,
             stored_tail,
             allow_empty_prefix=True,
-            session_count=session_count,
+            session_count=len(stored_tail),
         )
         if cursor is not None:
             logger.debug(

--- a/engine.py
+++ b/engine.py
@@ -1890,16 +1890,16 @@ class LCMEngine(ContextEngine):
             # gateway restart may provide only newly arrived delta messages; if
             # the first delta happens to repeat the durable tail, treating that
             # row as replay silently loses it.  Only advance the cursor when the
-            # incoming prefix proves replay by looking like a complete durable
-            # context replay with a system prompt anchor.  Synthetic scaffold
-            # rows can be skipped on their own, but they do not prove that a
-            # concrete tail message is replay; ambiguous tail matches are
-            # persisted rather than risk data loss.
-            has_full_context_anchor = (
-                len(candidate_prefix) >= session_count
-                and any(identity[0] == "system" for identity in candidate_prefix)
+            # incoming prefix proves replay by covering the full durable session.
+            # A system prompt is a strong anchor, but older/minimal transcripts
+            # can start directly with user/assistant turns, so multi-row full
+            # replay is also accepted.  Singleton full replay remains ambiguous
+            # with a one-message delta that repeats the tail, so it is persisted
+            # rather than risk data loss.
+            has_full_context_replay = len(candidate_prefix) >= session_count and (
+                session_count > 1 or any(identity[0] == "system" for identity in candidate_prefix)
             )
-            if has_full_context_anchor:
+            if has_full_context_replay:
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 

--- a/engine.py
+++ b/engine.py
@@ -1865,12 +1865,14 @@ class LCMEngine(ContextEngine):
         stored_tail: list[tuple[str, str, str, str]],
         *,
         allow_empty_prefix: bool,
+        session_count: int,
     ) -> int | None:
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
+            candidate_messages = messages[:cursor]
             candidate_prefix = [
                 self._message_replay_identity(msg)
-                for msg in messages[:cursor]
+                for msg in candidate_messages
                 if not self._is_replayed_context_scaffold_message(msg)
                 and not self._matches_ignore_message_patterns(msg)
             ]
@@ -1881,7 +1883,23 @@ class LCMEngine(ContextEngine):
                 continue
             if len(candidate_prefix) > len(stored_tail):
                 continue
-            if self._matches_store_tail_suffix(stored_tail, candidate_prefix):
+            if not self._matches_store_tail_suffix(stored_tail, candidate_prefix):
+                continue
+
+            # Matching a stored suffix is not enough evidence by itself.  A
+            # gateway restart may provide only newly arrived delta messages; if
+            # the first delta happens to repeat the durable tail, treating that
+            # row as replay silently loses it.  Only advance the cursor when the
+            # incoming prefix proves replay by looking like a complete durable
+            # context replay with a system prompt anchor.  Synthetic scaffold
+            # rows can be skipped on their own, but they do not prove that a
+            # concrete tail message is replay; ambiguous tail matches are
+            # persisted rather than risk data loss.
+            has_full_context_anchor = (
+                len(candidate_prefix) >= session_count
+                and any(identity[0] == "system" for identity in candidate_prefix)
+            )
+            if has_full_context_anchor:
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 
@@ -1911,6 +1929,7 @@ class LCMEngine(ContextEngine):
             messages,
             stored_tail,
             allow_empty_prefix=True,
+            session_count=session_count,
         )
         if cursor is not None:
             logger.debug(

--- a/engine.py
+++ b/engine.py
@@ -1866,6 +1866,7 @@ class LCMEngine(ContextEngine):
         *,
         allow_empty_prefix: bool,
         session_count: int,
+        raw_session_count: int,
     ) -> int | None:
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
@@ -1896,10 +1897,18 @@ class LCMEngine(ContextEngine):
             # replay is also accepted.  Singleton full replay remains ambiguous
             # with a one-message delta that repeats the tail, so it is persisted
             # rather than risk data loss.
-            has_full_context_replay = len(candidate_prefix) >= session_count and (
+            has_effective_full_replay = len(candidate_prefix) >= session_count and (
                 session_count > 1 or any(identity[0] == "system" for identity in candidate_prefix)
             )
-            if has_full_context_replay:
+            has_scaffold_evidence = any(
+                self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages
+            )
+            has_raw_full_replay = (
+                not has_scaffold_evidence
+                and len(candidate_messages) >= raw_session_count
+                and raw_session_count > 1
+            )
+            if has_effective_full_replay or has_raw_full_replay:
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 
@@ -1930,6 +1939,7 @@ class LCMEngine(ContextEngine):
             stored_tail,
             allow_empty_prefix=True,
             session_count=len(stored_tail),
+            raw_session_count=session_count,
         )
         if cursor is not None:
             logger.debug(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -646,9 +646,13 @@ class TestEngineABC:
             "system",
             "user",
             "assistant",
+            "user",
+            "assistant",
             "assistant",
             "tool",
         ]
+        assert rows[-4]["content"] == "fresh user tail"
+        assert rows[-3]["content"] == "fresh assistant tail"
         assert rows[-1]["content"] == "tool output after compacted restart"
         assert rows[-1]["tool_call_id"] == "call_2"
         assert after_restart._ingest_cursor == len(active_context)
@@ -747,6 +751,171 @@ class TestEngineABC:
         assert rows[-2]["content"] == "repeatable request"
         assert rows[-1]["role"] == "assistant"
         assert rows[-1]["content"] == "repeatable answer"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_delta_message_matching_store_tail(self, tmp_path):
+        db_path = tmp_path / "restart-repeated-tail-delta.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "initial question"},
+            {"role": "assistant", "content": "initial answer"},
+            {"role": "user", "content": "retry"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        active_context = [{"role": "user", "content": "retry"}]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "repeat-tail-delta-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages) + 1
+        assert [row["content"] for row in rows[-2:]] == ["retry", "retry"]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_single_delta_message_matching_store_tail(self, tmp_path):
+        db_path = tmp_path / "restart-single-repeated-tail-delta.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "single-repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="single-repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "user", "content": "retry"}]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "single-repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="single-repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        active_context = [{"role": "user", "content": "retry"}]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "single-repeat-tail-delta-session",
+            limit=2,
+        )
+        assert len(rows) == 2
+        assert [row["content"] for row in rows] == ["retry", "retry"]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_scaffolded_delta_message_matching_store_tail(self, tmp_path):
+        db_path = tmp_path / "restart-scaffolded-repeated-tail-delta.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "scaffold-repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="scaffold-repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "initial question"},
+            {"role": "assistant", "content": "initial answer"},
+            {"role": "user", "content": "retry"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "scaffold-repeat-tail-delta-session",
+            platform="cli",
+            conversation_id="scaffold-repeat-tail-delta-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {"role": "user", "content": "retry"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "scaffold-repeat-tail-delta-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages) + 1
+        assert [row["content"] for row in rows[-2:]] == ["retry", "retry"]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_scaffolded_delta_message_matching_store_tail_with_followup(self, tmp_path):
+        db_path = tmp_path / "restart-scaffolded-repeated-tail-followup.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "scaffold-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="scaffold-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "initial question"},
+            {"role": "assistant", "content": "initial answer"},
+            {"role": "user", "content": "retry"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "scaffold-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="scaffold-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": "next answer"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "scaffold-repeat-tail-followup-session",
+            limit=len(persisted_messages) + 2,
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert [row["content"] for row in rows[-3:]] == ["retry", "retry", "next answer"]
         assert after_restart._ingest_cursor == len(active_context)
 
     def test_existing_session_restart_persists_new_system_message(self, tmp_path):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -753,6 +753,88 @@ class TestEngineABC:
         assert rows[-1]["content"] == "repeatable answer"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_existing_session_restart_reconciles_full_replay_without_system_prompt(self, tmp_path):
+        db_path = tmp_path / "restart-full-replay-no-system.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "full-replay-no-system-session",
+            platform="cli",
+            conversation_id="full-replay-no-system-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "full-replay-no-system-session",
+            platform="cli",
+            conversation_id="full-replay-no-system-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            *persisted_messages,
+            {"role": "user", "content": "new question after restart"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "full-replay-no-system-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages) + 1
+        assert [row["content"] for row in rows] == [
+            "first question",
+            "first answer",
+            "new question after restart",
+        ]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_reconciles_complete_replay_without_system_prompt(self, tmp_path):
+        db_path = tmp_path / "restart-complete-replay-no-system.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "complete-replay-no-system-session",
+            platform="cli",
+            conversation_id="complete-replay-no-system-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "complete-replay-no-system-session",
+            platform="cli",
+            conversation_id="complete-replay-no-system-conversation",
+            context_length=200000,
+        )
+
+        after_restart._ingest_messages(list(persisted_messages))
+
+        rows = after_restart._store.get_session_messages(
+            "complete-replay-no-system-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages)
+        assert [row["content"] for row in rows] == ["first question", "first answer"]
+        assert after_restart._ingest_cursor == len(persisted_messages)
+
     def test_existing_session_restart_persists_delta_message_matching_store_tail(self, tmp_path):
         db_path = tmp_path / "restart-repeated-tail-delta.db"
         config = LCMConfig(database_path=str(db_path))
@@ -825,6 +907,44 @@ class TestEngineABC:
         )
         assert len(rows) == 2
         assert [row["content"] for row in rows] == ["retry", "retry"]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_single_delta_message_matching_store_tail_with_followup(self, tmp_path):
+        db_path = tmp_path / "restart-single-repeated-tail-followup.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "single-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="single-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "user", "content": "retry"}]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "single-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="single-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": "next answer"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "single-repeat-tail-followup-session",
+            limit=3,
+        )
+        assert len(rows) == 3
+        assert [row["content"] for row in rows] == ["retry", "retry", "next answer"]
         assert after_restart._ingest_cursor == len(active_context)
 
     def test_existing_session_restart_persists_scaffolded_delta_message_matching_store_tail(self, tmp_path):


### PR DESCRIPTION
## Summary
- Requires stronger replay evidence before restart cursor reconciliation skips a non-empty suffix match.
- Preserves complete durable-context replay reconciliation, including minimal transcripts without a system prompt.
- Keeps LCM scaffold-only prefixes skipped while persisting ambiguous repeated tail deltas instead of risking data loss.

## Why
- A restarted existing session could receive a new delta message that repeated the durable store tail.
- The old cursor reconciliation could classify that repeated delta as replay and silently skip it.
- Conservative persistence is safer than losing user-visible conversation history.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py -k 'existing_session_restart or restart_reconciliation or cursor_advances_when_filter_drops_entire_batch' -q` -> 16 passed
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 476 passed
  - [x] `python -m pytest -q` -> 522 passed
  - [x] `python -m compileall -q .` -> pass
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> pass
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> pass
  - [x] `git diff --check` -> pass

## Notes
- Salvaged onto current `origin/main` at `85da51d`.
- Tosko4 commit authorship is preserved.
- Current pushed head: `7c440e8`.

Refs https://github.com/stephenschoettler/hermes-lcm/pull/111#discussion_r3193823494
