### PR TITLE
fix: match structured message text parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ environment variables:
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after manual `/new` (`-1` all, `0` none) |
 | `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
 | `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
-| `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, or the normalized form for structured/multimodal content) is excluded from LCM storage |
+| `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized tool outputs in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for tool output text |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
@@ -246,11 +246,14 @@ noise:
   so only the message content is distinctive.
 
 Message-level patterns are Python regex strings, comma-separated, compiled
-once at engine start. They run against the normalized message content (the
-same string LCM would have written to the store). Matching messages are
-skipped before storage, so new matching rows do not enter the messages table
-or FTS index. Filtering is role-agnostic by default, since cron alerts can
-be re-emitted under any role depending on the gateway.
+once at engine start. They run against plain message text. For structured
+multimodal payloads, LCM matches against concatenated text parts first, so
+anchored patterns bind to the text an operator sees. If a structured payload
+contains no text parts, matching falls back to the normalized JSON form that
+LCM would have written to the store. Matching messages are skipped before
+storage, so new matching rows do not enter the messages table or FTS index.
+Filtering is role-agnostic by default, since cron alerts can be re-emitted
+under any role depending on the gateway.
 
 Example operator config:
 

--- a/engine.py
+++ b/engine.py
@@ -49,7 +49,11 @@ from .session_patterns import (
 )
 from .message_patterns import compile_message_patterns, matches_message_pattern
 from .lifecycle_state import LifecycleStateStore
-from .message_content import normalize_content_value, text_content_for_pattern_matching
+from .message_content import (
+    normalize_content_value,
+    stored_text_content_for_pattern_matching,
+    text_content_for_pattern_matching,
+)
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
@@ -1793,10 +1797,15 @@ class LCMEngine(ContextEngine):
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
 
-    def _matches_ignore_message_patterns(self, msg: Dict[str, Any]) -> bool:
+    def _matches_ignore_message_patterns(self, msg: Dict[str, Any], *, stored_row: bool = False) -> bool:
         if not self._compiled_ignore_message_patterns:
             return False
-        text = text_content_for_pattern_matching(msg.get("content")) or ""
+        content = msg.get("content")
+        text = (
+            stored_text_content_for_pattern_matching(content)
+            if stored_row
+            else text_content_for_pattern_matching(content)
+        ) or ""
         return matches_message_pattern(text, self._compiled_ignore_message_patterns)
 
     def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
@@ -1891,7 +1900,7 @@ class LCMEngine(ContextEngine):
         stored_tail = [
             self._message_replay_identity(row)
             for row in stored_rows
-            if not self._matches_ignore_message_patterns(row)
+            if not self._matches_ignore_message_patterns(row, stored_row=True)
         ]
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,

--- a/engine.py
+++ b/engine.py
@@ -49,7 +49,7 @@ from .session_patterns import (
 )
 from .message_patterns import compile_message_patterns, matches_message_pattern
 from .lifecycle_state import LifecycleStateStore
-from .message_content import normalize_content_value
+from .message_content import normalize_content_value, text_content_for_pattern_matching
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
@@ -1796,7 +1796,7 @@ class LCMEngine(ContextEngine):
     def _matches_ignore_message_patterns(self, msg: Dict[str, Any]) -> bool:
         if not self._compiled_ignore_message_patterns:
             return False
-        text = normalize_content_value(msg.get("content")) or ""
+        text = text_content_for_pattern_matching(msg.get("content")) or ""
         return matches_message_pattern(text, self._compiled_ignore_message_patterns)
 
     def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
@@ -1951,7 +1951,7 @@ class LCMEngine(ContextEngine):
             for msg in new_messages:
                 if self._matches_ignore_message_patterns(msg):
                     self._ignored_message_count += 1
-                    text = normalize_content_value(msg.get("content")) or ""
+                    text = text_content_for_pattern_matching(msg.get("content")) or ""
                     excerpt = text[:80].replace("\n", " ")
                     logger.debug(
                         "LCM ignore_message_patterns dropped %s message: %r",

--- a/message_content.py
+++ b/message_content.py
@@ -71,3 +71,21 @@ def text_content_for_pattern_matching(content: Any) -> str | None:
         if parts:
             return "\n".join(parts)
     return normalize_content_value(content)
+
+
+def stored_text_content_for_pattern_matching(content: Any) -> str | None:
+    """Return message-filter text for content read back from storage.
+
+    Structured content is persisted as canonical JSON. Decode that legacy stored
+    representation when it round-trips to the same normalized string so restart
+    reconciliation applies the same text-first ignore policy to durable rows as
+    it applies to live structured messages.
+    """
+    if isinstance(content, str):
+        try:
+            decoded = json.loads(content)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return text_content_for_pattern_matching(content)
+        if isinstance(decoded, (list, dict)) and normalize_content_value(decoded) == content:
+            return text_content_for_pattern_matching(decoded)
+    return text_content_for_pattern_matching(content)

--- a/message_content.py
+++ b/message_content.py
@@ -14,6 +14,19 @@ from typing import Any
 _TEXT_PART_TYPES = {"text", "input_text", "output_text"}
 
 
+def _extract_text_part_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        nested = value.get("value")
+        if isinstance(nested, str):
+            return nested
+        nested = value.get("content")
+        if isinstance(nested, str):
+            return nested
+    return None
+
+
 def normalize_content_value(content: Any) -> str | None:
     """Return a stable text representation for message content.
 
@@ -49,9 +62,12 @@ def text_content_for_pattern_matching(content: Any) -> str | None:
                 parts.append(part)
             elif isinstance(part, dict):
                 part_type = part.get("type")
-                text = part.get("text")
-                if part_type in _TEXT_PART_TYPES and isinstance(text, str):
-                    parts.append(text)
+                if part_type in _TEXT_PART_TYPES:
+                    text = _extract_text_part_value(part.get("text"))
+                    if text is None:
+                        text = _extract_text_part_value(part.get("content"))
+                    if text:
+                        parts.append(text)
         if parts:
             return "\n".join(parts)
     return normalize_content_value(content)

--- a/message_content.py
+++ b/message_content.py
@@ -3,13 +3,15 @@
 Hermes/OpenAI-format messages may carry ``content`` as plain text or as
 structured content parts (for example text + image blocks). LCM persists and
 accounts for message content as text, so all write/matching/token paths should
-use the same normalization.
+use deliberate normalization.
 """
 
 from __future__ import annotations
 
 import json
 from typing import Any
+
+_TEXT_PART_TYPES = {"text", "input_text", "output_text"}
 
 
 def normalize_content_value(content: Any) -> str | None:
@@ -28,3 +30,28 @@ def normalize_content_value(content: Any) -> str | None:
         return json.dumps(content, ensure_ascii=False, sort_keys=True)
     except (TypeError, ValueError):
         return str(content)
+
+
+def text_content_for_pattern_matching(content: Any) -> str | None:
+    """Return the operator-visible text string used by message filters.
+
+    Structured multimodal payloads often arrive as lists of content parts. For
+    ignore-pattern matching, prefer concatenated text parts so anchored patterns
+    bind to the text an operator sees. If no text parts are present, fall back to
+    the stable normalized representation used for storage.
+    """
+    if content is None or isinstance(content, str):
+        return normalize_content_value(content)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                part_type = part.get("type")
+                text = part.get("text")
+                if part_type in _TEXT_PART_TYPES and isinstance(text, str):
+                    parts.append(text)
+        if parts:
+            return "\n".join(parts)
+    return normalize_content_value(content)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1410,6 +1410,32 @@ class TestMessageFiltering:
         assert engine._store.get_session_count("user-123") == 0
         assert engine._ignored_message_count == 1
 
+    def test_anchored_pattern_matches_structured_text_value_parts(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_multimodal_text_value.db",
+            ignore_message_patterns=["^Cronjob Response:"],
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": {"value": "Cronjob Response: nested text"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "content": "Cronjob Response: content field"}
+                ],
+            },
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("user-123") == 0
+        assert engine._ignored_message_count == 2
+
     def test_structured_content_without_text_parts_falls_back_to_normalized_json(self, tmp_path):
         engine = self._make_engine(
             tmp_path, "lcm_msg_multimodal_json_fallback.db",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1671,6 +1671,50 @@ class TestMessageFiltering:
         ]
         assert after_filter_restart._ingest_cursor == len(active_context)
 
+    def test_restart_reconciliation_matches_legacy_stored_json_with_text_first_filter(self, tmp_path):
+        db_path = tmp_path / "lcm_msg_legacy_multimodal_reconcile.db"
+        session_id = "legacy-structured-session"
+        active_context = [
+            {"role": "user", "content": "normal before ignored tail"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Cronjob Response: heartbeat"}],
+            },
+        ]
+
+        before_restart = LCMEngine(config=LCMConfig(database_path=str(db_path)))
+        before_restart.on_session_start(
+            session_id,
+            platform="telegram",
+            conversation_id="legacy-structured-conversation",
+            context_length=1000,
+        )
+        before_restart._ingest_messages(active_context)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(
+            config=LCMConfig(
+                database_path=str(db_path),
+                ignore_message_patterns=["^Cronjob Response:"],
+            )
+        )
+        after_restart.on_session_start(
+            session_id,
+            platform="telegram",
+            conversation_id="legacy-structured-conversation",
+            context_length=1000,
+        )
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(session_id)
+        assert [row["content"] for row in rows] == [
+            "normal before ignored tail",
+            '[{"text": "Cronjob Response: heartbeat", "type": "text"}]',
+        ]
+        assert after_restart._ingest_cursor == len(active_context)
+
 
 class TestEngineIngest:
     def test_ingest_stores_messages(self, engine):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1397,7 +1397,7 @@ class TestMessageFiltering:
         ]
         assert engine._ignored_message_count == 0
 
-    def test_anchored_pattern_does_not_match_multimodal_content(self, tmp_path):
+    def test_anchored_pattern_matches_multimodal_text_part_content(self, tmp_path):
         engine = self._make_engine(
             tmp_path, "lcm_msg_multimodal_anchored.db",
             ignore_message_patterns=["^Cronjob Response:"],
@@ -1407,8 +1407,21 @@ class TestMessageFiltering:
             "content": [{"type": "text", "text": "Cronjob Response: heartbeat"}],
         }
         engine._ingest_messages([multimodal])
-        assert engine._store.get_session_count("user-123") == 1
-        assert engine._ignored_message_count == 0
+        assert engine._store.get_session_count("user-123") == 0
+        assert engine._ignored_message_count == 1
+
+    def test_structured_content_without_text_parts_falls_back_to_normalized_json(self, tmp_path):
+        engine = self._make_engine(
+            tmp_path, "lcm_msg_multimodal_json_fallback.db",
+            ignore_message_patterns=["file_123"],
+        )
+        multimodal = {
+            "role": "user",
+            "content": [{"type": "input_file", "file_id": "file_123"}],
+        }
+        engine._ingest_messages([multimodal])
+        assert engine._store.get_session_count("user-123") == 0
+        assert engine._ignored_message_count == 1
 
     def test_unanchored_pattern_matches_multimodal_content(self, tmp_path):
         engine = self._make_engine(


### PR DESCRIPTION
## Summary
- Match `LCM_IGNORE_MESSAGE_PATTERNS` against structured-content text parts before normalized JSON fallback.
- Parse nested text payloads such as `text.value` and text stored under `content` for text blocks.
- Let anchored cron/noise patterns match the text an operator sees in multimodal payloads.
- Preserve normalized JSON fallback for structured payloads with no text parts.
- Update docs for the new text-first contract.

## Why
- Refs #119.
- Current matching serialized some structured text blocks to JSON first, so `^Cronjob Response:` did not match operator-visible text when the gateway wrapped it as nested structured content.
- Operators should not need weaker unanchored patterns only because content is represented as structured text parts.

## Validation
- RED: `python -m pytest tests/test_lcm_engine.py::TestMessageFiltering::test_anchored_pattern_matches_structured_text_value_parts -q` failed before the fix because both structured text-value messages were persisted.
- `python -m pytest tests/test_lcm_engine.py::TestMessageFiltering::test_anchored_pattern_matches_structured_text_value_parts tests/test_lcm_engine.py::TestMessageFiltering::test_anchored_pattern_matches_multimodal_text_part_content tests/test_lcm_engine.py::TestMessageFiltering::test_structured_content_without_text_parts_falls_back_to_normalized_json -q` -> 3 passed
- `python -m pytest tests/test_lcm_engine.py::TestMessageFiltering -q` -> 18 passed
- `python -m compileall -q message_content.py tests/test_lcm_engine.py`
- `git diff --check`

## Notes
- This does not close #119 by itself while #121 and #122 are still pending review/merge.
- The matching contract is text-first for structured content with text parts, then normalized JSON fallback when no text parts exist.
- Branch was rebased onto current `origin/main` at `f5f3932`.
