### PR TITLE
chore: address review follow-ups for message-ignore-patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,15 @@ Two operator-facing limitations to know about:
   JSON wrapper rather than to the inner text. If you expect cron alerts to
   arrive as multimodal payloads from your gateway, use unanchored patterns
   (for example `Cronjob Response:` instead of `^Cronjob Response:`).
-- **Compaction-window edge.** The filter runs at ingest time. On a rare
-  turn where a matching message is part of the chunk being summarized in
-  the same turn it arrived, the message's text may briefly appear inside
-  the resulting summary node text. The summary node's `source_ids` will
-  not reference the filtered message (it was never written to the store),
-  so DAG lineage stays clean; only the serialized summary text can carry
-  it. Closing this window is tracked as follow-up work.
+- **Compaction-window edge.** The filter runs at ingest time. When a
+  matching message is part of the chunk being summarized in the same
+  turn it arrived, the message's text may appear inside the resulting
+  summary node text. In long-running sessions where compaction triggers
+  every several dozen turns, this can affect multiple summary nodes per
+  day rather than only happening rarely. The summary node's `source_ids`
+  will not reference the filtered message (it was never written to the
+  store), so DAG lineage stays clean; only the serialized summary text
+  can carry it. Closing this window is tracked as follow-up work.
 
 `lcm_status` surfaces `ignore_message_patterns`, `ignore_message_patterns_source`
 (`default` or `env`), and a process-lifetime `ignored_message_count` so

--- a/schemas.py
+++ b/schemas.py
@@ -166,8 +166,10 @@ LCM_STATUS = {
     "description": (
         "Get a quick health overview of the LCM engine for the current session. "
         "Shows compression count, store size, DAG depth distribution, context usage, "
-        "and active configuration. Use this to understand how much history has been "
-        "compacted and how the engine is performing."
+        "active configuration, and session-filter state (whether the current session "
+        "is matched by ignore or stateless session patterns). Use this to understand "
+        "how much history has been compacted, how the engine is performing, and "
+        "whether the current session is subject to any noise-suppression filters."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1161,6 +1161,47 @@ class TestMessageFiltering:
 
         assert caplog.text.count("LCM ignore_message_patterns from env: ^Cronjob Response:") == 1
 
+    def test_stateless_session_skips_message_filter_entirely(self, tmp_path):
+        # Stateless sessions short-circuit ingest before the message filter runs,
+        # mirroring the ignored-session contract. The counter must not increment
+        # for a stateless session even when patterns would otherwise match.
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_stateless_msg.db"),
+            stateless_session_patterns=["telegram:*"],
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("debug", platform="telegram", context_length=1000)
+        engine._ingest_messages([
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "anything"},
+        ])
+        assert engine._store.get_session_count("debug") == 0
+        assert engine._ignored_message_count == 0
+
+    def test_cursor_advances_when_filter_drops_entire_batch(self, tmp_path):
+        # When every message in a batch matches a filter pattern, _ingest_cursor
+        # must still advance to len(messages). Otherwise a second call with the
+        # same list would re-evaluate every message and double-increment the
+        # counter. Regression guard for the all-filtered early-return path.
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_cursor_all_filtered.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        messages = [
+            {"role": "user", "content": "Cronjob Response: alpha"},
+            {"role": "user", "content": "Cronjob Response: beta"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 0
+        assert engine._ignored_message_count == 2
+        assert engine._ingest_cursor == len(messages)
+
+        # Second call with the same list must not re-process the messages.
+        engine._ingest_messages(messages)
+        assert engine._ignored_message_count == 2
+        assert engine._ingest_cursor == len(messages)
+
     def test_restart_reconciliation_skips_ignored_messages_when_matching_store_tail(self, tmp_path):
         db_path = tmp_path / "lcm_msg_restart_tail.db"
         config = LCMConfig(


### PR DESCRIPTION
Refs #119.

Small uncontroversial follow-ups from the multi-agent code review of PR #118 (`feat: add message-level ignore patterns for LCM ingest`). The full review report is on issue #119; this PR addresses only the items that don't need design discussion.

## What's in this PR

- **README framing fix.** The compaction-window edge case in the noise-suppression section was described as occurring "On a rare turn where..." Adversarial review's traffic math (hourly cron alerts + ~40-turn compaction cadence) suggested the framing oversold the guarantee. Updated to "When..." with honest language about long-running sessions where this can affect multiple summary nodes per day. Behavior unchanged.
- **Stateless + message-filter coexistence test.** Verifies the message filter is correctly bypassed when a session matches `stateless_session_patterns`. Only the ignored-session case was tested before; the stateless early-return path is identical but uncovered. (Three of the review reviewers independently flagged this gap.)
- **All-filtered cursor regression test.** When every message in a batch matches a configured pattern, `_ingest_cursor` advances to `len(messages)` and a subsequent call with the same list does not re-process. Asserts both that the cursor advances correctly and that the counter does not double-increment on the second call.
- **`LCM_STATUS` schema description update.** Mentions session-filter state explicitly so agents diagnosing missing messages know to look there.

## Intentionally excluded

The review surfaced three items that need maintainer input on fix shape before any code change lands. They are documented in #119 for discussion:

- **Pre-existing `lcm_status` tool-handler gap.** `tools.py:lcm_status` builds its own JSON dict and forwards a curated subset of `engine.get_status()`. The `session_filters` block currently only forwards the `ignored` and `stateless` booleans, not the raw pattern lists or source strings. This applies to all pattern types (session, stateless, message), not just the new ones from #118. The fix is straightforward but represents a contract expansion that affects existing behavior, so worth discussing first.
- **ReDoS guard for ingest path.** Operator-supplied regex without length cap or timeout can stall ingest synchronously. Multiple fix shapes possible (input length cap, `regex` library migration with timeout support, threading watchdog).
- **Multimodal anchored-pattern UX.** Documented as a known limitation; design call about whether to extract text parts before matching or keep current behavior.

## Test plan

- [x] `pytest tests/test_lcm_engine.py::TestMessageFiltering` -> 16 passed (was 14 in #118; +2 new tests)
- [x] `pytest -q` -> 478 passed (full suite, no regressions)