### PR TITLE
fix: handle multimodal first message assembly

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -631,11 +631,14 @@ class LCMEngine(ContextEngine):
             n = len(working_messages)
             fresh_tail_start = max(0, n - self._config.fresh_tail_count)
 
-            # Protect system prompt (always index 0)
+            # Keep the leading message anchored. It is usually the system
+            # prompt, but Hermes gateway sessions may pass only conversation
+            # messages here, so index 0 can be a user message.
             if fresh_tail_start <= 1:
                 break
 
-            # Skip system prompt (index 0), candidate raw backlog is indices 1..fresh_tail_start
+            # Skip the leading anchor, candidate raw backlog is indices
+            # 1..fresh_tail_start.
             candidate_raw = working_messages[1:fresh_tail_start]
             if not candidate_raw:
                 break
@@ -2361,6 +2364,24 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: context assembly ----------------------------------------
 
+    @staticmethod
+    def _append_lcm_note_to_content(content: Any) -> Any:
+        note = (
+            "\n\n[Note: This conversation uses Lossless Context Management (LCM). "
+            "Earlier turns have been compacted into hierarchical summaries below. "
+            "Use lcm_grep to search history, lcm_describe to inspect the DAG, "
+            "and lcm_expand to recover original details from any summary.]"
+        )
+        if isinstance(content, str):
+            return content + note
+        note_part = {"type": "text", "text": note.lstrip()}
+        if content is None:
+            return note.lstrip()
+        if isinstance(content, list):
+            return list(content) + [note_part]
+        normalized = normalize_content_value(content) or ""
+        return normalized + note
+
     def _assemble_context(
         self,
         system_msg: Dict[str, Any],
@@ -2371,24 +2392,26 @@ class LCMEngine(ContextEngine):
         """Build the active context from DAG summaries + fresh tail.
 
         Structure:
-          [system prompt (with LCM note)]
+          [leading anchor, normally system prompt]
           [highest-depth summary nodes first, then lower]
           [fresh tail messages]
         """
         result = []
 
-        # System prompt with LCM annotation
-        sys_msg = system_msg.copy()
-        if self.compression_count == 0 and include_lcm_note:
-            sys_content = sys_msg.get("content", "")
-            sys_msg["content"] = (
-                sys_content
-                + "\n\n[Note: This conversation uses Lossless Context Management (LCM). "
-                "Earlier turns have been compacted into hierarchical summaries below. "
-                "Use lcm_grep to search history, lcm_describe to inspect the DAG, "
-                "and lcm_expand to recover original details from any summary.]"
+        # Leading anchor with optional LCM annotation. Only append the note to
+        # an actual system message; gateway sessions can start with a structured
+        # multimodal user message, and that content must not be treated as a
+        # system prompt or concatenated with text.
+        leading_msg = system_msg.copy()
+        if (
+            leading_msg.get("role") == "system"
+            and self.compression_count == 0
+            and include_lcm_note
+        ):
+            leading_msg["content"] = self._append_lcm_note_to_content(
+                leading_msg.get("content", "")
             )
-        result.append(sys_msg)
+        result.append(leading_msg)
 
         assembly_cap = (
             assembly_cap_override
@@ -2399,7 +2422,7 @@ class LCMEngine(ContextEngine):
         tail_selected = tail_messages
         summary_budget = None
         if assembly_cap is not None:
-            used = count_message_tokens(sys_msg)
+            used = count_message_tokens(leading_msg)
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
             for msg in reversed(tail_messages):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2165,6 +2165,48 @@ class TestEngineCompress:
         result = engine.compress(messages)
         assert len(result) == len(messages)
 
+    def test_compress_handles_multimodal_first_user_message_without_system(self, engine, monkeypatch):
+        """Gateway sessions may pass conversation messages without a leading system prompt."""
+        def mock_summary(**kwargs):
+            return "Mock summary.\nExpand for details about: multimodal first user", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        first_user = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first user text"},
+                {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+            ],
+        }
+        messages = [first_user]
+        for i in range(10):
+            messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
+            messages.append({"role": "user", "content": f"Question {i}: " + "x" * 200})
+
+        result = engine.compress(messages)
+
+        assert result[0] == first_user
+        assert isinstance(result[0]["content"], list)
+        assert all(
+            not (isinstance(part, dict) and "Lossless Context Management" in str(part.get("text", "")))
+            for part in result[0]["content"]
+        )
+        assert len(result) < len(messages)
+        assert engine.compression_count == 1
+
+    def test_assemble_context_appends_lcm_note_to_structured_system_content(self, engine):
+        system_msg = {
+            "role": "system",
+            "content": [{"type": "text", "text": "You are helpful."}],
+        }
+
+        result = engine._assemble_context(system_msg, [])
+
+        assert result[0]["role"] == "system"
+        assert result[0]["content"][:-1] == system_msg["content"]
+        assert result[0]["content"][-1]["type"] == "text"
+        assert "Lossless Context Management" in result[0]["content"][-1]["text"]
+
     def test_compress_preserves_system_and_tail(self, engine):
         """Compression should always keep system prompt and fresh tail."""
         messages = self._make_long_conversation(20)


### PR DESCRIPTION
## Summary

Fixes context assembly when Hermes gateway sessions do not include a leading system prompt in the message list.

The change keeps the existing leading-message anchor behavior, but only appends the LCM note when that leading message is actually `role: system`. If the first message is a multimodal user message, LCM leaves it unchanged instead of treating it like a system prompt. Structured system content is also handled safely by appending the note as a text content part rather than concatenating a string onto a list.

Fixes #131

## Why

Hermes core can pass only conversation messages to context engines. In gateway sessions, that means `messages[0]` can be the first user message. When that first user message contains image parts, `_assemble_context()` was doing `list + str` while adding the LCM note, which raised `TypeError` during compression.

## Validation

- [x] Focused validation: `pytest -q tests/test_lcm_engine.py::TestEngineCompress::test_compress_handles_multimodal_first_user_message_without_system tests/test_lcm_engine.py::TestEngineCompress::test_assemble_context_appends_lcm_note_to_structured_system_content tests/test_lcm_engine.py::TestEngineCompress::test_compress_preserves_system_and_tail tests/test_lcm_engine.py::TestEngineCompress::test_compress_leaf_node_tracks_source_ids_for_content_part_messages` -> `4 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `478 passed`
  - [x] `pytest -q` -> `524 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`

## Notes

No new configuration. The no-system case omits the LCM note rather than injecting a synthetic system message, because that keeps the returned message shape closest to what Hermes supplied.
