### PR TITLE
feat: externalize oversized payloads during ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ compacted.
 - **Agent tools** - `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query`
 - **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
 - **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
-- **Large output controls** - optional externalization and transcript GC for oversized tool results
+- **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
 - **Diagnostics** - `lcm_status`, `lcm_doctor`, and optional `/lcm` slash commands
 
 ## LCM vs built-in compression
@@ -193,8 +193,8 @@ environment variables:
 | `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
 | `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
 | `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized tool outputs in plugin-managed JSON files |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for tool output text |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
 | `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
 | `LCM_EXPANSION_MODEL` | summary model / auxiliary | Override `lcm_expand_query` synthesis model |

--- a/engine.py
+++ b/engine.py
@@ -24,8 +24,10 @@ from .dag import SummaryDAG, SummaryNode
 from .escalation import summarize_with_escalation
 from .externalize import (
     build_transcript_gc_placeholder,
-    maybe_externalize_tool_output,
+    extract_externalized_ref,
     find_externalized_payload_for_message,
+    load_externalized_payload,
+    maybe_externalize_tool_output,
     reassign_externalized_payloads,
 )
 from .extraction import (
@@ -33,6 +35,7 @@ from .extraction import (
     sanitize_pre_compaction_content,
     sanitize_pre_compaction_tool_arguments,
 )
+from .ingest_protection import protect_message_for_ingest, protect_messages_for_ingest
 from .schemas import (
     LCM_DESCRIBE,
     LCM_DOCTOR,
@@ -1872,9 +1875,25 @@ class LCMEngine(ContextEngine):
             return str(tool_calls)
 
     def _message_replay_identity(self, msg: Dict[str, Any]) -> tuple[str, str, str, str]:
+        content = normalize_content_value(msg.get("content")) or ""
+        # Durable rows may contain ingest-time externalization placeholders.
+        # Replay matching should not depend on the current write-time
+        # externalization flag: a restart with the knob toggled must still match
+        # raw live messages against already-externalized rows, and vice versa.
+        # Hydrating the stored placeholder for identity comparison is read-only
+        # and avoids creating payload files while reconciling.
+        ref = extract_externalized_ref(content)
+        if ref:
+            payload = load_externalized_payload(
+                ref,
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            if payload is not None and isinstance(payload.get("content"), str):
+                content = payload["content"]
         return (
             str(msg.get("role") or "unknown"),
-            normalize_content_value(msg.get("content")) or "",
+            content,
             str(msg.get("tool_call_id") or ""),
             self._stable_tool_calls_identity(msg.get("tool_calls")),
         )
@@ -2040,10 +2059,16 @@ class LCMEngine(ContextEngine):
             self._ingest_cursor = n
             return
 
-        estimates = [count_message_tokens(m) for m in new_messages]
+        protected_messages = protect_messages_for_ingest(
+            new_messages,
+            session_id=self._session_id,
+            config=self._config,
+            hermes_home=self._hermes_home,
+        )
+        estimates = [count_message_tokens(m) for m in protected_messages]
         self._store.append_batch(
             self._session_id,
-            new_messages,
+            protected_messages,
             estimates,
             source=self._session_platform,
         )
@@ -2065,11 +2090,22 @@ class LCMEngine(ContextEngine):
         ids: list[int] = []
         store_idx = 0
         for msg in messages:
-            role = msg.get("role", "")
-            content = normalize_content_value(msg.get("content")) or ""
+            protected_msg = protect_message_for_ingest(
+                msg,
+                session_id=self._session_id,
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            wanted_identity = self._message_replay_identity(msg)
+            role = protected_msg.get("role", "")
+            content = normalize_content_value(protected_msg.get("content")) or ""
             probe_idx = store_idx
             while probe_idx < len(candidates):
                 stored = candidates[probe_idx]
+                if self._message_replay_identity(stored) == wanted_identity:
+                    ids.append(stored["store_id"])
+                    store_idx = probe_idx + 1
+                    break
                 if stored.get("role", "") == role and (stored.get("content") or "") == content:
                     ids.append(stored["store_id"])
                     store_idx = probe_idx + 1
@@ -2120,6 +2156,18 @@ class LCMEngine(ContextEngine):
             tool_call_id = stored.get("tool_call_id", "") or ""
             if not content:
                 continue
+
+            ref = extract_externalized_ref(content)
+            if ref:
+                externalized = load_externalized_payload(
+                    ref,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                if externalized is not None and externalized.get("kind", "tool_result") == "tool_result":
+                    placeholder = build_transcript_gc_placeholder(externalized)
+                    self._store.gc_externalized_tool_result(store_id, placeholder)
+                    continue
 
             lookup_candidates = []
             sanitized_content = sanitize_pre_compaction_content(content)

--- a/externalize.py
+++ b/externalize.py
@@ -1,4 +1,10 @@
-"""Helpers for optional large tool-output externalization during pre-compaction serialization."""
+"""Helpers for optional large-payload externalization.
+
+Externalization started as a pre-compaction serializer guard for oversized tool
+outputs. The same durable payload format is also used by the ingest path so
+obvious oversized content can be kept out of SQLite/FTS while remaining
+recoverable through the LCM inspection and expansion tools.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 def _tool_call_stub(tool_call_id: str) -> str:
     return (tool_call_id or "tool-result").replace("/", "-").replace(":", "-")[:48]
+
+
+def _safe_stub(value: str, fallback: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", (value or "").strip())
+    return (text or fallback)[:48]
 
 
 def _content_digest_prefix(content: str) -> str:
@@ -44,6 +55,7 @@ def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]
         "ref": path.name,
         "kind": payload.get("kind", "tool_result"),
         "tool_call_id": payload.get("tool_call_id", ""),
+        "role": payload.get("role", ""),
         "session_id": payload.get("session_id", ""),
         "content_chars": payload.get("content_chars", len(payload.get("content", ""))),
         "content_bytes": payload.get("content_bytes", len((payload.get("content", "") or "").encode("utf-8"))),
@@ -52,6 +64,13 @@ def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]
 
 
 def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
+    kind = summary.get("kind", "tool_result") or "tool_result"
+    if kind != "tool_result":
+        return (
+            f"[Externalized payload: kind={kind}; role={summary.get('role') or '?'}; "
+            f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; "
+            f"ref={summary.get('ref', '')}]"
+        )
     return (
         f"[Externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
         f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
@@ -59,6 +78,12 @@ def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
 
 
 def build_transcript_gc_placeholder(summary: Dict[str, Any]) -> str:
+    kind = summary.get("kind", "tool_result") or "tool_result"
+    if kind != "tool_result":
+        return (
+            f"[GC'd externalized payload: kind={kind}; role={summary.get('role') or '?'}; "
+            f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
+        )
     return (
         f"[GC'd externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
         f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
@@ -140,6 +165,8 @@ def find_externalized_payload_for_message(
     *,
     tool_call_id: str = "",
     session_id: str = "",
+    kind: str | None = "tool_result",
+    role: str = "",
     config,
     hermes_home: str = "",
 ) -> Dict[str, Any] | None:
@@ -150,17 +177,19 @@ def find_externalized_payload_for_message(
         return None
 
     digest_prefix = _content_digest_prefix(content)
-    tool_stub = _tool_call_stub(tool_call_id)
-    candidates = sorted(storage_dir.glob(f"*_{tool_stub}_{digest_prefix}_*.json"))
+    candidates = sorted(storage_dir.glob(f"*_{digest_prefix}_*.json"))
     fallback_match = None
     for path in candidates:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
-        if payload.get("kind") != "tool_result":
+        if kind is not None and payload.get("kind", "tool_result") != kind:
             continue
         if (payload.get("tool_call_id") or "") != (tool_call_id or ""):
+            continue
+        payload_role = payload.get("role") or ""
+        if role and payload_role and payload_role != role:
             continue
         if payload.get("content") != content:
             continue
@@ -183,6 +212,34 @@ def maybe_externalize_tool_output(
     config,
     hermes_home: str = "",
 ) -> Dict[str, Any] | None:
+    return maybe_externalize_payload(
+        content,
+        kind="tool_result",
+        tool_call_id=tool_call_id,
+        session_id=session_id,
+        role="tool",
+        config=config,
+        hermes_home=hermes_home,
+    )
+
+
+def maybe_externalize_payload(
+    content: str,
+    *,
+    kind: str = "raw_payload",
+    tool_call_id: str = "",
+    session_id: str = "",
+    role: str = "",
+    config,
+    hermes_home: str = "",
+) -> Dict[str, Any] | None:
+    """Externalize one oversized normalized payload if configured.
+
+    Returns a dict with a compact placeholder and the durable JSON payload path,
+    or ``None`` when disabled, below threshold, or storage is unavailable. On
+    storage failure callers should keep the original content so there is no
+    silent data loss.
+    """
     if not getattr(config, "large_output_externalization_enabled", False):
         return None
 
@@ -193,13 +250,15 @@ def maybe_externalize_tool_output(
     try:
         storage_dir = resolve_large_output_storage_dir(config, hermes_home=hermes_home)
     except OSError as exc:
-        logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
+        logger.warning("Large payload externalization skipped (non-blocking): %s", exc)
         return None
 
     existing = find_externalized_payload_for_message(
         content,
         tool_call_id=tool_call_id,
         session_id=session_id,
+        kind=kind,
+        role=role,
         config=config,
         hermes_home=hermes_home,
     )
@@ -213,13 +272,21 @@ def maybe_externalize_tool_output(
     digest_prefix = _content_digest_prefix(content)
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
     unique_suffix = f"{time.time_ns():x}"
-    tool_stub = _tool_call_stub(tool_call_id)
-    filename = f"{timestamp}_{tool_stub}_{digest_prefix}_{unique_suffix}.json"
+    if kind == "tool_result":
+        # Keep the original filename shape for compatibility with existing
+        # externalized tool-output stores and tests.
+        filename = f"{timestamp}_{_tool_call_stub(tool_call_id)}_{digest_prefix}_{unique_suffix}.json"
+    else:
+        filename = (
+            f"{timestamp}_{_safe_stub(kind, 'payload')}_"
+            f"{_safe_stub(role, 'message')}_{digest_prefix}_{unique_suffix}.json"
+        )
     path = storage_dir / filename
 
     payload = {
-        "kind": "tool_result",
+        "kind": kind,
         "tool_call_id": tool_call_id,
+        "role": role,
         "session_id": session_id,
         "content": content,
         "content_chars": len(content),
@@ -229,12 +296,14 @@ def maybe_externalize_tool_output(
     try:
         path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     except OSError as exc:
-        logger.warning("Large tool-output externalization skipped (non-blocking): %s", exc)
+        logger.warning("Large payload externalization skipped (non-blocking): %s", exc)
         return None
 
     placeholder = _build_externalized_placeholder(
         {
+            "kind": kind,
             "tool_call_id": tool_call_id,
+            "role": role,
             "content_chars": payload["content_chars"],
             "content_bytes": payload["content_bytes"],
             "ref": path.name,

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1,0 +1,113 @@
+"""Ingest-time protection for oversized message payloads.
+
+This module prepares copies of messages for durable storage only. It must not
+mutate the active provider transcript: assistant ``tool_calls`` and adjacent tool
+results remain intact in the live message list while SQLite receives compact
+externalized placeholders for supported oversized payload classes.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from .externalize import maybe_externalize_payload
+from .message_content import normalize_content_value
+
+_MEDIA_DATA_URI_RE = re.compile(
+    r"data:(?:image|audio|video)/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\s]{16,}",
+    re.IGNORECASE,
+)
+_MEDIA_TYPE_HINTS = ("image", "audio", "video")
+_MEDIA_VALUE_KEYS = (
+    "image_url",
+    "input_image",
+    "output_image",
+    "audio_url",
+    "video_url",
+    "image",
+    "audio",
+    "video",
+)
+
+
+def _contains_media_payload(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(_MEDIA_DATA_URI_RE.search(value))
+    if isinstance(value, list):
+        return any(_contains_media_payload(item) for item in value)
+    if isinstance(value, dict):
+        block_type = str(value.get("type") or "").lower()
+        if any(hint in block_type for hint in _MEDIA_TYPE_HINTS):
+            return True
+        for key, nested in value.items():
+            key_text = str(key).lower()
+            if key_text in _MEDIA_VALUE_KEYS:
+                return True
+            if _contains_media_payload(nested):
+                return True
+    return False
+
+
+def _externalization_kind_for_message(message: Dict[str, Any]) -> str:
+    role = str(message.get("role") or "unknown")
+    if role == "tool":
+        return "tool_result"
+    if _contains_media_payload(message.get("content")):
+        return "media_payload"
+    return "raw_payload"
+
+
+def protect_message_for_ingest(
+    message: Dict[str, Any],
+    *,
+    session_id: str,
+    config,
+    hermes_home: str = "",
+) -> Dict[str, Any]:
+    """Return a storage-safe copy of ``message``.
+
+    The original message is never modified. If externalization is disabled,
+    below threshold, or storage cannot be written, the returned copy keeps the
+    original content so LCM does not silently lose data.
+    """
+    protected = dict(message)
+    normalized_content = normalize_content_value(message.get("content"))
+    if not normalized_content:
+        return protected
+
+    role = str(message.get("role") or "unknown")
+    kind = _externalization_kind_for_message(message)
+    externalized = maybe_externalize_payload(
+        normalized_content,
+        kind=kind,
+        tool_call_id=str(message.get("tool_call_id") or ""),
+        session_id=session_id,
+        role=role,
+        config=config,
+        hermes_home=hermes_home,
+    )
+    if externalized:
+        protected["content"] = externalized["placeholder"]
+    return protected
+
+
+def protect_messages_for_ingest(
+    messages: List[Dict[str, Any]],
+    *,
+    session_id: str,
+    config,
+    hermes_home: str = "",
+) -> List[Dict[str, Any]]:
+    """Return storage-safe copies of all messages."""
+    return [
+        protect_message_for_ingest(
+            message,
+            session_id=session_id,
+            config=config,
+            hermes_home=hermes_home,
+        )
+        for message in messages
+    ]

--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sqlite3
 import sys
 import time
@@ -36,6 +37,8 @@ def _ensure_local_package_importable() -> None:
 
 _ensure_local_package_importable()
 
+from hermes_lcm.config import LCMConfig  # noqa: E402
+from hermes_lcm.ingest_protection import protect_message_for_ingest  # noqa: E402
 from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
 from hermes_lcm.tokens import count_message_tokens  # noqa: E402
 
@@ -535,9 +538,27 @@ def import_lossless_claw(
     _ensure_import_table(conn)
 
     imported = 0
+    ingest_config = LCMConfig.from_env()
+    hermes_home = os.environ.get("HERMES_HOME", "")
     try:
         for candidate in to_import:
-            tool_calls_json = json.dumps(candidate.tool_calls) if candidate.tool_calls else None
+            original_msg: dict[str, Any] = {
+                "role": candidate.role,
+                "content": candidate.content,
+            }
+            if candidate.tool_call_id:
+                original_msg["tool_call_id"] = candidate.tool_call_id
+            if candidate.tool_calls:
+                original_msg["tool_calls"] = candidate.tool_calls
+            if candidate.tool_name:
+                original_msg["tool_name"] = candidate.tool_name
+            protected_msg = protect_message_for_ingest(
+                original_msg,
+                session_id=candidate.target_session_id,
+                config=ingest_config,
+                hermes_home=hermes_home,
+            )
+            tool_calls_json = json.dumps(protected_msg.get("tool_calls")) if protected_msg.get("tool_calls") else None
             cur = conn.execute(
                 """INSERT INTO messages
                    (session_id, source, role, content, tool_call_id, tool_calls,
@@ -546,13 +567,13 @@ def import_lossless_claw(
                 (
                     candidate.target_session_id,
                     _normalize_source_value(candidate.source),
-                    candidate.role,
-                    candidate.content,
-                    candidate.tool_call_id,
+                    protected_msg.get("role", candidate.role),
+                    protected_msg.get("content"),
+                    protected_msg.get("tool_call_id"),
                     tool_calls_json,
-                    candidate.tool_name,
+                    protected_msg.get("tool_name"),
                     candidate.timestamp,
-                    candidate.token_estimate,
+                    count_message_tokens(protected_msg),
                 ),
             )
             conn.execute(

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -210,6 +210,49 @@ def test_dry_run_handles_uri_reserved_source_db_path(tmp_path: Path):
     assert not target_db.exists()
 
 
+def test_apply_import_routes_oversized_payloads_through_ingest_protection(tmp_path: Path, monkeypatch):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    externalized_dir = tmp_path / "externalized"
+    create_lossless_source(source_db)
+
+    large_content = "IMPORT_RAW_NEEDLE:" + ("q" * 5000)
+    conn = sqlite3.connect(source_db)
+    conn.execute("UPDATE messages SET content = ? WHERE message_id = 10", (large_content,))
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", "1")
+    monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", "200")
+    monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", str(externalized_dir))
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        apply=True,
+    )
+
+    assert result.imported == 2
+    db = sqlite3.connect(target_db)
+    content = db.execute(
+        "SELECT content FROM messages WHERE role = 'user' ORDER BY store_id LIMIT 1"
+    ).fetchone()[0]
+    db.close()
+    assert content.startswith("[Externalized payload: kind=raw_payload;")
+    assert "IMPORT_RAW_NEEDLE" not in content
+
+    payload_files = list(externalized_dir.glob("*.json"))
+    assert len(payload_files) == 1
+    payload = json.loads(payload_files[0].read_text())
+    assert payload["kind"] == "raw_payload"
+    assert payload["session_id"] == "openclaw-lcm:agent:sammy:runtime-session-1"
+    assert payload["content"] == large_content
+
+
 def test_apply_imports_messages_with_provenance_backup_and_search(tmp_path: Path):
     importer = load_importer_module()
     source_db = tmp_path / "lossless.db"

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2956,6 +2956,201 @@ class TestEscalation:
         assert "Additional instructions:" not in l2
 
 
+class TestIngestExternalization:
+    def _engine(self, tmp_path: Path):
+        from hermes_lcm.engine import LCMEngine
+
+        output_dir = tmp_path / "externalized"
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_externalization_path=str(output_dir),
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "ingest-session"
+        return engine, output_dir
+
+    def test_ingest_externalizes_large_tool_result_before_sqlite_and_preserves_tool_pair_replay(self, tmp_path):
+        import hermes_lcm.tools as lcm_tools
+
+        engine, output_dir = self._engine(tmp_path)
+        large_result = "TOOL_UNIQUE_NEEDLE:" + ("x" * 5000)
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Calling the tool",
+                "tool_calls": [
+                    {
+                        "id": "call_ingest_big",
+                        "type": "function",
+                        "function": {"name": "dump", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_ingest_big", "content": large_result},
+        ]
+
+        engine._ingest_messages(messages)
+
+        assert messages[1]["content"] == large_result
+        assert messages[0]["tool_calls"][0]["id"] == "call_ingest_big"
+
+        stored = engine._store.get_session_messages("ingest-session")
+        assert len(stored) == 2
+        assert stored[0]["tool_calls"] == messages[0]["tool_calls"]
+        assert stored[1]["role"] == "tool"
+        assert stored[1]["content"].startswith("[Externalized tool output:")
+        assert "TOOL_UNIQUE_NEEDLE" not in stored[1]["content"]
+        assert engine._store.search("TOOL_UNIQUE_NEEDLE", session_id="ingest-session") == []
+
+        payload_files = list(output_dir.glob("*.json"))
+        assert len(payload_files) == 1
+        payload = json.loads(payload_files[0].read_text())
+        assert payload["kind"] == "tool_result"
+        assert payload["tool_call_id"] == "call_ingest_big"
+        assert payload["content"] == large_result
+
+        by_store_id = json.loads(lcm_tools.lcm_expand({"store_id": stored[1]["store_id"]}, engine=engine))
+        ref = by_store_id["externalized_ref"]
+        expanded = json.loads(lcm_tools.lcm_expand({"externalized_ref": ref, "max_tokens": 20_000}, engine=engine))
+        assert expanded["kind"] == "tool_result"
+        assert expanded["content"] == large_result
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+        assert replay._store.get_session_count("ingest-session") == 2
+
+    def test_restart_replay_matches_externalized_rows_when_knob_is_disabled(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        engine, _output_dir = self._engine(tmp_path)
+        large_result = "TOGGLE_EXTERNALIZED_NEEDLE:" + ("x" * 5000)
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_toggle", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_toggle", "content": large_result},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        disabled_config = LCMConfig(
+            database_path=engine._config.database_path,
+            large_output_externalization_enabled=False,
+            large_output_externalization_threshold_chars=200,
+            large_output_externalization_path=engine._config.large_output_externalization_path,
+        )
+        replay = LCMEngine(config=disabled_config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 2
+        assert replay._ingest_cursor == len(messages)
+
+    def test_restart_replay_matches_raw_rows_when_knob_is_enabled_later(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        db_path = tmp_path / "toggle-raw.db"
+        output_dir = tmp_path / "externalized"
+        disabled_config = LCMConfig(
+            database_path=str(db_path),
+            large_output_externalization_enabled=False,
+            large_output_externalization_threshold_chars=200,
+            large_output_externalization_path=str(output_dir),
+        )
+        raw_engine = LCMEngine(config=disabled_config, hermes_home=str(tmp_path / "hermes"))
+        raw_engine._session_id = "ingest-session"
+        large_result = "TOGGLE_RAW_NEEDLE:" + ("y" * 5000)
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_raw", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_raw", "content": large_result},
+        ]
+        raw_engine._ingest_messages(messages)
+        assert raw_engine._store.get_session_count("ingest-session") == 2
+
+        enabled_config = LCMConfig(
+            database_path=str(db_path),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_externalization_path=str(output_dir),
+        )
+        replay = LCMEngine(config=enabled_config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 2
+        assert replay._ingest_cursor == len(messages)
+        assert not output_dir.exists()
+
+    def test_ingest_externalizes_structured_media_payload_before_fts(self, tmp_path):
+        import hermes_lcm.tools as lcm_tools
+
+        engine, output_dir = self._engine(tmp_path)
+        data_uri = "data:image/png;base64," + ("A" * 1000)
+        content = [
+            {"type": "text", "text": "Please inspect the screenshot."},
+            {"type": "image_url", "image_url": {"url": data_uri}},
+        ]
+
+        engine._ingest_messages([{"role": "user", "content": content}])
+
+        stored = engine._store.get_session_messages("ingest-session")
+        assert len(stored) == 1
+        assert stored[0]["content"].startswith("[Externalized payload: kind=media_payload;")
+        assert "data:image/png;base64" not in stored[0]["content"]
+        assert engine._store.search("AAAA", session_id="ingest-session") == []
+
+        payload_path = next(output_dir.glob("*.json"))
+        payload = json.loads(payload_path.read_text())
+        assert payload["kind"] == "media_payload"
+        assert "data:image/png;base64" in payload["content"]
+        expanded = json.loads(
+            lcm_tools.lcm_expand(
+                {"externalized_ref": payload_path.name, "max_tokens": 20_000},
+                engine=engine,
+            )
+        )
+        assert expanded["kind"] == "media_payload"
+        assert "Please inspect the screenshot." in expanded["content"]
+        assert "data:image/png;base64" in expanded["content"]
+
+    def test_ingest_externalizes_generic_oversized_raw_payload_fallback(self, tmp_path):
+        engine, output_dir = self._engine(tmp_path)
+        content = "GENERIC_RAW_NEEDLE:" + ("z" * 5000)
+
+        engine._ingest_messages([{"role": "user", "content": content}])
+
+        stored = engine._store.get_session_messages("ingest-session")
+        assert stored[0]["content"].startswith("[Externalized payload: kind=raw_payload;")
+        assert "GENERIC_RAW_NEEDLE" not in stored[0]["content"]
+        assert engine._store.search("GENERIC_RAW_NEEDLE", session_id="ingest-session") == []
+
+        payload = json.loads(next(output_dir.glob("*.json")).read_text())
+        assert payload["kind"] == "raw_payload"
+        assert payload["role"] == "user"
+        assert payload["content"] == content
+
+    def test_engine_bootstrap_does_not_externalize_until_ingest_path_runs(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        output_dir = tmp_path / "externalized"
+        config = LCMConfig(
+            database_path=str(tmp_path / "empty.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=10,
+            large_output_externalization_path=str(output_dir),
+        )
+
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+
+        assert not output_dir.exists()
+
+
 class TestExtraction:
     def test_serialize_messages_replaces_pure_inline_media_with_attachment_marker(self, tmp_path):
         from hermes_lcm.config import LCMConfig

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -9827,7 +9827,10 @@ class TestEngineTools:
 
         engine.compress(messages)
 
-        assert engine._store.get(tool_store_id)["content"] == content
+        pinned_content = engine._store.get(tool_store_id)["content"]
+        assert pinned_content.startswith("[Externalized tool output:")
+        assert not pinned_content.startswith("[GC'd externalized tool output:")
+        assert content[:100] not in pinned_content
 
     def test_gc_helper_does_not_miss_tool_rows_when_chunk_contains_unmatched_synthetic_messages(self, tmp_path):
         config = LCMConfig(

--- a/tools.py
+++ b/tools.py
@@ -263,7 +263,12 @@ def _is_compact_externalized_marker(content: str, ref: str | None) -> bool:
         return False
     if len(content) > 512:
         return False
-    return content.startswith("[Externalized tool output:") or content.startswith("[GC'd externalized tool output:")
+    return (
+        content.startswith("[Externalized tool output:")
+        or content.startswith("[GC'd externalized tool output:")
+        or content.startswith("[Externalized payload:")
+        or content.startswith("[GC'd externalized payload:")
+    )
 
 
 def _pagination_payload(
@@ -967,6 +972,7 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
                 "externalized_ref": externalized_ref,
                 "kind": payload.get("kind", "tool_result"),
                 "tool_call_id": payload.get("tool_call_id", ""),
+                "role": payload.get("role", ""),
                 "session_id": payload.get("session_id", ""),
                 "content_chars": payload.get("content_chars", 0),
                 "content_bytes": payload.get("content_bytes", 0),
@@ -1069,6 +1075,7 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
                 "source_type": "externalized_payload",
                 "kind": payload.get("kind", "tool_result"),
                 "tool_call_id": payload.get("tool_call_id", ""),
+                "role": payload.get("role", ""),
                 "session_id": payload.get("session_id", ""),
                 "content_chars": payload.get("content_chars", len(content)),
                 "content_bytes": payload.get("content_bytes", 0),


### PR DESCRIPTION
## Summary

Moves large-payload protection into the ingest path before rows are appended to `MessageStore`. Oversized tool results, structured media payloads, and generic raw payloads are stored as compact externalized references when externalization is enabled.

The active provider transcript is left untouched. Stored placeholders remain recoverable through the existing externalized payload inspection and expansion paths.

## Why

Pre-compaction serialization was too late. A large tool result or media block could already be written into SQLite and FTS before LCM had a chance to replace it with a durable reference.

## Validation

- [x] Focused validation: `pytest tests/test_lcm_core.py::TestIngestExternalization tests/test_import_lossless_claw.py::test_apply_import_routes_oversized_payloads_through_ingest_protection -q` -> `7 passed`
- [x] Focused audit: Codex CLI read-only diff review -> no blockers before PR
- [x] Existing externalized payload recovery checks -> `3 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `507 passed`
  - [x] `pytest -q` -> `554 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`

## Notes

Import uses the same ingest protection path when applying rows. Bootstrap itself does not create externalized payload files before messages enter ingest.

Codex flagged replay matching across externalization toggles. The current head canonicalizes externalized placeholders for replay identity without creating new payload files, with regressions for both toggle directions.

Refs #139
