### PR TITLE
fix: restore filtered grep and carried source expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ for earlier separate sessions or broad cross-session history.
 
 | Tool | Use |
 |------|-----|
-| `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Use `session_search` for earlier separate sessions or broad cross-session recall. |
+| `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Raw-message filters `role`, `time_from`, and `time_to` are pushed into the search query; when any of them is supplied, summary hits are omitted so the filter contract stays exact. Use `session_search` for earlier separate sessions or broad cross-session recall. |
 | `lcm_load_session` | Load one ordered raw-message transcript page for an explicit `session_id`. This is not search: it returns raw rows in `store_id` order, bounded by `limit`, with per-message content bounded by `max_content_chars`, and continues with `after_store_id` from `next_cursor`. |
 | `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
 | `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
@@ -327,9 +327,16 @@ Hermes `session_search` for broad cross-session history outside the LCM database
 Within the current session, `source` filters raw rows directly and filters
 summary nodes by descendant raw-message source lineage. `unknown` is a real
 source value, not a wildcard. Legacy blank-source rows are treated as `unknown`.
+`role`, `time_from`, and `time_to` are raw-message filters and are applied in the
+message search query before result limiting. `time_from` and `time_to` accept Unix
+seconds or timezone-aware ISO 8601 strings; naive ISO strings are rejected so the
+same query means the same thing across machines. When a raw-message filter is
+active, `lcm_grep` returns raw rows only and reports `summary_results_omitted`.
 
 Carried-over summary nodes can become current-session content after `/new`, but
-their source eligibility still comes from the descendant raw messages.
+their source eligibility still comes from the descendant raw messages. Expanding
+a carried-over current-session node recovers those original raw message sources
+even when the sources still belong to the previous session.
 
 ### Lossless raw recovery contract
 

--- a/dag.py
+++ b/dag.py
@@ -380,7 +380,6 @@ class SummaryDAG:
                 return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
 
             raw_nodes = [self._row_to_node(r) for r in rows]
-            raw_primary_values: list[float] = []
             for node in raw_nodes:
                 if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
                     continue
@@ -388,20 +387,25 @@ class SummaryDAG:
                 if apply_directness_adjustment and node.search_rank is not None:
                     rank_adjustment = max(float(node.search_directness), 0.0)
                     node.search_rank = float(node.search_rank) - (rank_adjustment * 2e-7)
-                raw_primary_values.append(_fts_primary_value(node, sort))
                 results.append(node)
             results.sort(key=lambda node: _fts_result_sort_key(node, sort))
 
-            if not apply_directness_adjustment or len(rows) < fetch_limit or len(results) <= limit:
+            exhausted = len(rows) < fetch_limit or scanned_rows >= candidate_cap
+            if source and not exhausted:
+                offset += len(rows)
+                remaining = candidate_cap - scanned_rows
+                if remaining <= 0:
+                    return results[:limit]
+                fetch_limit = min(fetch_limit * 2, remaining)
+                continue
+
+            if exhausted or not apply_directness_adjustment or len(results) <= limit:
                 return results[:limit]
 
             worst_visible_primary = _fts_primary_value(results[min(limit, len(results)) - 1], sort)
-            last_fetched_primary = raw_primary_values[-1]
+            last_fetched_primary = _fts_primary_value(raw_nodes[-1], sort)
             best_unseen_primary = last_fetched_primary - max_rank_bonus
             if best_unseen_primary > worst_visible_primary:
-                return results[:limit]
-
-            if scanned_rows >= candidate_cap:
                 return results[:limit]
 
             offset += len(rows)
@@ -431,33 +435,44 @@ class SummaryDAG:
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
         fetch_limit = compute_like_fallback_fetch_limit(limit, terms, phrases)
-        args.append(fetch_limit)
-
-        rows = self._conn.execute(
-            f"""SELECT * FROM summary_nodes
-                WHERE {' AND '.join(where)}
-                LIMIT ?""",
-            args,
-        ).fetchall()
+        base_args = list(args)
         collapse_risky_repeats = contains_risky_fts_ascii(query)
+        candidate_cap = compute_search_candidate_cap(limit)
+        offset = 0
+        scanned_rows = 0
         nodes: list[SummaryNode] = []
         source_match_cache: dict[int, bool] = {}
-        for row in rows:
-            node = self._row_to_node(row)
-            if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
-                continue
-            score = sum(
-                min(count_term_matches(node.summary, term), 1) if collapse_risky_repeats else count_term_matches(node.summary, term)
-                for term in terms
-            )
-            if score <= 0:
-                continue
-            node.search_rank = -float(score)
-            node.search_directness = compute_directness_score(node.summary, terms, phrases)
-            nodes.append(node)
+        while True:
+            rows = self._conn.execute(
+                f"""SELECT * FROM summary_nodes
+                    WHERE {' AND '.join(where)}
+                    LIMIT ? OFFSET ?""",
+                [*base_args, fetch_limit, offset],
+            ).fetchall()
+            scanned_rows += len(rows)
+            for row in rows:
+                node = self._row_to_node(row)
+                if source and not self._node_matches_source(node.node_id, source, cache=source_match_cache):
+                    continue
+                score = sum(
+                    min(count_term_matches(node.summary, term), 1) if collapse_risky_repeats else count_term_matches(node.summary, term)
+                    for term in terms
+                )
+                if score <= 0:
+                    continue
+                node.search_rank = -float(score)
+                node.search_directness = compute_directness_score(node.summary, terms, phrases)
+                nodes.append(node)
 
-        nodes.sort(key=lambda node: _fallback_result_sort_key(node, sort))
-        return nodes[:limit]
+            nodes.sort(key=lambda node: _fallback_result_sort_key(node, sort))
+            if not source or len(rows) < fetch_limit or scanned_rows >= candidate_cap:
+                return nodes[:limit]
+
+            offset += len(rows)
+            remaining = candidate_cap - scanned_rows
+            if remaining <= 0:
+                return nodes[:limit]
+            fetch_limit = min(fetch_limit * 2, remaining)
 
     # -- DAG traversal ------------------------------------------------------
 

--- a/schemas.py
+++ b/schemas.py
@@ -67,6 +67,25 @@ LCM_GREP = {
                     "Use 'unknown' for explicit unknown-source content."
                 ),
             },
+            "role": {
+                "type": "string",
+                "enum": ["system", "user", "assistant", "tool", "unknown"],
+                "description": "Optional raw-message role filter. When supplied, lcm_grep returns raw message hits only.",
+            },
+            "time_from": {
+                "type": ["number", "string"],
+                "description": (
+                    "Optional inclusive minimum raw-message timestamp. Accepts Unix seconds or timezone-aware ISO 8601; "
+                    "naive ISO timestamps are rejected. When supplied, lcm_grep returns raw message hits only."
+                ),
+            },
+            "time_to": {
+                "type": ["number", "string"],
+                "description": (
+                    "Optional inclusive maximum raw-message timestamp. Accepts Unix seconds or timezone-aware ISO 8601; "
+                    "naive ISO timestamps are rejected. When supplied, lcm_grep returns raw message hits only."
+                ),
+            },
         },
         "required": ["query"],
     },

--- a/store.py
+++ b/store.py
@@ -626,7 +626,10 @@ class MessageStore:
 
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None,
-               source: str | None = None) -> List[Dict[str, Any]]:
+               source: str | None = None,
+               role: str | None = None,
+               time_from: float | None = None,
+               time_to: float | None = None) -> List[Dict[str, Any]]:
         """FTS5 search across raw messages.
 
         Retrieval contract:
@@ -641,7 +644,16 @@ class MessageStore:
         terms = extract_search_terms(safe_query)
         phrases = extract_quoted_phrases(safe_query)
         if requires_like_fallback(query):
-            return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+            return self._search_like(
+                query,
+                session_id=session_id,
+                limit=limit,
+                sort=sort,
+                source=source,
+                role=role,
+                time_from=time_from,
+                time_to=time_to,
+            )
 
         order_by = _build_search_order_by(
             sort,
@@ -666,6 +678,15 @@ class MessageStore:
                 if source_clause:
                     where.append(source_clause)
                     args.extend(source_args)
+                if role is not None:
+                    where.append("m.role = ?")
+                    args.append(role)
+                if time_from is not None:
+                    where.append("m.timestamp >= ?")
+                    args.append(time_from)
+                if time_to is not None:
+                    where.append("m.timestamp <= ?")
+                    args.append(time_to)
                 args.extend([fetch_limit, offset])
                 rows = self._conn.execute(
                     f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
@@ -681,7 +702,16 @@ class MessageStore:
                 scanned_rows += len(rows)
             except sqlite3.Error as exc:
                 logger.warning("FTS message search failed, falling back to LIKE: %s", exc)
-                return self._search_like(query, session_id=session_id, limit=limit, sort=sort, source=source)
+                return self._search_like(
+                    query,
+                    session_id=session_id,
+                    limit=limit,
+                    sort=sort,
+                    source=source,
+                    role=role,
+                    time_from=time_from,
+                    time_to=time_to,
+                )
 
             raw_primary_values: list[float] = []
             for r in rows:
@@ -717,7 +747,10 @@ class MessageStore:
 
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,
-                     source: str | None = None) -> List[Dict[str, Any]]:
+                     source: str | None = None,
+                     role: str | None = None,
+                     time_from: float | None = None,
+                     time_to: float | None = None) -> List[Dict[str, Any]]:
         safe_query = sanitize_fts5_query(query)
         terms = extract_search_terms(safe_query)
         phrases = extract_quoted_phrases(safe_query)
@@ -734,6 +767,15 @@ class MessageStore:
         if source_clause:
             where.append(source_clause)
             args.extend(source_args)
+        if role is not None:
+            where.append("role = ?")
+            args.append(role)
+        if time_from is not None:
+            where.append("timestamp >= ?")
+            args.append(time_from)
+        if time_to is not None:
+            where.append("timestamp <= ?")
+            args.append(time_to)
         like_clauses = []
         for term in terms:
             like_clauses.append("content LIKE ? ESCAPE '\\'")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -390,12 +390,10 @@ class TestEngineABC:
         assert grep_props["session_scope"]["enum"] == ["current", "all", "session"]
         assert "session_id" in grep_props
         assert "session_scope='session'" in grep_props["session_id"]["description"]
-        # role/time_from/time_to filters are intentionally absent in this
-        # version; they need to be pushed into the search layer before being
-        # exposed again. See follow-up issue tracking that work.
-        assert "role" not in grep_props
-        assert "time_from" not in grep_props
-        assert "time_to" not in grep_props
+        assert "role" in grep_props
+        assert grep_props["role"]["enum"] == ["system", "user", "assistant", "tool", "unknown"]
+        assert "time_from" in grep_props
+        assert "time_to" in grep_props
         assert "source" in grep_props
         assert "descendant source lineage" in grep_props["source"]["description"]
         assert "unknown" in grep_props["source"]["description"]
@@ -3281,6 +3279,75 @@ class TestSessionRollover:
         assert engine._dag.get_node(pruned_node_id) is None
         assert engine._store.get_session_count("old-retrieval") == 1
         assert engine._store.get_session_count("new-retrieval") == 0
+
+    def test_expand_retained_rollover_summary_recovers_original_session_sources(self, engine):
+        engine._config.new_session_retain_depth = 2
+        engine.on_session_start("old-expand", platform="discord", context_length=200000)
+        old_store_id = engine._store.append(
+            "old-expand",
+            {"role": "user", "content": "discord carried source payload"},
+            token_estimate=9,
+            source="discord",
+        )
+        retained_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-expand",
+            depth=2,
+            summary="carried rollover summary about discord payload",
+            token_count=7,
+            source_token_count=9,
+            source_ids=[old_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+
+        moved = engine.rollover_session(
+            "old-expand",
+            "new-expand",
+            previous_messages=[],
+            platform="discord",
+            context_length=200000,
+        )
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": retained_node_id}))
+
+        assert moved == 1
+        assert expanded["pagination"]["total_sources"] == 1
+        assert expanded["pagination"]["returned_sources"] == 1
+        assert expanded["expanded"][0]["store_id"] == old_store_id
+        assert expanded["expanded"][0]["content"] == "discord carried source payload"
+
+    def test_expand_retained_depth_zero_summary_recovers_original_session_sources(self, engine):
+        engine._config.new_session_retain_depth = -1
+        engine.on_session_start("old-expand-d0", platform="discord", context_length=200000)
+        old_store_id = engine._store.append(
+            "old-expand-d0",
+            {"role": "user", "content": "depth zero carried source payload"},
+            token_estimate=9,
+            source="discord",
+        )
+        retained_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-expand-d0",
+            depth=0,
+            summary="depth zero carried rollover summary",
+            token_count=7,
+            source_token_count=9,
+            source_ids=[old_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+
+        moved = engine.rollover_session(
+            "old-expand-d0",
+            "new-expand-d0",
+            previous_messages=[],
+            platform="discord",
+            context_length=200000,
+        )
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": retained_node_id}))
+
+        assert moved == 1
+        assert expanded["expanded"][0]["session_id"] == "old-expand-d0"
+        assert expanded["expanded"][0]["from_current_session"] is False
+        assert expanded["expanded"][0]["content"] == "depth zero carried source payload"
 
     def test_rollover_session_compression_boundary_keeps_depth_zero_nodes(self, engine):
         engine._config.new_session_retain_depth = 2
@@ -7133,6 +7200,155 @@ class TestEngineTools:
         )
         assert result["sort"] == "relevance"
 
+    def test_handle_grep_role_filter_pushes_into_message_search(self, engine):
+        assistant_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "docker target assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1000.0, assistant_id),
+        )
+        for idx in range(25):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"docker noisy user {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (2000.0 + idx, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker", "role": "assistant", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "assistant"
+        assert result["total_results"] == 1
+        assert result["results"][0]["role"] == "assistant"
+        assert "target assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_time_filter_pushes_into_message_search(self, engine):
+        older_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "docker older assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1000.0, older_id),
+        )
+        for idx in range(25):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"docker newer user {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (2000.0 + idx, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker", "time_to": 1500.0, "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["time_to"] == 1500.0
+        assert result["total_results"] == 1
+        assert result["results"][0]["timestamp"] == 1000.0
+        assert "older assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_rejects_naive_iso_time_filter(self, engine):
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker", "time_to": "2026-05-06T10:00:00"},
+        ))
+
+        assert "error" in result
+        assert "timezone" in result["error"]
+
+    def test_handle_grep_like_fallback_applies_role_filter_before_limit(self, engine):
+        assistant_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "docker-compose target assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1000.0, assistant_id),
+        )
+        for idx in range(25):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"docker-compose noisy user {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (2000.0 + idx, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker-compose", "role": "assistant", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "assistant"
+        assert result["total_results"] == 1
+        assert result["results"][0]["role"] == "assistant"
+        assert "target assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_like_fallback_applies_time_filter_before_limit(self, engine):
+        older_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "docker-compose older assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1000.0, older_id),
+        )
+        for idx in range(25):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "user", "content": f"docker-compose newer user {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (2000.0 + idx, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker-compose", "time_to": 1500.0, "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["time_to"] == 1500.0
+        assert result["total_results"] == 1
+        assert result["results"][0]["timestamp"] == 1000.0
+        assert "older assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_accepts_timezone_aware_iso_time_filter(self, engine):
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "docker timezone aware"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (1_700_000_000.0, store_id),
+        )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker", "time_from": "2023-11-14T22:13:20Z"},
+        ))
+
+        assert result["time_from"] == 1_700_000_000.0
+        assert result["total_results"] == 1
+        assert result["results"][0]["store_id"] == store_id
+
     def test_handle_grep_session_scope_all_returns_cross_session_hits(self, engine):
         engine._store.append("test-session", {"role": "user", "content": "docker rollout current session"})
         engine._store.append("old-session", {"role": "user", "content": "docker rollout old session"})
@@ -7270,6 +7486,178 @@ class TestEngineTools:
             for item in result["results"]
             if item["type"] == "summary"
         )
+
+    def test_handle_grep_source_filter_pages_past_newer_unrelated_summaries(self, engine):
+        discord_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "lineage row from discord"},
+            source="discord",
+        )
+        telegram_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "lineage row from telegram"},
+            source="telegram",
+        )
+
+        for idx in range(220):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"telegram summary {idx} about docker rollout",
+                    token_count=10,
+                    source_token_count=10,
+                    source_ids=[telegram_store_id],
+                    source_type="messages",
+                    created_at=1_800_000_000 + idx,
+                    latest_at=1_800_000_000 + idx,
+                )
+            )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="discord summary about docker rollout",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[discord_store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker", "session_scope": "current", "source": "discord", "limit": 1, "sort": "recency"},
+            )
+        )
+
+        assert result["total_results"] == 1
+        assert result["results"][0]["type"] == "summary"
+        assert "discord summary" in result["results"][0]["snippet"]
+
+    def test_handle_grep_source_filter_like_fallback_pages_past_unrelated_summaries(self, engine):
+        discord_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "lineage row from discord"},
+            source="discord",
+        )
+        telegram_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "lineage row from telegram"},
+            source="telegram",
+        )
+
+        for idx in range(220):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"telegram summary {idx} about docker:rollout",
+                    token_count=10,
+                    source_token_count=10,
+                    source_ids=[telegram_store_id],
+                    source_type="messages",
+                    created_at=1_800_000_000 + idx,
+                    latest_at=1_800_000_000 + idx,
+                )
+            )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="discord summary about docker:rollout",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[discord_store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker:rollout", "session_scope": "current", "source": "discord", "limit": 1, "sort": "recency"},
+            )
+        )
+
+        assert result["total_results"] == 1
+        assert result["results"][0]["type"] == "summary"
+        assert "discord summary" in result["results"][0]["snippet"]
+
+    def test_handle_grep_source_filter_like_fallback_sorts_across_matching_candidates(self, engine):
+        older_discord_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "older discord lineage"},
+            source="discord",
+        )
+        telegram_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "telegram lineage"},
+            source="telegram",
+        )
+        newer_discord_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "newer discord lineage"},
+            source="discord",
+        )
+
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="older discord summary about docker:rollout",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[older_discord_store_id],
+                source_type="messages",
+                created_at=1_700_000_000,
+                latest_at=1_700_000_000,
+            )
+        )
+        for idx in range(220):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"telegram summary {idx} about docker:rollout",
+                    token_count=10,
+                    source_token_count=10,
+                    source_ids=[telegram_store_id],
+                    source_type="messages",
+                    created_at=1_800_000_000 + idx,
+                    latest_at=1_800_000_000 + idx,
+                )
+            )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="newer discord summary about docker:rollout",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[newer_discord_store_id],
+                source_type="messages",
+                created_at=1_900_000_000,
+                latest_at=1_900_000_000,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {"query": "docker:rollout", "session_scope": "current", "source": "discord", "limit": 1, "sort": "recency"},
+            )
+        )
+
+        assert result["total_results"] == 2
+        assert len(result["results"]) == 1
+        assert result["results"][0]["type"] == "summary"
+        assert "newer discord summary" in result["results"][0]["snippet"]
 
     def test_handle_grep_unknown_source_filter_matches_unknown_messages_and_summaries(self, engine):
         unknown_store_id = engine._store.append(

--- a/tools.py
+++ b/tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -103,12 +104,18 @@ def _get_session_node(engine: "LCMEngine", node_id: int):
     return node
 
 
-def _get_externalized_payload(engine: "LCMEngine", ref: str) -> dict[str, Any] | None:
+def _get_externalized_payload(
+    engine: "LCMEngine",
+    ref: str,
+    *,
+    allowed_session_ids: set[str] | None = None,
+) -> dict[str, Any] | None:
     payload = load_externalized_payload(ref, config=engine._config, hermes_home=engine._hermes_home)
     if payload is None:
         return None
     payload_session_id = payload.get("session_id") or ""
-    if payload_session_id and payload_session_id != engine.current_session_id:
+    allowed = allowed_session_ids or {engine.current_session_id}
+    if payload_session_id and payload_session_id not in allowed:
         return None
     return payload
 
@@ -158,6 +165,43 @@ def _parse_optional_float(value: Any, name: str) -> tuple[float | None, str | No
         return float(value), None
     except (TypeError, ValueError, OverflowError):
         return None, f"{name} must be a number"
+
+
+def _parse_optional_timestamp(value: Any, name: str) -> tuple[float | None, str | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, f"{name} must be a Unix timestamp or timezone-aware ISO 8601 string"
+    if isinstance(value, (int, float)):
+        try:
+            return float(value), None
+        except (TypeError, ValueError, OverflowError):
+            return None, f"{name} must be a Unix timestamp or timezone-aware ISO 8601 string"
+    text = str(value).strip()
+    if not text:
+        return None, f"{name} must not be empty"
+    try:
+        return float(text), None
+    except (TypeError, ValueError, OverflowError):
+        pass
+    iso_text = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(iso_text)
+    except ValueError:
+        return None, f"{name} must be a Unix timestamp or timezone-aware ISO 8601 string"
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None, f"{name} ISO timestamp must include a timezone offset or Z"
+    return parsed.timestamp(), None
+
+
+def _parse_grep_role(value: Any) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, None
+    role = str(value or "").strip()
+    valid_roles = {"system", "user", "assistant", "tool", "unknown"}
+    if role not in valid_roles:
+        return None, "role must be one of: system, user, assistant, tool, unknown"
+    return role, None
 
 
 def _parse_strict_int(value: Any, name: str) -> tuple[int | None, str | None]:
@@ -290,7 +334,7 @@ def _expand_message_sources(
             has_more = True
             break
         stored = stored_by_id.get(store_id)
-        if not stored or stored.get("session_id") != engine.current_session_id:
+        if not stored:
             next_source_offset = source_index + 1
             next_content_offset = 0
             has_more = next_source_offset < total_sources
@@ -301,7 +345,11 @@ def _expand_message_sources(
         externalized = None
         ref = extract_externalized_ref(transcript_content)
         if ref:
-            externalized = _get_externalized_payload(engine, ref)
+            externalized = _get_externalized_payload(
+                engine,
+                ref,
+                allowed_session_ids={engine.current_session_id, stored.get("session_id", "")},
+            )
         if hydrate_externalized_content and externalized is not None:
             content = externalized.get("content", "")
             content_source = "externalized_payload"
@@ -313,6 +361,9 @@ def _expand_message_sources(
         expanded = {
             "store_id": stored["store_id"],
             "source_index": source_index,
+            "session_id": stored.get("session_id", ""),
+            "source": stored.get("source") or "",
+            "from_current_session": stored.get("session_id", "") == engine.current_session_id,
             "role": stored["role"],
             "content": sliced["content"],
             "content_chars": sliced["content_chars"],
@@ -731,6 +782,18 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         str(raw_session_id_arg).strip() if raw_session_id_arg is not None else ""
     )
     source = str(args.get("source") or "").strip() or None
+    role, role_error = _parse_grep_role(args.get("role"))
+    if role_error:
+        return json.dumps({"error": role_error})
+    time_from, time_from_error = _parse_optional_timestamp(args.get("time_from"), "time_from")
+    if time_from_error:
+        return json.dumps({"error": time_from_error})
+    time_to, time_to_error = _parse_optional_timestamp(args.get("time_to"), "time_to")
+    if time_to_error:
+        return json.dumps({"error": time_to_error})
+    if time_from is not None and time_to is not None and time_to < time_from:
+        return json.dumps({"error": "time_to must be greater than or equal to time_from"})
+    raw_message_filter_active = role is not None or time_from is not None or time_to is not None
 
     if requested_session_scope == "current":
         if explicit_session_id:
@@ -782,6 +845,9 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
             limit=source_limit,
             sort=sort,
             source=source,
+            role=role,
+            time_from=time_from,
+            time_to=time_to,
         )
         for hit in msg_hits:
             timestamp_value = hit.get("timestamp", 0) or 0
@@ -809,7 +875,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     # contract would push this tool toward a memory-system shape rather than
     # a plugin-local archive search. Raw-message hits remain expandable across
     # sessions via lcm_expand(store_id=...).
-    if session_scope == "current":
+    if session_scope == "current" and not raw_message_filter_active:
         try:
             node_hits = engine._dag.search(
                 query,
@@ -864,6 +930,14 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         "total_results": len(results),
         "results": results[:limit],
     }
+    if role is not None:
+        response["role"] = role
+    if time_from is not None:
+        response["time_from"] = time_from
+    if time_to is not None:
+        response["time_to"] = time_to
+    if raw_message_filter_active:
+        response["summary_results_omitted"] = True
     if session_scope == "session":
         response["session_id"] = explicit_session_id
     if requested_limit > _LCM_GREP_HARD_LIMIT_CAP:
@@ -945,9 +1019,9 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     - ``store_id``: fetch a single raw message by store_id; works across sessions
     - ``node_id``: expand a summary node to its source content (current session only)
 
-    Only ``store_id`` mode is cross-session in this version. Cross-session DAG
-    expansion via ``node_id`` is intentionally not supported (it would require
-    descending session-bound source ids).
+    Only ``store_id`` mode accepts an arbitrary cross-session target. ``node_id``
+    stays current-session scoped, but carried-over current-session nodes may
+    reference raw source rows that still belong to the previous session.
     """
     engine = _require_engine(kwargs)
     if engine is None:


### PR DESCRIPTION
## Summary

This fixes two retrieval gaps around the newer cross-session and rollover flows.

What changed:

- `lcm_grep` exposes `role`, `time_from`, and `time_to` again, and applies them inside `MessageStore.search` before candidate limiting. The LIKE fallback path gets the same filters.
- `lcm_grep` omits summary hits when raw-message filters are active, so a role or timestamp filter does not return unfiltered summaries.
- Summary source filtering now pages through bounded DAG search candidates when `source` is active, instead of filtering only the first candidate window. This covers both FTS and LIKE fallback paths.
- `lcm_expand(node_id=...)` can now expand a current-session carried-over summary node whose raw `source_ids` still point at the previous session.
- README and tool schema text document the raw-filter and carried-over expansion contracts.

Fixes #108
Fixes #110

## Why

#108 was still open because `role`, `time_from`, and `time_to` were absent from `lcm_grep`, and passing them manually was ignored after the first candidate window. #110 was still reproducible because carried-over summaries moved to the new session, while their raw message sources stayed in the old session and were filtered out during expansion.

The latest update also fixes the remaining summary `source` filter gap from review: source matching for summary nodes is now bounded by the existing candidate cap, not by the first fetched window.

## Validation

- Focused retrieval and expansion validation: `10 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=`: `491 passed`
- `python -m pytest tests -q -o addopts=`: `537 passed`
- `python -m compileall -q .`
- `python -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check origin/main...HEAD`

## Notes

`node_id` expansion is still current-session scoped. The change is narrower than arbitrary cross-session DAG expansion: it only follows the explicit `source_ids` on a current-session node, which is the shape created by rollover carry-over.
