### PR TITLE
fix: clean unsafe assistant content during assembly

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -2097,6 +2097,7 @@ class LCMEngine(ContextEngine):
     ) -> int | None:
         sanitized_replay_tail = self._stored_tail_for_sanitized_active_replay(stored_tail)
         effective_session_count = len(sanitized_replay_tail)
+        sanitized_tail_collapsed = len(sanitized_replay_tail) < len(stored_tail)
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
@@ -2111,9 +2112,13 @@ class LCMEngine(ContextEngine):
                 if allow_empty_prefix:
                     return cursor
                 continue
-            if len(candidate_prefix) > len(sanitized_replay_tail):
-                continue
-            if not self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix):
+
+            matches_sanitized_tail = (
+                len(candidate_prefix) <= len(sanitized_replay_tail)
+                and self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix)
+            )
+            matches_raw_tail = self._matches_store_tail_suffix(stored_tail, candidate_prefix)
+            if not matches_sanitized_tail and not matches_raw_tail:
                 continue
 
             # Matching a stored suffix is not enough evidence by itself.  A
@@ -2121,19 +2126,21 @@ class LCMEngine(ContextEngine):
             # the first delta happens to repeat the durable tail, treating that
             # row as replay silently loses it.  Only advance the cursor when the
             # incoming prefix proves replay by covering the full durable session.
-            # A system prompt is a strong anchor, but older/minimal transcripts
-            # can start directly with user/assistant turns, so multi-row full
-            # replay is also accepted.  Singleton full replay remains ambiguous
-            # with a one-message delta that repeats the tail, so it is persisted
-            # rather than risk data loss.
-            has_effective_full_replay = len(candidate_prefix) >= effective_session_count and (
-                effective_session_count > 1 or any(identity[0] == "system" for identity in candidate_prefix)
+            # A system prompt is a strong anchor. Older/minimal transcripts can
+            # start directly with user/assistant turns, so multi-row full replay
+            # is accepted only when active cleanup did not collapse the durable
+            # tail; otherwise a fresh delta can repeat the remaining visible
+            # suffix and must be preserved.
+            candidate_has_system = any(identity[0] == "system" for identity in candidate_prefix)
+            has_effective_full_replay = matches_sanitized_tail and len(candidate_prefix) >= effective_session_count and (
+                candidate_has_system or (effective_session_count > 1 and not sanitized_tail_collapsed)
             )
             has_scaffold_evidence = any(
                 self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages
             )
             has_raw_full_replay = (
-                not has_scaffold_evidence
+                matches_raw_tail
+                and not has_scaffold_evidence
                 and len(candidate_messages) >= raw_session_count
                 and raw_session_count > 1
             )

--- a/engine.py
+++ b/engine.py
@@ -763,7 +763,10 @@ class LCMEngine(ContextEngine):
                     compressed,
                     assembly_cap_override=recovery_assembly_cap,
                 )
-            sanitized_messages = self._sanitize_active_context_messages(messages)
+            sanitized_messages = self._sanitize_active_context_messages(
+                messages,
+                insert_missing_tool_stubs=False,
+            )
             if len(sanitized_messages) != len(messages):
                 # _ingest_messages() already advanced the cursor to the original
                 # active-context length. If the host continues from the shorter
@@ -2574,7 +2577,12 @@ class LCMEngine(ContextEngine):
             return False
         return not cls._assistant_message_has_visible_content(msg)
 
-    def _sanitize_active_context_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _sanitize_active_context_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        insert_missing_tool_stubs: bool = True,
+    ) -> List[Dict[str, Any]]:
         """Drop unsafe assistant-only noise, then repair tool sequencing.
 
         This is intentionally active-context-only: callers pass the selected
@@ -2595,9 +2603,17 @@ class LCMEngine(ContextEngine):
                 dropped_assistant_messages,
             )
 
-        return self._sanitize_tool_pairs(cleaned)
+        return self._sanitize_tool_pairs(
+            cleaned,
+            insert_missing_tool_stubs=insert_missing_tool_stubs,
+        )
 
-    def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _sanitize_tool_pairs(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        insert_missing_tool_stubs: bool = True,
+    ) -> List[Dict[str, Any]]:
         """Return provider-safe active-context tool-call/result sequencing.
 
         Raw store and DAG history remain lossless. This guardrail only sanitizes
@@ -2641,7 +2657,7 @@ class LCMEngine(ContextEngine):
                         dropped_tool_results += 1
                         i += 1
 
-                    if not matched_direct_result:
+                    if not matched_direct_result and insert_missing_tool_stubs:
                         sanitized.append({
                             "role": "tool",
                             "content": "[Result from earlier conversation — see context summary above]",

--- a/engine.py
+++ b/engine.py
@@ -2118,6 +2118,11 @@ class LCMEngine(ContextEngine):
                 and self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix)
             )
             matches_raw_tail = self._matches_store_tail_suffix(stored_tail, candidate_prefix)
+            raw_tail_suffix = stored_tail[-len(candidate_prefix) :] if matches_raw_tail else []
+            raw_suffix_needs_cleanup_equivalence = any(
+                self._active_cleanup_replay_identity(identity) != identity
+                for identity in raw_tail_suffix
+            )
             if not matches_sanitized_tail and not matches_raw_tail:
                 continue
 
@@ -2144,7 +2149,14 @@ class LCMEngine(ContextEngine):
                 and len(candidate_messages) >= raw_session_count
                 and raw_session_count > 1
             )
-            if has_effective_full_replay or has_raw_full_replay:
+            has_raw_cleanup_replay = (
+                matches_raw_tail
+                and has_scaffold_evidence
+                and cursor < len(messages)
+                and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
+                and raw_suffix_needs_cleanup_equivalence
+            )
+            if has_effective_full_replay or has_raw_full_replay or has_raw_cleanup_replay:
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 

--- a/engine.py
+++ b/engine.py
@@ -2008,6 +2008,52 @@ class LCMEngine(ContextEngine):
             return False
         return stored_tail[-len(candidate_prefix) :] == candidate_prefix
 
+    @classmethod
+    def _identity_content_for_active_cleanup(cls, content: str) -> Any:
+        """Decode canonical stored JSON content before active-cleanup checks.
+
+        Structured assistant content is persisted as deterministic JSON. Active
+        replay cleanup sees the original list/dict shape, so restart
+        reconciliation has to decode the stored identity before deciding whether
+        a durable assistant row could be absent from sanitized active context.
+        """
+        if not isinstance(content, str):
+            return content
+        try:
+            decoded = json.loads(content)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return content
+        if isinstance(decoded, (list, dict)) and normalize_content_value(decoded) == content:
+            return decoded
+        return content
+
+    @classmethod
+    def _is_active_context_droppable_identity(cls, identity: tuple[str, str, str, str]) -> bool:
+        """Return true for durable rows sanitized out of active replay only."""
+        role, content, _tool_call_id, tool_calls = identity
+        if role != "assistant" or tool_calls:
+            return False
+        return cls._should_drop_active_assistant_message({
+            "role": role,
+            "content": cls._identity_content_for_active_cleanup(content),
+        })
+
+    def _stored_tail_for_sanitized_active_replay(
+        self,
+        stored_tail: list[tuple[str, str, str, str]],
+    ) -> list[tuple[str, str, str, str]]:
+        """Drop only rows active-context cleanup may remove from replay.
+
+        Raw storage remains lossless. This view is used only to reconcile a
+        restarted process when the host replays sanitized active context that no
+        longer contains assistant messages with no visible content.
+        """
+        return [
+            identity
+            for identity in stored_tail
+            if not self._is_active_context_droppable_identity(identity)
+        ]
+
     def _find_reconciled_cursor_for_store_tail(
         self,
         messages: List[Dict[str, Any]],
@@ -2017,6 +2063,8 @@ class LCMEngine(ContextEngine):
         session_count: int,
         raw_session_count: int,
     ) -> int | None:
+        sanitized_replay_tail = self._stored_tail_for_sanitized_active_replay(stored_tail)
+        effective_session_count = len(sanitized_replay_tail)
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
@@ -2031,9 +2079,9 @@ class LCMEngine(ContextEngine):
                 if allow_empty_prefix:
                     return cursor
                 continue
-            if len(candidate_prefix) > len(stored_tail):
+            if len(candidate_prefix) > len(sanitized_replay_tail):
                 continue
-            if not self._matches_store_tail_suffix(stored_tail, candidate_prefix):
+            if not self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix):
                 continue
 
             # Matching a stored suffix is not enough evidence by itself.  A
@@ -2046,8 +2094,8 @@ class LCMEngine(ContextEngine):
             # replay is also accepted.  Singleton full replay remains ambiguous
             # with a one-message delta that repeats the tail, so it is persisted
             # rather than risk data loss.
-            has_effective_full_replay = len(candidate_prefix) >= session_count and (
-                session_count > 1 or any(identity[0] == "system" for identity in candidate_prefix)
+            has_effective_full_replay = len(candidate_prefix) >= effective_session_count and (
+                effective_session_count > 1 or any(identity[0] == "system" for identity in candidate_prefix)
             )
             has_scaffold_evidence = any(
                 self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages

--- a/engine.py
+++ b/engine.py
@@ -2047,12 +2047,19 @@ class LCMEngine(ContextEngine):
         identity: tuple[str, str, str, str],
     ) -> tuple[str, str, str, str] | None:
         role, content, tool_call_id, tool_calls = identity
-        if role != "assistant" or tool_calls:
+        if role != "assistant":
             return identity
-        cleaned = cls._clean_active_assistant_message({
+        msg: dict[str, Any] = {
             "role": role,
             "content": cls._identity_content_for_active_cleanup(content),
-        })
+        }
+        if tool_calls:
+            try:
+                decoded_tool_calls = json.loads(tool_calls)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                decoded_tool_calls = tool_calls
+            msg["tool_calls"] = decoded_tool_calls
+        cleaned = cls._clean_active_assistant_message(msg)
         if cleaned is None:
             return None
         return (
@@ -2655,11 +2662,13 @@ class LCMEngine(ContextEngine):
     def _clean_active_assistant_message(cls, msg: Dict[str, Any]) -> Dict[str, Any] | None:
         if msg.get("role") != "assistant":
             return msg
-        if msg.get("tool_calls"):
+        if "content" not in msg:
             return msg
         cleaned_content = cls._sanitize_active_assistant_content(msg.get("content"))
         if cleaned_content is None:
-            return None
+            if not msg.get("tool_calls"):
+                return None
+            cleaned_content = ""
         if cleaned_content == msg.get("content"):
             return msg
         cleaned = dict(msg)
@@ -2690,7 +2699,7 @@ class LCMEngine(ContextEngine):
         dropped_assistant_messages = 0
         stripped_assistant_messages = 0
         for msg in messages:
-            if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+            if msg.get("role") == "assistant":
                 cleaned_msg = self._clean_active_assistant_message(msg)
                 if cleaned_msg is None:
                     dropped_assistant_messages += 1

--- a/engine.py
+++ b/engine.py
@@ -21,7 +21,7 @@ from agent.context_engine import ContextEngine
 
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
-from .escalation import summarize_with_escalation
+from .escalation import _strip_reasoning_blocks, summarize_with_escalation
 from .externalize import (
     build_transcript_gc_placeholder,
     extract_externalized_ref,
@@ -66,6 +66,17 @@ logger = logging.getLogger(__name__)
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
 _SESSION_END_BUSY_TIMEOUT_MS = 50
+_VISIBLE_TEXT_PART_TYPES = {"text", "input_text", "output_text"}
+_INTERNAL_ASSISTANT_PART_TYPES = {
+    "analysis",
+    "chain_of_thought",
+    "internal",
+    "reasoning",
+    "redacted_thinking",
+    "scratchpad",
+    "thought",
+    "thinking",
+}
 
 
 def _strip_metadata_scalar(value: str) -> str:
@@ -752,7 +763,14 @@ class LCMEngine(ContextEngine):
                     compressed,
                     assembly_cap_override=recovery_assembly_cap,
                 )
-            return messages
+            sanitized_messages = self._sanitize_active_context_messages(messages)
+            if len(sanitized_messages) != len(messages):
+                # _ingest_messages() already advanced the cursor to the original
+                # active-context length. If the host continues from the shorter
+                # sanitized context, keeping the old cursor would make the next
+                # appended messages look already ingested.
+                self._ingest_cursor = len(sanitized_messages)
+            return sanitized_messages
 
         # Step 6: Check if condensation is needed
         self._maybe_condense(
@@ -805,10 +823,10 @@ class LCMEngine(ContextEngine):
             ", forced overflow recovery" if force_overflow else "",
         )
 
-        # ── Tool-pair guardrail (same as _assemble_context) ──
+        # ── Active-context cleanup / tool-pair guardrail (same as _assemble_context) ──
         # compress() output is consumed directly by the main loop in some
         # edge cases (e.g. forced overflow recovery bypassing _assemble_context).
-        compressed = self._sanitize_tool_pairs(compressed)
+        compressed = self._sanitize_active_context_messages(compressed)
 
         return compressed
 
@@ -2452,6 +2470,85 @@ class LCMEngine(ContextEngine):
 
     # -- Internal: tool-pair sanitization ------------------------------------
 
+    @staticmethod
+    def _structured_part_text(part: Dict[str, Any]) -> str:
+        for key in ("text", "content", "value"):
+            value = part.get(key)
+            if isinstance(value, str):
+                return value
+            if isinstance(value, dict):
+                nested = value.get("value")
+                if isinstance(nested, str):
+                    return nested
+                nested = value.get("content")
+                if isinstance(nested, str):
+                    return nested
+        return ""
+
+    @classmethod
+    def _structured_part_has_visible_assistant_content(cls, part: Any) -> bool:
+        if part is None:
+            return False
+        if isinstance(part, str):
+            return bool(_strip_reasoning_blocks(part).strip())
+        if not isinstance(part, dict):
+            return bool(str(part).strip())
+
+        part_type = str(part.get("type") or "").strip().lower()
+        if part_type in _INTERNAL_ASSISTANT_PART_TYPES:
+            return False
+        if part_type in _VISIBLE_TEXT_PART_TYPES:
+            return bool(_strip_reasoning_blocks(cls._structured_part_text(part)).strip())
+
+        # Unknown non-internal content blocks may be visible (for example
+        # images/audio/annotations in provider-specific formats).  Preserve
+        # them rather than risk dropping a legitimate assistant turn.
+        return True
+
+    @classmethod
+    def _assistant_message_has_visible_content(cls, msg: Dict[str, Any]) -> bool:
+        content = msg.get("content")
+        if content is None:
+            return False
+        if isinstance(content, str):
+            return bool(_strip_reasoning_blocks(content).strip())
+        if isinstance(content, list):
+            return any(cls._structured_part_has_visible_assistant_content(part) for part in content)
+        if isinstance(content, dict):
+            return cls._structured_part_has_visible_assistant_content(content)
+        return bool(str(content).strip())
+
+    @classmethod
+    def _should_drop_active_assistant_message(cls, msg: Dict[str, Any]) -> bool:
+        if msg.get("role") != "assistant":
+            return False
+        if msg.get("tool_calls"):
+            return False
+        return not cls._assistant_message_has_visible_content(msg)
+
+    def _sanitize_active_context_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Drop unsafe assistant-only noise, then repair tool sequencing.
+
+        This is intentionally active-context-only: callers pass the selected
+        provider replay context, and this helper never mutates stored rows,
+        source mappings, or DAG nodes.
+        """
+        cleaned: list[Dict[str, Any]] = []
+        dropped_assistant_messages = 0
+        for msg in messages:
+            if self._should_drop_active_assistant_message(msg):
+                dropped_assistant_messages += 1
+                continue
+            cleaned.append(msg)
+
+        if dropped_assistant_messages:
+            logger.info(
+                "LCM active-context cleanup: dropped %d assistant message(s) with no visible content",
+                dropped_assistant_messages,
+            )
+
+        return self._sanitize_tool_pairs(cleaned)
+
     def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Return provider-safe active-context tool-call/result sequencing.
 
@@ -2820,12 +2917,10 @@ class LCMEngine(ContextEngine):
         # Fresh tail
         result.extend(tail_selected)
 
-        # ── Tool-pair guardrail ──
-        # Regression fix: after LCM compression, the assembled active context
-        # may contain orphan tool results (call_id with no matching assistant
-        # tool_call) or assistant tool_calls with missing results. Both violate
-        # the OpenAI message format contract and cause 400 errors from providers.
-        result = self._sanitize_tool_pairs(result)
+        # ── Active-context cleanup / tool-pair guardrail ──
+        # Drop assistant turns that carry only blank/internal structured content,
+        # then ensure provider-valid tool-call/result sequencing.
+        result = self._sanitize_active_context_messages(result)
         if (
             assembly_cap is not None
             and anchor_part is not None
@@ -2845,7 +2940,7 @@ class LCMEngine(ContextEngine):
                     trimmed = msg.copy()
                     trimmed["content"] = "\n\n---\n\n".join(parts)
                     trimmed_result.append(trimmed)
-            result = self._sanitize_tool_pairs(trimmed_result)
+            result = self._sanitize_active_context_messages(trimmed_result)
 
         return result
 
@@ -2987,7 +3082,7 @@ class LCMEngine(ContextEngine):
             include_lcm_note=False,
         )
         if len(candidate) == 1 and tail_messages:
-            return self._sanitize_tool_pairs([system_msg, tail_messages[-1]])
+            return self._sanitize_active_context_messages([system_msg, tail_messages[-1]])
         return candidate
 
     @staticmethod

--- a/engine.py
+++ b/engine.py
@@ -2394,12 +2394,21 @@ class LCMEngine(ContextEngine):
                 hermes_home=self._hermes_home,
             )
             wanted_identity = self._message_replay_identity(msg)
+            wanted_cleanup_identity = self._active_cleanup_replay_identity(wanted_identity)
             role = protected_msg.get("role", "")
             content = normalize_content_value(protected_msg.get("content")) or ""
             probe_idx = store_idx
             while probe_idx < len(candidates):
                 stored = candidates[probe_idx]
-                if self._message_replay_identity(stored) == wanted_identity:
+                stored_identity = self._message_replay_identity(stored)
+                if stored_identity == wanted_identity:
+                    ids.append(stored["store_id"])
+                    store_idx = probe_idx + 1
+                    break
+                if (
+                    wanted_cleanup_identity is not None
+                    and self._active_cleanup_replay_identity(stored_identity) == wanted_cleanup_identity
+                ):
                     ids.append(stored["store_id"])
                     store_idx = probe_idx + 1
                     break

--- a/engine.py
+++ b/engine.py
@@ -2041,21 +2041,43 @@ class LCMEngine(ContextEngine):
             "content": cls._identity_content_for_active_cleanup(content),
         })
 
+    @classmethod
+    def _active_cleanup_replay_identity(
+        cls,
+        identity: tuple[str, str, str, str],
+    ) -> tuple[str, str, str, str] | None:
+        role, content, tool_call_id, tool_calls = identity
+        if role != "assistant" or tool_calls:
+            return identity
+        cleaned = cls._clean_active_assistant_message({
+            "role": role,
+            "content": cls._identity_content_for_active_cleanup(content),
+        })
+        if cleaned is None:
+            return None
+        return (
+            role,
+            normalize_content_value(cleaned.get("content")) or "",
+            tool_call_id,
+            tool_calls,
+        )
+
     def _stored_tail_for_sanitized_active_replay(
         self,
         stored_tail: list[tuple[str, str, str, str]],
     ) -> list[tuple[str, str, str, str]]:
-        """Drop only rows active-context cleanup may remove from replay.
+        """Mirror active-context cleanup for restart replay reconciliation.
 
         Raw storage remains lossless. This view is used only to reconcile a
-        restarted process when the host replays sanitized active context that no
-        longer contains assistant messages with no visible content.
+        restarted process when the host replays sanitized active context where
+        assistant rows may be removed or have internal content stripped.
         """
-        return [
-            identity
-            for identity in stored_tail
-            if not self._is_active_context_droppable_identity(identity)
-        ]
+        sanitized_tail: list[tuple[str, str, str, str]] = []
+        for identity in stored_tail:
+            cleaned_identity = self._active_cleanup_replay_identity(identity)
+            if cleaned_identity is not None:
+                sanitized_tail.append(cleaned_identity)
+        return sanitized_tail
 
     def _find_reconciled_cursor_for_store_tail(
         self,

--- a/engine.py
+++ b/engine.py
@@ -2570,12 +2570,87 @@ class LCMEngine(ContextEngine):
         return bool(str(content).strip())
 
     @classmethod
+    def _strip_structured_text_part(cls, part: Dict[str, Any]) -> Dict[str, Any] | None:
+        cleaned = dict(part)
+        for key in ("text", "content", "value"):
+            value = cleaned.get(key)
+            if isinstance(value, str):
+                stripped = _strip_reasoning_blocks(value)
+                if not stripped.strip():
+                    return None
+                cleaned[key] = stripped
+                return cleaned
+            if isinstance(value, dict):
+                nested = dict(value)
+                for nested_key in ("value", "content", "text"):
+                    nested_value = nested.get(nested_key)
+                    if isinstance(nested_value, str):
+                        stripped = _strip_reasoning_blocks(nested_value)
+                        if not stripped.strip():
+                            return None
+                        nested[nested_key] = stripped
+                        cleaned[key] = nested
+                        return cleaned
+        return cleaned if cls._structured_part_has_visible_assistant_content(cleaned) else None
+
+    @classmethod
+    def _sanitize_active_assistant_content(cls, content: Any) -> Any | None:
+        if content is None:
+            return None
+        if isinstance(content, str):
+            stripped = _strip_reasoning_blocks(content)
+            return stripped if stripped.strip() else None
+        if isinstance(content, list):
+            cleaned_parts: list[Any] = []
+            for part in content:
+                if isinstance(part, str):
+                    stripped = _strip_reasoning_blocks(part)
+                    if stripped.strip():
+                        cleaned_parts.append(stripped)
+                    continue
+                if isinstance(part, dict):
+                    part_type = str(part.get("type") or "").strip().lower()
+                    if part_type in _INTERNAL_ASSISTANT_PART_TYPES:
+                        continue
+                    if part_type in _VISIBLE_TEXT_PART_TYPES:
+                        cleaned_part = cls._strip_structured_text_part(part)
+                        if cleaned_part is not None:
+                            cleaned_parts.append(cleaned_part)
+                        continue
+                if cls._structured_part_has_visible_assistant_content(part):
+                    cleaned_parts.append(part)
+            return cleaned_parts or None
+        if isinstance(content, dict):
+            part_type = str(content.get("type") or "").strip().lower()
+            if part_type in _INTERNAL_ASSISTANT_PART_TYPES:
+                return None
+            if part_type in _VISIBLE_TEXT_PART_TYPES:
+                return cls._strip_structured_text_part(content)
+            return content if cls._structured_part_has_visible_assistant_content(content) else None
+        return content if str(content).strip() else None
+
+    @classmethod
+    def _clean_active_assistant_message(cls, msg: Dict[str, Any]) -> Dict[str, Any] | None:
+        if msg.get("role") != "assistant":
+            return msg
+        if msg.get("tool_calls"):
+            return msg
+        cleaned_content = cls._sanitize_active_assistant_content(msg.get("content"))
+        if cleaned_content is None:
+            return None
+        if cleaned_content == msg.get("content"):
+            return msg
+        cleaned = dict(msg)
+        cleaned["content"] = cleaned_content
+        return cleaned
+
+    @classmethod
     def _should_drop_active_assistant_message(cls, msg: Dict[str, Any]) -> bool:
         if msg.get("role") != "assistant":
             return False
         if msg.get("tool_calls"):
             return False
-        return not cls._assistant_message_has_visible_content(msg)
+        return cls._clean_active_assistant_message(msg) is None
 
     def _sanitize_active_context_messages(
         self,
@@ -2591,9 +2666,16 @@ class LCMEngine(ContextEngine):
         """
         cleaned: list[Dict[str, Any]] = []
         dropped_assistant_messages = 0
+        stripped_assistant_messages = 0
         for msg in messages:
-            if self._should_drop_active_assistant_message(msg):
-                dropped_assistant_messages += 1
+            if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+                cleaned_msg = self._clean_active_assistant_message(msg)
+                if cleaned_msg is None:
+                    dropped_assistant_messages += 1
+                    continue
+                if cleaned_msg is not msg:
+                    stripped_assistant_messages += 1
+                cleaned.append(cleaned_msg)
                 continue
             cleaned.append(msg)
 
@@ -2601,6 +2683,11 @@ class LCMEngine(ContextEngine):
             logger.info(
                 "LCM active-context cleanup: dropped %d assistant message(s) with no visible content",
                 dropped_assistant_messages,
+            )
+        if stripped_assistant_messages:
+            logger.info(
+                "LCM active-context cleanup: stripped internal content from %d assistant message(s)",
+                stripped_assistant_messages,
             )
 
         return self._sanitize_tool_pairs(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7945,6 +7945,37 @@ class TestAssemblyToolPairGuardrail:
         assert rows[-1]["content"] == "new follow-up"
         assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
 
+    def test_active_context_cleanup_strips_internal_parts_from_mixed_assistant_content(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_mixed_internal_cleanup.db"),
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("mixed-internal-cleanup-test", context_length=200000)
+        mixed_content = [
+            {"type": "thinking", "text": "secret chain of thought"},
+            {"type": "text", "text": "visible final"},
+        ]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": mixed_content},
+            {"role": "assistant", "content": "<think>hidden</think>string final"},
+        ]
+
+        active_context = instance.compress(messages)
+
+        assert active_context[2] == {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "visible final"}],
+        }
+        assert active_context[3] == {"role": "assistant", "content": "string final"}
+        rows = instance._store.get_session_messages("mixed-internal-cleanup-test")
+        assert rows[2]["content"] == json.dumps(mixed_content, ensure_ascii=False, sort_keys=True)
+        assert rows[3]["content"] == "<think>hidden</think>string final"
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7848,6 +7848,59 @@ class TestAssemblyToolPairGuardrail:
         assert len(rows) == len(messages) + 1
         assert rows[-1]["content"] == "new follow-up"
 
+    def test_rebind_reconciliation_tolerates_sanitized_active_context_cleanup(self, tmp_path):
+        db_path = str(tmp_path / "lcm_rebind_sanitized_active_cleanup.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "rebind-cleanup-test"
+        blank_content = [{"type": "text", "text": ""}]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": blank_content},
+            {"role": "assistant", "content": "visible answer"},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        sanitized = first.compress(messages)
+
+        assert len(sanitized) == 3
+        assert first._store.get_session_count(session_id) == 4
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(sanitized + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 5
+        assert [row["role"] for row in rows] == [
+            "system",
+            "user",
+            "assistant",
+            "assistant",
+            "user",
+        ]
+        assert [row["content"] for row in rows] == [
+            "sys",
+            "question",
+            json.dumps(blank_content, ensure_ascii=False, sort_keys=True),
+            "visible answer",
+            "new follow-up",
+        ]
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert rebound._last_ingest_reconciliation["cursor"] == len(sanitized)
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7743,9 +7743,11 @@ class TestAssemblyToolPairGuardrail:
 
         result = instance._assemble_context(sys_msg, tail_messages)
 
-        assert tool_call_msg in result
+        expected_tool_call_msg = dict(tool_call_msg)
+        expected_tool_call_msg["content"] = ""
+        assert expected_tool_call_msg in result
         assert tool_result_msg in result
-        call_index = result.index(tool_call_msg)
+        call_index = result.index(expected_tool_call_msg)
         assert result[call_index + 1] == tool_result_msg
         self._assert_provider_tool_sequence_valid(result)
 
@@ -8021,6 +8023,81 @@ class TestAssemblyToolPairGuardrail:
         assert [row["role"] for row in rows] == ["system", "user", "assistant", "user"]
         assert rows[2]["content"] == json.dumps(mixed_content, ensure_ascii=False, sort_keys=True)
         assert rows[3]["content"] == "new follow-up"
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
+
+    def test_active_context_cleanup_strips_internal_content_from_assistant_tool_calls(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_tool_call_internal_cleanup.db"),
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        instance = LCMEngine(config=config)
+        session_id = "tool-call-internal-cleanup-test"
+        instance.on_session_start(session_id, context_length=200000)
+        tool_call = {
+            "id": "call_lookup",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "<think>hidden</think>", "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": "call_lookup", "content": "result"},
+        ]
+
+        active_context = instance.compress(messages)
+
+        assert active_context[2] == {"role": "assistant", "content": "", "tool_calls": [tool_call]}
+        assert active_context[3] == {"role": "tool", "tool_call_id": "call_lookup", "content": "result"}
+        rows = instance._store.get_session_messages(session_id)
+        assert rows[2]["content"] == "<think>hidden</think>"
+        assert rows[2]["tool_calls"] == [tool_call]
+
+    def test_rebind_reconciliation_tolerates_stripped_assistant_tool_call_content(self, tmp_path):
+        db_path = str(tmp_path / "lcm_rebind_tool_call_internal_cleanup.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "rebind-tool-call-internal-cleanup-test"
+        tool_call = {
+            "id": "call_lookup",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "<think>hidden</think>", "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": "call_lookup", "content": "result"},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        active_context = first.compress(messages)
+        assert active_context[2]["content"] == ""
+        assert first._store.get_session_count(session_id) == 4
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(active_context + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 5
+        assert [row["role"] for row in rows] == ["system", "user", "assistant", "tool", "user"]
+        assert rows[2]["content"] == "<think>hidden</think>"
+        assert rows[4]["content"] == "new follow-up"
         assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
         assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -8101,6 +8101,62 @@ class TestAssemblyToolPairGuardrail:
         assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
         assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
 
+    def test_source_id_mapping_matches_stripped_assistant_active_context(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_source_id_stripped_cleanup.db"),
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        instance = LCMEngine(config=config)
+        session_id = "source-id-stripped-cleanup-test"
+        instance.on_session_start(session_id, context_length=200000)
+        mixed_content = [
+            {"type": "thinking", "text": "secret chain of thought"},
+            {"type": "text", "text": "visible final"},
+        ]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": mixed_content},
+        ]
+
+        active_context = instance.compress(messages)
+        rows = instance._store.get_session_messages(session_id)
+
+        assert active_context[2]["content"] == [{"type": "text", "text": "visible final"}]
+        assert rows[2]["content"] == json.dumps(mixed_content, ensure_ascii=False, sort_keys=True)
+        assert instance._get_store_ids_for_messages([active_context[2]]) == [rows[2]["store_id"]]
+
+    def test_source_id_mapping_matches_stripped_tool_call_active_context(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_source_id_tool_call_cleanup.db"),
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        instance = LCMEngine(config=config)
+        session_id = "source-id-tool-call-cleanup-test"
+        instance.on_session_start(session_id, context_length=200000)
+        tool_call = {
+            "id": "call_lookup",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "<think>hidden</think>", "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": "call_lookup", "content": "result"},
+        ]
+
+        active_context = instance.compress(messages)
+        rows = instance._store.get_session_messages(session_id)
+
+        assert active_context[2]["content"] == ""
+        assert rows[2]["content"] == "<think>hidden</think>"
+        assert instance._get_store_ids_for_messages([active_context[2]]) == [rows[2]["store_id"]]
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1125,6 +1125,122 @@ class TestEngineABC:
         assert [row["content"] for row in rows[-3:]] == ["retry", "retry", "next answer"]
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_existing_session_restart_persists_cleanup_sensitive_scaffolded_repeated_tail(self, tmp_path):
+        db_path = tmp_path / "restart-cleanup-sensitive-scaffold-repeat-tail.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "cleanup-sensitive-scaffold-repeat-tail-session",
+            platform="cli",
+            conversation_id="cleanup-sensitive-scaffold-repeat-tail-conversation",
+            context_length=200000,
+        )
+        literal_json_text = json.dumps(
+            [{"type": "thinking", "text": "visible literal JSON payload"}],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": "older answer"},
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": literal_json_text},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "cleanup-sensitive-scaffold-repeat-tail-session",
+            platform="cli",
+            conversation_id="cleanup-sensitive-scaffold-repeat-tail-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": literal_json_text},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "cleanup-sensitive-scaffold-repeat-tail-session",
+            limit=len(persisted_messages) + 2,
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert [row["content"] for row in rows[-4:]] == [
+            "retry",
+            literal_json_text,
+            "retry",
+            literal_json_text,
+        ]
+        assert after_restart._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert after_restart._last_ingest_reconciliation["reason"] == "skipped scaffold-only prefix"
+        assert after_restart._ingest_cursor == len(active_context)
+
+    def test_existing_session_restart_persists_cleanup_sensitive_scaffolded_repeated_tail_with_followup(self, tmp_path):
+        db_path = tmp_path / "restart-cleanup-sensitive-scaffold-repeat-tail-followup.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "cleanup-sensitive-scaffold-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="cleanup-sensitive-scaffold-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        literal_json_text = json.dumps(
+            [{"type": "thinking", "text": "visible literal JSON payload"}],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": "older answer"},
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": literal_json_text},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "cleanup-sensitive-scaffold-repeat-tail-followup-session",
+            platform="cli",
+            conversation_id="cleanup-sensitive-scaffold-repeat-tail-followup-conversation",
+            context_length=200000,
+        )
+        active_context = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {"role": "user", "content": "retry"},
+            {"role": "assistant", "content": literal_json_text},
+            {"role": "user", "content": "new follow-up"},
+        ]
+
+        after_restart._ingest_messages(active_context)
+
+        rows = after_restart._store.get_session_messages(
+            "cleanup-sensitive-scaffold-repeat-tail-followup-session",
+            limit=len(persisted_messages) + 3,
+        )
+        assert len(rows) == len(persisted_messages) + 3
+        assert [row["content"] for row in rows[-5:]] == [
+            "retry",
+            literal_json_text,
+            "retry",
+            literal_json_text,
+            "new follow-up",
+        ]
+        assert after_restart._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert after_restart._last_ingest_reconciliation["reason"] == "skipped scaffold-only prefix"
+        assert after_restart._ingest_cursor == len(active_context)
+
     def test_existing_session_restart_persists_new_system_message(self, tmp_path):
         db_path = tmp_path / "restart-new-system.db"
         config = LCMConfig(database_path=str(db_path))
@@ -8098,6 +8214,102 @@ class TestAssemblyToolPairGuardrail:
         assert [row["role"] for row in rows] == ["system", "user", "assistant", "tool", "user"]
         assert rows[2]["content"] == "<think>hidden</think>"
         assert rows[4]["content"] == "new follow-up"
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
+
+    def test_rebind_reconciliation_keeps_literal_json_string_assistant_content(self, tmp_path):
+        db_path = str(tmp_path / "lcm_rebind_literal_json_string_cleanup.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "rebind-literal-json-string-test"
+        literal_json_text = json.dumps(
+            [{"type": "thinking", "text": "this is user-visible literal JSON text"}],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": literal_json_text},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        active_context = first.compress(messages)
+
+        assert active_context == messages
+        assert first._store.get_session_count(session_id) == 3
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(active_context + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 4
+        assert [row["role"] for row in rows] == ["system", "user", "assistant", "user"]
+        assert [row["content"] for row in rows].count(literal_json_text) == 1
+        assert rows[-1]["content"] == "new follow-up"
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
+
+    def test_compacted_rebind_keeps_literal_json_string_assistant_content(self, tmp_path, monkeypatch):
+        db_path = str(tmp_path / "lcm_rebind_compacted_literal_json_string_cleanup.db")
+        config = LCMConfig(
+            fresh_tail_count=2,
+            database_path=db_path,
+            leaf_chunk_tokens=1,
+            context_threshold=0.95,
+        )
+        session_id = "rebind-compacted-literal-json-string-test"
+        literal_json_text = json.dumps(
+            [{"type": "thinking", "text": "this is still visible literal JSON"}],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+        def mock_summary(**kwargs):
+            return "Older literal-json replay setup summary", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "older question"},
+            {"role": "assistant", "content": "older answer"},
+            {"role": "user", "content": "fresh question"},
+            {"role": "assistant", "content": literal_json_text},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        active_context = first.compress(messages)
+        assert any("Older literal-json replay setup summary" in (msg.get("content") or "") for msg in active_context)
+        assert active_context[-2:] == messages[-2:]
+        assert first._store.get_session_count(session_id) == len(messages)
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=2,
+            database_path=db_path,
+            leaf_chunk_tokens=1,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(active_context + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count(literal_json_text) == 1
+        assert rows[-1]["content"] == "new follow-up"
         assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
         assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7901,6 +7901,50 @@ class TestAssemblyToolPairGuardrail:
         assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
         assert rebound._last_ingest_reconciliation["cursor"] == len(sanitized)
 
+    def test_no_compaction_cleanup_does_not_return_untracked_tool_stubs_after_rebind(self, tmp_path):
+        db_path = str(tmp_path / "lcm_no_compaction_pending_tool_stub.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "pending-tool-stub-test"
+        pending_call = {
+            "id": "call_pending",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "tool_calls": [pending_call]},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        active_context = first.compress(messages)
+
+        assert active_context == messages
+        assert all(msg.get("role") != "tool" for msg in active_context)
+        assert first._store.get_session_count(session_id) == 3
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(active_context + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 4
+        assert [row["role"] for row in rows] == ["system", "user", "assistant", "user"]
+        assert rows[-1]["content"] == "new follow-up"
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7976,6 +7976,54 @@ class TestAssemblyToolPairGuardrail:
         assert rows[2]["content"] == json.dumps(mixed_content, ensure_ascii=False, sort_keys=True)
         assert rows[3]["content"] == "<think>hidden</think>string final"
 
+    def test_rebind_reconciliation_tolerates_stripped_active_assistant_content(self, tmp_path):
+        db_path = str(tmp_path / "lcm_rebind_stripped_active_cleanup.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "rebind-stripped-cleanup-test"
+        mixed_content = [
+            {"type": "thinking", "text": "secret chain of thought"},
+            {"type": "text", "text": "visible final"},
+        ]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": mixed_content},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        active_context = first.compress(messages)
+
+        assert active_context == [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": [{"type": "text", "text": "visible final"}]},
+        ]
+        assert first._store.get_session_count(session_id) == 3
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress(active_context + [{"role": "user", "content": "new follow-up"}])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 4
+        assert [row["role"] for row in rows] == ["system", "user", "assistant", "user"]
+        assert rows[2]["content"] == json.dumps(mixed_content, ensure_ascii=False, sort_keys=True)
+        assert rows[3]["content"] == "new follow-up"
+        assert rebound._last_ingest_reconciliation["action"] == "advanced cursor"
+        assert rebound._last_ingest_reconciliation["cursor"] == len(active_context)
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7705,6 +7705,149 @@ class TestAssemblyToolPairGuardrail:
         ]
         assert len(stub_ids) >= 1, f"No stub result for assistant tool_call: {stub_ids}"
 
+    def test_assemble_drops_structured_blank_and_thinking_only_assistant_messages(self, tmp_path):
+        instance = self._make_engine(tmp_path, "lcm_blank_thinking_cleanup.db")
+        sys_msg = {"role": "system", "content": "sys"}
+        blank_content = [{"type": "text", "text": ""}]
+        thinking_content = [{"type": "thinking", "thinking": "private chain of thought"}]
+        visible_content = [{"type": "text", "text": "Visible answer"}]
+        tail_messages = [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": blank_content},
+            {"role": "assistant", "content": thinking_content},
+            {"role": "assistant", "content": visible_content},
+        ]
+
+        result = instance._assemble_context(sys_msg, tail_messages)
+
+        assert {"role": "assistant", "content": blank_content} not in result
+        assert {"role": "assistant", "content": thinking_content} not in result
+        assert {"role": "assistant", "content": visible_content} in result
+        self._assert_provider_tool_sequence_valid(result)
+
+    def test_assemble_cleanup_preserves_valid_tool_call_adjacency(self, tmp_path):
+        instance = self._make_engine(tmp_path, "lcm_tool_call_cleanup_preserve.db")
+        sys_msg = {"role": "system", "content": "sys"}
+        tool_call_msg = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "deciding which tool to call"}],
+            "tool_calls": [{"id": "call_keep", "function": {"name": "terminal", "arguments": "{}"}}],
+        }
+        tool_result_msg = {"role": "tool", "tool_call_id": "call_keep", "content": "tool output"}
+        tail_messages = [
+            {"role": "user", "content": "run it"},
+            tool_call_msg,
+            tool_result_msg,
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        result = instance._assemble_context(sys_msg, tail_messages)
+
+        assert tool_call_msg in result
+        assert tool_result_msg in result
+        call_index = result.index(tool_call_msg)
+        assert result[call_index + 1] == tool_result_msg
+        self._assert_provider_tool_sequence_valid(result)
+
+    def test_assemble_cleanup_repairs_tool_sequence_after_dropping_blank_turn(self, tmp_path):
+        instance = self._make_engine(tmp_path, "lcm_tool_call_cleanup_repair.db")
+        sys_msg = {"role": "system", "content": "sys"}
+        tool_call_msg = {
+            "role": "assistant",
+            "tool_calls": [{"id": "call_repair", "function": {"name": "terminal", "arguments": "{}"}}],
+        }
+        blank_content = [{"type": "text", "text": ""}]
+        real_tool_result = {"role": "tool", "tool_call_id": "call_repair", "content": "real output"}
+        tail_messages = [
+            {"role": "user", "content": "run it"},
+            tool_call_msg,
+            {"role": "assistant", "content": blank_content},
+            real_tool_result,
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        result = instance._assemble_context(sys_msg, tail_messages)
+
+        assert {"role": "assistant", "content": blank_content} not in result
+        call_index = result.index(tool_call_msg)
+        assert result[call_index + 1] == real_tool_result
+        self._assert_provider_tool_sequence_valid(result)
+
+    def test_compress_drops_unsafe_assistant_content_without_mutating_store(self, tmp_path, monkeypatch):
+        def mock_summary(**kwargs):
+            return "Leaf summary.\nExpand for details about: cleanup", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        config = LCMConfig(
+            fresh_tail_count=4,
+            database_path=str(tmp_path / "lcm_compress_cleanup.db"),
+            leaf_chunk_tokens=80,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "compress-cleanup-test"
+        instance.compression_count = 1
+        instance.context_length = 200000
+        instance.threshold_tokens = 1
+
+        blank_content = [{"type": "text", "text": ""}]
+        thinking_content = [{"type": "reasoning", "text": "internal reasoning only"}]
+        visible_content = [{"type": "text", "text": "Visible final answer"}]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "old question " + "x" * 200},
+            {"role": "assistant", "content": "old answer " + "y" * 200},
+            {"role": "user", "content": "current question"},
+            {"role": "assistant", "content": blank_content},
+            {"role": "assistant", "content": thinking_content},
+            {"role": "assistant", "content": visible_content},
+        ]
+
+        result = instance.compress(messages)
+
+        assert {"role": "assistant", "content": blank_content} not in result
+        assert {"role": "assistant", "content": thinking_content} not in result
+        assert {"role": "assistant", "content": visible_content} in result
+        assert instance._store.get_session_count("compress-cleanup-test") == len(messages)
+        stored_contents = [
+            row.get("content")
+            for row in instance._store.get_range("compress-cleanup-test", limit=20)
+        ]
+        assert json.dumps(blank_content, ensure_ascii=False, sort_keys=True) in stored_contents
+        assert json.dumps(thinking_content, ensure_ascii=False, sort_keys=True) in stored_contents
+        self._assert_provider_tool_sequence_valid(result)
+
+    def test_no_compaction_cleanup_resets_cursor_for_next_turn(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_no_compaction_cursor_cleanup.db"),
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "cursor-cleanup-test"
+        instance.context_length = 200000
+        instance.threshold_tokens = 190000
+
+        blank_content = [{"type": "text", "text": ""}]
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": blank_content},
+            {"role": "assistant", "content": "visible answer"},
+        ]
+
+        sanitized = instance.compress(messages)
+        assert len(sanitized) == len(messages) - 1
+        assert instance._ingest_cursor == len(sanitized)
+        assert instance._store.get_session_count("cursor-cleanup-test") == len(messages)
+
+        next_messages = sanitized + [{"role": "user", "content": "new follow-up"}]
+        instance.compress(next_messages)
+
+        rows = instance._store.get_session_messages("cursor-cleanup-test")
+        assert len(rows) == len(messages) + 1
+        assert rows[-1]["content"] == "new follow-up"
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -8157,6 +8157,45 @@ class TestAssemblyToolPairGuardrail:
         assert rows[2]["content"] == "<think>hidden</think>"
         assert instance._get_store_ids_for_messages([active_context[2]]) == [rows[2]["store_id"]]
 
+    def test_rebind_reconciliation_preserves_visible_suffix_delta_when_sanitized_tail_collapsed(self, tmp_path):
+        db_path = str(tmp_path / "lcm_rebind_collapsed_tail_delta.db")
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        )
+        session_id = "collapsed-tail-delta-test"
+        stored_messages = [
+            {"role": "assistant", "content": [{"type": "thinking", "text": "hidden"}]},
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"},
+        ]
+
+        first = LCMEngine(config=config)
+        first.on_session_start(session_id, context_length=200000)
+        first.compress(stored_messages)
+        assert first._store.get_session_count(session_id) == 3
+        first.shutdown()
+
+        rebound = LCMEngine(config=LCMConfig(
+            fresh_tail_count=10,
+            database_path=db_path,
+            leaf_chunk_tokens=10_000,
+            context_threshold=0.95,
+        ))
+        rebound.on_session_start(session_id, context_length=200000)
+        rebound.compress([
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"},
+        ])
+
+        rows = rebound._store.get_session_messages(session_id)
+        assert len(rows) == 5
+        assert [row["role"] for row in rows] == ["assistant", "user", "assistant", "user", "assistant"]
+        assert [row["content"] for row in rows[-2:]] == ["ping", "pong"]
+        assert rebound._last_ingest_reconciliation["action"] == "persisted batch"
+
     def test_compress_output_is_valid_tool_pair_sequence(self, tmp_path, monkeypatch):
         """Full compress() output must not contain orphan tool results
         and must include stubs for missing results."""


### PR DESCRIPTION
## Summary

Adds an active-context-only cleanup layer before assembled messages are returned to Hermes. Assistant turns that contain only blank structured text or internal thinking/reasoning blocks are dropped from provider replay, while stored rows and DAG content remain unchanged.

Tool-call messages are preserved, then the existing active-context tool-pair sanitizer repairs provider sequencing after cleanup.

## Why

Raw history can safely keep odd provider transcript shapes, but active prompt input still needs to satisfy provider constraints. Blank or thinking-only assistant turns are archive-safe but prompt-hostile.

## Validation

- [x] Focused validation: `pytest -q tests/test_lcm_engine.py::TestAssemblyToolPairGuardrail` -> `16 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `506 passed`
  - [x] `pytest -q` -> `552 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`

## Notes

This does not mutate the message store, source mappings, or summary DAG. It only changes the active context returned to the host.

Codex flagged the no-compaction path cursor. The current head resets `_ingest_cursor` to the sanitized active-context length when cleanup removes messages before returning without a compaction pass.

Refs #140
