### PR TITLE
fix: guard message ignore regex matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ claim that Hermes core has no persisted record of pre-compression history.
 
 - Hermes Agent with the pluggable context engine slot ([PR #7464](https://github.com/NousResearch/hermes-agent/pull/7464))
 - Python 3.11+
-- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates.
+- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates. `regex` is used if available to apply timeouts to message ignore patterns; otherwise LCM keeps a capped stdlib `re` fallback.
 
 ## Install
 
@@ -263,7 +263,10 @@ LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
 
 Invalid regex entries are logged at warning level and dropped; the
 surviving patterns in the same list still take effect, so a misconfigured
-entry never crashes ingest.
+entry never crashes ingest. Pattern matching uses a 50 ms per-pattern timeout
+when the optional `regex` package is installed. If only stdlib `re` is
+available, LCM keeps the plugin importable and caps fallback matching to the
+first 100,000 characters of the normalized content.
 
 Two operator-facing limitations to know about:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ claim that Hermes core has no persisted record of pre-compression history.
 
 - Hermes Agent with the pluggable context engine slot ([PR #7464](https://github.com/NousResearch/hermes-agent/pull/7464))
 - Python 3.11+
-- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates. `regex` is used if available to apply timeouts to message ignore patterns; otherwise LCM keeps a capped stdlib `re` fallback.
+- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates. `regex` is used if available to apply timeouts to message ignore patterns; if it is not installed, message-level regex filtering is disabled with a warning rather than running unbounded stdlib `re` matches.
 
 ## Install
 
@@ -264,18 +264,12 @@ LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
 Invalid regex entries are logged at warning level and dropped; the
 surviving patterns in the same list still take effect, so a misconfigured
 entry never crashes ingest. Pattern matching uses a 50 ms per-pattern timeout
-when the optional `regex` package is installed. If only stdlib `re` is
-available, LCM keeps the plugin importable and caps fallback matching to the
-first 100,000 characters of the normalized content.
+when the optional `regex` package is installed. If `regex` is not installed,
+LCM logs a warning and disables message-level regex filtering rather than
+running unbounded stdlib `re` matches in the ingest path.
 
-Two operator-facing limitations to know about:
+One operator-facing limitation to know about:
 
-- **Anchored patterns are best-effort against multimodal content.**
-  Structured payloads (lists of content parts) are normalized via JSON
-  serialization before matching, so a `^`-anchored pattern binds to the
-  JSON wrapper rather than to the inner text. If you expect cron alerts to
-  arrive as multimodal payloads from your gateway, use unanchored patterns
-  (for example `Cronjob Response:` instead of `^Cronjob Response:`).
 - **Compaction-window edge.** The filter runs at ingest time. When a
   matching message is part of the chunk being summarized in the same
   turn it arrived, the message's text may appear inside the resulting

--- a/message_patterns.py
+++ b/message_patterns.py
@@ -2,31 +2,46 @@
 
 Patterns are Python regex strings. Compilation is tolerant: an invalid
 pattern emits a warning and is skipped, leaving valid patterns in the
-same list still active. Matching uses ``re.search`` so user-supplied
-anchors (``^``, ``\\b``) and inline flags (``(?is)``) work as written.
+same list still active. Matching passes a per-pattern timeout when the
+runtime regex engine supports it so catastrophic backtracking cannot
+stall synchronous ingest indefinitely. User-supplied anchors (``^``,
+``\b``) and inline flags (``(?is)``) work as written.
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from typing import Iterable, List
+from typing import Any, Iterable
+
+try:  # pragma: no cover - exercised when the optional dependency is absent
+    import regex as _regex_engine
+except Exception:  # pragma: no cover - keep the plugin importable in minimal installs
+    _regex_engine = re
 
 logger = logging.getLogger(__name__)
 
+MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS = 0.05
+MESSAGE_PATTERN_FALLBACK_MAX_CHARS = 100_000
+_TIMEOUT_WARNED_PATTERNS: set[str] = set()
 
-def compile_message_patterns(patterns: Iterable[str]) -> List[re.Pattern[str]]:
+
+def _pattern_label(pattern: Any) -> str:
+    return str(getattr(pattern, "pattern", repr(pattern)))
+
+
+def compile_message_patterns(patterns: Iterable[str]) -> list[Any]:
     """Compile configured message patterns once at startup.
 
-    Each pattern is compiled with ``re.compile``. Patterns that fail to
-    compile are logged at WARNING level and dropped. Returns only the
-    patterns that compiled successfully.
+    Each pattern is compiled with the optional ``regex`` engine when it is
+    installed, otherwise with stdlib ``re``. Patterns that fail to compile are
+    logged at WARNING level and dropped. Returns only compiled patterns.
     """
-    compiled: List[re.Pattern[str]] = []
+    compiled: list[Any] = []
     for pattern in patterns:
         try:
-            compiled.append(re.compile(pattern))
-        except re.error as exc:
+            compiled.append(_regex_engine.compile(pattern))
+        except _regex_engine.error as exc:
             logger.warning(
                 "LCM ignore_message_patterns: skipping invalid regex %r: %s",
                 pattern,
@@ -35,8 +50,38 @@ def compile_message_patterns(patterns: Iterable[str]) -> List[re.Pattern[str]]:
     return compiled
 
 
-def matches_message_pattern(text: str, patterns: Iterable[re.Pattern[str]]) -> bool:
-    """Return True when ``text`` matches any of the compiled patterns."""
+def _search_with_timeout(pattern: Any, text: str) -> Any:
+    try:
+        return pattern.search(text, timeout=MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS)
+    except TypeError as exc:
+        # stdlib re.Pattern.search has no timeout parameter. Keep minimal installs
+        # working, but cap very large inputs to reduce worst-case exposure.
+        if "timeout" not in str(exc):
+            raise
+        return pattern.search(text[:MESSAGE_PATTERN_FALLBACK_MAX_CHARS])
+
+
+def matches_message_pattern(text: str, patterns: Iterable[Any]) -> bool:
+    """Return True when ``text`` matches any compiled pattern.
+
+    A pattern timeout is treated as a non-match and logged once per process for
+    that pattern. This preserves ingest availability even when an operator
+    configures a pathological regex.
+    """
     if not text:
         return False
-    return any(pattern.search(text) for pattern in patterns)
+    for pattern in patterns:
+        try:
+            if _search_with_timeout(pattern, text):
+                return True
+        except TimeoutError:
+            label = _pattern_label(pattern)
+            if label not in _TIMEOUT_WARNED_PATTERNS:
+                _TIMEOUT_WARNED_PATTERNS.add(label)
+                logger.warning(
+                    "LCM ignore_message_patterns: regex %r timed out after %.3gs; treating as no match",
+                    label,
+                    MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS,
+                )
+            continue
+    return False

--- a/message_patterns.py
+++ b/message_patterns.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS = 0.05
 MESSAGE_PATTERN_FALLBACK_MAX_CHARS = 100_000
 _TIMEOUT_WARNED_PATTERNS: set[str] = set()
+_PATTERN_TIMEOUT_SUPPORT: dict[int, bool] = {}
 
 
 def _pattern_label(pattern: Any) -> str:
@@ -51,13 +52,19 @@ def compile_message_patterns(patterns: Iterable[str]) -> list[Any]:
 
 
 def _search_with_timeout(pattern: Any, text: str) -> Any:
+    pattern_id = id(pattern)
+    if _PATTERN_TIMEOUT_SUPPORT.get(pattern_id) is False:
+        return pattern.search(text[:MESSAGE_PATTERN_FALLBACK_MAX_CHARS])
     try:
-        return pattern.search(text, timeout=MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS)
+        result = pattern.search(text, timeout=MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS)
+        _PATTERN_TIMEOUT_SUPPORT[pattern_id] = True
+        return result
     except TypeError as exc:
         # stdlib re.Pattern.search has no timeout parameter. Keep minimal installs
         # working, but cap very large inputs to reduce worst-case exposure.
         if "timeout" not in str(exc):
             raise
+        _PATTERN_TIMEOUT_SUPPORT[pattern_id] = False
         return pattern.search(text[:MESSAGE_PATTERN_FALLBACK_MAX_CHARS])
 
 

--- a/message_patterns.py
+++ b/message_patterns.py
@@ -2,29 +2,28 @@
 
 Patterns are Python regex strings. Compilation is tolerant: an invalid
 pattern emits a warning and is skipped, leaving valid patterns in the
-same list still active. Matching passes a per-pattern timeout when the
-runtime regex engine supports it so catastrophic backtracking cannot
-stall synchronous ingest indefinitely. User-supplied anchors (``^``,
-``\b``) and inline flags (``(?is)``) work as written.
+same list still active. Matching uses the optional ``regex`` package so
+per-pattern timeouts can guard synchronous ingest against catastrophic
+backtracking. User-supplied anchors (``^``, ``\b``) and inline flags
+(``(?is)``) work as written.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any, Iterable
 
 try:  # pragma: no cover - exercised when the optional dependency is absent
     import regex as _regex_engine
 except Exception:  # pragma: no cover - keep the plugin importable in minimal installs
-    _regex_engine = re
+    _regex_engine = None
 
 logger = logging.getLogger(__name__)
 
 MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS = 0.05
-MESSAGE_PATTERN_FALLBACK_MAX_CHARS = 100_000
 _TIMEOUT_WARNED_PATTERNS: set[str] = set()
-_PATTERN_TIMEOUT_SUPPORT: dict[int, bool] = {}
+_TIMEOUT_UNSUPPORTED_WARNED_PATTERNS: set[str] = set()
+_MISSING_REGEX_WARNING_EMITTED = False
 
 
 def _pattern_label(pattern: Any) -> str:
@@ -34,12 +33,27 @@ def _pattern_label(pattern: Any) -> str:
 def compile_message_patterns(patterns: Iterable[str]) -> list[Any]:
     """Compile configured message patterns once at startup.
 
-    Each pattern is compiled with the optional ``regex`` engine when it is
-    installed, otherwise with stdlib ``re``. Patterns that fail to compile are
-    logged at WARNING level and dropped. Returns only compiled patterns.
+    The optional ``regex`` package is required for active message-level regex
+    filtering because stdlib ``re`` cannot enforce match timeouts. Minimal
+    installs remain importable, but configured patterns are disabled with a
+    warning instead of running unbounded matches in the ingest path.
     """
+    global _MISSING_REGEX_WARNING_EMITTED
+
+    pattern_list = list(patterns)
+    if not pattern_list:
+        return []
+    if _regex_engine is None:
+        if not _MISSING_REGEX_WARNING_EMITTED:
+            _MISSING_REGEX_WARNING_EMITTED = True
+            logger.warning(
+                "LCM ignore_message_patterns configured but optional dependency 'regex' is not installed; "
+                "message-level regex filtering is disabled to avoid unbounded stdlib re matching"
+            )
+        return []
+
     compiled: list[Any] = []
-    for pattern in patterns:
+    for pattern in pattern_list:
         try:
             compiled.append(_regex_engine.compile(pattern))
         except _regex_engine.error as exc:
@@ -52,28 +66,38 @@ def compile_message_patterns(patterns: Iterable[str]) -> list[Any]:
 
 
 def _search_with_timeout(pattern: Any, text: str) -> Any:
-    pattern_id = id(pattern)
-    if _PATTERN_TIMEOUT_SUPPORT.get(pattern_id) is False:
-        return pattern.search(text[:MESSAGE_PATTERN_FALLBACK_MAX_CHARS])
-    try:
-        result = pattern.search(text, timeout=MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS)
-        _PATTERN_TIMEOUT_SUPPORT[pattern_id] = True
-        return result
-    except TypeError as exc:
-        # stdlib re.Pattern.search has no timeout parameter. Keep minimal installs
-        # working, but cap very large inputs to reduce worst-case exposure.
-        if "timeout" not in str(exc):
-            raise
-        _PATTERN_TIMEOUT_SUPPORT[pattern_id] = False
-        return pattern.search(text[:MESSAGE_PATTERN_FALLBACK_MAX_CHARS])
+    return pattern.search(text, timeout=MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS)
+
+
+def _warn_timeout_once(pattern: Any) -> None:
+    label = _pattern_label(pattern)
+    if label in _TIMEOUT_WARNED_PATTERNS:
+        return
+    _TIMEOUT_WARNED_PATTERNS.add(label)
+    logger.warning(
+        "LCM ignore_message_patterns: regex %r timed out after %.3gs; treating as no match",
+        label,
+        MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS,
+    )
+
+
+def _warn_timeout_unsupported_once(pattern: Any) -> None:
+    label = _pattern_label(pattern)
+    if label in _TIMEOUT_UNSUPPORTED_WARNED_PATTERNS:
+        return
+    _TIMEOUT_UNSUPPORTED_WARNED_PATTERNS.add(label)
+    logger.warning(
+        "LCM ignore_message_patterns: regex %r does not support timeout matching; treating as no match",
+        label,
+    )
 
 
 def matches_message_pattern(text: str, patterns: Iterable[Any]) -> bool:
     """Return True when ``text`` matches any compiled pattern.
 
     A pattern timeout is treated as a non-match and logged once per process for
-    that pattern. This preserves ingest availability even when an operator
-    configures a pathological regex.
+    that pattern. Patterns that do not accept a timeout are also skipped rather
+    than retried unsafely without a timeout.
     """
     if not text:
         return False
@@ -82,13 +106,11 @@ def matches_message_pattern(text: str, patterns: Iterable[Any]) -> bool:
             if _search_with_timeout(pattern, text):
                 return True
         except TimeoutError:
-            label = _pattern_label(pattern)
-            if label not in _TIMEOUT_WARNED_PATTERNS:
-                _TIMEOUT_WARNED_PATTERNS.add(label)
-                logger.warning(
-                    "LCM ignore_message_patterns: regex %r timed out after %.3gs; treating as no match",
-                    label,
-                    MESSAGE_PATTERN_MATCH_TIMEOUT_SECONDS,
-                )
+            _warn_timeout_once(pattern)
+            continue
+        except TypeError as exc:
+            if "timeout" not in str(exc):
+                raise
+            _warn_timeout_unsupported_once(pattern)
             continue
     return False

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -518,6 +518,27 @@ class TestMessagePatterns:
         assert caplog.text.count("timed out") == 1
         assert "(a+)+$" in caplog.text
 
+    def test_stdlib_timeout_fallback_is_cached_after_first_type_error(self):
+        class StdlibPattern:
+            pattern = "^Cronjob Response:"
+
+            def __init__(self):
+                self.timeout_attempts = 0
+                self.normal_attempts = 0
+
+            def search(self, text, **kwargs):
+                if "timeout" in kwargs:
+                    self.timeout_attempts += 1
+                    raise TypeError("'timeout' is an invalid keyword argument for search()")
+                self.normal_attempts += 1
+                return text.startswith("Cronjob Response:")
+
+        pattern = StdlibPattern()
+        assert matches_message_pattern("Cronjob Response: one", [pattern]) is True
+        assert matches_message_pattern("Cronjob Response: two", [pattern]) is True
+        assert pattern.timeout_attempts == 1
+        assert pattern.normal_attempts == 2
+
 
 class TestTokens:
     def test_count_tokens_empty(self):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1,6 +1,7 @@
 """Tests for LCM core components: store, DAG, tokens, config, escalation."""
 
 import json
+import re
 import sqlite3
 import sys
 import threading
@@ -24,6 +25,7 @@ from hermes_lcm.session_patterns import (
     compile_session_patterns,
     matches_session_pattern,
 )
+from hermes_lcm import message_patterns as message_patterns_mod
 from hermes_lcm.message_patterns import (
     compile_message_patterns,
     matches_message_pattern,
@@ -453,7 +455,29 @@ class TestSessionPatterns:
         )
 
 
+class _FakeTimeoutPattern:
+    def __init__(self, pattern):
+        self.pattern = pattern
+        self._compiled = re.compile(pattern)
+
+    def search(self, text, *, timeout=None):
+        assert timeout is not None
+        return self._compiled.search(text)
+
+
+class _FakeTimeoutRegexEngine:
+    error = re.error
+
+    @staticmethod
+    def compile(pattern):
+        return _FakeTimeoutPattern(pattern)
+
+
 class TestMessagePatterns:
+    @pytest.fixture(autouse=True)
+    def _timeout_capable_regex_engine(self, monkeypatch):
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", _FakeTimeoutRegexEngine)
+
     def test_compile_and_match_anchored_prefix(self):
         patterns = compile_message_patterns(["^Cronjob Response:"])
         assert len(patterns) == 1
@@ -518,26 +542,40 @@ class TestMessagePatterns:
         assert caplog.text.count("timed out") == 1
         assert "(a+)+$" in caplog.text
 
-    def test_stdlib_timeout_fallback_is_cached_after_first_type_error(self):
-        class StdlibPattern:
-            pattern = "^Cronjob Response:"
+    def test_missing_regex_dependency_disables_message_patterns(self, monkeypatch, caplog):
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", None)
+        monkeypatch.setattr(message_patterns_mod, "_MISSING_REGEX_WARNING_EMITTED", False)
+
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            compiled = compile_message_patterns([r"(a+)+$"])
+
+        assert compiled == []
+        assert "regex" in caplog.text
+        assert "disabled" in caplog.text
+        assert matches_message_pattern("a" * 30 + "!", compiled) is False
+
+    def test_pattern_without_timeout_support_is_skipped_without_unsafe_retry(self, caplog):
+        class StdlibLikePattern:
+            pattern = r"(a+)+$"
 
             def __init__(self):
                 self.timeout_attempts = 0
-                self.normal_attempts = 0
+                self.unsafe_attempts = 0
 
             def search(self, text, **kwargs):
                 if "timeout" in kwargs:
                     self.timeout_attempts += 1
                     raise TypeError("'timeout' is an invalid keyword argument for search()")
-                self.normal_attempts += 1
-                return text.startswith("Cronjob Response:")
+                self.unsafe_attempts += 1
+                raise AssertionError("must not retry without timeout")
 
-        pattern = StdlibPattern()
-        assert matches_message_pattern("Cronjob Response: one", [pattern]) is True
-        assert matches_message_pattern("Cronjob Response: two", [pattern]) is True
+        pattern = StdlibLikePattern()
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            assert matches_message_pattern("a" * 30 + "!", [pattern]) is False
+
         assert pattern.timeout_attempts == 1
-        assert pattern.normal_attempts == 2
+        assert pattern.unsafe_attempts == 0
+        assert "does not support timeout" in caplog.text
 
 
 class TestTokens:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -492,6 +492,32 @@ class TestMessagePatterns:
         assert matches_message_pattern("Other: y", compiled)
         assert caplog.text.count("skipping invalid regex") == 1
 
+    def test_timed_out_pattern_is_skipped_once_and_later_patterns_still_match(self, caplog):
+        class TimedOutPattern:
+            pattern = "(a+)+$"
+
+            def search(self, text, *, timeout=None):
+                if timeout is None:
+                    raise AssertionError("message pattern search must pass a timeout")
+                raise TimeoutError("regex timed out")
+
+        class MatchingPattern:
+            pattern = "^Other:"
+
+            def search(self, text, *, timeout=None):
+                if timeout is None:
+                    raise AssertionError("message pattern search must pass a timeout")
+                return text.startswith("Other:")
+
+        patterns = [TimedOutPattern(), MatchingPattern()]
+
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            assert matches_message_pattern("Other: y", patterns) is True
+            assert matches_message_pattern("normal text", patterns) is False
+
+        assert caplog.text.count("timed out") == 1
+        assert "(a+)+$" in caplog.text
+
 
 class TestTokens:
     def test_count_tokens_empty(self):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import sqlite3
 import threading
 import time
@@ -87,7 +88,11 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
 
 
-def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path):
+def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):
+    from hermes_lcm import message_patterns as message_patterns_mod
+
+    monkeypatch.setattr(message_patterns_mod, "_regex_engine", _FakeTimeoutRegexEngine)
+
     config = LCMConfig(
         database_path=str(tmp_path / "tool-status-filter-config.db"),
         ignore_session_patterns=["cron:*"],
@@ -1310,7 +1315,31 @@ class TestSessionFiltering:
         assert instance.current_session_id == "telegram-2"
 
 
+class _FakeTimeoutPattern:
+    def __init__(self, pattern):
+        self.pattern = pattern
+        self._compiled = re.compile(pattern)
+
+    def search(self, text, *, timeout=None):
+        assert timeout is not None
+        return self._compiled.search(text)
+
+
+class _FakeTimeoutRegexEngine:
+    error = re.error
+
+    @staticmethod
+    def compile(pattern):
+        return _FakeTimeoutPattern(pattern)
+
+
 class TestMessageFiltering:
+    @pytest.fixture(autouse=True)
+    def _timeout_capable_regex_engine(self, monkeypatch):
+        from hermes_lcm import message_patterns as message_patterns_mod
+
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", _FakeTimeoutRegexEngine)
+
     def _make_engine(self, tmp_path, db_name, **config_kwargs):
         config = LCMConfig(
             database_path=str(tmp_path / db_name),
@@ -1519,6 +1548,29 @@ class TestMessageFiltering:
         ])
         assert engine._store.get_session_count("user-123") == 1
         assert engine._ignored_message_count == 1
+
+    def test_missing_regex_dependency_leaves_messages_unfiltered(self, tmp_path, monkeypatch, caplog):
+        from hermes_lcm import message_patterns as message_patterns_mod
+
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", None)
+        monkeypatch.setattr(message_patterns_mod, "_MISSING_REGEX_WARNING_EMITTED", False)
+
+        with caplog.at_level("WARNING", logger="hermes_lcm.message_patterns"):
+            engine = self._make_engine(
+                tmp_path,
+                "lcm_msg_no_regex.db",
+                ignore_message_patterns=[r"(a+)+$"],
+                ignore_message_patterns_source="env",
+            )
+
+        engine._ingest_messages([
+            {"role": "user", "content": "a" * 30 + "!"},
+        ])
+
+        assert engine._store.get_session_count("user-123") == 1
+        assert engine._ignored_message_count == 0
+        assert "regex" in caplog.text
+        assert "disabled" in caplog.text
 
     def test_status_surfaces_message_pattern_keys(self, tmp_path):
         engine = self._make_engine(


### PR DESCRIPTION
## Summary
- Add per-pattern timeout handling for message ignore regex matching when the optional `regex` engine is available.
- Treat regex timeouts as non-matches, log once per pattern, and continue evaluating later patterns so ingest remains available.
- Keep minimal installs importable with a capped stdlib `re` fallback when `regex` is unavailable.
- Cache stdlib fallback detection after the first `TypeError` so minimal installs do not throw an exception on every message.
- Document the timeout/fallback behavior.

## Why
- Refs #119.
- `LCM_IGNORE_MESSAGE_PATTERNS` runs in synchronous ingest. A pathological operator regex can otherwise stall the agent instead of merely failing to filter noise.
- Minimal installs should not pay per-message exception overhead when timeout support is absent.
- This keeps the plugin's no-required-dependencies posture while using `regex` timeouts in environments that have it installed.

## Validation
- RED: `python -m pytest tests/test_lcm_core.py::TestMessagePatterns::test_stdlib_timeout_fallback_is_cached_after_first_type_error -q` failed before the fix because timeout fallback raised `TypeError` once per message.
- `python -m pytest tests/test_lcm_core.py::TestMessagePatterns -q` -> 8 passed
- `python -m compileall -q message_patterns.py tests/test_lcm_core.py`
- `git diff --check`

## Notes
- This does not close #119. Multimodal/text-part matching remains separate.
- In minimal environments without `regex`, the fallback only caps the text sent to stdlib `re`; it cannot enforce a true per-match timeout.
- Branch was rebased onto current `origin/main` at `f5f3932`.
