### PR TITLE
fix: skip stale short restart snapshots

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -297,6 +297,10 @@ class LCMEngine(ContextEngine):
         # next ingest.
         self._ingest_cursor: int = 0
         self._ingest_cursor_needs_reconcile = False
+        self._last_ingest_reconciliation: Dict[str, Any] = {
+            "action": "none",
+            "reason": "not run",
+        }
 
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
@@ -1212,6 +1216,7 @@ class LCMEngine(ContextEngine):
         self._last_compacted_store_id = 0
         self._ingest_cursor = 0
         self._ingest_cursor_needs_reconcile = False
+        self._last_ingest_reconciliation = {"action": "none", "reason": "not run"}
         self._context_probed = False
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False
@@ -1731,6 +1736,7 @@ class LCMEngine(ContextEngine):
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
             status["ignore_message_patterns_source"] = self._config.ignore_message_patterns_source
             status["ignored_message_count"] = self._ignored_message_count
+            status["ingest_reconciliation"] = dict(self._last_ingest_reconciliation)
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
             status["conversation_id"] = conversation_id
@@ -1943,6 +1949,66 @@ class LCMEngine(ContextEngine):
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 
+    def _record_ingest_reconciliation(
+        self,
+        *,
+        action: str,
+        reason: str,
+        cursor: int,
+        incoming: int,
+        session_count: int,
+        stored_tail_count: int,
+        effective_incoming: int | None = None,
+    ) -> None:
+        self._last_ingest_reconciliation = {
+            "action": action,
+            "reason": reason,
+            "cursor": cursor,
+            "incoming": incoming,
+            "session_count": session_count,
+            "stored_tail_count": stored_tail_count,
+        }
+        if effective_incoming is not None:
+            self._last_ingest_reconciliation["effective_incoming"] = effective_incoming
+
+    def _effective_replay_identities(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> list[tuple[str, str, str, str]]:
+        return [
+            self._message_replay_identity(msg)
+            for msg in messages
+            if not self._is_replayed_context_scaffold_message(msg)
+            and not self._matches_ignore_message_patterns(msg)
+        ]
+
+    def _is_suspicious_stale_no_overlap_snapshot(
+        self,
+        incoming_identities: list[tuple[str, str, str, str]],
+        stored_tail: list[tuple[str, str, str, str]],
+        stored_head: list[tuple[str, str, str, str]],
+    ) -> bool:
+        """Return true for short stale snapshots with no durable-tail overlap.
+
+        A restarted gateway can hand LCM a stale, short in-memory snapshot from
+        the beginning of a longer session.  When that snapshot has no overlap
+        with the durable tail, appending it as a delta creates duplicate rows.
+        Fail closed only when the short batch is proven stale by matching the
+        contiguous durable-store prefix; singleton no-overlap deltas remain
+        ambiguous and are preserved.
+        """
+        if len(incoming_identities) <= 1:
+            return False
+        if incoming_identities[0][0] != "system":
+            return False
+        if not stored_tail or len(incoming_identities) >= len(stored_tail):
+            return False
+        if set(incoming_identities).intersection(stored_tail):
+            return False
+        if len(incoming_identities) > len(stored_head):
+            return False
+        return stored_head[: len(incoming_identities)] == incoming_identities
+
     def _reconcile_ingest_cursor_from_store(self, messages: List[Dict[str, Any]]) -> int:
         """Infer the in-memory cursor for an existing session after process restart."""
         if not self._session_id or not messages:
@@ -1972,16 +2038,74 @@ class LCMEngine(ContextEngine):
             session_count=len(stored_tail),
             raw_session_count=session_count,
         )
-        if cursor is not None:
+        if cursor is not None and cursor > 0:
+            reason = (
+                "skipped scaffold-only prefix"
+                if not self._effective_replay_identities(messages[:cursor])
+                else "replayed durable tail"
+            )
+            self._record_ingest_reconciliation(
+                action="advanced cursor",
+                reason=reason,
+                cursor=cursor,
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=len(stored_tail),
+                effective_incoming=len(self._effective_replay_identities(messages)),
+            )
             logger.debug(
-                "LCM reconciled ingest cursor after existing-session bind: session=%s cursor=%d incoming=%d stored_tail=%d session_count=%d",
+                "LCM reconciled ingest cursor after existing-session bind: session=%s cursor=%d incoming=%d stored_tail=%d session_count=%d reason=%s",
                 self._session_id,
                 cursor,
                 len(messages),
                 len(stored_tail),
                 session_count,
+                reason,
             )
             return cursor
+
+        incoming_identities = self._effective_replay_identities(messages)
+        stored_head_rows = self._store.get_session_messages(
+            self._session_id,
+            limit=tail_limit,
+        )
+        stored_head = [self._message_replay_identity(row) for row in stored_head_rows]
+        # Stale-snapshot proof uses the raw durable prefix.  Ignore-message
+        # filters may suppress noisy rows for tail reconciliation, but filtered
+        # history alone must not create replay evidence for skipping a batch.
+        if self._is_suspicious_stale_no_overlap_snapshot(
+            incoming_identities,
+            stored_tail,
+            stored_head,
+        ):
+            self._record_ingest_reconciliation(
+                action="skipped batch",
+                reason="skipped stale no-overlap snapshot",
+                cursor=len(messages),
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=len(stored_tail),
+                effective_incoming=len(incoming_identities),
+            )
+            logger.warning(
+                "LCM skipped stale no-overlap snapshot after existing-session bind: session=%s incoming=%d effective_incoming=%d stored_tail=%d session_count=%d",
+                self._session_id,
+                len(messages),
+                len(incoming_identities),
+                len(stored_tail),
+                session_count,
+            )
+            return len(messages)
+
+        self._record_ingest_reconciliation(
+            action="persisted batch",
+            reason="persisted ambiguous delta",
+            cursor=0,
+            incoming=len(messages),
+            session_count=session_count,
+            stored_tail_count=len(stored_tail),
+            effective_incoming=len(incoming_identities),
+        )
         return 0
 
     def _ingest_messages(self, messages: List[Dict[str, Any]]) -> None:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1225,6 +1225,394 @@ class TestEngineABC:
         assert rows[0]["content"] == "tail before restart"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_existing_session_restart_skips_stale_short_no_overlap_snapshot(self, tmp_path, caplog):
+        db_path = tmp_path / "restart-stale-short-no-overlap.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "stale-short-session",
+            platform="cli",
+            conversation_id="stale-short-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "old startup question"},
+            {"role": "assistant", "content": "old startup answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "stale-short-session",
+            platform="cli",
+            conversation_id="stale-short-conversation",
+            context_length=200000,
+        )
+        stale_runtime_snapshot = persisted_messages[:3]
+
+        with caplog.at_level("WARNING", logger="hermes_lcm.engine"):
+            after_restart._ingest_messages(stale_runtime_snapshot)
+
+        rows = after_restart._store.get_session_messages(
+            "stale-short-session",
+            limit=len(persisted_messages) + len(stale_runtime_snapshot),
+        )
+        assert len(rows) == len(persisted_messages)
+        assert [row["content"] for row in rows[:3]] == [
+            "You are concise.",
+            "old startup question",
+            "old startup answer",
+        ]
+        assert after_restart._ingest_cursor == len(stale_runtime_snapshot)
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "skipped stale no-overlap snapshot"
+        )
+        assert "skipped stale no-overlap snapshot" in caplog.text
+
+    def test_existing_session_restart_persists_one_message_no_overlap_delta(self, tmp_path):
+        db_path = tmp_path / "restart-one-message-no-overlap.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "one-message-delta-session",
+            platform="cli",
+            conversation_id="one-message-delta-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "one-message-delta-session",
+            platform="cli",
+            conversation_id="one-message-delta-conversation",
+            context_length=200000,
+        )
+        delta = [{"role": "user", "content": "legitimate standalone delta"}]
+
+        after_restart._ingest_messages(delta)
+
+        rows = after_restart._store.get_session_messages(
+            "one-message-delta-session",
+            limit=len(persisted_messages) + 1,
+        )
+        assert len(rows) == len(persisted_messages) + 1
+        assert rows[-1]["content"] == "legitimate standalone delta"
+        assert after_restart._ingest_cursor == len(delta)
+        reconciliation = after_restart.get_status()["ingest_reconciliation"]
+        assert reconciliation["reason"] == "persisted ambiguous delta"
+        assert reconciliation["action"] == "persisted batch"
+
+    def test_existing_session_restart_scaffold_prefix_does_not_skip_unrelated_new_rows(self, tmp_path):
+        db_path = tmp_path / "restart-scaffold-prefix-unrelated.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "scaffold-prefix-session",
+            platform="cli",
+            conversation_id="scaffold-prefix-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "scaffold-prefix-session",
+            platform="cli",
+            conversation_id="scaffold-prefix-conversation",
+            context_length=200000,
+        )
+        replay_with_new_rows = [
+            {
+                "role": "system",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {
+                "role": "assistant",
+                "content": "[Recent Summary (d0, node 12)]\nEarlier details.\n[Expand for details: hint-12]",
+            },
+            {"role": "user", "content": "unrelated new request"},
+            {"role": "assistant", "content": "unrelated new answer"},
+        ]
+
+        after_restart._ingest_messages(replay_with_new_rows)
+
+        rows = after_restart._store.get_session_messages(
+            "scaffold-prefix-session",
+            limit=len(persisted_messages) + 2,
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert [row["content"] for row in rows[-2:]] == [
+            "unrelated new request",
+            "unrelated new answer",
+        ]
+        assert after_restart._ingest_cursor == len(replay_with_new_rows)
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "skipped scaffold-only prefix"
+        )
+
+    def test_existing_session_restart_persists_repeated_prefix_after_scaffold_only_prefix(self, tmp_path):
+        db_path = tmp_path / "restart-scaffold-prefix-repeat-old-prefix.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "scaffold-stale-prefix-session",
+            platform="cli",
+            conversation_id="scaffold-stale-prefix-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "old first question"},
+            {"role": "assistant", "content": "old first answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail after scaffold {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "scaffold-stale-prefix-session",
+            platform="cli",
+            conversation_id="scaffold-stale-prefix-conversation",
+            context_length=200000,
+        )
+        stale_replay = [
+            {
+                "role": "system",
+                "content": "[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+            },
+            {
+                "role": "assistant",
+                "content": "[Recent Summary (d0, node 12)]\nEarlier details.\n[Expand for details: hint-12]",
+            },
+            {"role": "user", "content": "old first question"},
+            {"role": "assistant", "content": "old first answer"},
+        ]
+
+        after_restart._ingest_messages(stale_replay)
+
+        rows = after_restart._store.get_session_messages(
+            "scaffold-stale-prefix-session",
+            limit=len(persisted_messages) + len(stale_replay),
+        )
+        assert len(rows) == len(persisted_messages) + 2
+        assert [row["content"] for row in rows[-2:]] == [
+            "old first question",
+            "old first answer",
+        ]
+        assert after_restart._ingest_cursor == len(stale_replay)
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "skipped scaffold-only prefix"
+        )
+
+    def test_restart_reconciliation_filtered_singleton_tail_stays_ambiguous(self, tmp_path):
+        db_path = tmp_path / "restart-filtered-singleton-tail.db"
+        before_restart = LCMEngine(config=LCMConfig(database_path=str(db_path)))
+        before_restart.on_session_start(
+            "filtered-singleton-session",
+            platform="telegram",
+            conversation_id="filtered-singleton-conversation",
+            context_length=1000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "real singleton tail"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(
+            config=LCMConfig(
+                database_path=str(db_path),
+                ignore_message_patterns=["^Cronjob Response:"],
+            )
+        )
+        after_restart.on_session_start(
+            "filtered-singleton-session",
+            platform="telegram",
+            conversation_id="filtered-singleton-conversation",
+            context_length=1000,
+        )
+
+        after_restart._ingest_messages([{"role": "user", "content": "real singleton tail"}])
+
+        rows = after_restart._store.get_session_messages("filtered-singleton-session")
+        assert [row["content"] for row in rows] == [
+            "Cronjob Response: heartbeat",
+            "real singleton tail",
+            "real singleton tail",
+        ]
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "persisted ambiguous delta"
+        )
+
+    def test_existing_session_restart_persists_prefix_repeated_without_system_anchor(self, tmp_path):
+        db_path = tmp_path / "restart-prefix-repeat-no-system-anchor.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "prefix-repeat-session",
+            platform="cli",
+            conversation_id="prefix-repeat-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "opening question"},
+            {"role": "assistant", "content": "opening answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "prefix-repeat-session",
+            platform="cli",
+            conversation_id="prefix-repeat-conversation",
+            context_length=200000,
+        )
+        repeated_prefix_delta = persisted_messages[:2]
+
+        after_restart._ingest_messages(repeated_prefix_delta)
+
+        rows = after_restart._store.get_session_messages(
+            "prefix-repeat-session",
+            limit=len(persisted_messages) + len(repeated_prefix_delta),
+        )
+        assert len(rows) == len(persisted_messages) + len(repeated_prefix_delta)
+        assert [row["content"] for row in rows[-2:]] == [
+            "opening question",
+            "opening answer",
+        ]
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "persisted ambiguous delta"
+        )
+
+    def test_restart_reconciliation_filtered_prefix_does_not_create_stale_proof(self, tmp_path):
+        db_path = tmp_path / "restart-filtered-prefix-stale-proof.db"
+        before_restart = LCMEngine(config=LCMConfig(database_path=str(db_path)))
+        before_restart.on_session_start(
+            "filtered-prefix-session",
+            platform="telegram",
+            conversation_id="filtered-prefix-conversation",
+            context_length=1000,
+        )
+        persisted_messages = [
+            {"role": "user", "content": "Cronjob Response: heartbeat"},
+            {"role": "user", "content": "real prefix question"},
+            {"role": "assistant", "content": "real prefix answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail after filter {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(
+            config=LCMConfig(
+                database_path=str(db_path),
+                ignore_message_patterns=["^Cronjob Response:"],
+            )
+        )
+        after_restart.on_session_start(
+            "filtered-prefix-session",
+            platform="telegram",
+            conversation_id="filtered-prefix-conversation",
+            context_length=1000,
+        )
+        ambiguous_delta = [
+            {"role": "user", "content": "real prefix question"},
+            {"role": "assistant", "content": "real prefix answer"},
+        ]
+
+        after_restart._ingest_messages(ambiguous_delta)
+
+        rows = after_restart._store.get_session_messages(
+            "filtered-prefix-session",
+            limit=len(persisted_messages) + len(ambiguous_delta),
+        )
+        assert len(rows) == len(persisted_messages) + len(ambiguous_delta)
+        assert [row["content"] for row in rows[-2:]] == [
+            "real prefix question",
+            "real prefix answer",
+        ]
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "persisted ambiguous delta"
+        )
+
+    def test_lcm_status_reports_ingest_reconciliation_diagnostics(self, tmp_path):
+        db_path = tmp_path / "restart-status-ingest-diagnostic.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "status-reconcile-session",
+            platform="cli",
+            conversation_id="status-reconcile-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "status-reconcile-session",
+            platform="cli",
+            conversation_id="status-reconcile-conversation",
+            context_length=200000,
+        )
+        after_restart._ingest_messages([{"role": "user", "content": "status delta"}])
+
+        payload = json.loads(lcm_tools.lcm_status({}, engine=after_restart))
+
+        assert payload["ingest_reconciliation"]["reason"] == "persisted ambiguous delta"
+        assert payload["ingest_reconciliation"]["action"] == "persisted batch"
+
     def test_get_status(self, engine):
         status = engine.get_status()
         assert status["engine"] == "lcm"

--- a/tools.py
+++ b/tools.py
@@ -1440,6 +1440,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     lifecycle_fragmentation = full_status.get("lifecycle_fragmentation")
     source_lineage = full_status.get("source_lineage")
     runtime_identity = full_status.get("runtime_identity")
+    ingest_reconciliation = full_status.get("ingest_reconciliation")
 
     # Filter classification for the session lcm_status is reporting on.
     # The engine encapsulates the foreground vs bound divergence; this tool
@@ -1504,6 +1505,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             ),
         },
         "source_lineage": source_lineage,
+        "ingest_reconciliation": ingest_reconciliation,
         "runtime_identity": runtime_identity,
         "lifecycle": lifecycle,
         "lifecycle_fragmentation": lifecycle_fragmentation,


### PR DESCRIPTION
## Summary

Adds a restart reconciliation guard for stale short snapshots that have no overlap with the durable tail. When a short incoming batch is proven to be an old durable prefix with a system anchor, LCM skips it instead of appending duplicate rows.

Ambiguous singleton deltas, repeated prefix-like deltas without a system anchor, scaffold-prefixed repeated deltas, and filtered-history cases stay conservative, so possible new user data is still persisted rather than silently dropped.

## Why

After a restart, a runtime can hand LCM a stale short snapshot from an existing longer session. Treating that as fresh delta data pollutes the raw store, FTS, source accounting, search, and later compaction.

## Validation

- [x] Focused validation: `pytest tests/test_lcm_engine.py -q -k "restart"` -> `26 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `509 passed`
  - [x] `pytest -q` -> `555 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`

## Notes

`lcm_status` now includes the latest ingest reconciliation decision so operators can distinguish a skipped stale no-overlap snapshot from a persisted ambiguous delta.

Codex flagged repeated-prefix data-loss edges. The current head keeps no-system repeated prefixes conservative, including the scaffold-prefixed case, and only skips the stale no-overlap prefix when the incoming batch has a system anchor.

Refs #141
