### PR TITLE
feat: add message-level ignore patterns for LCM ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ environment variables:
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after manual `/new` (`-1` all, `0` none) |
 | `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
 | `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
+| `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, or the normalized form for structured/multimodal content) is excluded from LCM storage |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized tool outputs in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for tool output text |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
@@ -227,6 +228,60 @@ Pattern matching checks multiple keys: raw `session_id`, `platform`, and
 
 Example: `cron:*` can match Hermes cron sessions, while exact raw session IDs
 still work.
+
+### Noise suppression
+
+LCM offers two layers of noise filtering, sized to two different shapes of
+noise:
+
+- **Session-level filters** (`LCM_IGNORE_SESSION_PATTERNS`,
+  `LCM_STATELESS_SESSION_PATTERNS`) catch the case where the noisy traffic
+  arrives as its own session or platform, for example a dedicated `cron:*`
+  session. Match keys cover the session id, the platform, and
+  `platform:session_id`.
+- **Message-level patterns** (`LCM_IGNORE_MESSAGE_PATTERNS`) catch the case
+  where cron alerts or other noise are injected into a normal Telegram or
+  WhatsApp conversation as ordinary user-visible messages. From LCM's
+  perspective the session/platform is `telegram` or `whatsapp`, not `cron`,
+  so only the message content is distinctive.
+
+Message-level patterns are Python regex strings, comma-separated, compiled
+once at engine start. They run against the normalized message content (the
+same string LCM would have written to the store). Matching messages are
+skipped before storage, so they never enter the messages table, the FTS
+index, or the DAG. Filtering is role-agnostic by default, since cron alerts
+can be re-emitted under any role depending on the gateway.
+
+Example operator config:
+
+```
+LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
+```
+
+Invalid regex entries are logged at warning level and dropped; the
+surviving patterns in the same list still take effect, so a misconfigured
+entry never crashes ingest.
+
+Two operator-facing limitations to know about:
+
+- **Anchored patterns are best-effort against multimodal content.**
+  Structured payloads (lists of content parts) are normalized via JSON
+  serialization before matching, so a `^`-anchored pattern binds to the
+  JSON wrapper rather than to the inner text. If you expect cron alerts to
+  arrive as multimodal payloads from your gateway, use unanchored patterns
+  (for example `Cronjob Response:` instead of `^Cronjob Response:`).
+- **Compaction-window edge.** The filter runs at ingest time. On a rare
+  turn where a matching message is part of the chunk being summarized in
+  the same turn it arrived, the message's text may briefly appear inside
+  the resulting summary node text. The summary node's `source_ids` will
+  not reference the filtered message (it was never written to the store),
+  so DAG lineage stays clean; only the serialized summary text can carry
+  it. Closing this window is tracked as follow-up work.
+
+`lcm_status` surfaces `ignore_message_patterns`, `ignore_message_patterns_source`
+(`default` or `env`), and a process-lifetime `ignored_message_count` so
+operators can confirm their pattern is loaded and watch how often it fires.
+The counter resets on engine restart.
 
 ### Large tool-output handling
 

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ noise:
 Message-level patterns are Python regex strings, comma-separated, compiled
 once at engine start. They run against the normalized message content (the
 same string LCM would have written to the store). Matching messages are
-skipped before storage, so they never enter the messages table, the FTS
-index, or the DAG. Filtering is role-agnostic by default, since cron alerts
-can be re-emitted under any role depending on the gateway.
+skipped before storage, so new matching rows do not enter the messages table
+or FTS index. Filtering is role-agnostic by default, since cron alerts can
+be re-emitted under any role depending on the gateway.
 
 Example operator config:
 

--- a/config.py
+++ b/config.py
@@ -85,14 +85,17 @@ class LCMConfig:
     # (0 = disabled). Effective cap becomes context_length - reserve_tokens_floor.
     reserve_tokens_floor: int = 0
 
-    # -- Session filtering ---
+    # -- Session and message filtering ---
     # Sessions to exclude from LCM storage entirely.
     ignore_session_patterns: list[str] = field(default_factory=list)
     # Sessions that may read carried-over LCM state but never write new data.
     stateless_session_patterns: list[str] = field(default_factory=list)
+    # Per-message regex patterns; matching messages are skipped before LCM storage.
+    ignore_message_patterns: list[str] = field(default_factory=list)
     # Diagnostics: where each pattern list came from.
     ignore_session_patterns_source: str = "default"
     stateless_session_patterns_source: str = "default"
+    ignore_message_patterns_source: str = "default"
 
     # -- Summary instructions ---
     # Custom instructions injected into all summarization prompts
@@ -215,5 +218,10 @@ class LCMConfig:
         if raw_stateless is not None:
             c.stateless_session_patterns = _parse_pattern_list(raw_stateless)
             c.stateless_session_patterns_source = "env"
+
+        raw_ignore_messages = os.environ.get("LCM_IGNORE_MESSAGE_PATTERNS")
+        if raw_ignore_messages is not None:
+            c.ignore_message_patterns = _parse_pattern_list(raw_ignore_messages)
+            c.ignore_message_patterns_source = "env"
 
         return c

--- a/engine.py
+++ b/engine.py
@@ -1667,6 +1667,12 @@ class LCMEngine(ContextEngine):
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
 
+    def _matches_ignore_message_patterns(self, msg: Dict[str, Any]) -> bool:
+        if not self._compiled_ignore_message_patterns:
+            return False
+        text = normalize_content_value(msg.get("content")) or ""
+        return matches_message_pattern(text, self._compiled_ignore_message_patterns)
+
     def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
         """Return true for active-context scaffolding that should not be re-ingested."""
         role = str(msg.get("role") or "")
@@ -1726,6 +1732,7 @@ class LCMEngine(ContextEngine):
                 self._message_replay_identity(msg)
                 for msg in messages[:cursor]
                 if not self._is_replayed_context_scaffold_message(msg)
+                and not self._matches_ignore_message_patterns(msg)
             ]
             if not candidate_prefix:
                 empty_prefix_cursor = cursor
@@ -1752,12 +1759,14 @@ class LCMEngine(ContextEngine):
             return 0
 
         tail_limit = min(max(len(messages) * 4, 64), session_count)
+        stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)
+        if not stored_rows:
+            return 0
         stored_tail = [
             self._message_replay_identity(row)
-            for row in self._store.get_session_tail(self._session_id, limit=tail_limit)
+            for row in stored_rows
+            if not self._matches_ignore_message_patterns(row)
         ]
-        if not stored_tail:
-            return 0
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,
@@ -1814,9 +1823,9 @@ class LCMEngine(ContextEngine):
         if self._compiled_ignore_message_patterns:
             kept: List[Dict[str, Any]] = []
             for msg in new_messages:
-                text = normalize_content_value(msg.get("content")) or ""
-                if matches_message_pattern(text, self._compiled_ignore_message_patterns):
+                if self._matches_ignore_message_patterns(msg):
                     self._ignored_message_count += 1
+                    text = normalize_content_value(msg.get("content")) or ""
                     excerpt = text[:80].replace("\n", " ")
                     logger.debug(
                         "LCM ignore_message_patterns dropped %s message: %r",

--- a/engine.py
+++ b/engine.py
@@ -39,6 +39,7 @@ from .session_patterns import (
     compile_session_patterns,
     matches_session_pattern,
 )
+from .message_patterns import compile_message_patterns, matches_message_pattern
 from .lifecycle_state import LifecycleStateStore
 from .message_content import normalize_content_value
 from .store import MessageStore
@@ -251,6 +252,10 @@ class LCMEngine(ContextEngine):
         self._compiled_stateless_session_patterns = compile_session_patterns(
             self._config.stateless_session_patterns
         )
+        self._compiled_ignore_message_patterns = compile_message_patterns(
+            self._config.ignore_message_patterns
+        )
+        self._ignored_message_count: int = 0
 
         # Track which store_ids have been ingested into the DAG
         self._last_compacted_store_id: int = 0
@@ -1557,8 +1562,11 @@ class LCMEngine(ContextEngine):
             status["session_stateless"] = self._session_stateless
             status["ignore_session_patterns"] = list(self._config.ignore_session_patterns)
             status["stateless_session_patterns"] = list(self._config.stateless_session_patterns)
+            status["ignore_message_patterns"] = list(self._config.ignore_message_patterns)
             status["ignore_session_patterns_source"] = self._config.ignore_session_patterns_source
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
+            status["ignore_message_patterns_source"] = self._config.ignore_message_patterns_source
+            status["ignored_message_count"] = self._ignored_message_count
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
             status["conversation_id"] = self._conversation_id
@@ -1625,6 +1633,12 @@ class LCMEngine(ContextEngine):
                     "LCM stateless_session_patterns from %s: %s",
                     self._config.stateless_session_patterns_source,
                     ", ".join(self._config.stateless_session_patterns),
+                )
+            if self._config.ignore_message_patterns:
+                logger.info(
+                    "LCM ignore_message_patterns from %s: %s",
+                    self._config.ignore_message_patterns_source,
+                    ", ".join(self._config.ignore_message_patterns),
                 )
             self._logged_filter_config = True
         if self._session_ignored:
@@ -1795,6 +1809,26 @@ class LCMEngine(ContextEngine):
         new_messages = messages[cursor:] if cursor < n else []
 
         if not new_messages:
+            return
+
+        if self._compiled_ignore_message_patterns:
+            kept: List[Dict[str, Any]] = []
+            for msg in new_messages:
+                text = normalize_content_value(msg.get("content")) or ""
+                if matches_message_pattern(text, self._compiled_ignore_message_patterns):
+                    self._ignored_message_count += 1
+                    excerpt = text[:80].replace("\n", " ")
+                    logger.debug(
+                        "LCM ignore_message_patterns dropped %s message: %r",
+                        msg.get("role", "unknown"),
+                        excerpt,
+                    )
+                    continue
+                kept.append(msg)
+            new_messages = kept
+
+        if not new_messages:
+            self._ingest_cursor = n
             return
 
         estimates = [count_message_tokens(m) for m in new_messages]

--- a/message_patterns.py
+++ b/message_patterns.py
@@ -1,0 +1,42 @@
+"""Message-content pattern helpers for LCM ingest filtering.
+
+Patterns are Python regex strings. Compilation is tolerant: an invalid
+pattern emits a warning and is skipped, leaving valid patterns in the
+same list still active. Matching uses ``re.search`` so user-supplied
+anchors (``^``, ``\\b``) and inline flags (``(?is)``) work as written.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+
+def compile_message_patterns(patterns: Iterable[str]) -> List[re.Pattern[str]]:
+    """Compile configured message patterns once at startup.
+
+    Each pattern is compiled with ``re.compile``. Patterns that fail to
+    compile are logged at WARNING level and dropped. Returns only the
+    patterns that compiled successfully.
+    """
+    compiled: List[re.Pattern[str]] = []
+    for pattern in patterns:
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as exc:
+            logger.warning(
+                "LCM ignore_message_patterns: skipping invalid regex %r: %s",
+                pattern,
+                exc,
+            )
+    return compiled
+
+
+def matches_message_pattern(text: str, patterns: Iterable[re.Pattern[str]]) -> bool:
+    """Return True when ``text`` matches any of the compiled patterns."""
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in patterns)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -24,6 +24,10 @@ from hermes_lcm.session_patterns import (
     compile_session_patterns,
     matches_session_pattern,
 )
+from hermes_lcm.message_patterns import (
+    compile_message_patterns,
+    matches_message_pattern,
+)
 
 
 class TestModelRouting:
@@ -298,8 +302,10 @@ class TestConfig:
         assert c.deferred_maintenance_max_passes == 4
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
+        assert c.ignore_message_patterns == []
         assert c.ignore_session_patterns_source == "default"
         assert c.stateless_session_patterns_source == "default"
+        assert c.ignore_message_patterns_source == "default"
         assert c.summary_model == ""
         assert c.expansion_model == ""
         assert c.expansion_context_tokens == 32_000
@@ -311,6 +317,10 @@ class TestConfig:
         monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.80")
         monkeypatch.setenv("LCM_IGNORE_SESSION_PATTERNS", "cron:*,subagent:**")
         monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "telegram:*, cli:debug")
+        monkeypatch.setenv(
+            "LCM_IGNORE_MESSAGE_PATTERNS",
+            "^Cronjob Response:,^>>>Cronjob Response<<<:",
+        )
         monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
         monkeypatch.setenv("LCM_EXPANSION_CONTEXT_TOKENS", "64000")
         monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
@@ -332,8 +342,13 @@ class TestConfig:
         assert c.context_threshold == 0.80
         assert c.ignore_session_patterns == ["cron:*", "subagent:**"]
         assert c.stateless_session_patterns == ["telegram:*", "cli:debug"]
+        assert c.ignore_message_patterns == [
+            "^Cronjob Response:",
+            "^>>>Cronjob Response<<<:",
+        ]
         assert c.ignore_session_patterns_source == "env"
         assert c.stateless_session_patterns_source == "env"
+        assert c.ignore_message_patterns_source == "env"
         assert c.expansion_model == "openai/gpt-5.4-mini"
         assert c.expansion_context_tokens == 64_000
         assert c.summary_timeout_ms == 45_000
@@ -399,6 +414,46 @@ class TestSessionPatterns:
             build_session_match_keys("sess-123", platform="cli"),
             patterns,
         )
+
+
+class TestMessagePatterns:
+    def test_compile_and_match_anchored_prefix(self):
+        patterns = compile_message_patterns(["^Cronjob Response:"])
+        assert len(patterns) == 1
+        assert matches_message_pattern("Cronjob Response: heartbeat ok", patterns)
+        assert not matches_message_pattern("could you check the cronjob response?", patterns)
+
+    def test_compile_inline_flags_and_wrapper_variants(self):
+        patterns = compile_message_patterns([r"(?is)^\s*(>>>\s*)?Cronjob Response"])
+        assert matches_message_pattern("Cronjob Response: heartbeat", patterns)
+        assert matches_message_pattern("   >>> Cronjob Response: heartbeat", patterns)
+        assert matches_message_pattern("\n  cronjob response: heartbeat", patterns)
+        assert not matches_message_pattern("normal user message", patterns)
+
+    def test_empty_patterns_never_match(self):
+        assert matches_message_pattern("Cronjob Response: x", []) is False
+
+    def test_empty_or_none_text_does_not_match(self):
+        patterns = compile_message_patterns(["^Cronjob"])
+        assert matches_message_pattern("", patterns) is False
+        assert matches_message_pattern(None, patterns) is False
+
+    def test_invalid_regex_is_logged_and_dropped(self, caplog):
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            compiled = compile_message_patterns(["[unclosed"])
+        assert compiled == []
+        assert "skipping invalid regex" in caplog.text
+        assert "[unclosed" in caplog.text
+
+    def test_mixed_validity_keeps_valid_patterns(self, caplog):
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            compiled = compile_message_patterns(
+                ["^Cronjob Response:", "[unclosed", "^Other:"]
+            )
+        assert len(compiled) == 2
+        assert matches_message_pattern("Cronjob Response: x", compiled)
+        assert matches_message_pattern("Other: y", compiled)
+        assert caplog.text.count("skipping invalid regex") == 1
 
 
 class TestTokens:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -959,6 +959,209 @@ class TestSessionFiltering:
         assert instance.compression_count == 0
 
 
+class TestMessageFiltering:
+    def _make_engine(self, tmp_path, db_name, **config_kwargs):
+        config = LCMConfig(
+            database_path=str(tmp_path / db_name),
+            **config_kwargs,
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("user-123", platform="telegram", context_length=1000)
+        return engine
+
+    def test_no_patterns_means_no_filtering(self, tmp_path):
+        engine = self._make_engine(tmp_path, "lcm_msg_unset.db")
+        messages = [
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "normal text"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 3
+        assert engine._ignored_message_count == 0
+
+    def test_anchored_prefix_drops_matching_message(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_anchor.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+            ignore_message_patterns_source="env",
+        )
+        messages = [
+            {"role": "user", "content": "Cronjob Response: hermie heartbeat\n(job_id: abc)"},
+            {"role": "user", "content": "can you check the database for me?"},
+            {"role": "assistant", "content": "Sure, looking now."},
+        ]
+        engine._ingest_messages(messages)
+
+        stored = engine._store.get_session_messages("user-123")
+        stored_contents = [row["content"] for row in stored]
+        assert len(stored) == 2
+        assert "Cronjob Response:" not in "\n".join(stored_contents)
+        assert "can you check the database for me?" in stored_contents
+        assert engine._ignored_message_count == 1
+
+    def test_triple_bracket_wrapper_variant_dropped(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_triple.db",
+            ignore_message_patterns=["^>>>Cronjob Response<<<:"],
+        )
+        messages = [
+            {"role": "user", "content": ">>>Cronjob Response<<<: heartbeat"},
+            {"role": "user", "content": "regular question"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 1
+
+    def test_inline_flag_pattern_drops_both_wrapper_variants(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_inline.db",
+            ignore_message_patterns=[r"(?is)^\s*(>>>\s*)?Cronjob Response"],
+        )
+        messages = [
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "  >>> Cronjob Response: heartbeat"},
+            {"role": "user", "content": "non-matching content"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 2
+
+    def test_active_pattern_does_not_regress_normal_messages(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_normal.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        messages = [
+            {"role": "user", "content": "Can you check the database for me?"},
+            {"role": "assistant", "content": "Looking now."},
+        ]
+        engine._ingest_messages(messages)
+        stored_contents = [
+            row["content"] for row in engine._store.get_session_messages("user-123")
+        ]
+        assert stored_contents == [
+            "Can you check the database for me?",
+            "Looking now.",
+        ]
+        assert engine._ignored_message_count == 0
+
+    def test_anchored_pattern_does_not_match_multimodal_content(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_multimodal_anchored.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        multimodal = {
+            "role": "user",
+            "content": [{"type": "text", "text": "Cronjob Response: heartbeat"}],
+        }
+        engine._ingest_messages([multimodal])
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 0
+
+    def test_unanchored_pattern_matches_multimodal_content(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_multimodal_substr.db",
+            ignore_message_patterns=["Cronjob Response:"],
+        )
+        multimodal = {
+            "role": "user",
+            "content": [{"type": "text", "text": "Cronjob Response: heartbeat"}],
+        }
+        engine._ingest_messages([multimodal])
+        assert engine._store.get_session_count("user-123") == 0
+        assert engine._ignored_message_count == 1
+
+    def test_filter_is_role_agnostic(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_roles.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        messages = [
+            {"role": "tool", "content": "Cronjob Response: tool-emitted"},
+            {"role": "assistant", "content": "Cronjob Response: assistant-quoted"},
+            {"role": "user", "content": "user-normal"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 2
+
+    def test_invalid_regex_warned_and_surviving_pattern_still_filters(self, tmp_path, caplog):
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            engine = self._make_engine(
+                tmp_path, "lcm_msg_invalid.db",
+                ignore_message_patterns=["[unclosed", "^Cronjob Response:"],
+            )
+
+        assert "skipping invalid regex" in caplog.text
+        assert "[unclosed" in caplog.text
+
+        engine._ingest_messages([
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "normal text"},
+        ])
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 1
+
+    def test_session_filter_and_message_filter_coexist(self, tmp_path):
+        # Session-level filter blocks all writes for a matched session,
+        # taking precedence over per-message filtering.
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_both_filters.db"),
+            ignore_session_patterns=["cron:*"],
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("cron_123", platform="cron", context_length=1000)
+        engine._ingest_messages([
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "anything"},
+        ])
+        assert engine._store.get_session_count("cron_123") == 0
+        # Counter does not increment for ignored sessions: ingest short-circuits before the message filter runs.
+        assert engine._ignored_message_count == 0
+
+        # On a normal-platform session, only the message filter applies.
+        engine.on_session_start("user-123", platform="telegram", context_length=1000)
+        engine._ingest_messages([
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "regular conversation"},
+        ])
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 1
+
+    def test_status_surfaces_message_pattern_keys(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_status.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+            ignore_message_patterns_source="env",
+        )
+        engine._ingest_messages([
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+        ])
+        status = engine.get_status()
+        assert status["ignore_message_patterns"] == ["^Cronjob Response:"]
+        assert status["ignore_message_patterns_source"] == "env"
+        assert status["ignored_message_count"] == 1
+        # Existing session-pattern keys are still surfaced unchanged.
+        assert status["ignore_session_patterns"] == []
+        assert status["ignore_session_patterns_source"] == "default"
+
+    def test_diagnostic_log_emits_once_per_engine(self, tmp_path, caplog):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_msg_log_once.db"),
+            ignore_message_patterns=["^Cronjob Response:"],
+            ignore_message_patterns_source="env",
+        )
+        engine = LCMEngine(config=config)
+
+        with caplog.at_level("INFO", logger="hermes_lcm.engine"):
+            engine.on_session_start("user-123", platform="telegram", context_length=1000)
+            engine.on_session_start("user-456", platform="telegram", context_length=1000)
+
+        assert caplog.text.count("LCM ignore_message_patterns from env: ^Cronjob Response:") == 1
+
+
 class TestEngineIngest:
     def test_ingest_stores_messages(self, engine):
         messages = [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1161,6 +1161,85 @@ class TestMessageFiltering:
 
         assert caplog.text.count("LCM ignore_message_patterns from env: ^Cronjob Response:") == 1
 
+    def test_restart_reconciliation_skips_ignored_messages_when_matching_store_tail(self, tmp_path):
+        db_path = tmp_path / "lcm_msg_restart_tail.db"
+        config = LCMConfig(
+            database_path=str(db_path),
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "user-123",
+            platform="telegram",
+            context_length=1000,
+            conversation_id="chat-1",
+        )
+        active_context = [
+            {"role": "user", "content": "first real message"},
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "assistant", "content": "real answer"},
+        ]
+        before_restart._ingest_messages(active_context)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "user-123",
+            platform="telegram",
+            context_length=1000,
+            conversation_id="chat-1",
+        )
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages("user-123")
+        assert [row["content"] for row in rows] == ["first real message", "real answer"]
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_restart_reconciliation_skips_historical_ignored_rows_when_filter_enabled_later(self, tmp_path):
+        db_path = tmp_path / "lcm_msg_restart_later_filter.db"
+        before_config = LCMConfig(database_path=str(db_path))
+
+        before_filter = LCMEngine(config=before_config)
+        before_filter.on_session_start(
+            "user-123",
+            platform="telegram",
+            context_length=1000,
+            conversation_id="chat-1",
+        )
+        active_context = [
+            {"role": "user", "content": "first real message"},
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "assistant", "content": "real answer"},
+        ]
+        before_filter._ingest_messages(active_context)
+        before_filter._store.close()
+        before_filter._dag.close()
+        before_filter._lifecycle.close()
+
+        after_config = LCMConfig(
+            database_path=str(db_path),
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        after_filter_restart = LCMEngine(config=after_config)
+        after_filter_restart.on_session_start(
+            "user-123",
+            platform="telegram",
+            context_length=1000,
+            conversation_id="chat-1",
+        )
+        after_filter_restart._ingest_messages(active_context)
+
+        rows = after_filter_restart._store.get_session_messages("user-123")
+        assert [row["content"] for row in rows] == [
+            "first real message",
+            "Cronjob Response: heartbeat",
+            "real answer",
+        ]
+        assert after_filter_restart._ingest_cursor == len(active_context)
+
 
 class TestEngineIngest:
     def test_ingest_stores_messages(self, engine):


### PR DESCRIPTION
Closes #117.

## Summary

Adds `LCM_IGNORE_MESSAGE_PATTERNS`, a comma-separated list of Python regex patterns that drops noise out of the immutable LCM message store at ingest time. Designed for the case where Hermes cron alerts (e.g. `Cronjob Response: hermie-hourly-heartbeat`) are delivered into a normal Telegram or WhatsApp conversation as ordinary user-visible messages, so session-level globs like `cron:*` cannot catch them.

The implementation mirrors the existing `LCM_IGNORE_SESSION_PATTERNS` shape: dataclass field + source-diagnostics field, env-parse block in `LCMConfig.from_env()`, dedicated helper module (`message_patterns.py`), one-shot diagnostic log gated by the existing `_logged_filter_config` flag, and three new keys in `lcm_status`. Default behavior is unchanged: when the env var is absent, no filtering happens and all existing tests still pass.

## What's in this PR

- `config.py`: `ignore_message_patterns: list[str]` + `ignore_message_patterns_source: str` fields, `from_env()` block reading `LCM_IGNORE_MESSAGE_PATTERNS`.
- `message_patterns.py` (new): `compile_message_patterns(patterns)` which catches `re.error` per-pattern with a `logger.warning`, and `matches_message_pattern(text, patterns)` using `re.search` so user-supplied anchors (`^`, `\b`) and inline flags (`(?is)`) work as written.
- `engine.py`: compile patterns at init, filter matching messages in `_ingest_messages` before `append_batch`, increment a process-lifetime `_ignored_message_count` counter, surface the new keys in `lcm_status`, extend `_log_session_filter_diagnostics`.
- `tests/test_lcm_core.py`: helper-level `TestMessagePatterns`, plus `LCM_IGNORE_MESSAGE_PATTERNS` coverage in `TestConfig`.
- `tests/test_lcm_engine.py`: new `TestMessageFiltering` class covering anchored matching, wrapper variants, inline-flag patterns, the must-not-regress baseline (active pattern + non-matching messages), multimodal content (both anchored-does-not-match and unanchored-substring-does-match cases), role-agnostic filtering, invalid-regex tolerance, coexistence with `LCM_IGNORE_SESSION_PATTERNS`, status surface, and once-per-engine-instance diagnostic logging.
- `README.md`: env var table row + a noise-suppression section explaining when to use session-level vs message-level filtering, the operator example config line, and two documented limitations.

## Operator example

```
LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
```

`lcm_status` then reports `ignore_message_patterns`, `ignore_message_patterns_source` (`default` or `env`), and a process-lifetime `ignored_message_count` so operators can confirm their config was loaded and watch how often it fires.

## Documented limitations

- **Anchored patterns are best-effort against multimodal content.** Structured payloads (lists of content parts) are normalized via `normalize_content_value`'s JSON serialization before matching, so `^Cronjob Response:` binds to the JSON wrapper rather than to the inner text. Operators who need multimodal coverage should write unanchored patterns. Tests assert both the anchored-does-not-match and unanchored-substring-does-match cases explicitly so the contract is documented in code.
- **Compaction-window edge.** The filter runs at ingest. On a rare turn where a matching message is part of the chunk being summarized in the same turn it arrived, its text may briefly appear inside the resulting summary node text. The summary node's `source_ids` will not reference the filtered message (it was never written to the store), so DAG lineage stays clean. Closing this window cleanly requires also adjusting the `len(compacted_chunk)`-based slice arithmetic in `compress()`, which materially expands the diff; tracked as follow-up work.

## Test plan

- [x] `pytest tests/test_lcm_core.py::TestMessagePatterns` — 6 helper tests pass.
- [x] `pytest tests/test_lcm_core.py::TestConfig` — defaults + from_env coverage pass with the new field.
- [x] `pytest tests/test_lcm_engine.py::TestMessageFiltering` — 12 ingest/status/log scenarios pass.
- [x] `pytest tests/test_lcm_engine.py::TestSessionFiltering` — regression guard for session-level filter, all green.
- [x] `pytest tests/test_lcm_engine.py::TestEngineIngest` — regression guard for cursor invariant, all green.
- [x] Full suite: 471 passed (up from 453 before this PR).