### PR TITLE
fix: prevent ignored sessions from rebinding current LCM session

### DIFF
--- a/command.py
+++ b/command.py
@@ -89,7 +89,7 @@ def _status_text(engine) -> str:
     db_path = Path(engine._store.db_path)
     db_exists = db_path.exists()
     db_size = db_path.stat().st_size if db_exists else 0
-    session_bound = bool(engine._session_id)
+    session_bound = bool(engine.current_session_id)
     source_stats = status.get("source_lineage") or {}
     runtime_identity = status.get("runtime_identity") or {}
     source_stats = {
@@ -113,8 +113,8 @@ def _status_text(engine) -> str:
         f"plugin_git_branch: {runtime_identity.get('plugin_git_branch') or '(unavailable)'}",
         f"plugin_git_dirty: {runtime_identity.get('plugin_git_dirty') if runtime_identity.get('plugin_git_dirty') is not None else '(unavailable)'}",
         f"hermes_home: {runtime_identity.get('hermes_home', '') or '(unset)'}",
-        f"session_id: {engine._session_id or '(unbound)'}",
-        f"session_platform: {status.get('session_platform') or ('(unbound)' if not session_bound else '(unknown)')}",
+        f"session_id: {engine.current_session_id or '(unbound)'}",
+        f"session_platform: {engine.current_session_platform or ('(unbound)' if not session_bound else '(unknown)')}",
         f"database_path: {db_path}",
         f"database_path_source: {runtime_identity.get('database_path_source', '(unknown)')}",
         f"database_exists: {_fmt_bool(db_exists)}",
@@ -128,8 +128,13 @@ def _status_text(engine) -> str:
         f"last_cache_write_tokens: {status.get('last_cache_write_tokens', 0)}",
         f"last_reasoning_tokens: {status.get('last_reasoning_tokens', 0)}",
         f"cache_read_ratio: {float(status.get('cache_read_ratio', 0.0) or 0.0) * 100:.1f}%",
-        f"session_ignored: {_fmt_bool(status.get('session_ignored'))}",
-        f"session_stateless: {_fmt_bool(status.get('session_stateless'))}",
+        # Filter classification for current_session_id (the foreground view).
+        # When a side channel is in flight, get_status() reports the bound
+        # session's flags; we read the engine properties instead so this row
+        # stays consistent with the session_id row above.
+        f"session_ignored: {_fmt_bool(engine.current_session_ignored)}",
+        f"session_stateless: {_fmt_bool(engine.current_session_stateless)}",
+        f"side_channel_active: {_fmt_bool(engine.side_channel_active)}",
         f"conversation_id: {runtime_identity.get('conversation_id', '') or '(unbound)'}",
         f"lifecycle_current_session_id: {runtime_identity.get('lifecycle_current_session_id', '') or '(none)'}",
         f"lifecycle_last_finalized_session_id: {runtime_identity.get('lifecycle_last_finalized_session_id', '') or '(none)'}",
@@ -220,6 +225,12 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
             stateless_count += 1
         if not matched_classes:
             continue
+        # Protect the actively-bound session from cleanup, not the foreground
+        # view. While a cron tick has rebound the engine, _session_id points
+        # at the cron session and the engine is actively writing through it
+        # via lifecycle hooks; deleting that data mid-flight would corrupt
+        # the cleanup pass. current_session_id (foreground) is the wrong
+        # field here.
         if session_id == getattr(engine, "_session_id", ""):
             protected_count += 1
             continue
@@ -245,7 +256,13 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
 def _scan_retention_candidates(engine) -> dict[str, Any]:
     conn = engine._store._conn
     now = datetime.now().timestamp()
-    session_id = getattr(engine, "_session_id", "")
+    # SQL is scoped to the foreground session so /lcm doctor retention
+    # reports the operator's real conversation rather than whatever side
+    # channel (cron tick, debug probe) currently owns engine._session_id.
+    # The "protected" flag below still keys off engine._session_id (the
+    # actively-bound row) because that is the row receiving live writes
+    # from the concurrent run.
+    session_id = engine.current_session_id
     if not session_id:
         return {
             "error": None,
@@ -340,6 +357,8 @@ def _scan_retention_candidates(engine) -> dict[str, Any]:
         first_activity_at = min(float(ts) for ts in (first_message_at, first_node_at) if ts is not None)
         last_activity_at = max(float(ts) for ts in (last_message_at, last_node_at) if ts is not None)
         age_days = max(0.0, (now - last_activity_at) / 86400.0)
+        # Bound (not foreground): protect the live session from retention
+        # bookkeeping while the engine may still be writing to it.
         protected = session_id == getattr(engine, "_session_id", "")
         total_footprint_tokens = int(token_total) + int(node_token_total)
         if protected:
@@ -927,6 +946,10 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
     avoid half-cleaned state if a later table delete fails.
     """
     conn = engine._store._conn
+    # Protect the actively-bound session id, not current_session_id. While a
+    # cron tick has rebound the engine, _session_id is the row the engine is
+    # actively writing to via lifecycle hooks; deleting it during cleanup
+    # would race with that ingest.
     protected_session_ids = {getattr(engine, "_session_id", "")}
     protected_session_ids = {str(s) for s in protected_session_ids if s}
     session_ids = {str(s) for s in session_ids if s and str(s) not in protected_session_ids}

--- a/engine.py
+++ b/engine.py
@@ -250,6 +250,18 @@ class LCMEngine(ContextEngine):
 
         self._session_id: str = ""
         self._session_platform: str = ""
+        # Tracks the most recent non-ignored, non-stateless binding so that
+        # user-facing tools (lcm_status, lcm_grep default scope, lcm_describe,
+        # lcm_expand_query, lcm_doctor) keep showing the foreground session
+        # even while a side-channel session (cron, debug) temporarily owns the
+        # engine's _session_id binding. Updated alongside _session_id only
+        # when _refresh_session_filters classifies the new session as a real
+        # foreground (neither ignored nor stateless). Read via the
+        # `current_session_id` / `current_session_platform` properties and
+        # `current_session_ignored` / `current_session_stateless` /
+        # `side_channel_active` companion predicates.
+        self._foreground_session_id: str = ""
+        self._foreground_session_platform: str = ""
         self._conversation_id: str = ""
         self._session_match_keys: list[str] = []
         self._session_ignored = False
@@ -318,6 +330,66 @@ class LCMEngine(ContextEngine):
     @property
     def name(self) -> str:
         return "lcm"
+
+    @property
+    def current_session_id(self) -> str:
+        """User-facing "current session" id surfaced by LCM tools.
+
+        Returns the most recent foreground binding (the last session id that
+        ``_refresh_session_filters`` classified as neither ignored nor
+        stateless). Falls back to ``_session_id`` when no foreground has
+        ever been bound, so unattended cron-only or stateless-only processes
+        remain observable via ``lcm_status``.
+
+        Lifecycle paths (compress, ingest, on_session_end, etc.) must keep
+        reading ``_session_id`` directly because those paths must follow the
+        binding the engine is actually servicing. Only tool-surface code
+        paths that report a "current session" view to operators should read
+        this property.
+        """
+        return self._foreground_session_id or self._session_id
+
+    @property
+    def current_session_platform(self) -> str:
+        """Platform string paired with ``current_session_id``."""
+        if self._foreground_session_id:
+            return self._foreground_session_platform
+        return self._session_platform
+
+    @property
+    def side_channel_active(self) -> bool:
+        """True when an ignored or stateless session has temporarily rebound
+        ``_session_id`` while a real foreground binding still exists.
+
+        Operators reading lcm_status during this window see the foreground
+        session id and counts (because tools read ``current_session_id``)
+        but the engine itself is servicing the side channel. This predicate
+        lets diagnostic surfaces (lcm_status, /lcm command) make the
+        divergence explicit without recomputing the underlying invariant.
+        """
+        return bool(self._foreground_session_id) and self._foreground_session_id != self._session_id
+
+    @property
+    def current_session_ignored(self) -> bool:
+        """``_session_ignored`` reported for ``current_session_id``.
+
+        When a side channel is in flight the foreground is by definition
+        non-ignored; otherwise this is the bound session's ignore flag.
+        """
+        if self.side_channel_active:
+            return False
+        return self._session_ignored
+
+    @property
+    def current_session_stateless(self) -> bool:
+        """``_session_stateless`` reported for ``current_session_id``.
+
+        When a side channel is in flight the foreground is by definition
+        non-stateless; otherwise this is the bound session's stateless flag.
+        """
+        if self.side_channel_active:
+            return False
+        return self._session_stateless
 
     # -- ContextEngine required methods ------------------------------------
 
@@ -1114,6 +1186,16 @@ class LCMEngine(ContextEngine):
         self._session_id = session_id
         self._session_platform = str(kwargs.get("platform") or "")
         self._refresh_session_filters()
+        # Hold the foreground view stable when the new binding is a side
+        # channel (cron tick inside the gateway process, debug probe, etc.).
+        # Tools that report "current session" to operators must keep pointing
+        # at the real foreground rather than the ignored/stateless session
+        # that just stole _session_id. Lifecycle paths still read _session_id
+        # directly so cron's compress short-circuits correctly via the
+        # _session_ignored / _session_stateless gates.
+        if not self._session_ignored and not self._session_stateless:
+            self._foreground_session_id = session_id
+            self._foreground_session_platform = self._session_platform
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
         # Pick up context_length from kwargs if provided

--- a/engine.py
+++ b/engine.py
@@ -262,6 +262,7 @@ class LCMEngine(ContextEngine):
         # `side_channel_active` companion predicates.
         self._foreground_session_id: str = ""
         self._foreground_session_platform: str = ""
+        self._foreground_conversation_id: str = ""
         self._conversation_id: str = ""
         self._session_match_keys: list[str] = []
         self._session_ignored = False
@@ -355,6 +356,13 @@ class LCMEngine(ContextEngine):
         if self._foreground_session_id:
             return self._foreground_session_platform
         return self._session_platform
+
+    @property
+    def current_conversation_id(self) -> str:
+        """Conversation id paired with ``current_session_id``."""
+        if self._foreground_session_id:
+            return self._foreground_conversation_id
+        return self._conversation_id
 
     @property
     def side_channel_active(self) -> bool:
@@ -767,6 +775,10 @@ class LCMEngine(ContextEngine):
         state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
         self._conversation_id = state.conversation_id
         self._last_compacted_store_id = state.current_frontier_store_id
+        if not self._session_ignored and not self._session_stateless:
+            self._foreground_session_id = session_id
+            self._foreground_session_platform = self._session_platform
+            self._foreground_conversation_id = state.conversation_id
 
     def _persist_frontier_marker(self) -> None:
         if not self._session_id or not self._conversation_id:
@@ -1581,14 +1593,21 @@ class LCMEngine(ContextEngine):
         return "default_home"
 
     def get_runtime_identity(self) -> Dict[str, Any]:
-        """Return operator-facing identity for the loaded LCM runtime."""
+        """Return operator-facing identity for the loaded LCM runtime.
+
+        The public identity follows the same foreground-session view as
+        ``lcm_status`` and other tools. When a side-channel session is bound,
+        the bound session details are still exposed separately for diagnostics.
+        """
         metadata = _plugin_metadata()
         git_identity = _git_runtime_identity(_PLUGIN_ROOT)
+        session_id = self.current_session_id
+        conversation_id = self.current_conversation_id
         lifecycle_state = None
         lifecycle_error = ""
-        if self._conversation_id:
+        if conversation_id:
             try:
-                lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
+                lifecycle_state = self._lifecycle.get_by_conversation(conversation_id)
             except Exception as exc:  # pragma: no cover - defensive
                 lifecycle_error = str(exc)
 
@@ -1601,13 +1620,19 @@ class LCMEngine(ContextEngine):
             "hermes_home": str(self._hermes_home or ""),
             "database_path": str(self._store.db_path),
             "database_path_source": self._database_path_source(),
-            "session_id": self._session_id,
-            "session_platform": self._session_platform,
-            "session_bound": bool(self._session_id),
-            "conversation_id": self._conversation_id,
+            "session_id": session_id,
+            "session_platform": self.current_session_platform,
+            "session_bound": bool(session_id),
+            "conversation_id": conversation_id,
             "lifecycle_current_session_id": "",
             "lifecycle_last_finalized_session_id": "",
         }
+        if self.side_channel_active:
+            identity.update({
+                "bound_session_id": self._session_id,
+                "bound_session_platform": self._session_platform,
+                "bound_conversation_id": self._conversation_id,
+            })
         identity.update(git_identity)
         if lifecycle_state is not None:
             identity.update({
@@ -1635,11 +1660,13 @@ class LCMEngine(ContextEngine):
             "context_length": self.context_length,
             "threshold_tokens": self.threshold_tokens,
         })
-        lifecycle_state = self._lifecycle.get_by_conversation(self._conversation_id)
+        session_id = self.current_session_id
+        conversation_id = self.current_conversation_id
+        lifecycle_state = self._lifecycle.get_by_conversation(conversation_id) if conversation_id else None
         status["engine"] = "lcm"
         status["runtime_identity"] = self.get_runtime_identity()
         try:
-            status["source_lineage"] = self._store.get_source_stats(self._session_id or None)
+            status["source_lineage"] = self._store.get_source_stats(session_id or None)
         except Exception as exc:  # pragma: no cover - defensive
             status["source_lineage"] = {"error": str(exc)}
         try:
@@ -1653,12 +1680,12 @@ class LCMEngine(ContextEngine):
             )
         except Exception as exc:  # pragma: no cover - defensive
             status["lifecycle_fragmentation"] = {"error": str(exc), "read_only": True}
-        if self._session_id:
-            status["store_messages"] = self._store.get_session_count(self._session_id)
-            status["dag_nodes"] = len(self._dag.get_session_nodes(self._session_id))
-            status["session_platform"] = self._session_platform
-            status["session_ignored"] = self._session_ignored
-            status["session_stateless"] = self._session_stateless
+        if session_id:
+            status["store_messages"] = self._store.get_session_count(session_id)
+            status["dag_nodes"] = len(self._dag.get_session_nodes(session_id))
+            status["session_platform"] = self.current_session_platform
+            status["session_ignored"] = self.current_session_ignored
+            status["session_stateless"] = self.current_session_stateless
             status["ignore_session_patterns"] = list(self._config.ignore_session_patterns)
             status["stateless_session_patterns"] = list(self._config.stateless_session_patterns)
             status["ignore_message_patterns"] = list(self._config.ignore_message_patterns)
@@ -1668,7 +1695,7 @@ class LCMEngine(ContextEngine):
             status["ignored_message_count"] = self._ignored_message_count
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
-            status["conversation_id"] = self._conversation_id
+            status["conversation_id"] = conversation_id
             if lifecycle_state is not None:
                 status["lifecycle"] = {
                     "conversation_id": lifecycle_state.conversation_id,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1017,6 +1017,7 @@ class TestSessionFiltering:
         instance.on_session_start(
             "20260506_201605_75a4c6",
             platform="telegram",
+            conversation_id="telegram-conversation",
             context_length=200_000,
         )
         instance._store.append(
@@ -1029,6 +1030,7 @@ class TestSessionFiltering:
         instance.on_session_start(
             "cron_eee06bdbb09b_20260506_210051",
             platform="cron",
+            conversation_id="cron-conversation",
             context_length=200_000,
         )
 
@@ -1046,6 +1048,7 @@ class TestSessionFiltering:
         assert instance._foreground_session_id == "20260506_201605_75a4c6"
         assert instance.current_session_id == "20260506_201605_75a4c6"
         assert instance.current_session_platform == "telegram"
+        assert instance.current_conversation_id == "telegram-conversation"
 
     def test_ignored_session_compress_does_not_leak_into_foreground_store(self, tmp_path):
         """Regression: the foreground view must not come at the cost of
@@ -1103,6 +1106,7 @@ class TestSessionFiltering:
         instance.on_session_start(
             "20260506_201605_75a4c6",
             platform="telegram",
+            conversation_id="telegram-conversation",
             context_length=200_000,
         )
         instance._store.append(
@@ -1115,6 +1119,7 @@ class TestSessionFiltering:
         instance.on_session_start(
             "cron_eee06bdbb09b_20260506_210051",
             platform="cron",
+            conversation_id="cron-conversation",
             context_length=200_000,
         )
 
@@ -1122,6 +1127,15 @@ class TestSessionFiltering:
 
         assert payload["session_id"] == "20260506_201605_75a4c6"
         assert payload["store"]["messages"] == 1
+        assert payload["source_lineage"]["messages_total"] == 1
+        assert payload["runtime_identity"]["session_id"] == "20260506_201605_75a4c6"
+        assert payload["runtime_identity"]["session_platform"] == "telegram"
+        assert payload["runtime_identity"]["conversation_id"] == "telegram-conversation"
+        assert payload["runtime_identity"]["bound_session_id"] == "cron_eee06bdbb09b_20260506_210051"
+        assert payload["runtime_identity"]["bound_session_platform"] == "cron"
+        assert payload["runtime_identity"]["bound_conversation_id"] == "cron-conversation"
+        assert payload["lifecycle"]["conversation_id"] == "telegram-conversation"
+        assert payload["lifecycle"]["current_session_id"] == "20260506_201605_75a4c6"
         assert payload["session_filters"]["ignored"] is False
         assert payload["session_filters"]["stateless"] is False
         assert payload["session_filters"]["side_channel_active"] is True
@@ -1201,11 +1215,31 @@ class TestSessionFiltering:
             ignore_session_patterns=["cron:*"],
         )
         instance = LCMEngine(config=config)
-        instance.on_session_start("telegram-foreground", platform="telegram", context_length=200_000)
-        instance.on_session_start("cron_xxx", platform="cron", context_length=200_000)
+        instance.on_session_start(
+            "telegram-foreground",
+            platform="telegram",
+            conversation_id="telegram-conversation",
+            context_length=200_000,
+        )
+        instance._store.append(
+            "telegram-foreground",
+            {"role": "user", "content": "telegram row"},
+            token_estimate=2,
+            source="telegram",
+        )
+        instance.on_session_start(
+            "cron_xxx",
+            platform="cron",
+            conversation_id="cron-conversation",
+            context_length=200_000,
+        )
 
         text = _status_text(instance)
         assert "session_id: telegram-foreground" in text
+        assert "conversation_id: telegram-conversation" in text
+        assert "lifecycle_current_session_id: telegram-foreground" in text
+        assert "source_messages_total: 1" in text
+        assert "store_messages: 1" in text
         assert "session_ignored: no" in text
         assert "session_stateless: no" in text
         assert "side_channel_active: yes" in text

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -113,6 +113,7 @@ def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path):
         "ignore_message_patterns": ["^Cronjob Response:"],
         "ignore_message_patterns_source": "env",
         "ignored_message_count": 1,
+        "side_channel_active": False,
     }
 
 
@@ -998,6 +999,281 @@ class TestSessionFiltering:
         assert instance._store.get_session_count("debug") == 0
         assert instance._dag.get_session_nodes("debug") == []
         assert instance.compression_count == 0
+
+    def test_ignored_session_does_not_rebind_foreground_view(self, tmp_path):
+        """A cron-style ignored session arriving while a foreground session is
+        bound must not steal the engine's foreground "current session" view.
+        The engine continues to rebind ``_session_id`` so cron's own compress
+        / handle_tool_call calls correctly short-circuit on
+        ``_session_ignored=True``, but ``current_session_id`` (the property
+        every LCM tool reads) keeps pointing at the foreground binding.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_no_rebind_ignored.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+
+        instance.on_session_start(
+            "20260506_201605_75a4c6",
+            platform="telegram",
+            context_length=200_000,
+        )
+        instance._store.append(
+            "20260506_201605_75a4c6",
+            {"role": "user", "content": "hi from telegram"},
+            token_estimate=4,
+            source="telegram",
+        )
+
+        instance.on_session_start(
+            "cron_eee06bdbb09b_20260506_210051",
+            platform="cron",
+            context_length=200_000,
+        )
+
+        # Bound state continues to follow the side channel so cron's own
+        # compress and handle_tool_call calls correctly short-circuit on
+        # _session_ignored=True. This is the pre-fix behavior and must be
+        # preserved -- without it, cron messages would ingest into the
+        # foreground store via _ingest_messages.
+        assert instance._session_id == "cron_eee06bdbb09b_20260506_210051"
+        assert instance._session_ignored is True
+
+        # Foreground view stays stable across the rebind. Tools that read
+        # current_session_id (lcm_status, lcm_grep default scope, etc.)
+        # continue to see the operator's real conversation.
+        assert instance._foreground_session_id == "20260506_201605_75a4c6"
+        assert instance.current_session_id == "20260506_201605_75a4c6"
+        assert instance.current_session_platform == "telegram"
+
+    def test_ignored_session_compress_does_not_leak_into_foreground_store(self, tmp_path):
+        """Regression: the foreground view must not come at the cost of
+        leaking the side channel's transcript into the foreground store. With
+        the bound binding still pointing at the cron session,
+        ``_session_ignored=True`` correctly gates ingest so cron's compress
+        and should_compress_preflight calls leave the foreground row count
+        untouched.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_no_leak_ignored.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start(
+            "telegram-foreground",
+            platform="telegram",
+            context_length=200_000,
+        )
+        instance._store.append(
+            "telegram-foreground",
+            {"role": "user", "content": "telegram-1"},
+            token_estimate=2,
+            source="telegram",
+        )
+        instance.on_session_start(
+            "cron_xxx",
+            platform="cron",
+            context_length=200_000,
+        )
+
+        cron_messages = [
+            {"role": "system", "content": "sys-cron"},
+            {"role": "user", "content": "cron-1"},
+            {"role": "assistant", "content": "cron-2"},
+            {"role": "user", "content": "cron-3"},
+        ]
+        instance.should_compress_preflight(cron_messages)
+        instance.compress(cron_messages)
+
+        assert instance._store.get_session_count("telegram-foreground") == 1
+        assert instance._store.get_session_count("cron_xxx") == 0
+
+    def test_lcm_status_stays_on_foreground_after_cron_tick(self, tmp_path):
+        """End-to-end: lcm_status must still report the Telegram session id
+        and its row counts after a cron-style ignored session has rebound the
+        engine. The bound side channel surfaces only via the diagnostic
+        ``side_channel_in_flight`` / ``bound_session_id`` keys.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_status_after_cron.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start(
+            "20260506_201605_75a4c6",
+            platform="telegram",
+            context_length=200_000,
+        )
+        instance._store.append(
+            "20260506_201605_75a4c6",
+            {"role": "user", "content": "telegram message"},
+            token_estimate=3,
+            source="telegram",
+        )
+
+        instance.on_session_start(
+            "cron_eee06bdbb09b_20260506_210051",
+            platform="cron",
+            context_length=200_000,
+        )
+
+        payload = json.loads(lcm_tools.lcm_status({}, engine=instance))
+
+        assert payload["session_id"] == "20260506_201605_75a4c6"
+        assert payload["store"]["messages"] == 1
+        assert payload["session_filters"]["ignored"] is False
+        assert payload["session_filters"]["stateless"] is False
+        assert payload["session_filters"]["side_channel_active"] is True
+        assert (
+            payload["session_filters"]["side_channel_session_id"]
+            == "cron_eee06bdbb09b_20260506_210051"
+        )
+
+    def test_lcm_status_reports_bound_session_when_no_foreground_yet(self, tmp_path):
+        """A fresh engine that only ever binds an ignored session must still
+        report something usable via lcm_status, with the bound session's
+        ignore flag intact so operators can see why the row count is zero.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_first_bind_ignored.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+
+        instance.on_session_start(
+            "cron_first_run_20260506_210051",
+            platform="cron",
+            context_length=200_000,
+        )
+
+        assert instance._session_id == "cron_first_run_20260506_210051"
+        assert instance._session_ignored is True
+        assert instance._foreground_session_id == ""
+        assert instance.current_session_id == "cron_first_run_20260506_210051"
+
+        payload = json.loads(lcm_tools.lcm_status({}, engine=instance))
+        assert payload["session_id"] == "cron_first_run_20260506_210051"
+        assert payload["session_filters"]["ignored"] is True
+        assert payload["session_filters"]["side_channel_active"] is False
+        assert "side_channel_session_id" not in payload["session_filters"]
+
+    def test_stateless_session_does_not_rebind_foreground_view(self, tmp_path):
+        """The same protection applies to stateless side-channel sessions: a
+        ``debug:*``-style session must not clobber the foreground
+        ``current_session_id`` view, even though it does claim ``_session_id``
+        for its own lifecycle gating.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_no_rebind_stateless.db"),
+            stateless_session_patterns=["debug:*"],
+        )
+        instance = LCMEngine(config=config)
+
+        instance.on_session_start(
+            "telegram-foreground",
+            platform="telegram",
+            context_length=200_000,
+        )
+
+        instance.on_session_start(
+            "debug:probe-1",
+            platform="debug",
+            context_length=200_000,
+        )
+
+        assert instance._session_id == "debug:probe-1"
+        assert instance._session_stateless is True
+        assert instance._foreground_session_id == "telegram-foreground"
+        assert instance.current_session_id == "telegram-foreground"
+        assert instance.current_session_platform == "telegram"
+
+    def test_lcm_command_status_text_is_consistent_with_lcm_status_during_cron_tick(self, tmp_path):
+        """The /lcm command's _status_text and the lcm_status tool must agree
+        on session_id, session_ignored, and session_stateless during a cron
+        tick. Without this, an operator reading /lcm status sees session_id
+        for the foreground but ignored=true for the side channel.
+        """
+        from hermes_lcm.command import _status_text
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_command_consistency.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("telegram-foreground", platform="telegram", context_length=200_000)
+        instance.on_session_start("cron_xxx", platform="cron", context_length=200_000)
+
+        text = _status_text(instance)
+        assert "session_id: telegram-foreground" in text
+        assert "session_ignored: no" in text
+        assert "session_stateless: no" in text
+        assert "side_channel_active: yes" in text
+
+    def test_lcm_doctor_retention_targets_foreground_during_cron_tick(self, tmp_path):
+        """The /lcm doctor retention surface must report on the foreground
+        session, not the cron-style side channel that briefly owns
+        engine._session_id. The SQL filter and the row aggregation both need
+        to follow current_session_id.
+        """
+        from hermes_lcm.command import _scan_retention_candidates
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_retention_during_cron.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("telegram-foreground", platform="telegram", context_length=200_000)
+        instance._store.append(
+            "telegram-foreground",
+            {"role": "user", "content": "telegram retention test"},
+            token_estimate=3,
+            source="telegram",
+        )
+        instance.on_session_start("cron_xxx", platform="cron", context_length=200_000)
+
+        scan = _scan_retention_candidates(instance)
+        assert scan["error"] is None
+        # Foreground row surfaces; cron's empty session is not the scan
+        # target. protected is False because the bound id is cron, not the
+        # row we are reporting on.
+        assert scan["sessions_analyzed"] == 1
+        assert scan["sessions"][0]["session_id"] == "telegram-foreground"
+        assert scan["sessions"][0]["protected"] is False
+
+    def test_foreground_view_advances_when_a_real_foreground_arrives(self, tmp_path):
+        """``_foreground_session_id`` advances forward through real foreground
+        bindings (e.g., compression rollovers) but is never set to an ignored
+        or stateless session id. This is the rebind path the bug fix must not
+        regress.
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_foreground_advances.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+
+        instance.on_session_start(
+            "telegram-1",
+            platform="telegram",
+            context_length=200_000,
+        )
+        assert instance._foreground_session_id == "telegram-1"
+
+        instance.on_session_start(
+            "cron_xxx",
+            platform="cron",
+            context_length=200_000,
+        )
+        assert instance._foreground_session_id == "telegram-1"
+
+        instance.on_session_start(
+            "telegram-2",
+            platform="telegram",
+            context_length=200_000,
+        )
+        assert instance._foreground_session_id == "telegram-2"
+        assert instance.current_session_id == "telegram-2"
 
 
 class TestMessageFiltering:

--- a/tools.py
+++ b/tools.py
@@ -98,7 +98,7 @@ def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
 
 def _get_session_node(engine: "LCMEngine", node_id: int):
     node = engine._dag.get_node(node_id)
-    if node is None or node.session_id != engine._session_id:
+    if node is None or node.session_id != engine.current_session_id:
         return None
     return node
 
@@ -108,7 +108,7 @@ def _get_externalized_payload(engine: "LCMEngine", ref: str) -> dict[str, Any] |
     if payload is None:
         return None
     payload_session_id = payload.get("session_id") or ""
-    if payload_session_id and payload_session_id != engine._session_id:
+    if payload_session_id and payload_session_id != engine.current_session_id:
         return None
     return payload
 
@@ -290,7 +290,7 @@ def _expand_message_sources(
             has_more = True
             break
         stored = stored_by_id.get(store_id)
-        if not stored or stored.get("session_id") != engine._session_id:
+        if not stored or stored.get("session_id") != engine.current_session_id:
             next_source_offset = source_index + 1
             next_content_offset = 0
             has_more = next_source_offset < total_sources
@@ -394,7 +394,7 @@ def _expand_child_nodes(
     children: list[tuple[int, Any]] = []
     for relative_index, child_id in enumerate(selected_source_ids):
         child = engine._dag.get_node(child_id)
-        if child is None or child.session_id != engine._session_id:
+        if child is None or child.session_id != engine.current_session_id:
             continue
         children.append((source_offset + relative_index, child))
 
@@ -597,7 +597,7 @@ def _serialize_loaded_message(engine: "LCMEngine", row: dict[str, Any], max_cont
         "content_returned_chars": content_slice["content_returned_chars"],
         "content_truncated": content_slice["content_truncated"],
         "next_content_offset": content_slice["next_content_offset"],
-        "from_current_session": bool(engine._session_id) and stored_session_id == engine._session_id,
+        "from_current_session": bool(engine.current_session_id) and stored_session_id == engine.current_session_id,
     }
     if row.get("tool_call_id"):
         item["tool_call_id"] = row.get("tool_call_id")
@@ -740,7 +740,10 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         # MessageStore.search and SummaryDAG.search treat session_id="" as a
         # literal scoped filter, so an unbound engine searching scope=current
         # returns zero results rather than leaking cross-session matches.
-        search_session_id: str | None = engine._session_id
+        # Read current_session_id (the foreground view) so a cron-style side
+        # channel that briefly owns engine._session_id does not redirect the
+        # default search scope away from the operator's real conversation.
+        search_session_id: str | None = engine.current_session_id
         session_scope = "current"
     elif requested_session_scope == "all":
         if explicit_session_id:
@@ -761,14 +764,14 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         # current-session path and report. The data-layer empty-string scoping
         # contract keeps an unbound engine from leaking cross-session matches
         # here too.
-        search_session_id = engine._session_id
+        search_session_id = engine.current_session_id
         session_scope = "current"
         logger.warning(
             "Ignoring unsupported session_scope=%s for lcm_grep",
             requested_session_scope,
         )
 
-    current_session_id = engine._session_id
+    current_session_id = engine.current_session_id
     has_current_session = bool(current_session_id)
     results: list[Dict[str, Any]] = []
 
@@ -899,7 +902,7 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
         )
 
     node_id = args.get("node_id")
-    session_id = engine._session_id
+    session_id = engine.current_session_id
 
     if node_id is not None:
         node = _get_session_node(engine, node_id)
@@ -1014,7 +1017,7 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             return json.dumps({"error": f"Message store_id {store_id} not found"})
         transcript_content = stored.get("content", "") or ""
         sliced = _slice_content_for_response(transcript_content, max_tokens, content_offset)
-        engine_session_id = engine._session_id
+        engine_session_id = engine.current_session_id
         stored_session_id = stored.get("session_id", "")
         result: Dict[str, Any] = {
             "store_id": store_id,
@@ -1145,7 +1148,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             if node is not None:
                 nodes.append(node)
     elif query:
-        nodes = engine._dag.search(query, session_id=engine._session_id, limit=max_results)
+        nodes = engine._dag.search(query, session_id=engine.current_session_id, limit=max_results)
     else:
         return json.dumps({"error": "Provide either query or node_ids"})
 
@@ -1329,7 +1332,13 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
-    session_id = engine._session_id
+    # Read the foreground view so a side-channel session that briefly owns
+    # engine._session_id (cron tick inside the gateway process, debug probe,
+    # etc.) does not divert lcm_status away from the operator's real
+    # conversation. Falls back to the bound id when no foreground has ever
+    # been bound, so cron-only or stateless-only deployments still report
+    # something usable.
+    session_id = engine.current_session_id
     if not session_id:
         return json.dumps({
             "error": "No active session",
@@ -1357,6 +1366,11 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     lifecycle_fragmentation = full_status.get("lifecycle_fragmentation")
     source_lineage = full_status.get("source_lineage")
     runtime_identity = full_status.get("runtime_identity")
+
+    # Filter classification for the session lcm_status is reporting on.
+    # The engine encapsulates the foreground vs bound divergence; this tool
+    # just reads the property contract.
+    side_channel_active = engine.side_channel_active
 
     return json.dumps({
         "session_id": session_id,
@@ -1399,8 +1413,8 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "expansion_model": engine._config.expansion_model or "(summary model)",
         },
         "session_filters": {
-            "ignored": engine._session_ignored,
-            "stateless": engine._session_stateless,
+            "ignored": engine.current_session_ignored,
+            "stateless": engine.current_session_stateless,
             "ignore_session_patterns": full_status.get("ignore_session_patterns", []),
             "ignore_session_patterns_source": full_status.get("ignore_session_patterns_source", "default"),
             "stateless_session_patterns": full_status.get("stateless_session_patterns", []),
@@ -1408,6 +1422,12 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "ignore_message_patterns": full_status.get("ignore_message_patterns", []),
             "ignore_message_patterns_source": full_status.get("ignore_message_patterns_source", "default"),
             "ignored_message_count": full_status.get("ignored_message_count", 0),
+            "side_channel_active": side_channel_active,
+            **(
+                {"side_channel_session_id": engine._session_id}
+                if side_channel_active
+                else {}
+            ),
         },
         "source_lineage": source_lineage,
         "runtime_identity": runtime_identity,
@@ -1423,7 +1443,10 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": "LCM engine not initialized"})
 
     checks: list[dict] = []
-    session_id = engine._session_id
+    # Diagnose the foreground session, not whatever side-channel session
+    # currently owns engine._session_id. Falls back to the bound id when no
+    # foreground has ever been bound.
+    session_id = engine.current_session_id
 
     # 1. Database integrity
     try:


### PR DESCRIPTION
## Summary

- Track the most recent non-ignored, non-stateless binding in a new `_foreground_session_id` field; expose it via `current_session_id` / `current_session_platform` properties on `LCMEngine`.
- Tool-surface code paths (`lcm_status`, `lcm_grep` default scope, `_get_session_node`, `_get_externalized_payload`, `_expand_message_sources`, `_expand_child_nodes`, `_serialize_loaded_message`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_doctor`, `_status_text`, `_doctor_retention_text`) now read `current_session_id` so a cron-style ignored session that briefly rebinds `_session_id` cannot divert lcm_status / lcm_grep / etc. away from the operator's foreground conversation.
- Lifecycle paths inside the engine (`compress`, `should_compress_preflight`, `_ingest_messages`, `handle_tool_call`) continue to read `_session_id` directly, so cron's own calls still short-circuit on `_session_ignored=True` and cannot leak cron transcripts into the foreground store.
- `lcm_status` surfaces the diagnostic `session_filters.side_channel_active` flag (and `side_channel_session_id` when active) so operators can still observe a cron tick that has rebound the engine. `/lcm status` reports the same flag.

## Why

`hermes-lcm` registers a single `LCMEngine` per gateway process. When a cron job runs in the same process as a Telegram (or any other) conversation, cron's `AIAgent.__init__` calls `engine.on_session_start("cron_...")`. That unconditionally sets `self._session_id = cron_xxx` before `_refresh_session_filters` evaluates the ignore patterns, so every LCM tool that defaults to "the current session" reports the cron id from concurrent foreground tool calls (e.g., `lcm_status` returning `session_id=cron_xxx, ignored=true, store.messages=0` while the foreground Telegram session has rows in `lcm.db`). Full diagnosis in #126.

The first iteration of this fix tried to skip the rebind for ignored sessions, but that introduced a worse regression: with `_session_ignored=False` (because the engine stayed bound to the foreground), cron's own `_ingest_messages` no longer short-circuited and cron transcripts leaked into the foreground store. An empirical probe confirmed 4 cron messages writing through to a 1-row foreground session.

The shadow-field approach in this PR avoids the regression by keeping the existing rebind path intact (so cron's lifecycle gating keeps working) while exposing a separate `current_session_id` view for tools. Bound state and foreground state are decoupled.

## Validation

- [x] Focused validation: `pytest tests/test_lcm_engine.py tests/test_lcm_command.py -q` -> `318 passed in 17.85s`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 449 passed
  - [x] `pytest -q` -> 497 passed
  - [x] `python -m compileall -q .` -> ok
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> ok
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> ok
  - [x] `git diff --check` -> ok
- [x] Cron-leak regression probe: ran `engine.on_session_start("telegram-fg")` -> append 1 row -> `engine.on_session_start("cron_xxx")` -> `engine.compress(cron_messages)` + `engine.should_compress_preflight(cron_messages)`. Result: telegram store stays at 1 row, cron store at 0 rows. Pre-fix probe (skip-rebind variant) showed 5 telegram rows.

## New tests

- `test_ignored_session_does_not_rebind_foreground_view` -- foreground view stays stable when an ignored session rebinds the bound state.
- `test_ignored_session_compress_does_not_leak_into_foreground_store` -- regression test for the rejected first-iteration approach: cron messages must not leak into the foreground store.
- `test_lcm_status_stays_on_foreground_after_cron_tick` -- end-to-end via the `lcm_status` tool, with `side_channel_active` and `side_channel_session_id` diagnostics.
- `test_lcm_status_reports_bound_session_when_no_foreground_yet` -- cron-only deployment: `current_session_id` falls back to `_session_id` so the surface remains observable.
- `test_stateless_session_does_not_rebind_foreground_view` -- the same protection applies to stateless side-channel sessions.
- `test_lcm_command_status_text_is_consistent_with_lcm_status_during_cron_tick` -- `/lcm status` operator surface stays consistent with `lcm_status` output.
- `test_lcm_doctor_retention_targets_foreground_during_cron_tick` -- `/lcm doctor retention` reports retention for the foreground session, not the cron-bound one.
- `test_foreground_view_advances_when_a_real_foreground_arrives` -- `_foreground_session_id` advances forward through real foreground bindings (e.g., compression rollovers) and is never set to an ignored or stateless id.
- `test_lcm_tool_status_forwards_filter_config_to_agent_surface` updated to expect the new `side_channel_active` key.

## Notes

- Reviewed twice via parallel multi-persona review (correctness, testing, maintainability, project-standards, agent-native, kieran-python, learnings-researcher). The first round caught the cron-leak regression on the rejected approach; the second round on the shadow-field approach surfaced the `_status_text` consistency gap, the operator-protection comments, and the `side_channel_active` encapsulation, all addressed in this PR.
- Out of scope: the deeper concurrency property -- a cron tick that rebinds `_session_id` to an ignored session also pauses foreground compaction during the cron run window, because the foreground thread's `compress` / `_ingest_messages` calls see `_session_ignored=True` until the next foreground `on_session_start`. Fixing that requires per-task session resolution (ContextVars or explicit thread-local push that propagates through `contextvars.copy_context()`), which is an architectural change outside this PR's scope. The window is bounded (cron runs are typically short, and a fresh `AIAgent` per inbound foreground message rebinds the engine back), and no data corrupts.
- `command.py` retention/cleanup sites (`_scan_clean_candidates`, `_delete_clean_candidates_atomically`, the `protected` flag in `_scan_retention_candidates`) intentionally read `_session_id` (bound), with comments explaining the contract: the actively-bound session is the row receiving live writes from the concurrent run, so deletion / cleanup must protect it regardless of the foreground view.

Refs #126

Closes #126
