### PR TITLE
fix: fall back to Hermes compression threshold

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,12 @@
 """LCM configuration with defaults and env var overrides."""
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional fallback for minimal installs
+    yaml = None
 
 
 def _parse_pattern_list(raw: str) -> list[str]:
@@ -37,6 +43,40 @@ def _parse_bool_env(key: str, default: bool) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     return default
+
+
+def _hermes_compression_threshold(default: float) -> float:
+    """Read Hermes compression.threshold when no LCM env override is present.
+
+    Hermes gateways may load ``~/.hermes/config.yaml`` without exporting every
+    setting into the process environment. Falling back to the main Hermes
+    compression threshold keeps LCM aligned with the active agent config while
+    still allowing ``LCM_CONTEXT_THRESHOLD`` to override it explicitly.
+    """
+    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    cfg_path = home / "config.yaml"
+    try:
+        text = cfg_path.read_text()
+        if yaml is not None:
+            cfg = yaml.safe_load(text) or {}
+            value = (cfg.get("compression") or {}).get("threshold")
+            if value is None:
+                return default
+            return float(value)
+
+        in_compression = False
+        for raw_line in text.splitlines():
+            line = raw_line.split("#", 1)[0].rstrip()
+            if not line.strip():
+                continue
+            if not line.startswith((" ", "\t")):
+                in_compression = line.strip() == "compression:"
+                continue
+            if in_compression and line.strip().startswith("threshold:"):
+                return float(line.split(":", 1)[1].strip().strip("'\""))
+        return default
+    except Exception:
+        return default
 
 
 @dataclass
@@ -147,7 +187,10 @@ class LCMConfig:
 
         c.fresh_tail_count = _int("LCM_FRESH_TAIL_COUNT", c.fresh_tail_count)
         c.leaf_chunk_tokens = _int("LCM_LEAF_CHUNK_TOKENS", c.leaf_chunk_tokens)
-        c.context_threshold = _float("LCM_CONTEXT_THRESHOLD", c.context_threshold)
+        c.context_threshold = _float(
+            "LCM_CONTEXT_THRESHOLD",
+            _hermes_compression_threshold(c.context_threshold),
+        )
         c.incremental_max_depth = _int("LCM_INCREMENTAL_MAX_DEPTH", c.incremental_max_depth)
         c.condensation_fanin = _int("LCM_CONDENSATION_FANIN", c.condensation_fanin)
         c.dynamic_leaf_chunk_enabled = _parse_bool_env(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -351,7 +351,8 @@ class TestConfig:
         assert c.large_output_externalization_path == "/tmp/lcm-large-outputs"
         assert c.large_output_transcript_gc_enabled is True
 
-    def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch):
+    def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "empty-hermes-home"))
         monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "not-a-number")
         monkeypatch.setenv("LCM_LEAF_CHUNK_TOKENS", "")
         monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "bad-float")
@@ -367,6 +368,42 @@ class TestConfig:
         assert c.max_assembly_tokens == 0
         assert c.reserve_tokens_floor == 0
         assert c.expansion_context_tokens == 32_000
+
+    def test_from_env_reads_hermes_compression_threshold_when_lcm_env_missing(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("compression:\n  threshold: 0.68\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.68
+
+    def test_from_env_lcm_threshold_env_overrides_hermes_config(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("compression:\n  threshold: 0.68\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.82")
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.82
+
+    def test_from_env_reads_hermes_threshold_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("compression:\n  threshold: '0.68'\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.68
 
 
 class TestSessionPatterns:


### PR DESCRIPTION
## Summary

- Falls back to Hermes `compression.threshold` from `config.yaml` when `LCM_CONTEXT_THRESHOLD` is not set in the process environment.
- Keeps `LCM_CONTEXT_THRESHOLD` as the explicit override when it is present.
- Adds tests for both the Hermes-config fallback and env override precedence.

## Why

Hermes gateway/runtime config can have the intended compression threshold without exporting a matching `LCM_CONTEXT_THRESHOLD` env var into the LCM process. In that case LCM silently falls back to its built-in `0.75`, which can drift from the active Hermes compression config and reintroduce context-window warnings.

## Tests

- `python3 -m pytest tests/test_lcm_core.py -q`
- `python3 -m pytest -q`
- `python3 -m py_compile config.py`