### PR TITLE
fix: pre-clean active tail before capped selection

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3068,7 +3068,11 @@ class LCMEngine(ContextEngine):
             used = count_message_tokens(leading_msg)
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
-            for msg in reversed(tail_messages):
+            tail_for_selection = self._sanitize_active_context_messages(
+                tail_messages,
+                insert_missing_tool_stubs=False,
+            )
+            for msg in reversed(tail_for_selection):
                 msg_tokens = count_message_tokens(msg)
                 if used + tail_token_total + msg_tokens > assembly_cap:
                     break

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7841,6 +7841,48 @@ class TestAssemblyToolPairGuardrail:
         assert {"role": "assistant", "content": visible_content} in result
         self._assert_provider_tool_sequence_valid(result)
 
+    def test_assembly_cap_ignores_dropped_internal_assistant_turns_during_tail_selection(self, tmp_path, monkeypatch):
+        import importlib
+
+        lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_message_tokens",
+            lambda msg: len(str(msg.get("content", ""))),
+        )
+        monkeypatch.setattr(
+            lcm_engine_module,
+            "count_messages_tokens",
+            lambda messages: sum(len(str(msg.get("content", ""))) for msg in messages),
+        )
+
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_cap_precleanup_tail.db"),
+            max_assembly_tokens=50,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "cap-precleanup-test"
+        instance.compression_count = 1
+        instance.context_length = 200000
+
+        sys_msg = {"role": "system", "content": "s" * 5}
+        user_msg = {"role": "user", "content": "VISIBLE_USER_OBJECTIVE"}
+        noisy_assistant = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "x" * 500}],
+        }
+
+        result = instance._assemble_context(
+            sys_msg,
+            [user_msg, noisy_assistant],
+            assembly_cap_override=50,
+        )
+
+        assert user_msg in result
+        assert noisy_assistant not in result
+        self._assert_provider_tool_sequence_valid(result)
+
     def test_assemble_cleanup_preserves_valid_tool_call_adjacency(self, tmp_path):
         instance = self._make_engine(tmp_path, "lcm_tool_call_cleanup_preserve.db")
         sys_msg = {"role": "system", "content": "sys"}


### PR DESCRIPTION
## Summary

This follows up on the remaining PR #149 Codex thread about capped tail selection.

When an assembly cap is active, `_assemble_context` was counting the newest tail messages before active-context cleanup ran. A large thinking-only assistant turn could therefore stop reverse tail selection before an older visible user turn was considered, even though cleanup would later drop that assistant turn entirely.

This change runs the active-context cleanup on the tail before capped selection, without inserting missing tool-result stubs at that pre-selection stage. The final assembled context still goes through the normal tool-pair guardrail before being returned.

## Validation

`python -m pytest tests/test_lcm_engine.py::TestAssemblyToolPairGuardrail::test_assembly_cap_ignores_dropped_internal_assistant_turns_during_tail_selection tests/test_lcm_engine.py::TestAssemblyToolPairGuardrail::test_assemble_drops_structured_blank_and_thinking_only_assistant_messages tests/test_lcm_engine.py::TestAssemblyToolPairGuardrail::test_assemble_cleanup_preserves_valid_tool_call_adjacency tests/test_lcm_engine.py::TestAssemblyToolPairGuardrail::test_assemble_cleanup_repairs_tool_sequence_after_dropping_blank_turn -q`

`python -m pytest -q`

Refs #149
