### PR TITLE
fix: add period to _FTS5_SPECIAL_CHARS to prevent FTS5 syntax errors on version-style queries

### DIFF
--- a/search_query.py
+++ b/search_query.py
@@ -27,7 +27,7 @@ _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
 _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
 # Characters that are special in FTS5 query syntax
-_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}')
+_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{.})')
 
 
 def _sanitize_unquoted_fts5_fragment(text: str) -> str:

--- a/search_query.py
+++ b/search_query.py
@@ -27,7 +27,7 @@ _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
 _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
 # Characters that are special in FTS5 query syntax
-_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{.})')
+_FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}.')
 
 
 def _sanitize_unquoted_fts5_fragment(text: str) -> str:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2010,6 +2010,11 @@ class TestDbBootstrapGuards:
     def test_sanitize_fts5_query_breaks_unbalanced_quotes_into_separate_terms(self):
         assert sanitize_fts5_query('foo"bar') == 'foo bar'
 
+    def test_sanitize_fts5_query_replaces_period_in_unquoted_terms(self):
+        assert sanitize_fts5_query("v2.21") == "v2 21"
+        assert sanitize_fts5_query("api.v2") == "api v2"
+        assert sanitize_fts5_query("hermes.lcm") == "hermes lcm"
+
     def test_ensure_external_content_fts_skips_rebuild_when_disk_is_low(self, tmp_path, monkeypatch):
         conn = sqlite3.connect(tmp_path / "low-disk.db")
         conn.executescript(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7260,6 +7260,22 @@ class TestEngineTools:
         assert result["results"][0]["timestamp"] == 1000.0
         assert "older assistant" in result["results"][0]["snippet"]
 
+    def test_handle_grep_sanitizes_period_in_unquoted_fts_query(self, engine):
+        engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "release notes for v2.21 and api.v2"},
+        )
+
+        result = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"query": "v2.21", "limit": 1},
+        ))
+
+        assert "error" not in result
+        assert result["total_results"] == 1
+        assert "release notes for" in result["results"][0]["snippet"]
+        assert "api" in result["results"][0]["snippet"]
+
     def test_handle_grep_rejects_naive_iso_time_filter(self, engine):
         result = json.loads(engine.handle_tool_call(
             "lcm_grep",


### PR DESCRIPTION
## Problem

`_FTS5_SPECIAL_CHARS` in `search_query.py` was missing the period character `.`. This caused FTS5 `syntax error near "."` crashes when users searched for version strings like `v2.21`, `api.v2`, model names like `minimax-m2.5-free`, etc.

## Root Cause

- `_FTS5_SPECIAL_CHARS = frozenset("\"()*^-:{}")` — no `.`
- Period IS in `_STRIP_EDGE_PUNCT` (for token edge stripping), but was NOT in the FTS5 sanitizer
- `sanitize_fts5_query("v2.21")` returned `"v2.21"` unchanged → FTS5 crash
- `contains_risky_fts_ascii()` only catches `-`, `/`, `:` (not `.`), so LIKE fallback did not trigger

## Fix

Added `.` to `_FTS5_SPECIAL_CHARS`:

```python
_FTS5_SPECIAL_CHARS = frozenset("\"()*^-:{.}")
```

**Before:** `sanitize_fts5_query("v2.21")` → `"v2.21"` → FTS5 crash

**After:** `sanitize_fts5_query("v2.21")` → `"v2 21"` → valid FTS5 (period replaced with space)

## Test

```python
sanitize_fts5_query("v2.21")           → "v2 21"
sanitize_fts5_query("api.v2")          → "api v2"
sanitize_fts5_query("hermes.lcm")        → "hermes lcm"
sanitize_fts5_query("minimax-m2.5-free") → "minimax m2 5 free" (falls back to LIKE due to -)
```