### PR TITLE
ci: update workflow runtimes and resource checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,12 @@
 - [ ] Default validation:
   - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
   - [ ] `pytest -q`
+  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
   - [ ] `python -m compileall -q .`
   - [ ] `python -m py_compile scripts/import_lossless_claw.py`
   - [ ] `bash -n scripts/install.sh scripts/update.sh`
   - [ ] `git diff --check`
+- [ ] Workflow validation, if workflows changed: `actionlint`
 
 ## Notes
 -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,26 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Lint GitHub Actions workflows
+        run: "$(go env GOPATH)/bin/actionlint"
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -21,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install pytest
+      - name: Install test dependencies
         run: pip install pytest
 
       - name: Stub hermes-agent ABC
@@ -53,5 +67,14 @@ jobs:
                   return {}
           STUB
 
-      - name: Run tests
-        run: python -m pytest tests/ -v
+      - name: Run pytest under low file descriptor limit
+        run: |
+          ulimit -n 1024
+          python -m pytest tests/ -q
+
+      - name: Run static validation
+        run: |
+          python -m compileall -q .
+          python -m py_compile scripts/import_lossless_claw.py
+          bash -n scripts/install.sh scripts/update.sh
+          git diff --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
 
       - name: Lint GitHub Actions workflows
-        run: "$(go env GOPATH)/bin/actionlint"
+        run: |
+          "$(go env GOPATH)"/bin/actionlint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body: ${{ steps.changelog.outputs.body }}
           generate_release_notes: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,12 @@ PR bodies should use this template. It is mirrored in `.github/PULL_REQUEST_TEMP
 - [ ] Default validation:
   - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
   - [ ] `pytest -q`
+  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
   - [ ] `python -m compileall -q .`
   - [ ] `python -m py_compile scripts/import_lossless_claw.py`
   - [ ] `bash -n scripts/install.sh scripts/update.sh`
   - [ ] `git diff --check`
+- [ ] Workflow validation, if workflows changed: `actionlint`
 
 ## Notes
 -
@@ -104,10 +106,17 @@ Default validation for code changes:
 ```bash
 pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
 pytest -q
+bash -lc 'ulimit -n 1024 && pytest -q'
 python -m compileall -q .
 python -m py_compile scripts/import_lossless_claw.py
 bash -n scripts/install.sh scripts/update.sh
 git diff --check
+```
+
+Workflow changes should also run:
+
+```bash
+actionlint
 ```
 
 If your PR only touches a narrow surface area, include the focused command too. Example:

--- a/dag.py
+++ b/dag.py
@@ -602,6 +602,13 @@ class SummaryDAG:
         )
 
     def close(self):
-        if self._conn:
-            self._conn.close()
+        conn = getattr(self, "_conn", None)
+        if conn:
+            conn.close()
             self._conn = None
+
+    def __del__(self):  # pragma: no cover - defensive resource cleanup
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/engine.py
+++ b/engine.py
@@ -3018,3 +3018,4 @@ class LCMEngine(ContextEngine):
     def shutdown(self):
         self._store.close()
         self._dag.close()
+        self._lifecycle.close()

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -57,9 +57,16 @@ class LifecycleStateStore:
         self._conn.commit()
 
     def close(self) -> None:
-        if self._conn is not None:
-            self._conn.close()
+        conn = getattr(self, "_conn", None)
+        if conn is not None:
+            conn.close()
             self._conn = None
+
+    def __del__(self) -> None:  # pragma: no cover - defensive resource cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def row_count(self) -> int:
         row = self._conn.execute("SELECT COUNT(*) AS count FROM lcm_lifecycle_state").fetchone()

--- a/store.py
+++ b/store.py
@@ -972,6 +972,13 @@ class MessageStore:
     # -- Lifecycle ----------------------------------------------------------
 
     def close(self):
-        if self._conn:
-            self._conn.close()
+        conn = getattr(self, "_conn", None)
+        if conn:
+            conn.close()
             self._conn = None
+
+    def __del__(self):  # pragma: no cover - defensive resource cleanup
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -30,7 +30,33 @@ def engine(tmp_path):
     e._session_id = "test-session"
     e.context_length = 200000
     e.threshold_tokens = int(200000 * config.context_threshold)
-    return e
+    try:
+        yield e
+    finally:
+        e.shutdown()
+
+
+def test_shutdown_closes_lifecycle_store(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "shutdown-lifecycle.db"))
+    engine = LCMEngine(config=config)
+
+    engine.shutdown()
+
+    assert engine._lifecycle._conn is None
+
+
+def test_engine_deallocation_releases_sqlite_fds_without_gc(tmp_path):
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.exists():
+        pytest.skip("fd count is Linux-specific")
+    before = len(list(fd_dir.iterdir()))
+
+    for idx in range(5):
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / f"engine-{idx}.db")))
+        del engine
+
+    after = len(list(fd_dir.iterdir()))
+    assert after <= before + 2
 
 
 def test_lcm_tool_status_reports_lifecycle_fragmentation_summary(engine, tmp_path):


### PR DESCRIPTION
## Summary
- Update pinned workflow actions to current Node 24 compatible releases.
- Add CI coverage for Python 3.14, workflow linting, low file descriptor pytest, and static validation.
- Fix SQLite handle cleanup so LCM engines release store, DAG, and lifecycle connections deterministically.
- Add regressions for lifecycle shutdown and short-lived engine FD cleanup.

## Why
- hermes-lcm has grown enough that pytest alone was no longer enough coverage for CI and resource hygiene.
- Local full-suite runs reproduced file descriptor exhaustion at nofile 1024 before the cleanup fix.
- README supports Python 3.11+, and local Hermes is already on Python 3.14.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py::test_engine_deallocation_releases_sqlite_fds_without_gc tests/test_lcm_engine.py::test_shutdown_closes_lifecycle_store -q` -> `2 passed`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `521 passed`
  - [x] `python -m pytest -q` -> `568 passed`
  - [x] `bash -lc 'ulimit -n 1024 && python -m pytest -q'` -> `568 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Workflow validation, if workflows changed: CI `workflow-lint` passed on `cc828a2`

## Notes
- Rebased onto current `origin/main` at `43624cf` and force-pushed `ci/node24-actions` with lease from `246424a` to `cc828a2`.
- Local `actionlint` is not installed in this environment. The PR CI workflow installs and runs `actionlint`; `workflow-lint` passed on the rebased head.
- YAML parse smoke passed before this rebase for `plugin.yaml`, workflow files, and issue template YAML.
- Static scan of added diff lines found no hardcoded secret, shell injection, eval/exec, pickle load, or obvious SQL formatting risks.

Refs: none
