### PR TITLE
fix: encode importer SQLite URI paths

### DIFF
--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -89,11 +89,14 @@ class ImportResult:
         }
 
 
+def _readonly_sqlite_uri(db_path: Path) -> str:
+    return db_path.resolve().as_uri() + "?mode=ro"
+
+
 def _connect_readonly(db_path: Path) -> sqlite3.Connection:
     if not db_path.is_file():
         raise FileNotFoundError(f"source DB not found: {db_path}")
-    uri = f"file:{db_path.resolve()}?mode=ro"
-    conn = sqlite3.connect(uri, uri=True)
+    conn = sqlite3.connect(_readonly_sqlite_uri(db_path), uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -454,8 +457,7 @@ def _backup_target(target_db: Path) -> str | None:
         backup_path = target_db.with_name(f"{target_db.name}.backup-{stamp}-{suffix}")
         suffix += 1
 
-    source_uri = f"file:{target_db.resolve()}?mode=ro"
-    source_conn = sqlite3.connect(source_uri, uri=True)
+    source_conn = sqlite3.connect(_readonly_sqlite_uri(target_db), uri=True)
     backup_conn = sqlite3.connect(backup_path)
     try:
         source_conn.backup(backup_conn)

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -189,6 +189,27 @@ def test_dry_run_does_not_create_target_db(tmp_path: Path):
     assert not target_db.exists()
 
 
+def test_dry_run_handles_uri_reserved_source_db_path(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless#archive?.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=False,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.would_import == 2
+    assert not target_db.exists()
+
+
 def test_apply_imports_messages_with_provenance_backup_and_search(tmp_path: Path):
     importer = load_importer_module()
     source_db = tmp_path / "lossless.db"
@@ -242,6 +263,41 @@ def test_apply_imports_messages_with_provenance_backup_and_search(tmp_path: Path
         "reply from old OpenClaw",
         "hello from old OpenClaw",
     ]
+
+
+def test_apply_backs_up_uri_reserved_target_db_path(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target#archive?.db"
+    create_lossless_source(source_db)
+    existing_store = MessageStore(target_db)
+    existing_store.append(
+        "existing-session",
+        {"role": "user", "content": "preexisting committed WAL row"},
+        token_estimate=3,
+        source="existing-source",
+    )
+    existing_store.close()
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.backup_path is not None
+    backup_path = Path(result.backup_path)
+    assert backup_path.exists()
+    assert backup_path.name.startswith("target#archive?.db.backup-")
+
+    backup_conn = sqlite3.connect(backup_path)
+    backup_rows = backup_conn.execute("SELECT session_id, content FROM messages").fetchall()
+    backup_conn.close()
+    assert backup_rows == [("existing-session", "preexisting committed WAL row")]
 
 
 def test_apply_is_idempotent_for_same_import_id(tmp_path: Path):


### PR DESCRIPTION
## Summary

The importer opened source DBs and backup targets with hand-built SQLite URIs like `file:{path}?mode=ro`. Paths containing URI-reserved characters such as `#` or `?` were then parsed as URI syntax instead of as filesystem paths.

This changes those read-only connections to build the URI from `Path.resolve().as_uri()` before appending `?mode=ro`, and adds regressions for both the source DB path and backup target path cases.

## Validation

`python -m pytest tests/test_import_lossless_claw.py -q -o addopts=`: 9 passed

`python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_import_lossless_claw.py -q -o addopts=`: 418 passed

`python -m pytest -q -o addopts=`: 455 passed

`python -m compileall -q .`, `bash -n scripts/install.sh scripts/update.sh`, and `git diff --check origin/main...HEAD` are clean.

Refs https://github.com/stephenschoettler/hermes-lcm/pull/107#discussion_r3193809311