### PR TITLE
fix: surface filter config in lcm_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,11 @@ Two operator-facing limitations to know about:
   store), so DAG lineage stays clean; only the serialized summary text
   can carry it. Closing this window is tracked as follow-up work.
 
-`lcm_status` surfaces `ignore_message_patterns`, `ignore_message_patterns_source`
-(`default` or `env`), and a process-lifetime `ignored_message_count` so
-operators can confirm their pattern is loaded and watch how often it fires.
+`lcm_status` surfaces the full filter contract under `session_filters`, including
+`ignore_session_patterns`, `stateless_session_patterns`, `ignore_message_patterns`,
+their `*_source` fields (`default` or `env`), the current session's `ignored` and
+`stateless` booleans, and a process-lifetime `ignored_message_count` so operators
+can confirm their patterns are loaded and watch how often message filters fire.
 The counter resets on engine restart.
 
 ### Large tool-output handling

--- a/schemas.py
+++ b/schemas.py
@@ -225,10 +225,10 @@ LCM_STATUS = {
     "description": (
         "Get a quick health overview of the LCM engine for the current session. "
         "Shows compression count, store size, DAG depth distribution, context usage, "
-        "active configuration, and session-filter state (whether the current session "
-        "is matched by ignore or stateless session patterns). Use this to understand "
-        "how much history has been compacted, how the engine is performing, and "
-        "whether the current session is subject to any noise-suppression filters."
+        "active configuration, and session/message filter state. Use this to "
+        "understand how much history has been compacted, how the engine is "
+        "performing, whether the current session is matched by ignore or stateless "
+        "session patterns, and which message noise-suppression patterns are loaded."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -87,6 +87,35 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
 
 
+def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "tool-status-filter-config.db"),
+        ignore_session_patterns=["cron:*"],
+        stateless_session_patterns=["debug:*"],
+        ignore_message_patterns=["^Cronjob Response:"],
+        ignore_session_patterns_source="env",
+        stateless_session_patterns_source="env",
+        ignore_message_patterns_source="env",
+    )
+    engine = LCMEngine(config=config)
+    engine.on_session_start("chat-1", platform="telegram", context_length=200000)
+    engine._ingest_messages([{"role": "user", "content": "Cronjob Response: heartbeat"}])
+
+    payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+
+    assert payload["session_filters"] == {
+        "ignored": False,
+        "stateless": False,
+        "ignore_session_patterns": ["cron:*"],
+        "ignore_session_patterns_source": "env",
+        "stateless_session_patterns": ["debug:*"],
+        "stateless_session_patterns_source": "env",
+        "ignore_message_patterns": ["^Cronjob Response:"],
+        "ignore_message_patterns_source": "env",
+        "ignored_message_count": 1,
+    }
+
+
 def test_lcm_tool_status_reports_runtime_identity_before_session_binding(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "unbound-tool-status.db"))
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))

--- a/tools.py
+++ b/tools.py
@@ -1401,6 +1401,13 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         "session_filters": {
             "ignored": engine._session_ignored,
             "stateless": engine._session_stateless,
+            "ignore_session_patterns": full_status.get("ignore_session_patterns", []),
+            "ignore_session_patterns_source": full_status.get("ignore_session_patterns_source", "default"),
+            "stateless_session_patterns": full_status.get("stateless_session_patterns", []),
+            "stateless_session_patterns_source": full_status.get("stateless_session_patterns_source", "default"),
+            "ignore_message_patterns": full_status.get("ignore_message_patterns", []),
+            "ignore_message_patterns_source": full_status.get("ignore_message_patterns_source", "default"),
+            "ignored_message_count": full_status.get("ignored_message_count", 0),
         },
         "source_lineage": source_lineage,
         "runtime_identity": runtime_identity,


### PR DESCRIPTION
## Summary
- Forward the full filter contract through the agent-facing `lcm_status` tool under `session_filters`.
- Add a regression test covering session pattern config, message pattern config, source fields, booleans, and `ignored_message_count`.
- Update README and schema wording so the documented `lcm_status` surface matches the tool JSON.

## Why
- Refs #119.
- `engine.get_status()` already exposed these keys, but `tools.py:lcm_status` rebuilt a curated JSON payload and dropped the pattern lists/source fields operators need when diagnosing missing messages.
- This PR chooses the symmetric contract from #119 option 1 for the status surface only. The regex ReDoS guard and multimodal anchored-pattern behavior remain separate scoped PRs.

## Validation
- RED: `python -m pytest tests/test_lcm_engine.py::test_lcm_tool_status_forwards_filter_config_to_agent_surface -q -o addopts=` failed before the tool payload forwarded filter config.
- `python -m pytest tests/test_lcm_engine.py::test_lcm_tool_status_forwards_filter_config_to_agent_surface -q` -> 1 passed
- `python -m compileall -q schemas.py tools.py tests/test_lcm_engine.py`
- `git diff --check`

## Notes
- This intentionally does not close #119. The remaining ReDoS and multimodal matching items are covered by separate scoped PRs.
- Branch was rebased onto current `origin/main` at `f5f3932`.
