### PR TITLE
feat: add explicit LCM session loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Expected signals:
 
 - plugin list includes `hermes-lcm`
 - selected context engine is `lcm`
-- tool list includes `lcm_grep`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, and `lcm_doctor`
+- tool list includes `lcm_grep`, `lcm_load_session`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, and `lcm_doctor`
 
 Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.8.0 (6 tools)
+  ✓ hermes-lcm v0.8.0 (7 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -249,6 +249,7 @@ for earlier separate sessions or broad cross-session history.
 | Tool | Use |
 |------|-----|
 | `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Use `session_search` for earlier separate sessions or broad cross-session recall. |
+| `lcm_load_session` | Load one ordered raw-message transcript page for an explicit `session_id`. This is not search: it returns raw rows in `store_id` order, bounded by `limit`, with per-message content bounded by `max_content_chars`, and continues with `after_store_id` from `next_cursor`. |
 | `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
 | `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
 | `lcm_expand_query` | Answer a question using expanded current-session LCM context while returning a bounded answer. |
@@ -260,8 +261,9 @@ for earlier separate sessions or broad cross-session history.
 LCM retrieval tools default to current-session scope. `lcm_grep` accepts
 `session_scope='all'` or `session_scope='session'` as an explicit opt-in for
 bounded archive search over rows already present in `lcm.db` (raw-message hits
-only); use Hermes `session_search` for broad cross-session history outside the
-LCM database.
+only). Once a session id is known, `lcm_load_session` can enumerate that session's
+raw transcript in chronological `store_id` pages without a search query. Use
+Hermes `session_search` for broad cross-session history outside the LCM database.
 
 Within the current session, `source` filters raw rows directly and filters
 summary nodes by descendant raw-message source lineage. `unknown` is a real
@@ -277,6 +279,7 @@ Lossless recovery means raw content is stored with stable source lineage and can
 be recovered in deterministic pages.
 
 - `lcm_expand(node_id=...)` pages immediate sources with `source_offset` and `source_limit`
+- `lcm_load_session(session_id=...)` pages ordered raw session rows with `after_store_id` and `next_cursor`; each row includes bounded content plus truncation metadata, and large individual rows can be recovered with `lcm_expand(store_id=...)` using `content_offset`
 - oversized raw messages continue with `content_offset`
 - `lcm_expand(externalized_ref=...)` pages payload content with `content_offset`
 - `lcm_expand_query` uses `context_max_tokens` for auxiliary context and reports truncation/pagination hints when needed
@@ -354,7 +357,7 @@ store.py         SQLite message store and FTS
 dag.py           summary DAG and FTS
 config.py        env var defaults and overrides
 command.py       /lcm command handlers
-tools.py         lcm_grep, lcm_describe, lcm_expand, lcm_expand_query
+tools.py         lcm_grep, lcm_load_session, lcm_describe, lcm_expand, lcm_expand_query
 schemas.py       tool schemas shown to the model
 tests/           standalone pytest coverage
 ```

--- a/engine.py
+++ b/engine.py
@@ -33,7 +33,15 @@ from .extraction import (
     sanitize_pre_compaction_content,
     sanitize_pre_compaction_tool_arguments,
 )
-from .schemas import LCM_DESCRIBE, LCM_DOCTOR, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_GREP, LCM_STATUS
+from .schemas import (
+    LCM_DESCRIBE,
+    LCM_DOCTOR,
+    LCM_EXPAND,
+    LCM_EXPAND_QUERY,
+    LCM_GREP,
+    LCM_LOAD_SESSION,
+    LCM_STATUS,
+)
 from .session_patterns import (
     build_session_match_keys,
     compile_session_patterns,
@@ -217,8 +225,8 @@ class LCMEngine(ContextEngine):
          are summarized into leaf nodes (D0) in a SummaryDAG
       3. When enough nodes accumulate at a depth, they're condensed into
          higher-depth nodes (D1, D2, ...)
-      4. The agent gets tools (lcm_grep, lcm_describe, lcm_expand) to
-         search and drill into compacted history
+      4. The agent gets tools (lcm_grep, lcm_load_session, lcm_describe,
+         lcm_expand) to search and drill into compacted history
       5. Active context = system prompt + DAG summaries + fresh tail
     """
 
@@ -1442,7 +1450,15 @@ class LCMEngine(ContextEngine):
         return self.carry_over_new_session_context(old_session_id, new_session_id)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [LCM_GREP, LCM_DESCRIBE, LCM_EXPAND, LCM_EXPAND_QUERY, LCM_STATUS, LCM_DOCTOR]
+        return [
+            LCM_GREP,
+            LCM_LOAD_SESSION,
+            LCM_DESCRIBE,
+            LCM_EXPAND,
+            LCM_EXPAND_QUERY,
+            LCM_STATUS,
+            LCM_DOCTOR,
+        ]
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
         # Ingest live messages if passed (enables current-turn search)
@@ -1458,6 +1474,7 @@ class LCMEngine(ContextEngine):
 
         handlers = {
             "lcm_grep": lcm_tools.lcm_grep,
+            "lcm_load_session": lcm_tools.lcm_load_session,
             "lcm_describe": lcm_tools.lcm_describe,
             "lcm_expand": lcm_tools.lcm_expand,
             "lcm_expand_query": lcm_tools.lcm_expand_query,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,6 +4,7 @@ description: "Lossless Context Management — standalone Hermes plugin with a DA
 author: "Voltropy / Hermes Community"
 provides_tools:
   - lcm_grep
+  - lcm_load_session
   - lcm_describe
   - lcm_expand
   - lcm_expand_query

--- a/schemas.py
+++ b/schemas.py
@@ -72,6 +72,65 @@ LCM_GREP = {
     },
 }
 
+LCM_LOAD_SESSION = {
+    "name": "lcm_load_session",
+    "description": (
+        "Load an ordered raw-message transcript page for one explicit session_id from the plugin-local LCM database. "
+        "This is enumeration, not search: it does not require a query, returns raw message content rather than snippets, "
+        "and orders rows chronologically by store_id. Use this after session_search or lcm_grep has identified a session_id "
+        "that already exists in lcm.db. Output is bounded by limit, per-row content is bounded by max_content_chars, "
+        "and row pagination uses after_store_id/next_cursor. "
+        "It returns raw rows only; cross-session summary/DAG expansion remains out of scope."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Explicit LCM session id to load. Required; no implicit current/all fallback is applied.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": (
+                    "Maximum raw messages to return (default 100, hard upper bound 200). "
+                    "Values above the cap are clamped and reported via limit_clamped_from."
+                ),
+                "default": 100,
+            },
+            "max_content_chars": {
+                "type": "integer",
+                "description": (
+                    "Maximum content characters to include per message (default 4000, hard upper bound 20000). "
+                    "Longer rows include content_truncated=true and can be recovered fully with lcm_expand(store_id=...)."
+                ),
+                "default": 4000,
+            },
+            "after_store_id": {
+                "type": "integer",
+                "description": (
+                    "Exclusive cursor for pagination. Pass the previous response's next_cursor "
+                    "to continue with rows whose store_id is greater than this value."
+                ),
+                "default": 0,
+            },
+            "roles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional role filter, for example ['user', 'assistant', 'tool', 'system'].",
+            },
+            "time_from": {
+                "type": "number",
+                "description": "Optional inclusive minimum message timestamp (Unix seconds).",
+            },
+            "time_to": {
+                "type": "number",
+                "description": "Optional inclusive maximum message timestamp (Unix seconds).",
+            },
+        },
+        "required": ["session_id"],
+    },
+}
+
 LCM_DESCRIBE = {
     "name": "lcm_describe",
     "description": (

--- a/store.py
+++ b/store.py
@@ -419,6 +419,81 @@ class MessageStore:
             ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    def _session_load_where(
+        self,
+        session_id: str,
+        *,
+        roles: list[str] | None = None,
+        time_from: float | None = None,
+        time_to: float | None = None,
+    ) -> tuple[list[str], list[Any]]:
+        where = ["session_id = ?"]
+        args: list[Any] = [session_id]
+        if roles:
+            placeholders = ",".join("?" for _ in roles)
+            where.append(f"role IN ({placeholders})")
+            args.extend(roles)
+        if time_from is not None:
+            where.append("timestamp >= ?")
+            args.append(time_from)
+        if time_to is not None:
+            where.append("timestamp <= ?")
+            args.append(time_to)
+        return where, args
+
+    def count_session_load_messages(
+        self,
+        session_id: str,
+        *,
+        roles: list[str] | None = None,
+        time_from: float | None = None,
+        time_to: float | None = None,
+    ) -> int:
+        """Count messages matching the lcm_load_session filter contract."""
+        where, args = self._session_load_where(
+            session_id,
+            roles=roles,
+            time_from=time_from,
+            time_to=time_to,
+        )
+        return int(
+            self._conn.execute(
+                f"SELECT COUNT(*) FROM messages WHERE {' AND '.join(where)}",
+                args,
+            ).fetchone()[0]
+        )
+
+    def load_session_page(
+        self,
+        session_id: str,
+        *,
+        after_store_id: int = 0,
+        limit: int = 100,
+        roles: list[str] | None = None,
+        time_from: float | None = None,
+        time_to: float | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Load one ordered raw-message page for a session.
+
+        ``after_store_id`` is exclusive so callers can use the previous page's
+        ``next_cursor`` without duplicating the cursor row.
+        """
+        where, args = self._session_load_where(
+            session_id,
+            roles=roles,
+            time_from=time_from,
+            time_to=time_to,
+        )
+        where.append("store_id > ?")
+        args.extend([after_store_id, limit])
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+               WHERE {' AND '.join(where)}
+               ORDER BY store_id LIMIT ?""",
+            args,
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def get_session_messages(self, session_id: str,
                              limit: int = 10000) -> List[Dict[str, Any]]:
         """Get all messages for a session, ordered by store_id."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -344,6 +344,7 @@ class TestEngineABC:
         assert "lcm_grep" in names
         assert "lcm_describe" in names
         assert "lcm_expand" in names
+        assert "lcm_load_session" in names
         assert "lcm_status" in names
         assert "lcm_doctor" in names
         assert "lcm_expand_query" in names
@@ -395,6 +396,15 @@ class TestEngineABC:
         assert "store_id" in expand_props
         assert "across sessions" in expand_props["store_id"]["description"].lower() or "cross-session" in expand_props["store_id"]["description"].lower()
         assert "pagination" in expand_props["source_offset"]["description"].lower()
+        load_schema = next(s for s in schemas if s["name"] == "lcm_load_session")
+        load_props = load_schema["parameters"]["properties"]
+        assert load_schema["parameters"]["required"] == ["session_id"]
+        assert "ordered raw-message transcript" in load_schema["description"]
+        assert "after_store_id" in load_props
+        assert "max_content_chars" in load_props
+        assert "roles" in load_props
+        assert "time_from" in load_props
+        assert "time_to" in load_props
         assert "current session" in expand_query_schema["description"].lower()
         assert "session_search" in expand_query_schema["description"]
         expand_query_props = expand_query_schema["parameters"]["properties"]
@@ -416,6 +426,8 @@ class TestEngineABC:
         assert "imported from OpenClaw" not in readme
         assert "imported from lossless-claw" not in readme
         assert "Lossless raw recovery contract" in readme
+        assert "lcm_load_session" in readme
+        assert "after_store_id" in readme
         assert "source_offset" in readme
         assert "content_offset" in readme
         assert "LCM_EXPANSION_CONTEXT_TOKENS" in readme
@@ -8579,6 +8591,197 @@ class TestHandleExpandStoreId:
         )
         assert expand_result["source_type"] == "raw_message"
         assert "phoenix payload" in expand_result["content"]
+
+
+class TestHandleLoadSession:
+    """Ordered, paged raw transcript loading by explicit session_id."""
+
+    def _seed_old_session(self, engine):
+        rows = [
+            ("user", "first old-session message", "cli", 100.0),
+            ("assistant", "second old-session answer", "cli", 200.0),
+            ("tool", "third old-session tool result", "cli", 300.0),
+            ("user", "fourth old-session follow-up", "telegram", 400.0),
+        ]
+        store_ids = []
+        for role, content, source, timestamp in rows:
+            store_id = engine._store.append(
+                "old-session",
+                {"role": role, "content": content, "tool_call_id": "call_x" if role == "tool" else None},
+                source=source,
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (timestamp, store_id),
+            )
+            store_ids.append(store_id)
+        engine._store._conn.commit()
+        engine._store.append("test-session", {"role": "user", "content": "current session message"})
+        return store_ids
+
+    def test_load_session_returns_ordered_bounded_raw_page(self, engine):
+        store_ids = self._seed_old_session(engine)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "limit": 2},
+            )
+        )
+
+        assert result["session_id"] == "old-session"
+        assert result["limit"] == 2
+        assert result["total_messages"] == 4
+        assert result["returned_messages"] == 2
+        assert result["has_more"] is True
+        assert result["next_cursor"] == store_ids[1]
+        assert [item["store_id"] for item in result["messages"]] == store_ids[:2]
+        assert [item["role"] for item in result["messages"]] == ["user", "assistant"]
+        assert result["messages"][0]["content"] == "first old-session message"
+        assert result["messages"][0]["content_chars"] == len("first old-session message")
+        assert result["messages"][0]["content_truncated"] is False
+        assert result["messages"][0]["from_current_session"] is False
+        assert "snippet" not in result["messages"][0]
+
+    def test_load_session_pages_after_store_id(self, engine):
+        store_ids = self._seed_old_session(engine)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "after_store_id": store_ids[1], "limit": 10},
+            )
+        )
+
+        assert result["after_store_id"] == store_ids[1]
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+        assert [item["store_id"] for item in result["messages"]] == store_ids[2:]
+
+    def test_load_session_filters_roles_and_time_range(self, engine):
+        store_ids = self._seed_old_session(engine)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {
+                    "session_id": "old-session",
+                    "roles": ["user", "tool"],
+                    "time_from": 250.0,
+                    "time_to": 450.0,
+                    "limit": 10,
+                },
+            )
+        )
+
+        assert result["roles"] == ["user", "tool"]
+        assert result["time_from"] == 250.0
+        assert result["time_to"] == 450.0
+        assert result["total_messages"] == 2
+        assert [item["store_id"] for item in result["messages"]] == [store_ids[2], store_ids[3]]
+        assert [item["role"] for item in result["messages"]] == ["tool", "user"]
+
+    def test_load_session_bounds_large_message_content(self, engine):
+        store_id = engine._store.append(
+            "large-session",
+            {"role": "assistant", "content": "abcdef"},
+            source="cli",
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "large-session", "max_content_chars": 3},
+            )
+        )
+
+        assert result["max_content_chars"] == 3
+        assert result["messages"][0]["store_id"] == store_id
+        assert result["messages"][0]["content"] == "abc"
+        assert result["messages"][0]["content_chars"] == 6
+        assert result["messages"][0]["content_returned_chars"] == 3
+        assert result["messages"][0]["content_truncated"] is True
+        assert result["messages"][0]["next_content_offset"] == 3
+
+    def test_load_session_clamps_max_content_chars(self, engine):
+        store_id = engine._store.append(
+            "large-session",
+            {"role": "user", "content": "x" * 25_000},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "large-session", "max_content_chars": 50_000},
+            )
+        )
+
+        assert result["max_content_chars"] == 20_000
+        assert result["max_content_chars_clamped_from"] == 50_000
+        assert result["messages"][0]["store_id"] == store_id
+        assert len(result["messages"][0]["content"]) == 20_000
+        assert result["messages"][0]["content_truncated"] is True
+
+    def test_load_session_rejects_missing_session_id_and_invalid_filters(self, engine):
+        missing = json.loads(engine.handle_tool_call("lcm_load_session", {}))
+        assert "error" in missing and "session_id" in missing["error"]
+
+        bad_roles = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "roles": "user"},
+            )
+        )
+        assert "error" in bad_roles and "roles" in bad_roles["error"]
+
+        bad_cursor = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "after_store_id": "not-an-id"},
+            )
+        )
+        assert "error" in bad_cursor and "after_store_id" in bad_cursor["error"]
+
+        bad_limit = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "limit": "not-a-limit"},
+            )
+        )
+        assert "error" in bad_limit and "limit" in bad_limit["error"]
+
+        bad_max_content_chars = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "max_content_chars": "not-a-size"},
+            )
+        )
+        assert "error" in bad_max_content_chars and "max_content_chars" in bad_max_content_chars["error"]
+
+        bad_range = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "old-session", "time_from": 5, "time_to": 4},
+            )
+        )
+        assert "error" in bad_range and "time_to" in bad_range["error"]
+
+    def test_load_session_clamps_limit_and_never_falls_back_to_current(self, engine):
+        self._seed_old_session(engine)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_load_session",
+                {"session_id": "missing-session", "limit": 5000},
+            )
+        )
+
+        assert result["session_id"] == "missing-session"
+        assert result["limit"] == 200
+        assert result["limit_clamped_from"] == 5000
+        assert result["total_messages"] == 0
+        assert result["messages"] == []
+        assert result["has_more"] is False
 
 
 class TestExtractionDuringCompress:

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -45,6 +45,23 @@ def test_standalone_install_scripts_exist_and_are_shell_scripts():
     assert update_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
 
 
+def test_plugin_manifest_lists_all_registered_tools():
+    repo_root = Path(__file__).resolve().parent.parent
+    manifest = (repo_root / "plugin.yaml").read_text(encoding="utf-8")
+
+    expected_tools = {
+        "lcm_grep",
+        "lcm_load_session",
+        "lcm_describe",
+        "lcm_expand",
+        "lcm_expand_query",
+        "lcm_status",
+        "lcm_doctor",
+    }
+    for tool_name in expected_tools:
+        assert f"  - {tool_name}\n" in manifest
+
+
 def test_install_script_creates_profile_aware_symlink_and_prints_activation_steps(tmp_path):
     repo_root = Path(__file__).resolve().parent.parent
     hermes_home = tmp_path / "hermes-home"
@@ -118,6 +135,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     tool_names = {schema["name"] for schema in engine.get_tool_schemas()}
     assert {
         "lcm_grep",
+        "lcm_load_session",
         "lcm_describe",
         "lcm_expand",
         "lcm_expand_query",

--- a/tools.py
+++ b/tools.py
@@ -151,8 +151,30 @@ def _parse_positive_int(value: Any, default: int) -> int:
     return max(1, _parse_int_value(value, default))
 
 
+def _parse_optional_float(value: Any, name: str) -> tuple[float | None, str | None]:
+    if value is None:
+        return None, None
+    try:
+        return float(value), None
+    except (TypeError, ValueError, OverflowError):
+        return None, f"{name} must be a number"
+
+
+def _parse_strict_int(value: Any, name: str) -> tuple[int | None, str | None]:
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        return int(value), None
+    except (TypeError, ValueError, OverflowError):
+        return None, f"{name} must be an integer"
+
+
 _LCM_GREP_VALID_SCOPES = frozenset({"current", "all", "session"})
 _LCM_GREP_HARD_LIMIT_CAP = 200
+_LCM_LOAD_SESSION_DEFAULT_LIMIT = 100
+_LCM_LOAD_SESSION_HARD_LIMIT_CAP = 200
+_LCM_LOAD_SESSION_DEFAULT_MAX_CONTENT_CHARS = 4000
+_LCM_LOAD_SESSION_HARD_MAX_CONTENT_CHARS = 20_000
 
 
 def _slice_content_for_response(content: str, max_tokens: int, content_offset: int = 0) -> dict[str, Any]:
@@ -529,6 +551,150 @@ def _synthesize_expansion_answer(
         content = str(content) if content else ""
     from .escalation import _strip_reasoning_blocks
     return _strip_reasoning_blocks(content).strip()
+
+
+def _parse_load_session_roles(value: Any) -> tuple[list[str], str | None]:
+    if value is None:
+        return [], None
+    if not isinstance(value, list):
+        return [], "roles must be an array of strings"
+    roles: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        role = str(item or "").strip()
+        if not role:
+            return [], "roles must contain only non-empty strings"
+        if role not in seen:
+            roles.append(role)
+            seen.add(role)
+    return roles, None
+
+
+def _slice_loaded_content(content: Any, max_content_chars: int) -> dict[str, Any]:
+    text = content or ""
+    sliced = text[:max_content_chars]
+    has_more = len(sliced) < len(text)
+    return {
+        "content": sliced,
+        "content_chars": len(text),
+        "content_returned_chars": len(sliced),
+        "content_truncated": has_more,
+        "next_content_offset": len(sliced) if has_more else 0,
+    }
+
+
+def _serialize_loaded_message(engine: "LCMEngine", row: dict[str, Any], max_content_chars: int) -> dict[str, Any]:
+    stored_session_id = row.get("session_id", "")
+    content_slice = _slice_loaded_content(row.get("content", "") or "", max_content_chars)
+    item: dict[str, Any] = {
+        "store_id": row.get("store_id"),
+        "session_id": stored_session_id,
+        "source": row.get("source") or "",
+        "role": row.get("role"),
+        "timestamp": row.get("timestamp", 0),
+        "content": content_slice["content"],
+        "content_chars": content_slice["content_chars"],
+        "content_returned_chars": content_slice["content_returned_chars"],
+        "content_truncated": content_slice["content_truncated"],
+        "next_content_offset": content_slice["next_content_offset"],
+        "from_current_session": bool(engine._session_id) and stored_session_id == engine._session_id,
+    }
+    if row.get("tool_call_id"):
+        item["tool_call_id"] = row.get("tool_call_id")
+    if row.get("tool_calls"):
+        item["tool_calls"] = row.get("tool_calls")
+    if row.get("tool_name"):
+        item["tool_name"] = row.get("tool_name")
+    return item
+
+
+def lcm_load_session(args: Dict[str, Any], **kwargs) -> str:
+    """Load an ordered, bounded raw-message page for one explicit session_id."""
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+
+    session_id = str(args.get("session_id") or "").strip()
+    if not session_id:
+        return json.dumps({"error": "session_id is required"})
+
+    raw_limit_arg = args.get("limit", _LCM_LOAD_SESSION_DEFAULT_LIMIT)
+    parsed_limit, limit_error = _parse_strict_int(raw_limit_arg, "limit")
+    if limit_error:
+        return json.dumps({"error": limit_error})
+    if parsed_limit is None or parsed_limit <= 0:
+        return json.dumps({"error": "limit must be a positive integer"})
+    requested_limit = parsed_limit
+    limit = min(requested_limit, _LCM_LOAD_SESSION_HARD_LIMIT_CAP)
+
+    raw_max_content_chars = args.get("max_content_chars", _LCM_LOAD_SESSION_DEFAULT_MAX_CONTENT_CHARS)
+    max_content_chars, max_content_error = _parse_strict_int(raw_max_content_chars, "max_content_chars")
+    if max_content_error:
+        return json.dumps({"error": max_content_error})
+    if max_content_chars is None or max_content_chars <= 0:
+        return json.dumps({"error": "max_content_chars must be a positive integer"})
+    requested_max_content_chars = max_content_chars
+    max_content_chars = min(max_content_chars, _LCM_LOAD_SESSION_HARD_MAX_CONTENT_CHARS)
+
+    after_store_id, cursor_error = _parse_strict_int(args.get("after_store_id", 0), "after_store_id")
+    if cursor_error:
+        return json.dumps({"error": cursor_error})
+    if after_store_id is None or after_store_id < 0:
+        return json.dumps({"error": "after_store_id must be a non-negative integer"})
+
+    roles, roles_error = _parse_load_session_roles(args.get("roles"))
+    if roles_error:
+        return json.dumps({"error": roles_error})
+
+    time_from, time_from_error = _parse_optional_float(args.get("time_from"), "time_from")
+    if time_from_error:
+        return json.dumps({"error": time_from_error})
+    time_to, time_to_error = _parse_optional_float(args.get("time_to"), "time_to")
+    if time_to_error:
+        return json.dumps({"error": time_to_error})
+    if time_from is not None and time_to is not None and time_to < time_from:
+        return json.dumps({"error": "time_to must be greater than or equal to time_from"})
+
+    total_messages = engine._store.count_session_load_messages(
+        session_id,
+        roles=roles or None,
+        time_from=time_from,
+        time_to=time_to,
+    )
+    rows = engine._store.load_session_page(
+        session_id,
+        after_store_id=after_store_id,
+        limit=limit + 1,
+        roles=roles or None,
+        time_from=time_from,
+        time_to=time_to,
+    )
+    page_rows = rows[:limit]
+    has_more = len(rows) > limit
+    next_cursor = page_rows[-1]["store_id"] if has_more and page_rows else None
+
+    response: dict[str, Any] = {
+        "session_id": session_id,
+        "limit": limit,
+        "max_content_chars": max_content_chars,
+        "after_store_id": after_store_id,
+        "total_messages": total_messages,
+        "returned_messages": len(page_rows),
+        "messages": [_serialize_loaded_message(engine, row, max_content_chars) for row in page_rows],
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+    if roles:
+        response["roles"] = roles
+    if time_from is not None:
+        response["time_from"] = time_from
+    if time_to is not None:
+        response["time_to"] = time_to
+    if requested_limit > _LCM_LOAD_SESSION_HARD_LIMIT_CAP:
+        response["limit_clamped_from"] = requested_limit
+    if requested_max_content_chars > _LCM_LOAD_SESSION_HARD_MAX_CONTENT_CHARS:
+        response["max_content_chars_clamped_from"] = requested_max_content_chars
+    return json.dumps(response)
 
 
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:


### PR DESCRIPTION
## Summary

This adds `lcm_load_session`, a small raw transcript loader for #112. It is meant for the case where a caller already has a concrete LCM `session_id` and wants to enumerate that session directly instead of using search-shaped tools.

What changed:

- new `lcm_load_session` tool schema, handler registration, and manifest entry
- explicit `session_id` requirement, with no implicit current-session fallback
- ordered raw rows by `store_id`
- row pagination through `after_store_id` and `next_cursor`
- optional role and timestamp filters
- hard caps for row count and per-message content size
- truncation metadata so large individual rows can be recovered with `lcm_expand(store_id=...)`

@castaples this targets the workflow from #112. @stephenschoettler could you take a look when you get a chance?

Closes #112

## Validation

- `python -m pytest tests/test_lcm_engine.py::TestEngineABC::test_tool_schemas tests/test_lcm_engine.py::TestEngineABC::test_readme_documents_session_scope_contract tests/test_lcm_engine.py::TestHandleLoadSession tests/test_packaging_install.py::test_plugin_manifest_lists_all_registered_tools tests/test_packaging_install.py::test_plugin_entrypoint_registers_lcm_context_engine -q -o addopts=`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_import_lossless_claw.py -q -o addopts=`
- `python -m pytest -q -o addopts=`
- `python -m compileall -q .`
- `python -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
