### PR TITLE
feat: add critical pressure escape for deferred compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ environment variables:
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized tool outputs in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for tool output text |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
+| `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | `0.0` | Disabled at `0.0`; when set, permits critical-pressure bypasses for bounded deferred catch-up and cache-friendly follow-on condensation only |
 | `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
 | `LCM_EXPANSION_MODEL` | summary model / auxiliary | Override `lcm_expand_query` synthesis model |
 | `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Context budget used by the auxiliary LLM for `lcm_expand_query` |
@@ -206,6 +207,23 @@ environment variables:
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
 
 Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
+
+### Cache policy boundary
+
+LCM is **cache-friendly**, not fully cache-aware. It may avoid some follow-on
+condensation churn, but current cache usage counters are retrospective status
+data only; they do not tell the plugin whether the next prompt mutation will
+break a hot provider cache. For that reason LCM does **not** implement
+provider/model TTL heuristics, provider-family detection, cache-touch/cache-break
+tracking, TTL delays, or full cache-aware deferred compaction.
+
+`LCM_CRITICAL_BUDGET_PRESSURE_RATIO` is a narrow escape hatch. It is disabled by
+default (`0.0`). When set, LCM compares prompt pressure against the context
+window and only at or above that ratio may bypass the existing polite gates for
+bounded deferred maintenance catch-up and cache-friendly follow-on condensation.
+Below that pressure, simpler existing behavior is preserved. Revisit full
+cache-aware deferred compaction only after Hermes core exposes reliable cache
+state / cache-break signals.
 
 ### Threshold ownership
 

--- a/config.py
+++ b/config.py
@@ -111,6 +111,9 @@ class LCMConfig:
     # Maximum extra leaf passes a debt-triggered later turn may spend on
     # catch-up work.
     deferred_maintenance_max_passes: int = 4
+    # Disabled at 0.0. When set, only bypass cache-friendly/deferred polite
+    # gates once prompt pressure reaches this fraction of the context window.
+    critical_budget_pressure_ratio: float = 0.0
 
     # -- Escalation ---
     # L2 bullet budget as fraction of L1
@@ -215,6 +218,10 @@ class LCMConfig:
         c.deferred_maintenance_max_passes = _int(
             "LCM_DEFERRED_MAINTENANCE_MAX_PASSES",
             c.deferred_maintenance_max_passes,
+        )
+        c.critical_budget_pressure_ratio = _float(
+            "LCM_CRITICAL_BUDGET_PRESSURE_RATIO",
+            c.critical_budget_pressure_ratio,
         )
         c.l2_budget_ratio = _float("LCM_L2_BUDGET_RATIO", c.l2_budget_ratio)
         c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)

--- a/engine.py
+++ b/engine.py
@@ -460,8 +460,8 @@ class LCMEngine(ContextEngine):
             return True
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
             return True
-        self._refresh_raw_backlog_debt(messages)
-        return self._should_run_deferred_maintenance(messages)
+        self._refresh_raw_backlog_debt(messages, observed_tokens=rough)
+        return self._should_run_deferred_maintenance(messages, observed_tokens=rough)
 
     def _working_leaf_chunk_tokens(self, raw_tokens_outside_tail: int) -> int:
         base = max(1, self._config.leaf_chunk_tokens)
@@ -619,8 +619,16 @@ class LCMEngine(ContextEngine):
         working_messages = list(messages)
         leaf_compacted_this_turn = False
         leaf_passes = 0
+        critical_budget_pressure = self._critical_budget_pressure_reached(
+            observed_tokens=observed_prompt_tokens,
+            messages=working_messages,
+        )
         deferred_maintenance_active = (
-            not force_overflow and self._should_run_deferred_maintenance(working_messages)
+            not force_overflow
+            and self._should_run_deferred_maintenance(
+                working_messages,
+                observed_tokens=observed_prompt_tokens,
+            )
         )
         if deferred_maintenance_active:
             self._lifecycle.record_maintenance_attempt(self._conversation_id)
@@ -654,14 +662,16 @@ class LCMEngine(ContextEngine):
             if self._config.dynamic_leaf_chunk_enabled:
                 working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
                 if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
-                    break
+                    if not (deferred_maintenance_active and critical_budget_pressure):
+                        break
                 if force_overflow:
                     to_compact = candidate_raw
                 else:
                     to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
             else:
                 if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
-                    break
+                    if not (deferred_maintenance_active and critical_budget_pressure):
+                        break
                 to_compact = candidate_raw
 
             if not to_compact:
@@ -716,10 +726,14 @@ class LCMEngine(ContextEngine):
                 remaining_raw_tokens = count_messages_tokens(remaining_raw)
                 remaining_threshold = self._working_leaf_chunk_tokens(remaining_raw_tokens)
                 if remaining_raw_tokens < remaining_threshold:
-                    break
+                    if not (deferred_maintenance_active and critical_budget_pressure):
+                        break
 
         if not leaf_compacted_this_turn:
-            self._refresh_raw_backlog_debt(working_messages)
+            self._refresh_raw_backlog_debt(
+                working_messages,
+                observed_tokens=observed_prompt_tokens,
+            )
             if force_overflow and len(messages) >= 1:
                 compressed = self._assemble_overflow_recovery_context(
                     messages[0],
@@ -738,10 +752,14 @@ class LCMEngine(ContextEngine):
             focus_topic=focus_topic,
             leaf_compacted_this_turn=True,
             force_overflow=force_overflow,
+            critical_budget_pressure=critical_budget_pressure,
         )
 
         # Step 7: Assemble new active context
-        self._refresh_raw_backlog_debt(working_messages)
+        self._refresh_raw_backlog_debt(
+            working_messages,
+            observed_tokens=observed_prompt_tokens,
+        )
         self._pending_context_anchor_messages = messages[1:]
         try:
             compressed = self._assemble_context(
@@ -1175,20 +1193,77 @@ class LCMEngine(ContextEngine):
         state = self._lifecycle.get_by_conversation(self._conversation_id)
         return bool(state and state.debt_kind == "raw_backlog" and state.debt_size_estimate > 0)
 
-    def _should_run_deferred_maintenance(self, messages: List[Dict[str, Any]]) -> bool:
+    def _budget_pressure_ratio(
+        self,
+        *,
+        observed_tokens: int | None = None,
+        messages: List[Dict[str, Any]] | None = None,
+    ) -> float | None:
+        if self.context_length <= 0:
+            return None
+        token_count: int | None = None
+        if observed_tokens is not None and observed_tokens > 0:
+            token_count = observed_tokens
+        elif messages is not None:
+            token_count = count_messages_tokens(messages)
+        elif self.last_prompt_tokens > 0:
+            token_count = self.last_prompt_tokens
+        if token_count is None or token_count <= 0:
+            return None
+        return token_count / self.context_length
+
+    def _critical_budget_pressure_reached(
+        self,
+        *,
+        observed_tokens: int | None = None,
+        messages: List[Dict[str, Any]] | None = None,
+    ) -> bool:
+        threshold = self._config.critical_budget_pressure_ratio
+        if threshold <= 0:
+            return False
+        pressure = self._budget_pressure_ratio(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
+        return pressure is not None and pressure >= threshold
+
+    def _should_run_deferred_maintenance(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        observed_tokens: int | None = None,
+    ) -> bool:
         if not self._has_raw_backlog_debt():
             return False
         raw_tokens = self._raw_backlog_tokens(messages)
         if raw_tokens <= 0:
             return False
-        return raw_tokens >= self._raw_backlog_threshold(raw_tokens)
+        if raw_tokens >= self._raw_backlog_threshold(raw_tokens):
+            return True
+        return self._critical_budget_pressure_reached(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
 
-    def _refresh_raw_backlog_debt(self, messages: List[Dict[str, Any]]) -> None:
+    def _refresh_raw_backlog_debt(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        observed_tokens: int | None = None,
+    ) -> None:
         if not self._config.deferred_maintenance_enabled or not self._conversation_id:
             return
         raw_tokens = self._raw_backlog_tokens(messages)
         threshold = self._raw_backlog_threshold(raw_tokens) if raw_tokens > 0 else 0
-        if raw_tokens > 0 and raw_tokens >= threshold:
+        keep_under_critical_pressure = (
+            raw_tokens > 0
+            and self._has_raw_backlog_debt()
+            and self._critical_budget_pressure_reached(
+                observed_tokens=observed_tokens,
+                messages=messages,
+            )
+        )
+        if raw_tokens > 0 and (raw_tokens >= threshold or keep_under_critical_pressure):
             self._lifecycle.record_debt(
                 self._conversation_id,
                 kind="raw_backlog",
@@ -2284,12 +2359,15 @@ class LCMEngine(ContextEngine):
         uncondensed_count: int,
         leaf_compacted_this_turn: bool,
         force_overflow: bool,
+        critical_budget_pressure: bool = False,
     ) -> tuple[bool, str]:
         if not leaf_compacted_this_turn:
             return True, ""
         if not self._config.cache_friendly_condensation_enabled:
             return True, ""
         if force_overflow:
+            return True, ""
+        if critical_budget_pressure:
             return True, ""
 
         fanin = max(1, self._config.condensation_fanin)
@@ -2306,6 +2384,7 @@ class LCMEngine(ContextEngine):
         *,
         leaf_compacted_this_turn: bool = False,
         force_overflow: bool = False,
+        critical_budget_pressure: bool = False,
     ) -> None:
         """Check if any depth level has enough nodes for condensation."""
         self._last_condensation_suppressed_reason = ""
@@ -2337,6 +2416,7 @@ class LCMEngine(ContextEngine):
                 uncondensed_count=len(uncondensed),
                 leaf_compacted_this_turn=leaf_compacted_this_turn,
                 force_overflow=force_overflow,
+                critical_budget_pressure=critical_budget_pressure,
             )
             if not allow_condense:
                 suppression_reason = reason or suppression_reason

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -302,6 +302,7 @@ class TestConfig:
         assert c.large_output_transcript_gc_enabled is False
         assert c.deferred_maintenance_enabled is False
         assert c.deferred_maintenance_max_passes == 4
+        assert c.critical_budget_pressure_ratio == 0.0
         assert c.ignore_session_patterns == []
         assert c.stateless_session_patterns == []
         assert c.ignore_message_patterns == []
@@ -331,6 +332,7 @@ class TestConfig:
         monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_MAX", "64000")
         monkeypatch.setenv("LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED", "1")
         monkeypatch.setenv("LCM_CACHE_FRIENDLY_MIN_DEBT_GROUPS", "3")
+        monkeypatch.setenv("LCM_CRITICAL_BUDGET_PRESSURE_RATIO", "0.92")
         monkeypatch.setenv("LCM_CUSTOM_INSTRUCTIONS", "Write as a neutral documenter.")
         monkeypatch.setenv("LCM_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("LCM_EXTRACTION_MODEL", "openai/gpt-5.4-mini")
@@ -359,6 +361,7 @@ class TestConfig:
         assert c.dynamic_leaf_chunk_max == 64_000
         assert c.cache_friendly_condensation_enabled is True
         assert c.cache_friendly_min_debt_groups == 3
+        assert c.critical_budget_pressure_ratio == 0.92
         assert c.custom_instructions == "Write as a neutral documenter."
         assert c.extraction_enabled is True
         assert c.extraction_model == "openai/gpt-5.4-mini"
@@ -376,6 +379,7 @@ class TestConfig:
         monkeypatch.setenv("LCM_MAX_ASSEMBLY_TOKENS", "nope")
         monkeypatch.setenv("LCM_RESERVE_TOKENS_FLOOR", "still-nope")
         monkeypatch.setenv("LCM_EXPANSION_CONTEXT_TOKENS", "nah")
+        monkeypatch.setenv("LCM_CRITICAL_BUDGET_PRESSURE_RATIO", "invalid")
 
         c = LCMConfig.from_env()
 
@@ -385,6 +389,7 @@ class TestConfig:
         assert c.max_assembly_tokens == 0
         assert c.reserve_tokens_floor == 0
         assert c.expansion_context_tokens == 32_000
+        assert c.critical_budget_pressure_ratio == 0.0
 
     def test_from_env_reads_hermes_compression_threshold_when_lcm_env_missing(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2817,6 +2817,58 @@ class TestEngineCompress:
         assert depth1 == []
         assert engine.get_status()["condensation_suppressed_reason"] == "cache_friendly_single_group"
 
+    def test_critical_budget_pressure_bypasses_cache_friendly_single_group_suppression(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=120,
+            condensation_fanin=2,
+            critical_budget_pressure_ratio=0.90,
+            database_path=str(tmp_path / "lcm_cache_friendly_critical.db"),
+        )
+        config.cache_friendly_condensation_enabled = True
+        config.cache_friendly_min_debt_groups = 2
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 1000
+        engine.threshold_tokens = int(1000 * config.context_threshold)
+
+        engine._dag.add_node(SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary="Earlier leaf",
+            token_count=40,
+            source_token_count=80,
+            source_ids=[1],
+            source_type="messages",
+            created_at=time.time() - 10,
+            expand_hint="earlier leaf",
+        ))
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ("chunk " * 35),
+            })
+
+        import hermes_lcm.engine as engine_module
+
+        def mock_summary(**kwargs):
+            if kwargs["depth"] == 0:
+                return "Leaf summary.\nExpand for details about: oldest raw chunk", 1
+            return "Condensed summary.\nExpand for details about: d0 summaries", 1
+
+        monkeypatch.setattr(engine_module, "summarize_with_escalation", mock_summary)
+
+        engine.compress(messages, current_tokens=900)
+
+        depth1 = engine._dag.get_session_nodes("test-session", depth=1)
+        assert len(depth1) == 1
+        assert engine.get_status()["condensation_suppressed_reason"] == ""
+
     def test_cache_friendly_gating_allows_condensation_when_debt_reaches_two_groups(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
@@ -6468,6 +6520,94 @@ class TestDeferredMaintenanceDebt:
         tool_status = json.loads(engine.handle_tool_call("lcm_status", {}))
         assert tool_status["lifecycle"]["debt_kind"] == "raw_backlog"
         assert tool_status["config"]["deferred_maintenance_enabled"] is True
+        assert tool_status["config"]["critical_budget_pressure_ratio"] == 0.0
+
+    def test_critical_budget_pressure_drains_under_threshold_deferred_debt(self, engine, monkeypatch):
+        engine._config.leaf_chunk_tokens = 10_000
+        engine._config.fresh_tail_count = 1
+        engine._config.deferred_maintenance_enabled = True
+        engine._config.critical_budget_pressure_ratio = 0.90
+        engine.on_session_start("critical-debt-session", platform="cli", context_length=100)
+        engine._lifecycle.record_debt(engine._conversation_id, kind="raw_backlog", size_estimate=500)
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "small raw backlog"},
+            {"role": "assistant", "content": "small raw answer"},
+            {"role": "user", "content": "fresh tail"},
+        ]
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", lambda **kwargs: ("critical debt summary", 1))
+        monkeypatch.setattr(
+            engine,
+            "_assemble_context",
+            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+        )
+
+        compressed = engine.compress(messages, current_tokens=90)
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+
+        assert state is not None
+        assert state.debt_kind is None
+        assert state.debt_size_estimate == 0
+        assert len(engine._dag.get_session_nodes("critical-debt-session", depth=0)) == 1
+        assert compressed == [messages[0], messages[-1]]
+
+    def test_critical_budget_pressure_continues_dynamic_catchup_after_first_pass(self, engine, monkeypatch):
+        engine._config.leaf_chunk_tokens = 50
+        engine._config.dynamic_leaf_chunk_enabled = True
+        engine._config.dynamic_leaf_chunk_max = 50
+        engine._config.fresh_tail_count = 1
+        engine._config.deferred_maintenance_enabled = True
+        engine._config.deferred_maintenance_max_passes = 4
+        engine._config.critical_budget_pressure_ratio = 0.90
+        engine.on_session_start("critical-dynamic-debt-session", platform="cli", context_length=100)
+        engine._lifecycle.record_debt(engine._conversation_id, kind="raw_backlog", size_estimate=500)
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "first " + ("chunk " * 20)},
+            {"role": "assistant", "content": "second " + ("chunk " * 20)},
+            {"role": "user", "content": "third " + ("chunk " * 20)},
+            {"role": "assistant", "content": "fresh tail"},
+        ]
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", lambda **kwargs: ("critical dynamic summary", 1))
+        monkeypatch.setattr(
+            engine,
+            "_assemble_context",
+            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+        )
+
+        engine.compress(messages, current_tokens=90)
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+
+        assert len(engine._dag.get_session_nodes("critical-dynamic-debt-session", depth=0)) >= 2
+        assert state is not None
+        assert state.debt_kind is None
+        assert state.debt_size_estimate == 0
+
+    def test_critical_budget_pressure_needs_context_telemetry_for_under_threshold_debt(self, engine):
+        engine._config.leaf_chunk_tokens = 10_000
+        engine._config.fresh_tail_count = 1
+        engine._config.deferred_maintenance_enabled = True
+        engine._config.critical_budget_pressure_ratio = 0.90
+        engine.on_session_start("missing-telemetry-debt-session", platform="cli", context_length=0)
+        engine._lifecycle.record_debt(engine._conversation_id, kind="raw_backlog", size_estimate=500)
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "small raw backlog"},
+            {"role": "assistant", "content": "small raw answer"},
+            {"role": "user", "content": "fresh tail"},
+        ]
+
+        assert engine._should_run_deferred_maintenance(messages, observed_tokens=90) is False
+        engine._refresh_raw_backlog_debt(messages, observed_tokens=90)
+        state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+        assert state is not None
+        assert state.debt_kind is None
+        assert state.debt_size_estimate == 0
 
 
 class TestUnlimitedCondensationDepth:

--- a/tools.py
+++ b/tools.py
@@ -1480,6 +1480,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "cache_friendly_min_debt_groups": engine._config.cache_friendly_min_debt_groups,
             "deferred_maintenance_enabled": engine._config.deferred_maintenance_enabled,
             "deferred_maintenance_max_passes": engine._config.deferred_maintenance_max_passes,
+            "critical_budget_pressure_ratio": engine._config.critical_budget_pressure_ratio,
             "context_threshold": engine._config.context_threshold,
             "max_depth": engine._config.incremental_max_depth,
             "condensation_fanin": engine._config.condensation_fanin,


### PR DESCRIPTION
## Summary

Implements Stephen's Option C decision from #142: LCM stays cache-friendly, not fully cache-aware, and gets only a narrow critical-pressure escape hatch.

The new `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` setting is disabled by default. When configured, it can bypass existing polite gates for bounded deferred maintenance catch-up and cache-friendly follow-on condensation once prompt pressure reaches the configured ratio.

## Why

Current cache counters are retrospective status data. They do not tell the plugin whether the next prompt mutation will break a hot provider cache, so provider TTL heuristics and provider-family detection do not belong in `hermes-lcm` yet.

## Validation

- [x] Focused validation: deferred maintenance and cache-friendly condensation tests -> `7 passed`
- [x] Focused audit: Codex CLI read-only diff review against Stephen's decision -> no blockers before PR
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `505 passed`
  - [x] `pytest -q` -> `551 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`

## Notes

This intentionally does not add cache-touch tracking, cache-break tracking, TTL delays, provider/model heuristics, or provider-family detection. The README documents that full cache-aware deferred compaction should wait until Hermes core exposes reliable cache state.

Codex flagged that the critical-pressure bypass also needs to apply after each dynamic leaf pass. The current head mirrors that bypass in the post-pass remainder check and adds regression coverage.

Refs #142
