### PR TITLE
fix: add period to _FTS5_SPECIAL_CHARS to prevent FTS5 syntax errors on version-style queries

### DIFF
--- a/search_query.py
+++ b/search_query.py
@@ -27,7 +27,7 @@ _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
 _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
 # Characters that are special in FTS5 query syntax
-_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}')
+_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{.})')
 
 
 def _sanitize_unquoted_fts5_fragment(text: str) -> str:


### PR DESCRIPTION
## Problem

`_FTS5_SPECIAL_CHARS` in `search_query.py` was missing the period character `.`. This caused FTS5 `syntax error near "."` crashes when users searched for version strings like `v2.21`, `api.v2`, model names like `minimax-m2.5-free`, etc.

## Root Cause

- `_FTS5_SPECIAL_CHARS = frozenset("\"()*^-:{}")` — no `.`
- Period IS in `_STRIP_EDGE_PUNCT` (for token edge stripping), but was NOT in the FTS5 sanitizer
- `sanitize_fts5_query("v2.21")` returned `"v2.21"` unchanged → FTS5 crash
- `contains_risky_fts_ascii()` only catches `-`, `/`, `:` (not `.`), so LIKE fallback did not trigger

## Fix

Added `.` to `_FTS5_SPECIAL_CHARS`:

```python
_FTS5_SPECIAL_CHARS = frozenset("\"()*^-:{.}")
```

**Before:** `sanitize_fts5_query("v2.21")` → `"v2.21"` → FTS5 crash

**After:** `sanitize_fts5_query("v2.21")` → `"v2 21"` → valid FTS5 (period replaced with space)

## Test

```python
sanitize_fts5_query("v2.21")           → "v2 21"
sanitize_fts5_query("api.v2")          → "api v2"
sanitize_fts5_query("hermes.lcm")        → "hermes lcm"
sanitize_fts5_query("minimax-m2.5-free") → "minimax m2 5 free" (falls back to LIKE due to -)
```

## Verification

The fix was verified on the running `lcm.db` database — FTS5 `MATCH` queries on period-containing strings now work correctly without crashing.