### PR TITLE
chore: release v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.8.0 (7 tools)
+  ✓ hermes-lcm v0.9.0 (7 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.8.0
+version: 0.9.0
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -119,7 +119,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.8.0" in result
+    assert "plugin_version: 0.9.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -159,7 +159,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.8.0" in result
+    assert "plugin_version: 0.9.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -147,7 +147,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.8.0"
+    assert identity["plugin_version"] == "0.9.0"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -166,7 +166,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.8.0"
+    assert payload["runtime_identity"]["plugin_version"] == "0.9.0"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 class TestEscalationStripReasoning:

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -123,7 +123,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.8.0"
+    assert identity["plugin_version"] == "0.9.0"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]


### PR DESCRIPTION
## Summary
- Bumps `hermes-lcm` from 0.8.0 to 0.9.0.
- Prepares the tag-driven release `v0.9.0`.

## Changes since v0.8.0
- fix: report FTS integrity failures separately (#98)
- fix: route configured custom provider model overrides (#99)
- fix: treat empty session ids as scoped search filters
- docs: prune stale README content (#106)
- feat: add bounded cross-session search to lcm_grep (#102)
- feat: add lossless-claw LCM importer (#107)
- fix: reconcile ingest cursor after session restart (#111)
- feat: add message-level ignore patterns for LCM ingest (#118)
- fix: fall back to Hermes compression threshold (#114)
- fix: encode importer SQLite URI paths (#115)
- feat: add explicit LCM session loader (#116)
- chore: address review follow-ups for message-ignore-patterns (#119) (#120)
- docs: add pull request template (#124)
- fix: surface filter config in lcm_status (#121)

## Version files
- `plugin.yaml`
- `README.md`
- `tests/test_lcm_command.py`
- `tests/test_lcm_engine.py`
- `tests/test_packaging_install.py`

## Validation
- `python -m pytest tests/test_lcm_command.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - 318 passed locally on the rebased head
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_import_lossless_claw.py -q`
  - 452 passed locally
- `python -m pytest -q`
  - 489 passed locally
- `python -m compileall -q .`
- `python -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`

## Release path
After this PR lands on `main` and CI is green, the release watcher will push annotated tag `v0.9.0`. The existing release workflow will create the GitHub release from that tag.

