### PR TITLE
fix: preserve latest user objective during compaction

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -181,6 +181,9 @@ _SYNTHETIC_ASSISTANT_NOISE = {
     "pong",
 }
 
+_PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
+_PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+
 
 def _tool_call_id(tool_call: Any) -> str:
     if not isinstance(tool_call, dict):
@@ -323,6 +326,10 @@ class LCMEngine(ContextEngine):
         self.summary_model = self._config.summary_model
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
+        # Temporary source window used only while compress() assembles context.
+        # _assemble_context also serves tests and recovery paths directly, so
+        # keep anchoring opt-in rather than changing its public behavior.
+        self._pending_context_anchor_messages: Optional[List[Dict[str, Any]]] = None
         self._logged_filter_config = False
         self._pending_reset_session_id: str = ""
         self._pending_reset_conversation_id: str = ""
@@ -735,11 +742,15 @@ class LCMEngine(ContextEngine):
 
         # Step 7: Assemble new active context
         self._refresh_raw_backlog_debt(working_messages)
-        compressed = self._assemble_context(
-            working_messages[0],
-            working_messages[1:],
-            assembly_cap_override=recovery_assembly_cap,
-        )
+        self._pending_context_anchor_messages = messages[1:]
+        try:
+            compressed = self._assemble_context(
+                working_messages[0],
+                working_messages[1:],
+                assembly_cap_override=recovery_assembly_cap,
+            )
+        finally:
+            self._pending_context_anchor_messages = None
         self.compression_count += 1
         if recovery_assembly_cap is None:
             self._last_overflow_recovery_failed = False
@@ -1840,6 +1851,8 @@ class LCMEngine(ContextEngine):
                 "[Note: This conversation uses Lossless Context Management (LCM)." in content
                 and "Earlier turns have been compacted into hierarchical summaries below." in content
             )
+        if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
+            return True
         if "[Expand for details:" not in content:
             return False
         return bool(
@@ -2397,6 +2410,60 @@ class LCMEngine(ContextEngine):
         normalized = normalize_content_value(content) or ""
         return normalized + note
 
+    @staticmethod
+    def _is_preserved_todo_context_message(message: Dict[str, Any]) -> bool:
+        content = text_content_for_pattern_matching(message.get("content")) or ""
+        return content.lstrip().startswith(_PRESERVED_TODO_CONTEXT_PREFIX)
+
+    @staticmethod
+    def _preserved_objective_context_content(message: Dict[str, Any]) -> str:
+        content = text_content_for_pattern_matching(message.get("content")) or ""
+        return content if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX) else ""
+
+    @staticmethod
+    def _build_preserved_objective_summary_part(message: Dict[str, Any]) -> str:
+        content = text_content_for_pattern_matching(message.get("content")) or ""
+        return f"{_PRESERVED_OBJECTIVE_CONTEXT_PREFIX}\n{content}"
+
+    def _latest_user_context_anchor(
+        self,
+        messages: List[Dict[str, Any]],
+        selected_tail: List[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Return a scaffolded newest real user objective omitted from the tail.
+
+        Tool-heavy turns can push the operative user request outside the fresh
+        tail while retaining only assistant/tool traces from that turn.  The
+        returned text is active-context scaffolding, not raw conversation: it is
+        emitted inside the summary block so restart reconciliation ignores it
+        instead of ingesting a duplicate non-contiguous user message.
+
+        If a previous compaction already emitted the preserved-objective
+        scaffold and no newer real user turn exists, carry that scaffold forward
+        as the next anchor source so repeated compaction does not summarize the
+        active objective away one compression later.
+        """
+        selected_tail_messages = [msg for msg in selected_tail if isinstance(msg, dict)]
+        for message in reversed(messages):
+            if not isinstance(message, dict):
+                continue
+            preserved_objective = self._preserved_objective_context_content(message)
+            if preserved_objective:
+                if any(
+                    self._preserved_objective_context_content(selected) == preserved_objective
+                    for selected in selected_tail_messages
+                ):
+                    return None
+                return preserved_objective
+            if message.get("role") != "user":
+                continue
+            if self._is_preserved_todo_context_message(message):
+                continue
+            if any(message == selected for selected in selected_tail_messages):
+                return None
+            return self._build_preserved_objective_summary_part(message)
+        return None
+
     def _assemble_context(
         self,
         system_msg: Dict[str, Any],
@@ -2435,6 +2502,8 @@ class LCMEngine(ContextEngine):
         )
 
         tail_selected = tail_messages
+        anchor_source = getattr(self, "_pending_context_anchor_messages", None)
+        anchor_part: Optional[str] = None
         summary_budget = None
         if assembly_cap is not None:
             used = count_message_tokens(leading_msg)
@@ -2448,15 +2517,24 @@ class LCMEngine(ContextEngine):
                 tail_token_total += msg_tokens
             tail_selected = list(reversed(kept_tail_reversed))
             summary_budget = max(0, assembly_cap - used - tail_token_total)
+        if anchor_source is not None:
+            anchor_part = self._latest_user_context_anchor(anchor_source, tail_selected)
 
         # Collect DAG summaries — highest depth first for context hierarchy
+        summary_parts: list[str] = []
+        last_role = result[-1].get("role", "system")
+        summary_role = "assistant" if last_role != "assistant" else "user"
+        if anchor_part is not None:
+            anchor_msg = {"role": summary_role, "content": anchor_part}
+            if summary_budget is None or count_message_tokens(anchor_msg) <= summary_budget:
+                summary_parts.append(anchor_part)
+
         all_nodes = self._dag.get_session_nodes(self._session_id)
         if all_nodes:
             # Group by depth, take the most recent uncondensed at each level
             # For active context, we want the highest-level summaries
             # that haven't been condensed into even higher levels
             depths = sorted(set(n.depth for n in all_nodes), reverse=True)
-            summary_parts = []
             for d in depths:
                 uncondensed = self._dag.get_uncondensed_at_depth(self._session_id, d)
                 for node in uncondensed:
@@ -2471,22 +2549,21 @@ class LCMEngine(ContextEngine):
                         f"[Expand for details: {node.expand_hint}]"
                     )
 
-            if summary_parts:
-                # Choose role to avoid consecutive same-role
-                last_role = result[-1].get("role", "system")
-                summary_role = "assistant" if last_role != "assistant" else "user"
-                selected_parts = summary_parts
-                if summary_budget is not None:
-                    selected_parts = []
-                    for part in summary_parts:
-                        candidate = "\n\n---\n\n".join(selected_parts + [part])
-                        candidate_msg = {"role": summary_role, "content": candidate}
-                        if count_message_tokens(candidate_msg) > summary_budget:
-                            break
-                        selected_parts.append(part)
-                if selected_parts:
-                    combined = "\n\n---\n\n".join(selected_parts)
-                    result.append({"role": summary_role, "content": combined})
+        if summary_parts:
+            selected_parts = summary_parts
+            if summary_budget is not None:
+                selected_parts = []
+                for part in summary_parts:
+                    candidate = "\n\n---\n\n".join(selected_parts + [part])
+                    candidate_msg = {"role": summary_role, "content": candidate}
+                    if count_message_tokens(candidate_msg) > summary_budget:
+                        if part == anchor_part:
+                            continue
+                        break
+                    selected_parts.append(part)
+            if selected_parts:
+                combined = "\n\n---\n\n".join(selected_parts)
+                result.append({"role": summary_role, "content": combined})
 
         # Fresh tail
         result.extend(tail_selected)
@@ -2497,6 +2574,26 @@ class LCMEngine(ContextEngine):
         # tool_call) or assistant tool_calls with missing results. Both violate
         # the OpenAI message format contract and cause 400 errors from providers.
         result = self._sanitize_tool_pairs(result)
+        if (
+            assembly_cap is not None
+            and anchor_part is not None
+            and count_messages_tokens(result) > assembly_cap
+        ):
+            trimmed_result: list[Dict[str, Any]] = []
+            for msg in result:
+                content = normalize_content_value(msg.get("content")) or ""
+                if _PRESERVED_OBJECTIVE_CONTEXT_PREFIX not in content:
+                    trimmed_result.append(msg)
+                    continue
+                parts = [
+                    part for part in content.split("\n\n---\n\n")
+                    if not part.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX)
+                ]
+                if parts:
+                    trimmed = msg.copy()
+                    trimmed["content"] = "\n\n---\n\n".join(parts)
+                    trimmed_result.append(trimmed)
+            result = self._sanitize_tool_pairs(trimmed_result)
 
         return result
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -655,6 +655,69 @@ class TestEngineABC:
         assert rows[-1]["tool_call_id"] == "call_2"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_existing_compacted_session_restart_ignores_preserved_objective_anchor(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "restart-anchored-compacted.db"
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(db_path),
+        )
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "anchored-compacted-session",
+            platform="cli",
+            conversation_id="anchored-compacted-conversation",
+            context_length=200000,
+        )
+
+        def mock_summary(**kwargs):
+            return "Older board cleanup summary.\nExpand for details about: board cleanup", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        latest_request = "increase kanban autonomy"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "clean up temporary boards"},
+            {"role": "assistant", "content": "I will inspect boards."},
+            {"role": "user", "content": latest_request},
+            {
+                "role": "assistant",
+                "content": "inspect blocker handling",
+                "tool_calls": [{"id": "call_1", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "blocker output"},
+            {
+                "role": "assistant",
+                "content": "inspect notifier handling",
+                "tool_calls": [{"id": "call_2", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "notifier output"},
+        ]
+        active_context = before_restart.compress(messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "anchored-compacted-session",
+            platform="cli",
+            conversation_id="anchored-compacted-conversation",
+            context_length=200000,
+        )
+        replay_with_new_message = active_context + [
+            {"role": "user", "content": "follow-up after restart"},
+        ]
+
+        after_restart._ingest_messages(replay_with_new_message)
+
+        rows = after_restart._store.get_session_messages("anchored-compacted-session")
+        assert rows[-1]["content"] == "follow-up after restart"
+        assert [row["content"] for row in rows].count(latest_request) == 1
+        assert all("Current user objective preserved" not in row["content"] for row in rows)
+        assert after_restart._ingest_cursor == len(replay_with_new_message)
+
     def test_existing_large_session_restart_reconciles_beyond_short_tail_window(self, tmp_path):
         db_path = tmp_path / "restart-large.db"
         config = LCMConfig(database_path=str(db_path))
@@ -2204,6 +2267,118 @@ class TestEngineCompress:
         assert result[0]["content"][:-1] == system_msg["content"]
         assert result[0]["content"][-1]["type"] == "text"
         assert "Lossless Context Management" in result[0]["content"][-1]["text"]
+
+    def test_compress_preserves_latest_user_request_outside_fresh_tail(self, tmp_path, monkeypatch):
+        """The latest real user request anchors the task even after tool-heavy turns.
+
+        A long assistant/tool sequence after the user request can push that user
+        message outside the ordinary fresh-tail window.  If compaction only keeps
+        summaries plus the mechanical tail, the next turn may see old summarized
+        goals and tool traces but not the current objective verbatim.
+        """
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_latest_user_anchor.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("latest-user-anchor", platform="discord", context_length=200000)
+
+        latest_request = "We need to increase the autonomy of the kanban board."
+        stale_request = "Could you clean up the temporary kanban boards?"
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": stale_request},
+            {"role": "assistant", "content": "I will inspect the boards."},
+            {"role": "user", "content": latest_request},
+            {
+                "role": "user",
+                "content": "[Your active task list was preserved across context compression]\n- [>] inspect blocker handling",
+            },
+            {
+                "role": "assistant",
+                "content": "I will inspect blocker handling.",
+                "tool_calls": [{
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": "search_files", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_0", "content": "blocker code"},
+            {
+                "role": "assistant",
+                "content": "I will inspect notifier handling.",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "notifier code"},
+            {
+                "role": "assistant",
+                "content": "I will inspect dispatcher handling.",
+                "tool_calls": [{
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "dispatcher code"},
+        ]
+
+        def mock_summary(**kwargs):
+            return "Older Kanban-board cleanup discussion.\nExpand for details about: stale board cleanup", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        result = instance.compress(messages)
+        result_contents = [msg.get("content") for msg in result]
+
+        anchor_content = next(content for content in result_contents if latest_request in content)
+        assert anchor_content.startswith("[Current user objective preserved from compacted history]")
+        assert stale_request not in "\n".join(result_contents)
+        assert result_contents.index(anchor_content) < result_contents.index("I will inspect notifier handling.")
+
+    def test_compress_carries_preserved_user_request_across_repeated_compaction(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_repeated_latest_user_anchor.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("repeated-latest-user-anchor", platform="discord", context_length=200000)
+
+        latest_request = "LATEST OBJECTIVE: increase autonomy"
+
+        def mock_summary(**kwargs):
+            return "Tool-heavy turn summary.\nExpand for details about: active objective", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        first = instance.compress([
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "old request"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": latest_request},
+            {"role": "assistant", "content": "tool1", "tool_calls": [{"id": "call_1", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "out1"},
+            {"role": "assistant", "content": "tool2", "tool_calls": [{"id": "call_2", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_2", "content": "out2"},
+        ])
+        first_serialized = "\n".join(str(msg.get("content", "")) for msg in first)
+        assert latest_request in first_serialized
+        assert "[Current user objective preserved from compacted history]" in first_serialized
+
+        second = instance.compress(first + [
+            {"role": "assistant", "content": "tool3", "tool_calls": [{"id": "call_3", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_3", "content": "out3"},
+            {"role": "assistant", "content": "tool4", "tool_calls": [{"id": "call_4", "type": "function"}]},
+            {"role": "tool", "tool_call_id": "call_4", "content": "out4"},
+        ])
+        second_serialized = "\n".join(str(msg.get("content", "")) for msg in second)
+        assert latest_request in second_serialized
+        assert second_serialized.count("[Current user objective preserved from compacted history]") == 1
 
     def test_compress_preserves_system_and_tail(self, engine):
         """Compression should always keep system prompt and fresh tail."""
@@ -6519,6 +6694,52 @@ class TestAssemblyGuardrails:
         )
 
         assert result[1:] == []
+
+    def test_context_anchor_is_budgeted_under_max_assembly_tokens(self, tmp_path, monkeypatch):
+        import importlib
+
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_guardrail_anchor_budget.db"),
+            max_assembly_tokens=120,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+        monkeypatch.setattr(lcm_engine_module, "count_tokens", lambda text: len(text))
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "summarize_with_escalation",
+            lambda **kwargs: ("summary", 1),
+        )
+
+        oversized_anchor = "current objective " * 7
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": "stale"},
+            {"role": "user", "content": oversized_anchor},
+            {"role": "assistant", "content": "a" * 50},
+            {"role": "tool", "tool_call_id": "call_anchor", "content": "t" * 50},
+        ]
+
+        result = instance.compress(messages, current_tokens=140)
+
+        assert lcm_engine_module.count_messages_tokens(result) <= 120
+        assert oversized_anchor not in [msg.get("content") for msg in result]
+        assert not instance.get_status()["overflow_recovery_failed"]
 
     def test_reserve_tokens_floor_warns_when_misconfigured(self, tmp_path, caplog):
         config = LCMConfig(


### PR DESCRIPTION
## Summary
- Keep the latest real user message as an explicit active-context anchor when LCM compaction would otherwise omit it from the fresh tail.
- Skip Hermes' synthetic preserved-todo context when choosing that anchor, so the real user request remains dominant.
- Add a regression test for a tool-heavy turn where assistant/tool messages push the current user request outside the normal fresh-tail window.

## Bug
In long gateway sessions, a user can change objectives and then the assistant may run many tool calls before LCM compacts. Because the fresh tail is message-count based, those assistant/tool messages can push the latest user request out of the active context. The next post-compaction prompt can then contain old summarized goals plus mechanical tool traces, but not the current user request verbatim. In practice this can make the agent regress to an older task after a compression/session split.

A user-side workaround is to increase the fresh-tail count, but that is not a rigorous fix: tool-heavy turns can still exceed the configured window, and a larger tail increases context/cost for every session. The engine should preserve the active objective directly.

## Fix
The change is intentionally small:

1. During normal `compress()`, temporarily provide `_assemble_context()` with the original pre-compaction message window.
2. `_assemble_context()` keeps the newest non-synthetic user message if it is not already present in the selected tail.
3. The anchor is inserted after summaries and before the fresh tail, so provider-safe assistant/tool sequencing remains intact.
4. Direct `_assemble_context()` callers and overflow recovery paths keep their existing behavior because anchoring is opt-in during normal compaction only.

## Testing
- `pytest tests/test_lcm_engine.py::TestEngineCompress::test_compress_preserves_latest_user_request_outside_fresh_tail -q`
  - Verified RED before the implementation: failed because the latest user request was absent from compressed active context.
  - Verified GREEN after the implementation: passed.
- `pytest tests/test_lcm_engine.py::TestEngineCompress -q`
  - `18 passed`
- `git diff --check`
- `pytest tests -q`
  - `523 passed, 39 warnings`


_NOTE:_ This was put together in conjunction with gpt-5.5 through hermes-agent mainly as a tool for identifying the problem through log investigations with human guidance for applying the fix. Feel free to leave feedback on the implementation, I naturally do not have deep experience with the codebase but just wanted to use my experiences to help forward this great project! Thanks in advance for the consideration.