### PR TITLE
fix: preserve recency in LIKE fallback grep

### DIFF
--- a/store.py
+++ b/store.py
@@ -782,31 +782,154 @@ class MessageStore:
             args.append(f"%{escape_like(term)}%")
         where.append("(" + " OR ".join(like_clauses) + ")")
         fetch_limit = compute_like_fallback_fetch_limit(limit, terms, phrases)
-        args.append(fetch_limit)
-
-        rows = self._conn.execute(
-            f"""SELECT {_MESSAGE_SELECT_COLUMNS}
-                FROM messages
-                WHERE {' AND '.join(where)}
-                LIMIT ?""",
-            args,
-        ).fetchall()
+        base_args = list(args)
+        normalized_sort = normalize_search_sort(sort)
         results: List[Dict[str, Any]] = []
         collapse_risky_repeats = contains_risky_fts_ascii(query)
-        for row in rows:
-            result = self._row_to_dict(row)
-            content = result.get("content") or ""
-            score = sum(
-                min(count_term_matches(content, term), 1) if collapse_risky_repeats else count_term_matches(content, term)
-                for term in terms
+        order_by = ""
+        order_args: list[Any] = []
+        if normalized_sort == "recency":
+            role_bias = "CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
+
+            def count_expr(term: str) -> tuple[str, list[Any]]:
+                return (
+                    "((LENGTH(LOWER(content)) - LENGTH(REPLACE(LOWER(content), LOWER(?), ''))) "
+                    "/ NULLIF(LENGTH(?), 0))",
+                    [term, term],
+                )
+
+            score_exprs: list[str] = []
+            for term in terms:
+                if collapse_risky_repeats:
+                    score_exprs.append("CASE WHEN content LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END")
+                    order_args.append(f"%{escape_like(term)}%")
+                else:
+                    expr, expr_args = count_expr(term)
+                    score_exprs.append(expr)
+                    order_args.extend(expr_args)
+            score_expr = " + ".join(score_exprs) if score_exprs else "0"
+
+            def build_unique_exprs(selected_terms: list[str]) -> tuple[str, list[Any]]:
+                parts: list[str] = []
+                expr_args: list[Any] = []
+                for selected_term in selected_terms:
+                    expr, args_for_expr = count_expr(selected_term)
+                    parts.append(f"CASE WHEN ({expr}) > 0 THEN 1 ELSE 0 END")
+                    expr_args.extend(args_for_expr)
+                return (" + ".join(parts) if parts else "0", expr_args)
+
+            def build_total_exprs(selected_terms: list[str]) -> tuple[str, list[Any]]:
+                parts: list[str] = []
+                expr_args: list[Any] = []
+                for selected_term in selected_terms:
+                    expr, args_for_expr = count_expr(selected_term)
+                    parts.append(expr)
+                    expr_args.extend(args_for_expr)
+                return (" + ".join(parts) if parts else "0", expr_args)
+
+            directness_args: list[Any] = []
+            unique_score_expr, expr_args = build_unique_exprs(terms)
+            directness_args.extend(expr_args)
+            normalized_phrases = {(phrase or "").strip().lower() for phrase in phrases if (phrase or "").strip()}
+            if phrases:
+                phrase_hit_exprs: list[str] = []
+                for phrase in phrases:
+                    phrase_hit_exprs.append("CASE WHEN INSTR(LOWER(content), LOWER(?)) > 0 THEN 1 ELSE 0 END")
+                    directness_args.append(phrase)
+                phrase_hit_expr = " + ".join(phrase_hit_exprs) if phrase_hit_exprs else "0"
+                non_phrase_terms = [term for term in terms if term.strip().lower() not in normalized_phrases]
+                non_phrase_total_expr, expr_args = build_total_exprs(non_phrase_terms)
+                directness_args.extend(expr_args)
+                non_phrase_unique_expr, expr_args = build_unique_exprs(non_phrase_terms)
+                directness_args.extend(expr_args)
+                repetition_expr = f"MAX(({non_phrase_total_expr}) - ({non_phrase_unique_expr}), 0)"
+                directness_expr = f"(({unique_score_expr}) * 5.0) + (({phrase_hit_expr}) * 8.0) - MIN(({repetition_expr}), 6)"
+            else:
+                total_repetition_expr, expr_args = build_total_exprs(terms)
+                directness_args.extend(expr_args)
+                unique_repetition_expr, expr_args = build_unique_exprs(terms)
+                directness_args.extend(expr_args)
+                repetition_expr = f"MAX(({total_repetition_expr}) - ({unique_repetition_expr}), 0)"
+                directness_expr = f"(({unique_score_expr}) * 5.0) - MIN(({repetition_expr}), 6)"
+            order_args.extend(directness_args)
+            order_by = (
+                f"ORDER BY timestamp DESC, {role_bias} ASC, ({score_expr}) DESC, "
+                f"({directness_expr}) DESC, store_id DESC"
             )
-            if score <= 0:
-                continue
-            result["search_rank"] = -float(score)
-            result["snippet"] = build_snippet(content, terms)
-            result["_fallback_score"] = float(score)
-            result["_directness_score"] = _message_directness_score(result.get("role"), content, terms, phrases)
-            results.append(result)
+
+        def add_rows(rows: list[sqlite3.Row]) -> None:
+            for row in rows:
+                result = self._row_to_dict(row)
+                content = result.get("content") or ""
+                score = sum(
+                    min(count_term_matches(content, term), 1) if collapse_risky_repeats else count_term_matches(content, term)
+                    for term in terms
+                )
+                if score <= 0:
+                    continue
+                result["search_rank"] = -float(score)
+                result["snippet"] = build_snippet(content, terms)
+                result["_fallback_score"] = float(score)
+                result["_directness_score"] = _message_directness_score(result.get("role"), content, terms, phrases)
+                results.append(result)
+
+        if normalized_sort == "recency":
+            candidate_cap = compute_search_candidate_cap(limit)
+            offset = 0
+            scanned_rows = 0
+            while True:
+                batch_limit = min(fetch_limit, candidate_cap - scanned_rows)
+                if batch_limit <= 0:
+                    break
+                rows = self._conn.execute(
+                    f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+                        FROM messages
+                        WHERE {' AND '.join(where)}
+                        {order_by}
+                        LIMIT ? OFFSET ?""",
+                    [*base_args, *order_args, batch_limit, offset],
+                ).fetchall()
+                scanned_rows += len(rows)
+                add_rows(rows)
+                offset += len(rows)
+                if len(rows) < batch_limit:
+                    break
+                if scanned_rows >= candidate_cap:
+                    boundary_timestamp = rows[-1][8]
+                    boundary_role_bias = _message_role_bias(rows[-1][3])
+                    while True:
+                        tie_rows = self._conn.execute(
+                            f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+                                FROM messages
+                                WHERE {' AND '.join(where)}
+                                {order_by}
+                                LIMIT ? OFFSET ?""",
+                            [*base_args, *order_args, fetch_limit, offset],
+                        ).fetchall()
+                        if not tie_rows:
+                            break
+                        matching_tie_rows = []
+                        reached_next_primary_group = False
+                        for tie_row in tie_rows:
+                            if tie_row[8] == boundary_timestamp and _message_role_bias(tie_row[3]) == boundary_role_bias:
+                                matching_tie_rows.append(tie_row)
+                            else:
+                                reached_next_primary_group = True
+                                break
+                        add_rows(matching_tie_rows)
+                        if reached_next_primary_group or len(tie_rows) < fetch_limit:
+                            break
+                        offset += len(tie_rows)
+                    break
+        else:
+            rows = self._conn.execute(
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+                    FROM messages
+                    WHERE {' AND '.join(where)}
+                    LIMIT ?""",
+                [*base_args, fetch_limit],
+            ).fetchall()
+            add_rows(rows)
 
         results.sort(key=lambda result: _fallback_result_sort_key(result, sort))
         for result in results:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7299,6 +7299,130 @@ class TestEngineTools:
         assert result["results"][0]["role"] == "assistant"
         assert "target assistant" in result["results"][0]["snippet"]
 
+    def test_handle_grep_like_fallback_role_filter_preserves_recency_before_limit(self, engine):
+        for idx in range(220):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "assistant", "content": f"docker-compose older assistant {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (1000.0 + idx, store_id),
+            )
+        newest_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "docker-compose newest assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (5000.0, newest_id),
+        )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "docker-compose", "role": "assistant", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "assistant"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][0]["store_id"] == newest_id
+        assert "newest assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_like_fallback_recency_sorts_tied_cap_by_score(self, engine):
+        best_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "foo/bar best assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (5000.0, best_id),
+        )
+        for idx in range(600):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "assistant", "content": f"foo low assistant {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (5000.0, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "foo/bar", "role": "assistant", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "assistant"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][0]["store_id"] == best_id
+        assert "best assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_like_fallback_recency_sorts_tied_cap_by_directness(self, engine):
+        best_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "foo/bar baz direct assistant"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (5000.0, best_id),
+        )
+        for idx in range(600):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "assistant", "content": f"foo/bar baz foo foo foo foo low assistant {idx}"},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (5000.0, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "foo/bar baz", "role": "assistant", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "assistant"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["role"] == "assistant"
+        assert result["results"][0]["store_id"] == best_id
+        assert "direct assistant" in result["results"][0]["snippet"]
+
+    def test_handle_grep_like_fallback_recency_extends_tied_cap_for_json_penalty(self, engine):
+        best_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "content": "foo/bar direct tool"},
+        )
+        engine._store._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+            (5000.0, best_id),
+        )
+        for idx in range(600):
+            store_id = engine._store.append(
+                "test-session",
+                {"role": "tool", "content": f'{{"message":"foo/bar low tool {idx}"}}'},
+            )
+            engine._store._conn.execute(
+                "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+                (5000.0, store_id),
+            )
+        engine._store._conn.commit()
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "foo/bar", "role": "tool", "limit": 1, "sort": "recency"},
+        ))
+
+        assert result["role"] == "tool"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["role"] == "tool"
+        assert result["results"][0]["store_id"] == best_id
+        assert "direct tool" in result["results"][0]["snippet"]
+
     def test_handle_grep_like_fallback_applies_time_filter_before_limit(self, engine):
         older_id = engine._store.append(
             "test-session",


### PR DESCRIPTION
## Summary

This follows up on the Codex note from #135 and the follow-up review on this PR about LIKE fallback grep sorting.

When a query falls back to LIKE, for example `docker-compose`, recency sorting happened after a bounded SQL `LIMIT`. If `role` or other filters still left more than one page of matching rows, the newest or best matching message could be outside the first SQL window and never reach the Python recency sort.

The recency LIKE path now orders candidates by the same primary keys the Python fallback sort uses: timestamp, role bias, fallback score, and directness. If the candidate cap lands inside a timestamp and role tie, it keeps reading that primary tie group before applying the final Python sort. That keeps the cap bounded for older/lower-priority rows while avoiding truncation inside the group that can still win.

Relevance and hybrid keep their previous one-window behavior.

## Validation

Local validation passed:

- `python -m pytest tests/test_lcm_engine.py -k 'like_fallback and grep' -q -o addopts=`: `8 passed`
- `python -m pytest tests/test_lcm_engine.py -k 'relevance or hybrid' -q -o addopts=`: `16 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=`: `495 passed`
- `python -m pytest tests -q -o addopts=`: `541 passed`
- `python -m compileall -q .`
- `python -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check origin/main...HEAD`

GitHub CI is green on Python 3.11, 3.12, and 3.13 for `bda097b`.
