### PR TITLE
Harden LCM ingest against inline media/base64 payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ compacted.
 - **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
 - **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
 - **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
+- **Storage-boundary payload guard** - media-ish `data:*;base64` and long base64-looking strings are externalized before LCM writes them to SQLite
 - **Diagnostics** - `lcm_status`, `lcm_doctor`, and optional `/lcm` slash commands
 
 ## LCM vs built-in compression
@@ -398,10 +399,33 @@ The counter resets on engine restart.
 
 ### Large tool-output handling
 
-Externalization is opt-in. When enabled, oversized tool results are written to
-plugin-managed JSON files and referenced from summaries. They remain inspectable
-later through `lcm_describe(externalized_ref=...)` and
-`lcm_expand(externalized_ref=...)`.
+Externalization for ordinary large tool output is opt-in. When enabled,
+oversized tool results are written to plugin-managed JSON files and referenced
+from summaries. They remain inspectable later through
+`lcm_describe(externalized_ref=...)` and `lcm_expand(externalized_ref=...)`.
+
+The storage-boundary payload guard is separate from that opt-in. LCM always
+scans messages at the store boundary before writing `messages.content` or
+`messages.tool_calls` to SQLite. Inline `data:*;base64,...` payloads and
+conservative long base64-looking runs are replaced with compact placeholders and
+written to the same plugin-managed externalized-payload directory. This is a
+safer default for media-ish payloads: LCM still preserves lossless recovery via
+the placeholder `ref` and `lcm_expand(externalized_ref=...)`, but it does not
+duplicate those payload bytes into `lcm.db`, FTS shadow tables, WAL files, or
+ordinary SQLite backups. If externalization fails, LCM logs a warning and leaves
+the original text inline rather than dropping data.
+
+`lcm_doctor` reports SQLite `journal_mode`, `quick_check`, database/WAL sizes,
+the largest content/tool-call rows, suspicious inline `data:*;base64` rows,
+suspicious long base64-looking rows, and aggregate externalized-payload stats.
+Doctor output is metadata-only for these scans; it intentionally does not print
+raw payload previews.
+
+This guard is scoped to LCM's own `lcm.db` write boundary. It does not prevent
+Hermes core, or any other host layer, from writing inline payloads to Hermes
+`state.db`; that is upstream/outside LCM scope. It also does not rewrite
+historical rows already present in `lcm.db`. Cleaning older suspicious rows
+requires a separate backup-first cleanup or migration flow.
 
 Transcript GC is separate and also opt-in. It only rewrites already-externalized,
 already-summarized tool-role rows to compact placeholders. It keeps the same

--- a/command.py
+++ b/command.py
@@ -8,6 +8,7 @@ import sqlite3
 from typing import Any
 
 from .db_bootstrap import external_content_fts_needs_repair, repair_external_content_fts
+from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks
 from .dag import build_nodes_fts_spec
 from .session_patterns import build_session_match_keys, matches_session_pattern
 from .store import build_message_fts_spec
@@ -703,6 +704,40 @@ def _doctor_text(engine) -> str:
 
     db_exists = db_path.exists()
     db_size = db_path.stat().st_size if db_exists else 0
+    wal_path = Path(str(db_path) + "-wal")
+    wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+    try:
+        journal_row = store_conn.execute("PRAGMA journal_mode").fetchone()
+        journal_mode = str(journal_row[0]) if journal_row else "unknown"
+    except Exception as exc:  # pragma: no cover - defensive
+        journal_mode = f"error: {exc}"
+        issues.append("sqlite_journal_mode")
+    try:
+        quick_row = store_conn.execute("PRAGMA quick_check").fetchone()
+        quick_check = str(quick_row[0]) if quick_row else "unknown"
+    except Exception as exc:  # pragma: no cover - defensive
+        quick_check = f"error: {exc}"
+        issues.append("sqlite_quick_check")
+    try:
+        payload_risks = scan_sqlite_payload_risks(store_conn)
+        externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
+    except Exception:  # pragma: no cover - defensive
+        payload_risks = {
+            "largest_content_rows": [],
+            "largest_tool_calls_rows": [],
+            "suspicious_data_uri_content_rows": [],
+            "suspicious_data_uri_tool_calls_rows": [],
+            "suspicious_base64_like_rows": [],
+        }
+        externalized_stats = {
+            "externalized_payload_count": 0,
+            "externalized_payload_bytes": 0,
+            "externalized_payload_chars": 0,
+            "externalized_payload_dir": "",
+            "latest_externalized_payload_path": "",
+            "latest_externalized_payload_mtime": 0,
+        }
+        issues.append("payload_storage")
     clean_scan = _scan_clean_candidates(engine)
 
     debt_rows = []
@@ -825,6 +860,9 @@ def _doctor_text(engine) -> str:
         f"database_path: {db_path}",
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
+        f"wal_size: {_fmt_size(wal_size)}",
+        f"journal_mode: {journal_mode}",
+        f"quick_check: {quick_check}",
         f"sqlite_integrity: {integrity}",
         f"messages_total: {total_messages}",
         f"message_sessions_total: {total_message_sessions}",
@@ -834,6 +872,16 @@ def _doctor_text(engine) -> str:
         f"messages_fts_rows: {store_fts_count}",
         f"nodes_fts: {node_fts}",
         f"nodes_fts_rows: {node_fts_count}",
+        f"largest_content_rows: {payload_risks['largest_content_rows']}",
+        f"largest_tool_calls_rows: {payload_risks['largest_tool_calls_rows']}",
+        f"suspicious_data_uri_content_rows: {payload_risks['suspicious_data_uri_content_rows']}",
+        f"suspicious_data_uri_tool_calls_rows: {payload_risks['suspicious_data_uri_tool_calls_rows']}",
+        f"suspicious_base64_like_rows: {payload_risks['suspicious_base64_like_rows']}",
+        f"externalized_payload_dir: {externalized_stats['externalized_payload_dir']}",
+        f"externalized_payload_count: {externalized_stats['externalized_payload_count']}",
+        f"externalized_payload_bytes: {externalized_stats['externalized_payload_bytes']}",
+        f"externalized_payload_chars: {externalized_stats['externalized_payload_chars']}",
+        f"latest_externalized_payload_path: {externalized_stats['latest_externalized_payload_path'] or '(none)'}",
     ]
     if issues:
         lines.append(f"issues: {', '.join(issues)}")

--- a/engine.py
+++ b/engine.py
@@ -35,7 +35,12 @@ from .extraction import (
     sanitize_pre_compaction_content,
     sanitize_pre_compaction_tool_arguments,
 )
-from .ingest_protection import protect_message_for_ingest, protect_messages_for_ingest
+from .ingest_protection import (
+    _json_has_duplicate_object_keys,
+    protect_inline_payloads_in_text,
+    protect_messages_for_ingest,
+    restore_ingest_payload_placeholders,
+)
 from .schemas import (
     LCM_DESCRIBE,
     LCM_DOCTOR,
@@ -265,7 +270,7 @@ class LCMEngine(ContextEngine):
         else:
             db_path = Path.home() / ".hermes" / "lcm.db"
 
-        self._store = MessageStore(db_path)
+        self._store = MessageStore(db_path, ingest_protection_config=self._config, hermes_home=hermes_home)
         self._dag = SummaryDAG(db_path)
         self._lifecycle = LifecycleStateStore(db_path)
 
@@ -1968,36 +1973,70 @@ class LCMEngine(ContextEngine):
         )
 
     @staticmethod
+    def _canonicalize_tool_call_identity_value(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: LCMEngine._canonicalize_tool_call_identity_value(val)
+                for key, val in value.items()
+            }
+        if isinstance(value, list):
+            return [LCMEngine._canonicalize_tool_call_identity_value(item) for item in value]
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped and stripped[0] in "[{":
+                if _json_has_duplicate_object_keys(value):
+                    return value
+                try:
+                    parsed = json.loads(value)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    return value
+                if isinstance(parsed, (dict, list)):
+                    canonical = LCMEngine._canonicalize_tool_call_identity_value(parsed)
+                    return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            return value
+        return value
+
+    @staticmethod
     def _stable_tool_calls_identity(tool_calls: Any) -> str:
         if not tool_calls:
             return ""
         try:
-            return json.dumps(tool_calls, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            canonical = LCMEngine._canonicalize_tool_call_identity_value(tool_calls)
+            return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
         except (TypeError, ValueError):
             return str(tool_calls)
 
-    def _message_replay_identity(self, msg: Dict[str, Any]) -> tuple[str, str, str, str]:
+    def _message_replay_identity(self, msg: Dict[str, Any], *, stored_row: bool = False) -> tuple[str, str, str, str]:
         content = normalize_content_value(msg.get("content")) or ""
-        # Durable rows may contain ingest-time externalization placeholders.
-        # Replay matching should not depend on the current write-time
-        # externalization flag: a restart with the knob toggled must still match
-        # raw live messages against already-externalized rows, and vice versa.
-        # Hydrating the stored placeholder for identity comparison is read-only
-        # and avoids creating payload files while reconciling.
-        ref = extract_externalized_ref(content)
-        if ref:
-            payload = load_externalized_payload(
-                ref,
+        tool_calls_identity = self._stable_tool_calls_identity(msg.get("tool_calls"))
+        if stored_row:
+            session_id = str(msg.get("session_id") or self._session_id or "")
+            content = restore_ingest_payload_placeholders(
+                content,
                 config=self._config,
                 hermes_home=self._hermes_home,
+                session_id=session_id,
             )
-            if payload is not None and isinstance(payload.get("content"), str):
-                content = payload["content"]
+            tool_calls_identity = restore_ingest_payload_placeholders(
+                tool_calls_identity,
+                config=self._config,
+                hermes_home=self._hermes_home,
+                session_id=session_id,
+            )
+            ref = extract_externalized_ref(content)
+            if ref:
+                payload = load_externalized_payload(
+                    ref,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                if payload is not None and isinstance(payload.get("content"), str):
+                    content = payload["content"]
         return (
             str(msg.get("role") or "unknown"),
             content,
             str(msg.get("tool_call_id") or ""),
-            self._stable_tool_calls_identity(msg.get("tool_calls")),
+            tool_calls_identity,
         )
 
     @staticmethod
@@ -2238,7 +2277,7 @@ class LCMEngine(ContextEngine):
         if not stored_rows:
             return 0
         stored_tail = [
-            self._message_replay_identity(row)
+            self._message_replay_identity(row, stored_row=True)
             for row in stored_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
         ]
@@ -2280,7 +2319,7 @@ class LCMEngine(ContextEngine):
             self._session_id,
             limit=tail_limit,
         )
-        stored_head = [self._message_replay_identity(row) for row in stored_head_rows]
+        stored_head = [self._message_replay_identity(row, stored_row=True) for row in stored_head_rows]
         # Stale-snapshot proof uses the raw durable prefix.  Ignore-message
         # filters may suppress noisy rows for tail reconciliation, but filtered
         # history alone must not create replay evidence for skipping a batch.
@@ -2406,21 +2445,13 @@ class LCMEngine(ContextEngine):
         ids: list[int] = []
         store_idx = 0
         for msg in messages:
-            protected_msg = protect_message_for_ingest(
-                msg,
-                session_id=self._session_id,
-                config=self._config,
-                hermes_home=self._hermes_home,
-            )
-            wanted_identity = self._message_replay_identity(msg)
-            wanted_cleanup_identity = self._active_cleanup_replay_identity(wanted_identity)
-            role = protected_msg.get("role", "")
-            content = normalize_content_value(protected_msg.get("content")) or ""
+            message_identity = self._message_replay_identity(msg)
+            wanted_cleanup_identity = self._active_cleanup_replay_identity(message_identity)
             probe_idx = store_idx
             while probe_idx < len(candidates):
                 stored = candidates[probe_idx]
-                stored_identity = self._message_replay_identity(stored)
-                if stored_identity == wanted_identity:
+                stored_identity = self._message_replay_identity(stored, stored_row=True)
+                if stored_identity == message_identity:
                     ids.append(stored["store_id"])
                     store_idx = probe_idx + 1
                     break
@@ -2428,10 +2459,6 @@ class LCMEngine(ContextEngine):
                     wanted_cleanup_identity is not None
                     and self._active_cleanup_replay_identity(stored_identity) == wanted_cleanup_identity
                 ):
-                    ids.append(stored["store_id"])
-                    store_idx = probe_idx + 1
-                    break
-                if stored.get("role", "") == role and (stored.get("content") or "") == content:
                     ids.append(stored["store_id"])
                     store_idx = probe_idx + 1
                     break
@@ -2520,7 +2547,6 @@ class LCMEngine(ContextEngine):
     def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Serialize messages into labeled text for the summarizer."""
         parts = []
-        assistant_tool_ids = _assistant_tool_call_ids(messages)
         matched_tool_ids = _matched_tool_call_ids(messages)
         for msg in messages:
             role = msg.get("role", "unknown")
@@ -2979,9 +3005,16 @@ class LCMEngine(ContextEngine):
         content = text_content_for_pattern_matching(message.get("content")) or ""
         return content if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX) else ""
 
-    @staticmethod
-    def _build_preserved_objective_summary_part(message: Dict[str, Any]) -> str:
+    def _build_preserved_objective_summary_part(self, message: Dict[str, Any]) -> str:
         content = text_content_for_pattern_matching(message.get("content")) or ""
+        content = protect_inline_payloads_in_text(
+            content,
+            role=str(message.get("role") or "user"),
+            session_id=self._session_id,
+            field_path="preserved_objective.content",
+            config=self._config,
+            hermes_home=self._hermes_home,
+        )
         return f"{_PRESERVED_OBJECTIVE_CONTEXT_PREFIX}\n{content}"
 
     def _latest_user_context_anchor(

--- a/engine.py
+++ b/engine.py
@@ -37,6 +37,7 @@ from .extraction import (
 )
 from .ingest_protection import (
     _json_has_duplicate_object_keys,
+    extract_ingest_externalized_refs,
     protect_inline_payloads_in_text,
     protect_messages_for_ingest,
     restore_ingest_payload_placeholders,
@@ -2025,15 +2026,50 @@ class LCMEngine(ContextEngine):
             )
         return value
 
+    def _restore_ingest_payload_placeholders_in_content_identity(self, content: str, *, session_id: str) -> str:
+        if not content:
+            return content
+        try:
+            decoded = json.loads(content)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return restore_ingest_payload_placeholders(
+                content,
+                config=self._config,
+                hermes_home=self._hermes_home,
+                session_id=session_id,
+            )
+        restore_as_structured = False
+        if isinstance(decoded, (dict, list)) and normalize_content_value(decoded) == content:
+            for ref in extract_ingest_externalized_refs(content):
+                payload = load_externalized_payload(
+                    ref,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                payload_session_id = (payload or {}).get("session_id") or ""
+                if session_id and payload_session_id and payload_session_id != session_id:
+                    continue
+                field_path = str((payload or {}).get("field_path") or "")
+                if field_path and field_path != "content":
+                    restore_as_structured = True
+                    break
+        if restore_as_structured:
+            restored = self._restore_ingest_payload_placeholders_in_value(decoded, session_id=session_id)
+            return normalize_content_value(restored) or ""
+        return restore_ingest_payload_placeholders(
+            content,
+            config=self._config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
+
     def _message_replay_identity(self, msg: Dict[str, Any], *, stored_row: bool = False) -> tuple[str, str, str, str]:
         content = normalize_content_value(msg.get("content")) or ""
         tool_calls = msg.get("tool_calls")
         if stored_row:
             session_id = str(msg.get("session_id") or self._session_id or "")
-            content = restore_ingest_payload_placeholders(
+            content = self._restore_ingest_payload_placeholders_in_content_identity(
                 content,
-                config=self._config,
-                hermes_home=self._hermes_home,
                 session_id=session_id,
             )
             tool_calls = self._restore_ingest_payload_placeholders_in_value(tool_calls, session_id=session_id)

--- a/engine.py
+++ b/engine.py
@@ -2006,9 +2006,28 @@ class LCMEngine(ContextEngine):
         except (TypeError, ValueError):
             return str(tool_calls)
 
+    def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:
+        if isinstance(value, dict):
+            return {
+                self._restore_ingest_payload_placeholders_in_value(key, session_id=session_id)
+                if isinstance(key, str)
+                else key: self._restore_ingest_payload_placeholders_in_value(val, session_id=session_id)
+                for key, val in value.items()
+            }
+        if isinstance(value, list):
+            return [self._restore_ingest_payload_placeholders_in_value(item, session_id=session_id) for item in value]
+        if isinstance(value, str):
+            return restore_ingest_payload_placeholders(
+                value,
+                config=self._config,
+                hermes_home=self._hermes_home,
+                session_id=session_id,
+            )
+        return value
+
     def _message_replay_identity(self, msg: Dict[str, Any], *, stored_row: bool = False) -> tuple[str, str, str, str]:
         content = normalize_content_value(msg.get("content")) or ""
-        tool_calls_identity = self._stable_tool_calls_identity(msg.get("tool_calls"))
+        tool_calls = msg.get("tool_calls")
         if stored_row:
             session_id = str(msg.get("session_id") or self._session_id or "")
             content = restore_ingest_payload_placeholders(
@@ -2017,12 +2036,7 @@ class LCMEngine(ContextEngine):
                 hermes_home=self._hermes_home,
                 session_id=session_id,
             )
-            tool_calls_identity = restore_ingest_payload_placeholders(
-                tool_calls_identity,
-                config=self._config,
-                hermes_home=self._hermes_home,
-                session_id=session_id,
-            )
+            tool_calls = self._restore_ingest_payload_placeholders_in_value(tool_calls, session_id=session_id)
             ref = extract_externalized_ref(content)
             if ref:
                 payload = load_externalized_payload(
@@ -2032,6 +2046,7 @@ class LCMEngine(ContextEngine):
                 )
                 if payload is not None and isinstance(payload.get("content"), str):
                     content = payload["content"]
+        tool_calls_identity = self._stable_tool_calls_identity(tool_calls)
         return (
             str(msg.get("role") or "unknown"),
             content,

--- a/externalize.py
+++ b/externalize.py
@@ -11,13 +11,24 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
 from typing import Any, Dict
 
 DEFAULT_LARGE_OUTPUT_DIRNAME = "lcm-large-outputs"
-_EXTERNALIZED_REF_RE = re.compile(r"ref=([^;\]\s]+)")
+_EXTERNALIZED_REF_RE = re.compile(
+    r"\[(?:Externalized|GC'd externalized) (?:tool output|payload):.*?;\s*ref=([^;\]\s]+)\]"
+)
+
+
+def _placeholder_metadata(value: Any) -> str:
+    text = str(value or "?")
+    safe = re.sub(r"[^A-Za-z0-9_.:/-]+", "-", text).strip("-")
+    return (safe or "?")[:120]
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,7 +54,23 @@ def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool)
         path = base / DEFAULT_LARGE_OUTPUT_DIRNAME
     if create:
         path.mkdir(parents=True, exist_ok=True)
+        try:
+            path.chmod(0o700)
+        except OSError as exc:
+            logger.warning("Could not restrict LCM externalized payload directory permissions for %s: %s", path, exc)
     return path
+
+
+def _write_externalized_payload(path: Path, payload: Dict[str, Any]) -> None:
+    data = json.dumps(payload, ensure_ascii=False, indent=2)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            fd = -1
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 def resolve_large_output_storage_dir(config, hermes_home: str = "") -> Path:
@@ -57,6 +84,7 @@ def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]
         "tool_call_id": payload.get("tool_call_id", ""),
         "role": payload.get("role", ""),
         "session_id": payload.get("session_id", ""),
+        "field_path": payload.get("field_path", ""),
         "content_chars": payload.get("content_chars", len(payload.get("content", ""))),
         "content_bytes": payload.get("content_bytes", len((payload.get("content", "") or "").encode("utf-8"))),
         "created_at": payload.get("created_at"),
@@ -72,7 +100,7 @@ def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
             f"ref={summary.get('ref', '')}]"
         )
     return (
-        f"[Externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
+        f"[Externalized tool output: tool_call_id={_placeholder_metadata(summary.get('tool_call_id') or '?')}; "
         f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
     )
 
@@ -85,7 +113,7 @@ def build_transcript_gc_placeholder(summary: Dict[str, Any]) -> str:
             f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
         )
     return (
-        f"[GC'd externalized tool output: tool_call_id={summary.get('tool_call_id') or '?'}; "
+        f"[GC'd externalized tool output: tool_call_id={_placeholder_metadata(summary.get('tool_call_id') or '?')}; "
         f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
     )
 
@@ -100,6 +128,16 @@ def extract_externalized_ref(text: str) -> str | None:
     if not ref or Path(ref).name != ref:
         return None
     return ref
+
+
+def is_externalized_placeholder(text: str) -> bool:
+    """Return true for a compact legacy externalized payload/tool marker."""
+    if not isinstance(text, str):
+        return False
+    stripped = text.strip()
+    if not stripped or len(stripped) > 512:
+        return False
+    return bool(_EXTERNALIZED_REF_RE.fullmatch(stripped))
 
 
 def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dict[str, Any] | None:
@@ -147,7 +185,7 @@ def reassign_externalized_payloads(
         payload["session_id"] = new_session_id
         tmp_path = path.with_name(f"{path.name}.tmp")
         try:
-            tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            _write_externalized_payload(tmp_path, payload)
             tmp_path.replace(path)
         except OSError as exc:
             logger.warning("Externalized payload session reassignment skipped for %s: %s", path.name, exc)
@@ -202,6 +240,59 @@ def find_externalized_payload_for_message(
         if fallback_match is None:
             fallback_match = summary
     return fallback_match
+
+
+def externalize_ingest_payload(
+    content: str,
+    *,
+    role: str = "",
+    session_id: str = "",
+    field_path: str = "",
+    config,
+    hermes_home: str = "",
+    kind: str = "ingest_payload",
+) -> Dict[str, Any] | None:
+    if not content:
+        return None
+    try:
+        storage_dir = resolve_large_output_storage_dir(config, hermes_home=hermes_home)
+    except OSError as exc:
+        logger.warning("LCM ingest payload externalization skipped (non-blocking): %s", exc)
+        return None
+
+    digest_prefix = _content_digest_prefix(content)
+    timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+    unique_suffix = f"{time.time_ns():x}"
+    field_stub = re.sub(r"[^A-Za-z0-9_.-]+", "-", field_path or "payload")[:48]
+    filename = f"{timestamp}_{kind}_{field_stub}_{digest_prefix}_{unique_suffix}.json"
+    path = storage_dir / filename
+    payload = {
+        "kind": kind,
+        "role": role,
+        "session_id": session_id,
+        "field_path": field_path,
+        "content": content,
+        "content_chars": len(content),
+        "content_bytes": len(content.encode("utf-8")),
+        "created_at": time.time(),
+    }
+    try:
+        _write_externalized_payload(path, payload)
+    except OSError as exc:
+        logger.warning("LCM ingest payload externalization skipped (non-blocking): %s", exc)
+        return None
+
+    summary = _externalized_summary(path, payload)
+    placeholder = (
+        f"[Externalized LCM ingest payload: kind={summary.get('kind') or kind}; "
+        f"field={_placeholder_metadata(summary.get('field_path') or '?')}; chars={summary.get('content_chars', 0)}; "
+        f"bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
+    )
+    return {
+        "placeholder": placeholder,
+        "path": path,
+        "payload": payload,
+    }
 
 
 def maybe_externalize_tool_output(
@@ -294,7 +385,7 @@ def maybe_externalize_payload(
         "created_at": time.time(),
     }
     try:
-        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        _write_externalized_payload(path, payload)
     except OSError as exc:
         logger.warning("Large payload externalization skipped (non-blocking): %s", exc)
         return None

--- a/externalize.py
+++ b/externalize.py
@@ -92,10 +92,11 @@ def _externalized_summary(path: Path, payload: Dict[str, Any]) -> Dict[str, Any]
 
 
 def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
-    kind = summary.get("kind", "tool_result") or "tool_result"
+    kind = _placeholder_metadata(summary.get("kind", "tool_result") or "tool_result")
     if kind != "tool_result":
+        role = _placeholder_metadata(summary.get("role") or "?")
         return (
-            f"[Externalized payload: kind={kind}; role={summary.get('role') or '?'}; "
+            f"[Externalized payload: kind={kind}; role={role}; "
             f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; "
             f"ref={summary.get('ref', '')}]"
         )
@@ -106,10 +107,11 @@ def _build_externalized_placeholder(summary: Dict[str, Any]) -> str:
 
 
 def build_transcript_gc_placeholder(summary: Dict[str, Any]) -> str:
-    kind = summary.get("kind", "tool_result") or "tool_result"
+    kind = _placeholder_metadata(summary.get("kind", "tool_result") or "tool_result")
     if kind != "tool_result":
+        role = _placeholder_metadata(summary.get("role") or "?")
         return (
-            f"[GC'd externalized payload: kind={kind}; role={summary.get('role') or '?'}; "
+            f"[GC'd externalized payload: kind={kind}; role={role}; "
             f"chars={summary.get('content_chars', 0)}; ref={summary.get('ref', '')}]"
         )
     return (
@@ -263,8 +265,9 @@ def externalize_ingest_payload(
     digest_prefix = _content_digest_prefix(content)
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
     unique_suffix = f"{time.time_ns():x}"
+    kind_stub = _safe_stub(kind, "ingest_payload")
     field_stub = re.sub(r"[^A-Za-z0-9_.-]+", "-", field_path or "payload")[:48]
-    filename = f"{timestamp}_{kind}_{field_stub}_{digest_prefix}_{unique_suffix}.json"
+    filename = f"{timestamp}_{kind_stub}_{field_stub}_{digest_prefix}_{unique_suffix}.json"
     path = storage_dir / filename
     payload = {
         "kind": kind,
@@ -284,7 +287,7 @@ def externalize_ingest_payload(
 
     summary = _externalized_summary(path, payload)
     placeholder = (
-        f"[Externalized LCM ingest payload: kind={summary.get('kind') or kind}; "
+        f"[Externalized LCM ingest payload: kind={_placeholder_metadata(summary.get('kind') or kind)}; "
         f"field={_placeholder_metadata(summary.get('field_path') or '?')}; chars={summary.get('content_chars', 0)}; "
         f"bytes={summary.get('content_bytes', 0)}; ref={summary.get('ref', '')}]"
     )

--- a/extraction.py
+++ b/extraction.py
@@ -6,7 +6,6 @@ daily note files so key decisions survive even if the DAG summary loses nuance.
 
 import json
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -162,7 +161,10 @@ def _sanitize_content_block(content: Any) -> str:
 
 def _sanitize_json_like(value: Any) -> Any:
     if isinstance(value, dict):
-        return {key: _sanitize_json_like(val) for key, val in value.items()}
+        return {
+            _sanitize_string_media(key) if isinstance(key, str) else key: _sanitize_json_like(val)
+            for key, val in value.items()
+        }
     if isinstance(value, list):
         return [_sanitize_json_like(item) for item in value]
     if isinstance(value, str):

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -343,6 +343,18 @@ def _protect_value(
             )
         parsed = _maybe_parse_json_string(value)
         if parsed is not None:
+            canonical = json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+            if canonical != value:
+                raw_protected = _protect_payload_substrings(
+                    value,
+                    role=role,
+                    session_id=session_id,
+                    field_path=field_path,
+                    config=config,
+                    hermes_home=hermes_home,
+                )
+                if raw_protected != value:
+                    return raw_protected
             protected = _protect_value(
                 parsed,
                 role=role,

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -265,6 +265,15 @@ def _json_has_duplicate_object_keys(text: str) -> bool:
     return duplicate
 
 
+def _dict_field_path(parent: str, key: Any) -> str:
+    component = str(key)
+    return f"{parent}.{component}" if parent else component
+
+
+def _payload_key_field_path(parent: str) -> str:
+    return f"{parent}.<key>" if parent else "<key>"
+
+
 def _protect_value(
     value: Any,
     *,
@@ -276,18 +285,31 @@ def _protect_value(
     parse_json_strings: bool = False,
 ) -> Any:
     if isinstance(value, dict):
-        return {
-            key: _protect_value(
+        protected: dict[Any, Any] = {}
+        for key, val in value.items():
+            protected_key = (
+                _protect_payload_substrings(
+                    key,
+                    role=role,
+                    session_id=session_id,
+                    field_path=_payload_key_field_path(field_path),
+                    config=config,
+                    hermes_home=hermes_home,
+                )
+                if isinstance(key, str)
+                else key
+            )
+            child_path_key = "<key>" if protected_key != key else protected_key
+            protected[protected_key] = _protect_value(
                 val,
                 role=role,
                 session_id=session_id,
-                field_path=f"{field_path}.{key}" if field_path else str(key),
+                field_path=_dict_field_path(field_path, child_path_key),
                 config=config,
                 hermes_home=hermes_home,
                 parse_json_strings=parse_json_strings,
             )
-            for key, val in value.items()
-        }
+        return protected
     if isinstance(value, list):
         return [
             _protect_value(

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1,23 +1,31 @@
-"""Ingest-time protection for oversized message payloads.
+"""Storage-boundary protection for payloads that should not live inline in SQLite.
 
-This module prepares copies of messages for durable storage only. It must not
-mutate the active provider transcript: assistant ``tool_calls`` and adjacent tool
-results remain intact in the live message list while SQLite receives compact
-externalized placeholders for supported oversized payload classes.
+Hermes core may hand LCM messages that already contain inline media/base64
+payloads. LCM remains lossless by externalizing those payload strings and
+storing compact placeholders in ``messages.content`` / ``messages.tool_calls``.
+This avoids duplicating large/binary-ish payloads into SQLite rows, FTS shadow
+structures, WAL files, and backups while keeping recovery available through LCM
+externalized-payload tools.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import re
 from typing import Any, Dict, List
 
-from .externalize import maybe_externalize_payload
+from .externalize import (
+    externalize_ingest_payload,
+    extract_externalized_ref,
+    is_externalized_placeholder,
+    load_externalized_payload,
+    maybe_externalize_payload,
+)
 from .message_content import normalize_content_value
 
-_MEDIA_DATA_URI_RE = re.compile(
-    r"data:(?:image|audio|video)/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\s]{16,}",
-    re.IGNORECASE,
-)
+logger = logging.getLogger(__name__)
+
 _MEDIA_TYPE_HINTS = ("image", "audio", "video")
 _MEDIA_VALUE_KEYS = (
     "image_url",
@@ -35,7 +43,7 @@ def _contains_media_payload(value: Any) -> bool:
     if value is None:
         return False
     if isinstance(value, str):
-        return bool(_MEDIA_DATA_URI_RE.search(value))
+        return bool(_DATA_URI_BASE64_RE.search(value))
     if isinstance(value, list):
         return any(_contains_media_payload(item) for item in value)
     if isinstance(value, dict):
@@ -60,54 +68,542 @@ def _externalization_kind_for_message(message: Dict[str, Any]) -> str:
     return "raw_payload"
 
 
-def protect_message_for_ingest(
-    message: Dict[str, Any],
+# Any data URI base64 payload, not just image/audio/video. Keep the trailing
+# payload alphabet conservative so we do not slurp surrounding JSON/markdown.
+_DATA_URI_BASE64_RE = re.compile(
+    r"data:[A-Za-z0-9.+/-]*(?:;[A-Za-z0-9_.+%-]+=[-A-Za-z0-9_.+%/]+)*;base64,[A-Za-z0-9+/=]{256,}(?=$|[^A-Za-z0-9+/=])",
+    re.IGNORECASE,
+)
+
+_BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=])([A-Za-z0-9+/=]{4096,})(?![A-Za-z0-9+/=])")
+_BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=\s]+$")
+_EXTERNALIZED_PLACEHOLDER_PREFIX = "[Externalized LCM ingest payload:"
+_GENERIC_BASE64_MIN_CHARS = 4096
+_INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
+
+
+def is_externalized_ingest_placeholder(text: str) -> bool:
+    return isinstance(text, str) and bool(_INGEST_PLACEHOLDER_RE.fullmatch(text.strip()))
+
+
+def contains_data_uri_base64(text: str) -> bool:
+    return isinstance(text, str) and bool(_DATA_URI_BASE64_RE.search(text))
+
+
+def contains_long_base64_run(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_CHARS) -> bool:
+    if not isinstance(text, str) or len(text) < min_chars:
+        return False
+    return any(looks_like_long_base64(match.group(1), min_chars=min_chars) for match in _BASE64_RUN_RE.finditer(text))
+
+
+def extract_ingest_externalized_refs(text: str) -> list[str]:
+    if not isinstance(text, str) or not text:
+        return []
+    refs: list[str] = []
+    for match in _INGEST_PLACEHOLDER_RE.finditer(text):
+        ref = match.group(1).strip()
+        if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def restore_ingest_payload_placeholders(
+    text: str,
     *,
-    session_id: str,
     config,
     hermes_home: str = "",
-) -> Dict[str, Any]:
-    """Return a storage-safe copy of ``message``.
+    session_id: str = "",
+) -> str:
+    """Restore ingest placeholders in a stored identity string for matching only.
 
-    The original message is never modified. If externalization is disabled,
-    below threshold, or storage cannot be written, the returned copy keeps the
-    original content so LCM does not silently lose data.
+    Missing or mismatched payload files leave the placeholder untouched so callers
+    never fabricate content or hide a recovery problem.
     """
-    protected = dict(message)
-    normalized_content = normalize_content_value(message.get("content"))
-    if not normalized_content:
-        return protected
+    if not isinstance(text, str) or _EXTERNALIZED_PLACEHOLDER_PREFIX not in text:
+        return text
 
-    role = str(message.get("role") or "unknown")
-    kind = _externalization_kind_for_message(message)
-    externalized = maybe_externalize_payload(
-        normalized_content,
-        kind=kind,
-        tool_call_id=str(message.get("tool_call_id") or ""),
-        session_id=session_id,
+    def replace(match: re.Match[str]) -> str:
+        ref = match.group(1).strip()
+        payload = load_externalized_payload(ref, config=config, hermes_home=hermes_home)
+        if payload is None or payload.get("kind") != "ingest_payload":
+            return match.group(0)
+        payload_session_id = payload.get("session_id") or ""
+        if session_id and payload_session_id and payload_session_id != session_id:
+            return match.group(0)
+        content = payload.get("content")
+        return content if isinstance(content, str) else match.group(0)
+
+    return _INGEST_PLACEHOLDER_RE.sub(replace, text)
+
+
+def looks_like_long_base64(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_CHARS) -> bool:
+    """Conservative long-base64 heuristic.
+
+    Avoids short hashes/IDs/JWT-ish snippets by requiring a very long run and a
+    high base64 alphabet ratio. PEM blocks and ordinary logs contain delimiters
+    or whitespace/headers that keep them from matching as one clean run.
+    """
+    if not isinstance(text, str) or len(text) < min_chars:
+        return False
+    compact = "".join(text.split())
+    if len(compact) < min_chars:
+        return False
+    if len(compact) % 4 == 1:
+        return False
+    if not _BASE64_ALPHABET_RE.match(text):
+        return False
+    base64_chars = sum(1 for ch in text if ch.isalnum() or ch in "+/=")
+    ratio = base64_chars / max(1, len(text))
+    if ratio < 0.98:
+        return False
+    # Require at least a bit of mixed alphabet so a long log line of one
+    # repeated character is not treated as a binary payload.
+    return len(set(compact.rstrip("="))) >= 8
+
+
+def _placeholder_for_payload(
+    payload: str,
+    *,
+    role: str,
+    session_id: str,
+    field_path: str,
+    config,
+    hermes_home: str,
+) -> str | None:
+    result = externalize_ingest_payload(
+        payload,
         role=role,
+        session_id=session_id,
+        field_path=field_path,
         config=config,
         hermes_home=hermes_home,
     )
-    if externalized:
-        protected["content"] = externalized["placeholder"]
-    return protected
+    if result is None:
+        logger.warning(
+            "LCM ingest protection could not externalize payload at %s; preserving inline content for lossless recovery",
+            field_path,
+        )
+        return None
+    return result["placeholder"]
 
 
-def protect_messages_for_ingest(
-    messages: List[Dict[str, Any]],
+def _protect_payload_substrings(
+    text: str,
     *,
+    role: str,
     session_id: str,
+    field_path: str,
+    config,
+    hermes_home: str,
+) -> str:
+    if not text or is_externalized_ingest_placeholder(text):
+        return text
+
+    def replace_data_uri(match: re.Match[str]) -> str:
+        payload = match.group(0)
+        return _placeholder_for_payload(
+            payload,
+            role=role,
+            session_id=session_id,
+            field_path=field_path,
+            config=config,
+            hermes_home=hermes_home,
+        ) or payload
+
+    protected = _DATA_URI_BASE64_RE.sub(replace_data_uri, text)
+
+    def replace_base64_run(match: re.Match[str]) -> str:
+        payload = match.group(1)
+        if not looks_like_long_base64(payload):
+            return payload
+        return _placeholder_for_payload(
+            payload,
+            role=role,
+            session_id=session_id,
+            field_path=field_path,
+            config=config,
+            hermes_home=hermes_home,
+        ) or payload
+
+    return _BASE64_RUN_RE.sub(replace_base64_run, protected)
+
+
+def _maybe_parse_json_string(text: str) -> Any | None:
+    stripped = text.strip()
+    if not stripped or stripped[0] not in "[{":
+        return None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return None
+    if isinstance(parsed, (dict, list)):
+        return parsed
+    return None
+
+
+def _json_has_duplicate_object_keys(text: str) -> bool:
+    stripped = text.strip() if isinstance(text, str) else ""
+    if not stripped or stripped[0] not in "[{":
+        return False
+    duplicate = False
+
+    def detect_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        nonlocal duplicate
+        seen: set[str] = set()
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in seen:
+                duplicate = True
+            seen.add(key)
+            result[key] = value
+        return result
+
+    try:
+        json.loads(text, object_pairs_hook=detect_pairs)
+    except Exception:
+        return False
+    return duplicate
+
+
+def _protect_value(
+    value: Any,
+    *,
+    role: str,
+    session_id: str,
+    field_path: str,
+    config,
+    hermes_home: str,
+    parse_json_strings: bool = False,
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _protect_value(
+                val,
+                role=role,
+                session_id=session_id,
+                field_path=f"{field_path}.{key}" if field_path else str(key),
+                config=config,
+                hermes_home=hermes_home,
+                parse_json_strings=parse_json_strings,
+            )
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _protect_value(
+                item,
+                role=role,
+                session_id=session_id,
+                field_path=f"{field_path}[{idx}]",
+                config=config,
+                hermes_home=hermes_home,
+                parse_json_strings=parse_json_strings,
+            )
+            for idx, item in enumerate(value)
+        ]
+    if not isinstance(value, str):
+        return value
+
+    if parse_json_strings:
+        if _json_has_duplicate_object_keys(value):
+            return _protect_payload_substrings(
+                value,
+                role=role,
+                session_id=session_id,
+                field_path=field_path,
+                config=config,
+                hermes_home=hermes_home,
+            )
+        parsed = _maybe_parse_json_string(value)
+        if parsed is not None:
+            protected = _protect_value(
+                parsed,
+                role=role,
+                session_id=session_id,
+                field_path=field_path,
+                config=config,
+                hermes_home=hermes_home,
+                parse_json_strings=True,
+            )
+            if protected != parsed:
+                return json.dumps(protected, ensure_ascii=False, separators=(",", ":"))
+            return value
+
+    return _protect_payload_substrings(
+        value,
+        role=role,
+        session_id=session_id,
+        field_path=field_path,
+        config=config,
+        hermes_home=hermes_home,
+    )
+
+
+def protect_inline_payloads_in_text(
+    text: str,
+    *,
+    role: str,
+    session_id: str,
+    field_path: str,
+    config,
+    hermes_home: str,
+) -> str:
+    """Externalize inline media/base64 payloads inside a text scaffold.
+
+    This is used for non-SQLite active-context scaffolds that still must not
+    duplicate media-ish payloads into summaries or preserved objective text.
+    """
+    if not isinstance(text, str):
+        return text
+    return _protect_payload_substrings(
+        text,
+        role=role,
+        session_id=session_id,
+        field_path=field_path,
+        config=config,
+        hermes_home=hermes_home,
+    )
+
+
+def _protect_tool_calls(tool_calls: Any, *, role: str, session_id: str, config, hermes_home: str) -> Any:
+    return _protect_value(
+        tool_calls,
+        role=role,
+        session_id=session_id,
+        field_path="tool_calls",
+        config=config,
+        hermes_home=hermes_home,
+        parse_json_strings=True,
+    )
+
+
+def protect_message_for_ingest(
+    message: Dict[str, Any],
     config,
     hermes_home: str = "",
-) -> List[Dict[str, Any]]:
-    """Return storage-safe copies of all messages."""
-    return [
-        protect_message_for_ingest(
-            message,
+    session_id: str = "",
+) -> Dict[str, Any]:
+    """Return a copy of ``message`` safe to persist in SQLite.
+
+    Payloads are externalized losslessly when they are inline media/base64-like
+    strings before they hit ``messages.content`` or ``messages.tool_calls``.
+    When the opt-in generic large-output externalization setting is enabled,
+    whole-message content still follows the existing threshold-based behavior.
+    """
+    msg = dict(message or {})
+    role = str(msg.get("role") or "unknown")
+    original_content = msg.get("content")
+    normalized_content = normalize_content_value(original_content)
+
+    # Preserve the pre-existing opt-in large-output behavior on message content.
+    # The always-on storage-boundary sanitizer below is a narrower safety net for
+    # inline media/base64 substrings, including cases below the generic threshold
+    # or when generic externalization is disabled.
+    if normalized_content:
+        if is_externalized_ingest_placeholder(normalized_content) or is_externalized_placeholder(normalized_content):
+            msg["content"] = original_content
+        else:
+            kind = _externalization_kind_for_message(msg)
+            externalized = maybe_externalize_payload(
+                normalized_content,
+                kind=kind,
+                tool_call_id=str(msg.get("tool_call_id") or ""),
+                session_id=session_id,
+                role=role,
+                config=config,
+                hermes_home=hermes_home,
+            )
+            if externalized:
+                msg["content"] = externalized["placeholder"]
+            else:
+                msg["content"] = _protect_value(
+                    original_content,
+                    role=role,
+                    session_id=session_id,
+                    field_path="content",
+                    config=config,
+                    hermes_home=hermes_home,
+                    parse_json_strings=False,
+                )
+    else:
+        msg["content"] = original_content
+
+    if msg.get("tool_calls"):
+        msg["tool_calls"] = _protect_tool_calls(
+            msg.get("tool_calls"),
+            role=role,
             session_id=session_id,
             config=config,
             hermes_home=hermes_home,
         )
+
+    return msg
+
+
+def protect_messages_for_ingest(
+    messages: List[Dict[str, Any]],
+    config,
+    hermes_home: str = "",
+    session_id: str = "",
+) -> List[Dict[str, Any]]:
+    return [
+        protect_message_for_ingest(
+            message,
+            config=config,
+            hermes_home=hermes_home,
+            session_id=session_id,
+        )
         for message in messages
     ]
+
+
+def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
+    """Return bounded diagnostics for suspicious inline payload storage.
+
+    Diagnostics intentionally omit previews/raw payload text. Rows include only
+    metadata needed for triage and a recoverability ref when a compact
+    externalized placeholder is present.
+    """
+
+    def make_row(row, *, field: str, length_key: str, category: str) -> dict[str, Any]:
+        store_id, session_id, source, role, length, value = row
+        value = value or ""
+        result = {
+            "store_id": int(store_id),
+            "session_id": session_id,
+            "source": source,
+            "role": role,
+            "field": field,
+            "length": int(length or 0),
+            length_key: int(length or 0),
+            "suspicious_category": category,
+        }
+        refs = extract_ingest_externalized_refs(value) if isinstance(value, str) else []
+        ref = refs[0] if refs else (extract_externalized_ref(value) if isinstance(value, str) else None)
+        if ref:
+            result["externalized_ref"] = ref
+        return result
+
+    largest_content = conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
+        FROM messages
+        ORDER BY content_len DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    largest_tool_calls = conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(tool_calls), 0) AS tool_calls_len, tool_calls
+        FROM messages
+        ORDER BY tool_calls_len DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    data_uri_content = conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
+        FROM messages
+        WHERE content LIKE '%data:%;base64,%'
+        ORDER BY content_len DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    data_uri_tool_calls = conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(tool_calls), 0) AS tool_calls_len, tool_calls
+        FROM messages
+        WHERE tool_calls LIKE '%data:%;base64,%'
+        ORDER BY tool_calls_len DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+
+    candidate_cap = max(limit * 20, limit)
+    generic_rows = []
+    for store_id, session_id, source, role, content, tool_calls in conn.execute(
+        """
+        SELECT store_id, session_id, source, role, content, tool_calls
+        FROM messages
+        WHERE COALESCE(length(content), 0) >= ? OR COALESCE(length(tool_calls), 0) >= ?
+        ORDER BY MAX(COALESCE(length(content), 0), COALESCE(length(tool_calls), 0)) DESC
+        LIMIT ?
+        """,
+        (_GENERIC_BASE64_MIN_CHARS, _GENERIC_BASE64_MIN_CHARS, candidate_cap),
+    ).fetchall():
+        for field, value in (("content", content), ("tool_calls", tool_calls)):
+            if isinstance(value, str) and contains_long_base64_run(value):
+                result = {
+                    "store_id": int(store_id),
+                    "session_id": session_id,
+                    "source": source,
+                    "role": role,
+                    "field": field,
+                    "length": len(value),
+                    "suspicious_category": "base64_like",
+                }
+                refs = extract_ingest_externalized_refs(value)
+                ref = refs[0] if refs else extract_externalized_ref(value)
+                if ref:
+                    result["externalized_ref"] = ref
+                generic_rows.append(result)
+                break
+        if len(generic_rows) >= limit:
+            break
+
+    return {
+        "largest_content_rows": [
+            make_row(row, field="content", length_key="content_len", category="largest_content")
+            for row in largest_content
+        ],
+        "largest_tool_calls_rows": [
+            make_row(row, field="tool_calls", length_key="tool_calls_len", category="largest_tool_calls")
+            for row in largest_tool_calls
+        ],
+        "suspicious_data_uri_content_rows": [
+            make_row(row, field="content", length_key="content_len", category="data_uri_base64")
+            for row in data_uri_content
+        ],
+        "suspicious_data_uri_tool_calls_rows": [
+            make_row(row, field="tool_calls", length_key="tool_calls_len", category="data_uri_base64")
+            for row in data_uri_tool_calls
+        ],
+        "suspicious_base64_like_rows": generic_rows,
+    }
+
+def externalized_payload_stats(config, hermes_home: str = "") -> dict[str, Any]:
+    from .externalize import get_large_output_storage_dir
+
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    count = 0
+    total_bytes = 0
+    total_chars = 0
+    latest_path = ""
+    latest_mtime = 0.0
+    if storage_dir.exists() and storage_dir.is_dir():
+        for path in storage_dir.glob("*.json"):
+            if not path.is_file():
+                continue
+            count += 1
+            try:
+                stat = path.stat()
+                total_bytes += int(stat.st_size)
+                if stat.st_mtime > latest_mtime:
+                    latest_mtime = stat.st_mtime
+                    latest_path = str(path)
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                total_chars += int(payload.get("content_chars") or len(payload.get("content", "") or ""))
+            except Exception:
+                continue
+    return {
+        "externalized_payload_dir": str(storage_dir),
+        "externalized_payload_count": count,
+        "externalized_payload_bytes": total_bytes,
+        "externalized_payload_chars": total_chars,
+        "latest_externalized_payload_path": latest_path,
+        "latest_externalized_payload_mtime": latest_mtime,
+    }

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -71,7 +71,7 @@ def _externalization_kind_for_message(message: Dict[str, Any]) -> str:
 # Any data URI base64 payload, not just image/audio/video. Keep the trailing
 # payload alphabet conservative so we do not slurp surrounding JSON/markdown.
 _DATA_URI_BASE64_RE = re.compile(
-    r"data:[A-Za-z0-9.+/-]*(?:;[A-Za-z0-9_.+%-]+=[-A-Za-z0-9_.+%/]+)*;base64,[A-Za-z0-9+/=]{256,}(?=$|[^A-Za-z0-9+/=])",
+    r"data:(?:[A-Za-z0-9.+-]|/|\\/)*(?:;[A-Za-z0-9_.+%-]+=(?:[-A-Za-z0-9_.+%]|/|\\/)*)*;base64,(?:[A-Za-z0-9+=]|/|\\/){256,}(?=$|[^A-Za-z0-9+/=])",
     re.IGNORECASE,
 )
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -70,8 +70,13 @@ def _externalization_kind_for_message(message: Dict[str, Any]) -> str:
 
 # Any data URI base64 payload, not just image/audio/video. Keep the trailing
 # payload alphabet conservative so we do not slurp surrounding JSON/markdown.
+# Raw scans can see JSON-escaped slashes before decoding, including both `\/`
+# and unicode escapes such as `\u002f` in duplicate-key argument strings.
+_JSON_ESCAPED_SLASH_RE = r"(?:/|\\/|\\u002[fF])"
 _DATA_URI_BASE64_RE = re.compile(
-    r"data:(?:[A-Za-z0-9.+-]|/|\\/)*(?:;[A-Za-z0-9_.+%-]+=(?:[-A-Za-z0-9_.+%]|/|\\/)*)*;base64,(?:[A-Za-z0-9+=]|/|\\/){256,}(?=$|[^A-Za-z0-9+/=])",
+    rf"data:(?:[A-Za-z0-9.+-]|{_JSON_ESCAPED_SLASH_RE})*"
+    rf"(?:;[A-Za-z0-9_.+%-]+=(?:[-A-Za-z0-9_.+%]|{_JSON_ESCAPED_SLASH_RE})*)*"
+    rf";base64,(?:[A-Za-z0-9+=]|{_JSON_ESCAPED_SLASH_RE}){{256,}}(?=$|[^A-Za-z0-9+/=])",
     re.IGNORECASE,
 )
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -75,8 +75,8 @@ _DATA_URI_BASE64_RE = re.compile(
     re.IGNORECASE,
 )
 
-_BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=])([A-Za-z0-9+/=]{4096,})(?![A-Za-z0-9+/=])")
-_BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=\s]+$")
+_BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{4096,})(?![A-Za-z0-9+/=_-])")
+_BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_\s-]+$")
 _EXTERNALIZED_PLACEHOLDER_PREFIX = "[Externalized LCM ingest payload:"
 _GENERIC_BASE64_MIN_CHARS = 4096
 _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
@@ -152,7 +152,7 @@ def looks_like_long_base64(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_CH
         return False
     if not _BASE64_ALPHABET_RE.match(text):
         return False
-    base64_chars = sum(1 for ch in text if ch.isalnum() or ch in "+/=")
+    base64_chars = sum(1 for ch in text if ch.isalnum() or ch in "+/=_-")
     ratio = base64_chars / max(1, len(text))
     if ratio < 0.98:
         return False

--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sqlite3
 import sys
 import time
@@ -39,6 +38,7 @@ _ensure_local_package_importable()
 
 from hermes_lcm.config import LCMConfig  # noqa: E402
 from hermes_lcm.ingest_protection import protect_message_for_ingest  # noqa: E402
+from hermes_lcm.message_content import normalize_content_value  # noqa: E402
 from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
 from hermes_lcm.tokens import count_message_tokens  # noqa: E402
 
@@ -533,30 +533,34 @@ def import_lossless_claw(
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     backup_path = _backup_target(target_path)
-    store = MessageStore(target_path)
+    protection_config = LCMConfig.from_env()
+    protection_config.database_path = str(target_path)
+    store = MessageStore(
+        target_path,
+        ingest_protection_config=protection_config,
+        hermes_home=str(target_path.parent),
+    )
     conn = store._conn
     _ensure_import_table(conn)
 
     imported = 0
-    ingest_config = LCMConfig.from_env()
-    hermes_home = os.environ.get("HERMES_HOME", "")
     try:
         for candidate in to_import:
-            original_msg: dict[str, Any] = {
+            msg: dict[str, Any] = {
                 "role": candidate.role,
                 "content": candidate.content,
             }
             if candidate.tool_call_id:
-                original_msg["tool_call_id"] = candidate.tool_call_id
+                msg["tool_call_id"] = candidate.tool_call_id
             if candidate.tool_calls:
-                original_msg["tool_calls"] = candidate.tool_calls
+                msg["tool_calls"] = candidate.tool_calls
             if candidate.tool_name:
-                original_msg["tool_name"] = candidate.tool_name
+                msg["tool_name"] = candidate.tool_name
             protected_msg = protect_message_for_ingest(
-                original_msg,
+                msg,
+                config=protection_config,
+                hermes_home=str(target_path.parent),
                 session_id=candidate.target_session_id,
-                config=ingest_config,
-                hermes_home=hermes_home,
             )
             tool_calls_json = json.dumps(protected_msg.get("tool_calls")) if protected_msg.get("tool_calls") else None
             cur = conn.execute(
@@ -568,7 +572,7 @@ def import_lossless_claw(
                     candidate.target_session_id,
                     _normalize_source_value(candidate.source),
                     protected_msg.get("role", candidate.role),
-                    protected_msg.get("content"),
+                    normalize_content_value(protected_msg.get("content")),
                     protected_msg.get("tool_call_id"),
                     tool_calls_json,
                     protected_msg.get("tool_name"),

--- a/store.py
+++ b/store.py
@@ -20,6 +20,8 @@ from .db_bootstrap import (
     ensure_external_content_fts,
     run_versioned_migrations,
 )
+from .config import LCMConfig
+from .ingest_protection import protect_message_for_ingest, protect_messages_for_ingest
 from .search_query import (
     build_snippet,
     compute_search_candidate_cap,
@@ -201,9 +203,11 @@ def build_message_fts_spec() -> ExternalContentFtsSpec:
 class MessageStore:
     """SQLite-backed immutable message store."""
 
-    def __init__(self, db_path: str | Path):
+    def __init__(self, db_path: str | Path, *, ingest_protection_config=None, hermes_home: str = ""):
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ingest_protection_config = ingest_protection_config or LCMConfig(database_path=str(self.db_path))
+        self._hermes_home = hermes_home or str(self.db_path.parent)
         self._conn: Optional[sqlite3.Connection] = None
         self._init_db()
 
@@ -257,6 +261,12 @@ class MessageStore:
     def append(self, session_id: str, msg: Dict[str, Any],
                token_estimate: int = 0, source: str = "") -> int:
         """Persist a message and return its store_id."""
+        msg = protect_message_for_ingest(
+            msg,
+            config=self._ingest_protection_config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
         tool_calls = msg.get("tool_calls")
         tc_json = json.dumps(tool_calls) if tool_calls else None
 
@@ -289,10 +299,17 @@ class MessageStore:
         if token_estimates is None:
             token_estimates = [0] * len(messages)
 
+        protected_messages = protect_messages_for_ingest(
+            messages,
+            config=self._ingest_protection_config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
+
         ids = []
         ts = time.time()
         with self._conn:
-            for msg, est in zip(messages, token_estimates):
+            for msg, est in zip(protected_messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
                 cur = self._conn.execute(

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -748,6 +748,45 @@ def test_ingest_externalizes_duplicate_key_json_argument_payload_without_collaps
     assert expanded["field_path"] == "tool_calls[0].function.arguments"
 
 
+def test_ingest_externalizes_duplicate_key_json_argument_escaped_data_uri(tmp_path):
+    engine = _engine(tmp_path)
+    medium_payload = base64.b64encode(b"medium-data-uri-payload" * 12).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+    escaped_data_uri = f"data:image\\/png;base64,{medium_payload}"
+    original_arguments = f'{{"image":"{escaped_data_uri}","image":"plain"}}'
+    message = {
+        "role": "assistant",
+        "content": "calling escaped duplicate-key function",
+        "tool_calls": [
+            {
+                "id": "call_duplicate_escaped",
+                "type": "function",
+                "function": {
+                    "name": "duplicate_key_function",
+                    "arguments": original_arguments,
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    parsed_tool_calls = json.loads(tool_calls)
+    protected_arguments = parsed_tool_calls[0]["function"]["arguments"]
+    assert "data:image" not in protected_arguments
+    assert medium_payload[:120] not in protected_arguments
+    assert ',"image":"plain"}' in protected_arguments
+    refs = extract_ingest_externalized_refs(protected_arguments)
+    assert len(refs) == 1
+    expanded = _expand_ref(engine, refs[0])
+    assert expanded["content"] == escaped_data_uri
+    assert expanded["field_path"] == "tool_calls[0].function.arguments"
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == refs
+    assert medium_payload[:120] not in json.dumps(raw_message)
+
+
 def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
     engine = _engine(tmp_path)
     tricky_key = "; ref=bogus]"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -917,6 +917,43 @@ def test_restart_replay_matches_escaped_duplicate_key_tool_argument_payload(tmp_
     assert _expand_ref(engine, refs[0])["content"] == escaped_data_uri
 
 
+def test_ingest_externalizes_unicode_escaped_slash_duplicate_key_tool_argument(tmp_path):
+    medium_payload = base64.b64encode(b"unicode-slash-data-uri-payload" * 10).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+
+    for label, slash_escape in (("lower", "\\u002f"), ("upper", "\\u002F")):
+        variant_path = tmp_path / label
+        variant_path.mkdir()
+        engine = _engine(variant_path)
+        escaped_data_uri = "data:image" + slash_escape + "png;base64," + medium_payload
+        original_arguments = f'{{"image":"{escaped_data_uri}","image":"plain"}}'
+
+        engine._ingest_messages([
+            {
+                "role": "assistant",
+                "content": f"calling {label} unicode escaped duplicate-key function",
+                "tool_calls": [
+                    {
+                        "id": f"call_duplicate_unicode_escaped_{label}",
+                        "type": "function",
+                        "function": {
+                            "name": "duplicate_key_function",
+                            "arguments": original_arguments,
+                        },
+                    }
+                ],
+            }
+        ])
+
+        _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+        assert "data:image" not in tool_calls
+        assert slash_escape + "png" not in tool_calls
+        assert medium_payload[:120] not in tool_calls
+        refs = extract_ingest_externalized_refs(tool_calls)
+        assert len(refs) == 1
+        assert _expand_ref(engine, refs[0])["content"] == escaped_data_uri
+
+
 def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
     engine = _engine(tmp_path)
     tricky_key = "; ref=bogus]"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -441,6 +441,97 @@ def test_replayed_original_tool_call_payload_reconciles_with_placeholder_row(tmp
     assert engine._store.count_session_load_messages(engine.current_session_id) == 2
 
 
+def test_restart_replay_matches_escaped_structured_content_payload(tmp_path):
+    medium_payload = base64.b64encode(b"medium-data-uri-payload" * 12).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+    escaped_data_uri = f"data:image\\/png;base64,{medium_payload}"
+    original_messages = [
+        {"role": "system", "content": "system anchor"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "inspect this image"},
+                {"type": "image_url", "image_url": {"url": escaped_data_uri}},
+            ],
+        },
+    ]
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert medium_payload[:120] not in content
+    refs = extract_ingest_externalized_refs(content)
+    assert len(refs) == 1
+    assert _expand_ref(engine, refs[0])["content"] == escaped_data_uri
+    engine._store.close()
+
+    replay_engine = _engine(tmp_path)
+    replay_engine._ingest_messages(original_messages)
+
+    assert replay_engine._store.count_session_load_messages(replay_engine.current_session_id) == 2
+
+
+def test_restart_replay_matches_plain_json_string_content_payload(tmp_path):
+    medium_payload = base64.b64encode(b"plain-json-data-uri-payload" * 12).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+    escaped_data_uri = f"data:image\\/png;base64,{medium_payload}"
+    original_messages = [
+        {"role": "system", "content": "system anchor"},
+        {"role": "user", "content": f'{{"url": "{escaped_data_uri}"}}'},
+    ]
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert medium_payload[:120] not in content
+    refs = extract_ingest_externalized_refs(content)
+    assert len(refs) == 1
+    assert _expand_ref(engine, refs[0])["content"] == escaped_data_uri
+    engine._store.close()
+
+    replay_engine = _engine(tmp_path)
+    replay_engine._ingest_messages(original_messages)
+
+    assert replay_engine._store.count_session_load_messages(replay_engine.current_session_id) == 2
+
+
+def test_restart_replay_does_not_skip_changed_structured_content_payload(tmp_path):
+    payload_a = base64.b64encode(b"structured-content-a" * 16).decode("ascii")
+    payload_b = base64.b64encode(b"structured-content-b" * 16).decode("ascii")
+    assert 256 <= len(payload_a) < 4096
+    assert 256 <= len(payload_b) < 4096
+
+    def messages(payload: str) -> list[dict]:
+        escaped_data_uri = f"data:image\\/png;base64,{payload}"
+        return [
+            {"role": "system", "content": "system anchor"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect this image"},
+                    {"type": "image_url", "image_url": {"url": escaped_data_uri}},
+                ],
+            },
+        ]
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(messages(payload_a))
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    replay_engine = _engine(tmp_path)
+    replay_engine._ingest_messages(messages(payload_b))
+
+    assert replay_engine._store.count_session_load_messages(replay_engine.current_session_id) == 4
+    _store_id, content, _tool_calls = _single_message_row(replay_engine, role="user")
+    assert payload_b[:120] not in content
+    refs = extract_ingest_externalized_refs(content)
+    assert len(refs) == 1
+    assert _expand_ref(replay_engine, refs[0])["content"] == f"data:image\\/png;base64,{payload_b}"
+
+
 def test_tool_call_replay_identity_preserves_duplicate_key_argument_payload_text(tmp_path):
     engine = _engine(tmp_path)
     payload_a = "data:image/png;base64," + base64.b64encode(b"payload-a" * 48).decode("ascii")

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -16,6 +16,7 @@ from hermes_lcm import tools as lcm_tools
 from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
+from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
 from hermes_lcm.externalize import extract_externalized_ref
 from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
 
@@ -494,6 +495,107 @@ def test_ingest_externalizes_tool_calls_function_arguments(tmp_path):
     assert raw_message["externalized_refs"] == [ref]
     assert raw_message["externalized_payloads"][0]["field_path"] == "tool_calls[0].function.arguments.image"
     assert "tool_calls" not in raw_message
+
+
+def test_ingest_externalizes_tool_call_argument_payload_keys(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "assistant",
+        "content": "calling keyed upload",
+        "tool_calls": [
+            {
+                "id": "call_keyed_upload",
+                "type": "function",
+                "function": {
+                    "name": "upload_image",
+                    "arguments": json.dumps({DATA_URI: "plain-value"}),
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert "data:image" not in tool_calls
+    assert DATA_PAYLOAD[:80] not in tool_calls
+    ref = _extract_ref(tool_calls)
+    parsed_tool_calls = json.loads(tool_calls)
+    parsed_args = json.loads(parsed_tool_calls[0]["function"]["arguments"])
+    protected_key = next(iter(parsed_args))
+    assert protected_key.startswith("[Externalized LCM ingest payload:")
+    assert parsed_args[protected_key] == "plain-value"
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == [ref]
+    assert DATA_PAYLOAD[:80] not in json.dumps(raw_message)
+
+
+def test_ingest_externalizes_structured_content_payload_keys(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "keep this searchable"},
+            {DATA_URI: "plain-value"},
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "keep this searchable" in content
+    assert "data:image" not in content
+    assert DATA_PAYLOAD[:80] not in content
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == [ref]
+    assert DATA_PAYLOAD[:80] not in json.dumps(raw_message)
+
+
+def test_pre_compaction_tool_arguments_sanitize_payload_keys():
+    sanitized = sanitize_pre_compaction_tool_arguments({DATA_URI: "plain-value"})
+
+    assert "data:image" not in sanitized
+    assert DATA_PAYLOAD[:80] not in sanitized
+    parsed = json.loads(sanitized)
+    assert parsed == {"[Media attachment]": "plain-value"}
+
+
+def test_payload_bearing_key_uses_neutral_child_field_path(tmp_path):
+    engine = _engine(tmp_path)
+    mixed_key = f"raw-label {DATA_URI} raw-suffix"
+    message = {
+        "role": "assistant",
+        "content": "calling keyed upload",
+        "tool_calls": [
+            {
+                "id": "call_keyed_upload",
+                "type": "function",
+                "function": {
+                    "name": "upload_image",
+                    "arguments": json.dumps({mixed_key: DATA_URI}),
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert "data:image" not in tool_calls
+    assert DATA_PAYLOAD[:80] not in tool_calls
+    payloads = [json.loads(path.read_text()) for path in _externalized_files(tmp_path)]
+    field_paths = [payload["field_path"] for payload in payloads]
+    assert len(field_paths) == 2
+    assert all("data:image" not in field_path for field_path in field_paths)
+    assert all(DATA_PAYLOAD[:80] not in field_path for field_path in field_paths)
+    assert all("raw-label" not in field_path for field_path in field_paths)
+    assert all("raw-suffix" not in field_path for field_path in field_paths)
+    assert "tool_calls[0].function.arguments.<key>" in field_paths
 
 
 def test_ingest_preserves_json_argument_string_when_no_payload_changes(tmp_path):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -787,6 +787,45 @@ def test_ingest_externalizes_duplicate_key_json_argument_escaped_data_uri(tmp_pa
     assert medium_payload[:120] not in json.dumps(raw_message)
 
 
+def test_restart_replay_matches_escaped_duplicate_key_tool_argument_payload(tmp_path):
+    medium_payload = base64.b64encode(b"medium-data-uri-payload" * 12).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+    escaped_data_uri = f"data:image\\/png;base64,{medium_payload}"
+    original_arguments = f'{{"image":"{escaped_data_uri}","image":"plain"}}'
+    original_messages = [
+        {"role": "system", "content": "system anchor"},
+        {
+            "role": "assistant",
+            "content": "calling escaped duplicate-key function",
+            "tool_calls": [
+                {
+                    "id": "call_duplicate_escaped",
+                    "type": "function",
+                    "function": {
+                        "name": "duplicate_key_function",
+                        "arguments": original_arguments,
+                    },
+                }
+            ],
+        },
+    ]
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert medium_payload[:120] not in tool_calls
+    refs = extract_ingest_externalized_refs(tool_calls)
+    assert len(refs) == 1
+    assert _expand_ref(engine, refs[0])["content"] == escaped_data_uri
+
+
 def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
     engine = _engine(tmp_path)
     tricky_key = "; ref=bogus]"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -24,6 +24,7 @@ from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
 DATA_PAYLOAD = base64.b64encode(("LCM payload boundary repro ".encode("ascii")) * 900).decode("ascii")
 DATA_URI = "data:image/png;base64," + DATA_PAYLOAD
 GENERIC_BASE64 = DATA_PAYLOAD * 2
+GENERIC_BASE64URL = base64.urlsafe_b64encode(bytes(range(256)) * 40).decode("ascii")
 
 
 def _engine(tmp_path: Path) -> LCMEngine:
@@ -226,6 +227,57 @@ def test_ingest_externalizes_generic_long_base64_string(tmp_path):
     assert len(content) < 300
     expanded = _expand_ref(engine, ref)
     assert expanded["content"] == GENERIC_BASE64
+
+
+def test_ingest_externalizes_generic_long_base64url_string(tmp_path):
+    engine = _engine(tmp_path)
+    assert "-" in GENERIC_BASE64URL and "_" in GENERIC_BASE64URL
+    assert "+" not in GENERIC_BASE64URL and "/" not in GENERIC_BASE64URL
+
+    engine._ingest_messages([{"role": "user", "content": f"prefix {GENERIC_BASE64URL} suffix"}])
+
+    store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "prefix " in content
+    assert " suffix" in content
+    assert GENERIC_BASE64URL[:120] not in content
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == GENERIC_BASE64URL
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_ref"] == ref
+    assert GENERIC_BASE64URL[:120] not in json.dumps(raw_message)
+
+
+def test_ingest_externalizes_base64url_tool_call_arguments(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "assistant",
+        "content": "calling upload",
+        "tool_calls": [
+            {
+                "id": "call_upload_urlsafe",
+                "type": "function",
+                "function": {
+                    "name": "upload_blob",
+                    "arguments": json.dumps({"blob": GENERIC_BASE64URL}),
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert GENERIC_BASE64URL[:120] not in tool_calls
+    ref = _extract_ref(tool_calls)
+    parsed_tool_calls = json.loads(tool_calls)
+    parsed_args = json.loads(parsed_tool_calls[0]["function"]["arguments"])
+    assert parsed_args["blob"].startswith("[Externalized LCM ingest payload:")
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == GENERIC_BASE64URL
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == [ref]
+    assert GENERIC_BASE64URL[:120] not in json.dumps(raw_message)
 
 
 def test_ingest_externalizes_embedded_generic_long_base64_run(tmp_path):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -17,7 +17,7 @@ from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
-from hermes_lcm.externalize import extract_externalized_ref
+from hermes_lcm.externalize import build_transcript_gc_placeholder, externalize_ingest_payload, extract_externalized_ref
 from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
 
 
@@ -77,16 +77,55 @@ def test_extract_externalized_ref_recovers_tool_and_non_tool_placeholders():
     placeholders = [
         "[Externalized tool output: tool_call_id=call_1; chars=1200; bytes=1200; ref=tool.json]",
         "[GC'd externalized tool output: tool_call_id=call_1; chars=1200; ref=tool-gc.json]",
-        "[Externalized payload: kind=media_payload; role=user; chars=1200; bytes=1200; ref=media.json]",
+        "[Externalized payload: kind=raw_payload; role=assistant; chars=1200; bytes=1200; ref=raw.json]",
         "[GC'd externalized payload: kind=raw_payload; role=assistant; chars=1200; ref=raw-gc.json]",
     ]
 
     assert [extract_externalized_ref(value) for value in placeholders] == [
         "tool.json",
         "tool-gc.json",
-        "media.json",
+        "raw.json",
         "raw-gc.json",
     ]
+
+
+def test_transcript_gc_placeholder_sanitizes_non_tool_metadata_before_ref():
+    placeholder = build_transcript_gc_placeholder(
+        {
+            "kind": "raw_payload; ref=kind-bogus]",
+            "role": "user; ref=role-bogus]",
+            "content_chars": 1200,
+            "ref": "real-ref.json",
+        }
+    )
+
+    assert "kind-bogus" in placeholder
+    assert "role-bogus" in placeholder
+    assert "; ref=kind-bogus]" not in placeholder
+    assert "; ref=role-bogus]" not in placeholder
+    assert extract_externalized_ref(placeholder) == "real-ref.json"
+
+
+def test_ingest_payload_placeholder_sanitizes_custom_kind_metadata_before_ref(tmp_path):
+    engine = _engine(tmp_path)
+    result = externalize_ingest_payload(
+        "payload content",
+        role="user",
+        session_id=engine.current_session_id,
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+        kind="ingest_payload; ref=kind-bogus]",
+    )
+
+    assert result is not None
+    placeholder = result["placeholder"]
+    assert "kind-bogus" in placeholder
+    assert "; ref=kind-bogus]" not in placeholder
+    refs = extract_ingest_externalized_refs(placeholder)
+    assert refs == [result["path"].name]
+    assert result["path"].name.startswith("20")
+    assert "ref=kind-bogus" not in result["path"].name
 
 
 def test_ingest_externalizes_plain_data_uri_user_content_before_sqlite_write(tmp_path):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1,0 +1,860 @@
+"""Regression tests for storage-boundary payload protection."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import re
+import sqlite3
+import stat
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+from hermes_lcm import tools as lcm_tools
+from hermes_lcm.command import handle_lcm_command
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.externalize import extract_externalized_ref
+from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
+
+
+DATA_PAYLOAD = base64.b64encode(("LCM payload boundary repro ".encode("ascii")) * 900).decode("ascii")
+DATA_URI = "data:image/png;base64," + DATA_PAYLOAD
+GENERIC_BASE64 = DATA_PAYLOAD * 2
+
+
+def _engine(tmp_path: Path) -> LCMEngine:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "payload-session",
+        platform="telegram",
+        conversation_id="payload-conversation",
+        context_length=200_000,
+    )
+    return engine
+
+
+def _single_message_row(engine: LCMEngine, *, role: str | None = None):
+    where = "WHERE session_id = ?"
+    args = [engine.current_session_id]
+    if role:
+        where += " AND role = ?"
+        args.append(role)
+    return engine._store._conn.execute(
+        f"SELECT store_id, content, tool_calls FROM messages {where} ORDER BY store_id DESC LIMIT 1",
+        args,
+    ).fetchone()
+
+
+def _extract_ref(text: str) -> str:
+    match = re.search(r";\s*ref=([^;\]\s]+)", text)
+    assert match, text
+    return match.group(1)
+
+
+def _extract_refs(text: str) -> list[str]:
+    refs = re.findall(r";\s*ref=([^;\]\s]+)", text)
+    assert refs, text
+    return refs
+
+
+def _expand_ref(engine: LCMEngine, ref: str) -> dict:
+    return json.loads(lcm_tools.lcm_expand({"externalized_ref": ref, "max_tokens": 100_000}, engine=engine))
+
+
+def _externalized_files(tmp_path: Path) -> list[Path]:
+    return sorted((tmp_path / "externalized").glob("*.json"))
+
+
+def test_extract_externalized_ref_recovers_tool_and_non_tool_placeholders():
+    placeholders = [
+        "[Externalized tool output: tool_call_id=call_1; chars=1200; bytes=1200; ref=tool.json]",
+        "[GC'd externalized tool output: tool_call_id=call_1; chars=1200; ref=tool-gc.json]",
+        "[Externalized payload: kind=media_payload; role=user; chars=1200; bytes=1200; ref=media.json]",
+        "[GC'd externalized payload: kind=raw_payload; role=assistant; chars=1200; ref=raw-gc.json]",
+    ]
+
+    assert [extract_externalized_ref(value) for value in placeholders] == [
+        "tool.json",
+        "tool-gc.json",
+        "media.json",
+        "raw-gc.json",
+    ]
+
+
+def test_ingest_externalizes_plain_data_uri_user_content_before_sqlite_write(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": "see image " + DATA_URI}])
+
+    store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+    assert DATA_PAYLOAD[:80] not in content
+    ref = _extract_ref(content)
+    assert _externalized_files(tmp_path)
+    assert engine._store.search("base64", session_id=engine.current_session_id) == []
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+    assert expanded["kind"] == "ingest_payload"
+
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_ref"] == ref
+    assert raw_message["externalized"]["kind"] == "ingest_payload"
+    assert raw_message["externalized"]["field_path"] == "content"
+
+
+def test_ingest_preserves_trailing_text_after_data_uri(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": DATA_URI + " please analyze this"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+    assert content.endswith(" please analyze this")
+    assert engine._store.search("analyze", session_id=engine.current_session_id)
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+
+
+def test_ingest_externalizes_data_uri_without_media_type_before_sqlite_write(tmp_path):
+    engine = _engine(tmp_path)
+    bare_data_uri = "data:;base64," + DATA_PAYLOAD
+
+    engine._ingest_messages([{"role": "user", "content": bare_data_uri}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:;base64" not in content
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == bare_data_uri
+
+
+def test_ingest_externalizes_medium_data_uri_with_hyphenated_parameter_value(tmp_path):
+    engine = _engine(tmp_path)
+    medium_payload = base64.b64encode(b"medium-data-uri-payload" * 12).decode("ascii")
+    assert 256 <= len(medium_payload) < 4096
+    data_uri = "data:image/png;charset=utf-8;base64," + medium_payload
+
+    engine._ingest_messages([{"role": "user", "content": "image " + data_uri}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "charset=utf-8" not in content
+    assert medium_payload[:120] not in content
+    assert engine._store.search("charset", session_id=engine.current_session_id) == []
+    assert engine._store.search(medium_payload[:64], session_id=engine.current_session_id) == []
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == data_uri
+
+
+def test_ingest_externalizes_structured_image_url_data_uri_before_sqlite_write(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "look at this image"},
+            {"type": "image_url", "image_url": {"url": DATA_URI}},
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "look at this image" in content
+    assert "data:image" not in content
+    ref = _extract_ref(content)
+    assert engine._store.search("look", session_id=engine.current_session_id)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+
+
+def test_ingest_externalizes_generic_long_base64_string(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": GENERIC_BASE64}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert GENERIC_BASE64[:120] not in content
+    ref = _extract_ref(content)
+    assert len(content) < 300
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == GENERIC_BASE64
+
+
+def test_ingest_externalizes_embedded_generic_long_base64_run(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": f"prefix {GENERIC_BASE64} suffix"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert GENERIC_BASE64[:120] not in content
+    assert content.startswith("prefix ")
+    assert content.endswith(" suffix")
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == GENERIC_BASE64
+
+
+def test_ingest_externalizes_data_uri_and_generic_base64_in_same_text(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": f"image {DATA_URI} blob {GENERIC_BASE64} done"}])
+
+    store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+    assert DATA_PAYLOAD[:120] not in content
+    assert GENERIC_BASE64[:120] not in content
+    assert content.startswith("image ")
+    assert content.endswith(" done")
+    refs = _extract_refs(content)
+    assert len(refs) == 2
+    expanded_payloads = [_expand_ref(engine, ref)["content"] for ref in refs]
+    assert expanded_payloads == [DATA_URI, GENERIC_BASE64]
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == refs
+
+
+def test_ingest_leaves_repeated_non_base64_text_inline(tmp_path):
+    engine = _engine(tmp_path)
+    repeated_text = "A" * 8000
+
+    engine._ingest_messages([{"role": "user", "content": repeated_text}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert content == repeated_text
+    assert _externalized_files(tmp_path) == []
+
+
+def test_ingest_does_not_mutate_input_message(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "uploading"}],
+        "tool_calls": [{"function": {"name": "upload", "arguments": json.dumps({"image": DATA_URI})}}],
+    }
+    original = deepcopy(message)
+
+    engine._ingest_messages([message])
+
+    assert message == original
+
+
+def test_ingest_protection_is_idempotent_for_existing_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})
+    _store_id, placeholder, _tool_calls = _single_message_row(engine, role="user")
+    files_before = _externalized_files(tmp_path)
+
+    engine._store.append(engine.current_session_id, {"role": "user", "content": placeholder})
+
+    _store_id, second_content, _tool_calls = _single_message_row(engine, role="user")
+    assert second_content == placeholder
+    assert _externalized_files(tmp_path) == files_before
+
+
+def test_engine_ingest_does_not_double_externalize_existing_externalized_payload_placeholder(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=50,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "double-protection-session",
+        platform="telegram",
+        conversation_id="double-protection-conversation",
+        context_length=200_000,
+    )
+    original = "see image " + DATA_URI
+
+    engine._ingest_messages([{"role": "user", "content": original}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert content.startswith("[Externalized payload: kind=media_payload;")
+    assert len(_externalized_files(tmp_path)) == 1
+    expanded = _expand_ref(engine, _extract_ref(content))
+    assert expanded["content"] == original
+
+
+def test_ingest_keeps_scanning_after_existing_placeholder_prefix(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})
+    _store_id, placeholder, _tool_calls = _single_message_row(engine, role="user")
+    first_ref = _extract_ref(placeholder)
+
+    engine._store.append(engine.current_session_id, {"role": "user", "content": f"{placeholder} plus {DATA_URI}"})
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+    assert content.startswith(placeholder)
+    assert " plus " in content
+    refs = _extract_refs(content)
+    assert len(refs) == 2
+    assert refs[0] == first_ref
+    assert refs[1] != first_ref
+    assert _expand_ref(engine, refs[0])["content"] == DATA_URI
+    assert _expand_ref(engine, refs[1])["content"] == DATA_URI
+
+
+def test_replayed_original_payload_reconciles_with_placeholder_row(tmp_path):
+    engine = _engine(tmp_path)
+    original_messages = [
+        {"role": "system", "content": "system anchor"},
+        {"role": "user", "content": "see image " + DATA_URI},
+    ]
+    engine._ingest_messages(original_messages)
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+
+
+def test_replayed_original_tool_call_payload_reconciles_with_placeholder_row(tmp_path):
+    engine = _engine(tmp_path)
+    original_messages = [
+        {"role": "system", "content": "system anchor"},
+        {
+            "role": "assistant",
+            "content": "calling upload",
+            "tool_calls": [
+                {
+                    "id": "call_upload",
+                    "type": "function",
+                    "function": {
+                        "name": "upload_image",
+                        "arguments": json.dumps({"image": DATA_URI}, indent=2),
+                    },
+                }
+            ],
+        },
+    ]
+    engine._ingest_messages(original_messages)
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(original_messages)
+
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+
+
+def test_tool_call_replay_identity_preserves_duplicate_key_argument_payload_text(tmp_path):
+    engine = _engine(tmp_path)
+    payload_a = "data:image/png;base64," + base64.b64encode(b"payload-a" * 48).decode("ascii")
+    payload_b = "data:image/png;base64," + base64.b64encode(b"payload-b" * 48).decode("ascii")
+    arguments_a = json.dumps({"image": payload_a}, separators=(",", ":"))[:-1] + ',"image":"plain"}'
+    arguments_b = json.dumps({"image": payload_b}, separators=(",", ":"))[:-1] + ',"image":"plain"}'
+
+    identity_a = engine._message_replay_identity(
+        {
+            "role": "assistant",
+            "content": "calling upload",
+            "tool_calls": [{"id": "call_upload", "function": {"name": "upload_image", "arguments": arguments_a}}],
+        }
+    )
+    identity_b = engine._message_replay_identity(
+        {
+            "role": "assistant",
+            "content": "calling upload",
+            "tool_calls": [{"id": "call_upload", "function": {"name": "upload_image", "arguments": arguments_b}}],
+        }
+    )
+
+    assert identity_a != identity_b
+    assert payload_a in identity_a[3]
+    assert payload_b in identity_b[3]
+
+
+def test_restart_replay_does_not_skip_changed_duplicate_key_tool_argument_payload(tmp_path):
+    payload_a = "data:image/png;base64," + base64.b64encode(b"payload-a" * 48).decode("ascii")
+    payload_b = "data:image/png;base64," + base64.b64encode(b"payload-b" * 48).decode("ascii")
+    arguments_a = json.dumps({"image": payload_a}, separators=(",", ":"))[:-1] + ',"image":"plain"}'
+    arguments_b = json.dumps({"image": payload_b}, separators=(",", ":"))[:-1] + ',"image":"plain"}'
+
+    def messages(arguments: str) -> list[dict]:
+        return [
+            {"role": "system", "content": "system anchor"},
+            {
+                "role": "assistant",
+                "content": "calling upload",
+                "tool_calls": [{"id": "call_upload", "function": {"name": "upload_image", "arguments": arguments}}],
+            },
+        ]
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(messages(arguments_a))
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    engine = _engine(tmp_path)
+    engine._ingest_messages(messages(arguments_b))
+
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 4
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert payload_b not in tool_calls
+    refs = extract_ingest_externalized_refs(tool_calls)
+    assert refs
+    assert _expand_ref(engine, refs[0])["content"] == payload_b
+
+
+def test_ingest_preserves_inline_payload_when_externalization_fails(tmp_path, monkeypatch):
+    from hermes_lcm import ingest_protection
+
+    engine = _engine(tmp_path)
+    monkeypatch.setattr(ingest_protection, "externalize_ingest_payload", lambda *args, **kwargs: None)
+
+    engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert content == DATA_URI
+    assert _externalized_files(tmp_path) == []
+
+
+def test_externalized_payload_files_are_private(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})
+
+    storage_dir = tmp_path / "externalized"
+    payload_file = _externalized_files(tmp_path)[0]
+    assert stat.S_IMODE(storage_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(payload_file.stat().st_mode) == 0o600
+
+
+def test_ingest_leaves_normal_media_reference_inline(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "normal media ref"},
+            {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "file:///tmp/example.png" in content
+    assert "ref=" not in content
+    assert _externalized_files(tmp_path) == []
+
+
+def test_ingest_externalizes_tool_result_data_uri_before_sqlite_write(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "tool", "tool_call_id": "call_media", "content": "tool saw " + DATA_URI}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="tool")
+    assert "data:image" not in content
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+    assert expanded["role"] == "tool"
+
+
+def test_ingest_externalizes_tool_calls_function_arguments(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "assistant",
+        "content": "calling upload",
+        "tool_calls": [
+            {
+                "id": "call_upload",
+                "type": "function",
+                "function": {
+                    "name": "upload_image",
+                    "arguments": json.dumps({"image": DATA_URI}),
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert "data:image" not in tool_calls
+    ref = _extract_ref(tool_calls)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+    parsed_tool_calls = json.loads(tool_calls)
+    parsed_args = json.loads(parsed_tool_calls[0]["function"]["arguments"])
+    assert parsed_args["image"].startswith("[Externalized LCM ingest payload:")
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == [ref]
+    assert raw_message["externalized_payloads"][0]["field_path"] == "tool_calls[0].function.arguments.image"
+    assert "tool_calls" not in raw_message
+
+
+def test_ingest_preserves_json_argument_string_when_no_payload_changes(tmp_path):
+    engine = _engine(tmp_path)
+    original_arguments = '{"b": 1, "a": 2, "b": 3}'
+    message = {
+        "role": "assistant",
+        "content": "calling ordinary function",
+        "tool_calls": [
+            {
+                "id": "call_plain",
+                "type": "function",
+                "function": {
+                    "name": "ordinary_function",
+                    "arguments": original_arguments,
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    parsed_tool_calls = json.loads(tool_calls)
+    assert parsed_tool_calls[0]["function"]["arguments"] == original_arguments
+    assert "ref=" not in tool_calls
+    assert _externalized_files(tmp_path) == []
+
+
+def test_ingest_externalizes_duplicate_key_json_argument_payload_without_collapsing_string(tmp_path):
+    engine = _engine(tmp_path)
+    original_arguments = json.dumps({"image": DATA_URI}, separators=(",", ":"))[:-1] + ',"image":"plain"}'
+    message = {
+        "role": "assistant",
+        "content": "calling duplicate-key function",
+        "tool_calls": [
+            {
+                "id": "call_duplicate",
+                "type": "function",
+                "function": {
+                    "name": "duplicate_key_function",
+                    "arguments": original_arguments,
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    parsed_tool_calls = json.loads(tool_calls)
+    protected_arguments = parsed_tool_calls[0]["function"]["arguments"]
+    assert "data:image" not in protected_arguments
+    assert ',"image":"plain"}' in protected_arguments
+    refs = extract_ingest_externalized_refs(protected_arguments)
+    assert len(refs) == 1
+    expanded = _expand_ref(engine, refs[0])
+    assert expanded["content"] == DATA_URI
+    assert expanded["field_path"] == "tool_calls[0].function.arguments"
+
+
+def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
+    engine = _engine(tmp_path)
+    tricky_key = "; ref=bogus]"
+    message = {
+        "role": "assistant",
+        "content": "calling upload",
+        "tool_calls": [
+            {
+                "id": "call_upload",
+                "type": "function",
+                "function": {
+                    "name": "upload_image",
+                    "arguments": json.dumps({tricky_key: DATA_URI}),
+                },
+            }
+        ],
+    }
+    messages = [{"role": "system", "content": "stable replay anchor"}, message]
+
+    engine._ingest_messages(messages)
+
+    store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert "data:image" not in tool_calls
+    assert tricky_key in tool_calls
+    assert "field=tool_calls-0-.function.arguments.-ref-bogus;" in tool_calls
+    refs = extract_ingest_externalized_refs(tool_calls)
+    assert len(refs) == 1
+    assert refs[0] != "bogus"
+    expanded = _expand_ref(engine, refs[0])
+    assert expanded["content"] == DATA_URI
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_refs"] == refs
+    assert raw_message["externalized_payloads"][0]["field_path"] == f"tool_calls[0].function.arguments.{tricky_key}"
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    engine._store.close()
+
+    replay_engine = _engine(tmp_path)
+    replay_engine._ingest_messages(messages)
+
+    assert replay_engine._store.count_session_load_messages(replay_engine.current_session_id) == 2
+
+
+def test_ingest_externalizes_nested_json_string_tool_arguments(tmp_path):
+    engine = _engine(tmp_path)
+    nested_arguments = json.dumps({"outer": json.dumps({"inner": DATA_URI})})
+
+    engine._ingest_messages([
+        {
+            "role": "assistant",
+            "content": "calling nested upload",
+            "tool_calls": [
+                {
+                    "id": "call_nested",
+                    "type": "function",
+                    "function": {"name": "upload_nested", "arguments": nested_arguments},
+                }
+            ],
+        }
+    ])
+
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    assert "data:image" not in tool_calls
+    ref = _extract_ref(tool_calls)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+
+
+def _load_importer_module():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "import_lossless_claw.py"
+    spec = importlib.util.spec_from_file_location("import_lossless_claw_payload_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_lossless_source(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                session_key TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE messages (
+                message_id INTEGER PRIMARY KEY,
+                conversation_id INTEGER NOT NULL,
+                seq INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                token_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT
+            );
+            """
+        )
+        conn.execute("INSERT INTO conversations VALUES (1, 'legacy-session', 'legacy-key', '2026-01-01 00:00')")
+        conn.execute(
+            "INSERT INTO messages VALUES (1, 1, 1, 'user', ?, 123, '2026-01-01 00:01')",
+            ("legacy " + DATA_URI,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_import_lossless_claw_externalizes_legacy_data_uri_content(tmp_path):
+    importer = _load_importer_module()
+    source_db = tmp_path / "source.db"
+    target_db = tmp_path / "target.db"
+    _create_lossless_source(source_db)
+
+    first = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="repro",
+        import_id="payload-import",
+        apply=True,
+    )
+    second = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="repro",
+        import_id="payload-import",
+        apply=True,
+    )
+
+    assert first.imported == 1
+    assert second.imported == 0
+    conn = sqlite3.connect(target_db)
+    try:
+        content = conn.execute("SELECT content FROM messages").fetchone()[0]
+    finally:
+        conn.close()
+    assert "data:image" not in content
+    ref = _extract_ref(content)
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(target_db)),
+        hermes_home=str(tmp_path),
+    )
+    engine.on_session_start("openclaw-lcm:agent:repro:legacy-session", platform="import", context_length=200_000)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+
+
+def test_import_lossless_claw_respects_externalization_path_env(tmp_path, monkeypatch):
+    importer = _load_importer_module()
+    source_db = tmp_path / "source.db"
+    target_db = tmp_path / "target.db"
+    custom_externalized = tmp_path / "custom-externalized"
+    _create_lossless_source(source_db)
+    monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", str(custom_externalized))
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="repro",
+        import_id="payload-import-custom-path",
+        apply=True,
+    )
+
+    assert result.imported == 1
+    conn = sqlite3.connect(target_db)
+    try:
+        content = conn.execute("SELECT content FROM messages").fetchone()[0]
+    finally:
+        conn.close()
+    ref = _extract_ref(content)
+    assert (custom_externalized / ref).exists()
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(target_db), large_output_externalization_path=str(custom_externalized)),
+        hermes_home=str(tmp_path),
+    )
+    engine.on_session_start("openclaw-lcm:agent:repro:legacy-session", platform="import", context_length=200_000)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == DATA_URI
+
+
+def test_store_id_expand_never_returns_raw_historical_tool_calls(tmp_path):
+    engine = _engine(tmp_path)
+    tool_calls = json.dumps([{"function": {"arguments": DATA_URI}}])
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "historical row with raw tool args",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            5,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+    store_id = engine._store._conn.execute("SELECT max(store_id) FROM messages").fetchone()[0]
+
+    raw_message_text = lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine)
+    raw_message = json.loads(raw_message_text)
+
+    assert "tool_calls" not in raw_message
+    assert DATA_URI not in raw_message_text
+    assert DATA_PAYLOAD[:120] not in raw_message_text
+
+
+def test_lcm_doctor_reports_largest_and_suspicious_payload_rows(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "small content",
+            None,
+            json.dumps([{"function": {"arguments": DATA_URI}}]),
+            None,
+            1.0,
+            5,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "largest_content_rows:" in result
+    assert "largest_tool_calls_rows:" in result
+    assert "suspicious_data_uri_content_rows:" in result
+    assert "suspicious_data_uri_tool_calls_rows:" in result
+    assert "suspicious_base64_like_rows:" in result
+
+
+def test_lcm_doctor_reports_embedded_generic_base64_without_raw_preview(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "small content",
+            None,
+            json.dumps([{"function": {"arguments": "prefix " + GENERIC_BASE64 + " suffix"}}]),
+            None,
+            1.0,
+            5,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    json_result_text = lcm_tools.lcm_doctor({}, engine=engine)
+    json_result = json.loads(json_result_text)
+
+    assert GENERIC_BASE64[:120] not in json_result_text
+    payload_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
+    rows = payload_check["detail"]["suspicious_base64_like_rows"]
+    assert rows
+    assert rows[0]["field"] == "tool_calls"
+    assert rows[0]["suspicious_category"] == "base64_like"
+
+
+def test_lcm_doctor_reports_externalized_payload_stats(tmp_path):
+    engine = _engine(tmp_path)
+    engine._ingest_messages([{"role": "user", "content": DATA_URI}])
+
+    text_result = handle_lcm_command("doctor", engine)
+    json_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+
+    assert "externalized_payload_count: 1" in text_result
+    assert "externalized_payload_bytes:" in text_result
+    externalized_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
+    assert externalized_check["detail"]["externalized_payload_count"] == 1
+    assert externalized_check["detail"]["externalized_payload_bytes"] > 0
+
+
+def test_readme_documents_storage_boundary_payload_guard():
+    readme = (Path(__file__).resolve().parent.parent / "README.md").read_text(encoding="utf-8")
+
+    assert "Storage-boundary payload guard" in readme
+    assert "messages.content" in readme
+    assert "messages.tool_calls" in readme
+    assert "data:*;base64" in readme
+    assert "Doctor output is metadata-only" in readme
+    assert "state.db" in readme
+    assert "upstream/outside LCM scope" in readme
+    assert "historical rows already present in `lcm.db`" in readme
+    assert "backup-first cleanup or migration" in readme

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -675,8 +675,43 @@ def test_ingest_externalizes_tool_calls_function_arguments(tmp_path):
     assert parsed_args["image"].startswith("[Externalized LCM ingest payload:")
     raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
     assert raw_message["externalized_refs"] == [ref]
-    assert raw_message["externalized_payloads"][0]["field_path"] == "tool_calls[0].function.arguments.image"
+    assert raw_message["externalized_payloads"][0]["field_path"] == "tool_calls[0].function.arguments"
     assert "tool_calls" not in raw_message
+
+
+def test_ingest_preserves_json_argument_scaffold_when_externalizing_payload(tmp_path):
+    engine = _engine(tmp_path)
+    original_arguments = json.dumps({"image": DATA_URI, "caption": "keep formatting"}, indent=2)
+    assert "\n  \"image\": " in original_arguments
+    message = {
+        "role": "assistant",
+        "content": "calling formatted upload",
+        "tool_calls": [
+            {
+                "id": "call_formatted_upload",
+                "type": "function",
+                "function": {
+                    "name": "upload_image",
+                    "arguments": original_arguments,
+                },
+            }
+        ],
+    }
+
+    engine._ingest_messages([message])
+
+    _store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
+    parsed_tool_calls = json.loads(tool_calls)
+    protected_arguments = parsed_tool_calls[0]["function"]["arguments"]
+    assert "data:image" not in protected_arguments
+    assert DATA_PAYLOAD[:80] not in protected_arguments
+    assert protected_arguments.startswith("{\n  \"image\": \"")
+    assert protected_arguments.endswith('\",\n  \"caption\": \"keep formatting\"\n}')
+    assert ",\n  \"caption\": " in protected_arguments
+    assert json.loads(protected_arguments)["caption"] == "keep formatting"
+    refs = extract_ingest_externalized_refs(protected_arguments)
+    assert len(refs) == 1
+    assert _expand_ref(engine, refs[0])["content"] == DATA_URI
 
 
 def test_ingest_externalizes_tool_call_argument_payload_keys(tmp_path):
@@ -777,7 +812,7 @@ def test_payload_bearing_key_uses_neutral_child_field_path(tmp_path):
     assert all(DATA_PAYLOAD[:80] not in field_path for field_path in field_paths)
     assert all("raw-label" not in field_path for field_path in field_paths)
     assert all("raw-suffix" not in field_path for field_path in field_paths)
-    assert "tool_calls[0].function.arguments.<key>" in field_paths
+    assert "tool_calls[0].function.arguments" in field_paths
 
 
 def test_ingest_preserves_json_argument_string_when_no_payload_changes(tmp_path):
@@ -978,7 +1013,7 @@ def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
     store_id, _content, tool_calls = _single_message_row(engine, role="assistant")
     assert "data:image" not in tool_calls
     assert tricky_key in tool_calls
-    assert "field=tool_calls-0-.function.arguments.-ref-bogus;" in tool_calls
+    assert "field=tool_calls-0-.function.arguments;" in tool_calls
     refs = extract_ingest_externalized_refs(tool_calls)
     assert len(refs) == 1
     assert refs[0] != "bogus"
@@ -986,7 +1021,7 @@ def test_ingest_ref_parser_ignores_ref_text_in_tool_argument_key(tmp_path):
     assert expanded["content"] == DATA_URI
     raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
     assert raw_message["externalized_refs"] == refs
-    assert raw_message["externalized_payloads"][0]["field_path"] == f"tool_calls[0].function.arguments.{tricky_key}"
+    assert raw_message["externalized_payloads"][0]["field_path"] == "tool_calls[0].function.arguments"
     assert engine._store.count_session_load_messages(engine.current_session_id) == 2
     engine._store.close()
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1868,8 +1868,8 @@ class TestLifecycleStateStore:
         state_db = tmp_path / "state.db"
         # Initialize all shared LCM tables; fragmentation diagnostics compare
         # lifecycle rows against raw-message and summary-DAG session coverage.
-        store = MessageStore(db_path)
-        dag = SummaryDAG(db_path)
+        _store = MessageStore(db_path)
+        _dag = SummaryDAG(db_path)
         state = LifecycleStateStore(db_path)
         conn = state._conn
         conn.execute(
@@ -3139,6 +3139,29 @@ class TestIngestExternalization:
         assert payload["kind"] == "raw_payload"
         assert payload["role"] == "user"
         assert payload["content"] == content
+
+    def test_non_tool_externalized_placeholder_sanitizes_role_metadata_for_ref_parsing(self, tmp_path):
+        import hermes_lcm.tools as lcm_tools
+
+        engine, output_dir = self._engine(tmp_path)
+        content = "INJECTED_ROLE_RAW_NEEDLE:" + ("z" * 5000)
+        injected_role = "user; ref=bogus]"
+
+        engine._ingest_messages([{"role": injected_role, "content": content}])
+
+        stored = engine._store.get_session_messages("ingest-session")
+        placeholder = stored[0]["content"]
+        assert placeholder.startswith("[Externalized payload: kind=raw_payload;")
+        assert "; ref=bogus]" not in placeholder
+        assert "INJECTED_ROLE_RAW_NEEDLE" not in placeholder
+
+        payload_file = next(output_dir.glob("*.json"))
+        payload = json.loads(payload_file.read_text())
+        assert payload["role"] == injected_role
+        by_store_id = json.loads(lcm_tools.lcm_expand({"store_id": stored[0]["store_id"], "max_tokens": 20_000}, engine=engine))
+        assert by_store_id["externalized_ref"] == payload_file.name
+        expanded = json.loads(lcm_tools.lcm_expand({"externalized_ref": by_store_id["externalized_ref"], "max_tokens": 20_000}, engine=engine))
+        assert expanded["content"] == content
 
     def test_engine_bootstrap_does_not_externalize_until_ingest_path_runs(self, tmp_path):
         from hermes_lcm.engine import LCMEngine

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -10172,6 +10172,45 @@ class TestEngineTools:
         assert "ref=" in item["content"]
         assert result["pagination"]["has_more"] is False
 
+    def test_handle_expand_paginates_long_text_with_embedded_ingest_placeholder(self, engine):
+        from hermes_lcm.tokens import count_tokens
+
+        data_uri = "data:image/png;base64," + ("QUJD" * 80)
+        content = ("intro " * 140) + data_uri + (" outro" * 140)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": content},
+        )
+        stored = engine._store.get_session_messages("test-session")[-1]
+        assert "[Externalized LCM ingest payload:" in stored["content"]
+        assert "ref=" in stored["content"]
+        assert data_uri not in stored["content"]
+        assert len(stored["content"]) > 512
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Long embedded ingest marker summary",
+                token_count=10,
+                source_token_count=count_tokens(stored["content"]),
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        first = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id, "max_tokens": 20}))
+
+        item = first["expanded"][0]
+        assert item["store_id"] == store_id
+        assert item["content"] != stored["content"]
+        assert item["content_truncated"] is True
+        assert item["next_content_offset"] > 0
+        assert count_tokens(item["content"]) <= 20
+        assert first["pagination"]["has_more"] is True
+        assert first["pagination"]["next_source_offset"] == 0
+        assert first["pagination"]["next_content_offset"] == item["next_content_offset"]
+
     def test_handle_expand_paginates_oversized_message_content_without_losing_raw_tail(self, engine):
         from hermes_lcm.tokens import count_tokens
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5794,7 +5794,7 @@ class TestSessionRollover:
             platform="telegram",
             context_length=200000,
         )
-        a = self._start_host_child(
+        self._start_host_child(
             engine,
             hermes_home,
             "background-review-a",
@@ -8551,7 +8551,7 @@ class TestAssemblyToolPairGuardrail:
         and must include stubs for missing results."""
         import importlib
         esc_module = importlib.import_module("hermes_lcm.escalation")
-        engine_module = importlib.import_module("hermes_lcm.engine")
+        importlib.import_module("hermes_lcm.engine")
 
         config = LCMConfig(
             fresh_tail_count=4,
@@ -9835,7 +9835,7 @@ class TestEngineTools:
         assert result["results"][0]["snippet"].startswith("Keep vendoring out")
 
     def test_handle_grep_recency_same_timestamp_pool_matches_store_ordering(self, engine):
-        ids = engine._store.append_batch(
+        engine._store.append_batch(
             "test-session",
             [
                 {
@@ -10137,6 +10137,40 @@ class TestEngineTools:
             "has_more": True,
             "remaining_sources": 2,
         }
+
+    def test_handle_expand_keeps_ingest_placeholder_ref_unsliced_under_tiny_budget(self, engine):
+        data_uri = "data:image/png;base64," + ("QUJD" * 80)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "see image " + data_uri + " please inspect"},
+        )
+        stored = engine._store.get_session_messages("test-session")[-1]
+        assert "see image [Externalized LCM ingest payload:" in stored["content"]
+        assert stored["content"].endswith(" please inspect")
+        assert "ref=" in stored["content"]
+        assert data_uri not in stored["content"]
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="Ingest marker recovery handle summary",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=0,
+            )
+        )
+
+        result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id, "max_tokens": 1}))
+
+        item = result["expanded"][0]
+        assert item["store_id"] == store_id
+        assert item["content"] == stored["content"]
+        assert item["content_truncated"] is False
+        assert item["next_content_offset"] == 0
+        assert "ref=" in item["content"]
+        assert result["pagination"]["has_more"] is False
 
     def test_handle_expand_paginates_oversized_message_content_without_losing_raw_tail(self, engine):
         from hermes_lcm.tokens import count_tokens

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -744,6 +744,30 @@ class TestEngineABC:
         assert all("Current user objective preserved" not in row["content"] for row in rows)
         assert after_restart._ingest_cursor == len(replay_with_new_message)
 
+    def test_preserved_objective_anchor_externalizes_inline_payloads(self, tmp_path):
+        db_path = tmp_path / "preserved-objective-payload.db"
+        data_uri = "data:image/png;base64," + ("QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=" * 20)
+        engine = LCMEngine(config=LCMConfig(database_path=str(db_path)), hermes_home=str(tmp_path))
+        engine.on_session_start(
+            "preserved-objective-payload-session",
+            platform="cli",
+            conversation_id="preserved-objective-payload-conversation",
+            context_length=200000,
+        )
+
+        anchor = engine._build_preserved_objective_summary_part(
+            {"role": "user", "content": "please inspect this screenshot " + data_uri}
+        )
+
+        assert "Current user objective preserved" in anchor
+        assert "data:image" not in anchor
+        match = re.search(r";\s*ref=([^;\]\s]+)", anchor)
+        assert match, anchor
+        expanded = json.loads(lcm_tools.lcm_expand({"externalized_ref": match.group(1), "max_tokens": 100_000}, engine=engine))
+        assert expanded["kind"] == "ingest_payload"
+        assert expanded["content"] == data_uri
+        assert expanded["field_path"] == "preserved_objective.content"
+
     def test_existing_large_session_restart_reconciles_beyond_short_tail_window(self, tmp_path):
         db_path = tmp_path / "restart-large.db"
         config = LCMConfig(database_path=str(db_path))
@@ -1418,6 +1442,61 @@ class TestEngineABC:
             "skipped stale no-overlap snapshot"
         )
         assert "skipped stale no-overlap snapshot" in caplog.text
+
+    def test_existing_session_restart_skips_stale_short_snapshot_with_externalized_head_payload(self, tmp_path):
+        db_path = tmp_path / "restart-stale-externalized-head.db"
+        config = LCMConfig(
+            database_path=str(db_path),
+            large_output_externalization_path=str(tmp_path / "externalized"),
+        )
+        before_restart = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        before_restart.on_session_start(
+            "stale-externalized-head-session",
+            platform="cli",
+            conversation_id="stale-externalized-head-conversation",
+            context_length=200000,
+        )
+        data_uri = "data:image/png;base64," + ("A" * 5000)
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "old startup image " + data_uri},
+            {"role": "assistant", "content": "old startup answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        stored_before_restart = before_restart._store.get_session_messages(
+            "stale-externalized-head-session",
+            limit=3,
+        )
+        assert "[Externalized LCM ingest payload:" in stored_before_restart[1]["content"]
+        assert data_uri not in stored_before_restart[1]["content"]
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        after_restart.on_session_start(
+            "stale-externalized-head-session",
+            platform="cli",
+            conversation_id="stale-externalized-head-conversation",
+            context_length=200000,
+        )
+        stale_runtime_snapshot = persisted_messages[:3]
+
+        after_restart._ingest_messages(stale_runtime_snapshot)
+
+        rows = after_restart._store.get_session_messages(
+            "stale-externalized-head-session",
+            limit=len(persisted_messages) + len(stale_runtime_snapshot),
+        )
+        assert len(rows) == len(persisted_messages)
+        assert after_restart._ingest_cursor == len(stale_runtime_snapshot)
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "skipped stale no-overlap snapshot"
+        )
 
     def test_existing_session_restart_persists_one_message_no_overlap_delta(self, tmp_path):
         db_path = tmp_path / "restart-one-message-no-overlap.db"
@@ -10406,10 +10485,14 @@ class TestEngineTools:
         )
         engine_b = LCMEngine(config=config_b, hermes_home=str(shared_home))
         engine_b._session_id = "session-b"
-        store_id = engine_b._store.append(
-            "session-b",
-            {"role": "tool", "tool_call_id": "call_shared", "content": content},
+        cur = engine_b._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("session-b", "", "tool", content, "call_shared", 0, 0, 0),
         )
+        engine_b._store._conn.commit()
+        store_id = int(cur.lastrowid)
         node_id = engine_b._dag.add_node(
             SummaryNode(
                 session_id="session-b",

--- a/tools.py
+++ b/tools.py
@@ -294,6 +294,7 @@ def _is_compact_externalized_marker(content: str, ref: str | None) -> bool:
         or content.startswith("[GC'd externalized tool output:")
         or content.startswith("[Externalized payload:")
         or content.startswith("[GC'd externalized payload:")
+        or "[Externalized LCM ingest payload:" in content
     )
 
 

--- a/tools.py
+++ b/tools.py
@@ -17,6 +17,12 @@ from .externalize import (
 from .dag import build_nodes_fts_spec
 from .db_bootstrap import check_external_content_fts_integrity
 from .extraction import sanitize_pre_compaction_content
+from .ingest_protection import (
+    externalized_payload_stats,
+    extract_ingest_externalized_refs,
+    restore_ingest_payload_placeholders,
+    scan_sqlite_payload_risks,
+)
 from .model_routing import apply_lcm_model_route
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 from .store import build_message_fts_spec
@@ -258,6 +264,26 @@ def _full_content_slice(content: str, content_offset: int = 0) -> dict[str, Any]
     }
 
 
+def _restore_ingest_placeholder_for_lookup(
+    content: str,
+    ref: str | None,
+    payload: dict[str, Any] | None,
+    *,
+    config,
+    hermes_home: str,
+    session_id: str,
+) -> str | None:
+    if not content or not ref or not payload or payload.get("kind") != "ingest_payload":
+        return None
+    restored = restore_ingest_payload_placeholders(
+        content,
+        config=config,
+        hermes_home=hermes_home,
+        session_id=session_id,
+    )
+    return restored if restored != content else None
+
+
 def _is_compact_externalized_marker(content: str, ref: str | None) -> bool:
     if not ref or not content:
         return False
@@ -348,13 +374,17 @@ def _expand_message_sources(
         content = transcript_content
         content_source = "message"
         externalized = None
-        ref = extract_externalized_ref(transcript_content)
+        ref_payload = None
+        ingest_refs = extract_ingest_externalized_refs(transcript_content)
+        ref = ingest_refs[0] if ingest_refs else extract_externalized_ref(transcript_content)
         if ref:
-            externalized = _get_externalized_payload(
+            ref_payload = _get_externalized_payload(
                 engine,
                 ref,
                 allowed_session_ids={engine.current_session_id, stored.get("session_id", "")},
             )
+            if ref_payload is not None and ref_payload.get("kind") != "ingest_payload":
+                externalized = ref_payload
         if hydrate_externalized_content and externalized is not None:
             content = externalized.get("content", "")
             content_source = "externalized_payload"
@@ -387,6 +417,19 @@ def _expand_message_sources(
                 expanded["externalized"] = externalized_summary
             if "externalized" not in expanded:
                 lookup_candidates = [transcript_content]
+                restored_ingest_content = _restore_ingest_placeholder_for_lookup(
+                    transcript_content,
+                    ref,
+                    ref_payload,
+                    config=engine._config,
+                    hermes_home=engine._hermes_home,
+                    session_id=stored.get("session_id", ""),
+                )
+                if restored_ingest_content is not None:
+                    lookup_candidates.insert(0, restored_ingest_content)
+                    sanitized_restored = sanitize_pre_compaction_content(restored_ingest_content)
+                    if sanitized_restored != restored_ingest_content:
+                        lookup_candidates.insert(0, sanitized_restored)
                 sanitized_content = sanitize_pre_compaction_content(transcript_content)
                 if sanitized_content != transcript_content:
                     lookup_candidates.insert(0, sanitized_content)
@@ -974,6 +1017,7 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
                 "tool_call_id": payload.get("tool_call_id", ""),
                 "role": payload.get("role", ""),
                 "session_id": payload.get("session_id", ""),
+                "field_path": payload.get("field_path", ""),
                 "content_chars": payload.get("content_chars", 0),
                 "content_bytes": payload.get("content_bytes", 0),
                 "created_at": payload.get("created_at"),
@@ -1077,6 +1121,7 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
                 "tool_call_id": payload.get("tool_call_id", ""),
                 "role": payload.get("role", ""),
                 "session_id": payload.get("session_id", ""),
+                "field_path": payload.get("field_path", ""),
                 "content_chars": payload.get("content_chars", len(content)),
                 "content_bytes": payload.get("content_bytes", 0),
                 "content": sliced["content"],
@@ -1122,15 +1167,37 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         # default. Externalized lookup remains session-scoped (per the existing
         # _get_externalized_payload contract); cross-session rows surface only the
         # ref string, with a hint pointing at the same-session expansion path.
-        ref = extract_externalized_ref(transcript_content)
-        if ref:
-            result["externalized_ref"] = ref
+        ref_values = [transcript_content]
+        if stored.get("tool_calls"):
+            try:
+                ref_values.append(json.dumps(stored.get("tool_calls"), ensure_ascii=False, sort_keys=True))
+            except (TypeError, ValueError):
+                ref_values.append(str(stored.get("tool_calls")))
+        refs: list[str] = []
+        for value in ref_values:
+            if not isinstance(value, str):
+                continue
+            for found_ref in extract_ingest_externalized_refs(value):
+                if found_ref not in refs:
+                    refs.append(found_ref)
+            legacy_ref = extract_externalized_ref(value)
+            if legacy_ref and legacy_ref not in refs:
+                refs.append(legacy_ref)
+        if refs:
+            result["externalized_refs"] = refs
+            result["externalized_ref"] = refs[0]
             if bool(engine_session_id) and stored_session_id == engine_session_id:
-                payload = _get_externalized_payload(engine, ref)
-                if payload is not None:
+                payload_summaries = []
+                for ref in refs:
+                    payload = _get_externalized_payload(engine, ref)
+                    if payload is None:
+                        continue
                     payload_summary = dict(payload)
                     payload_summary.pop("content", None)
-                    result["externalized"] = payload_summary
+                    payload_summaries.append(payload_summary)
+                if payload_summaries:
+                    result["externalized_payloads"] = payload_summaries
+                    result["externalized"] = payload_summaries[0]
             else:
                 result["externalized_note"] = (
                     "Externalized payload metadata is session-scoped; "
@@ -1569,7 +1636,45 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
                 "detail": str(e),
             })
 
-    # 2. FTS index sync
+    # 2. SQLite storage posture and payload diagnostics
+    try:
+        journal_mode_row = engine._store._conn.execute("PRAGMA journal_mode").fetchone()
+        quick_check_row = engine._store._conn.execute("PRAGMA quick_check").fetchone()
+        db_path = Path(engine._store.db_path)
+        wal_path = Path(str(db_path) + "-wal")
+        checks.append({
+            "check": "sqlite_storage",
+            "status": "pass" if quick_check_row and quick_check_row[0] == "ok" else "fail",
+            "detail": {
+                "journal_mode": journal_mode_row[0] if journal_mode_row else "unknown",
+                "quick_check": quick_check_row[0] if quick_check_row else "unknown",
+                "database_size_bytes": db_path.stat().st_size if db_path.exists() else 0,
+                "wal_size_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
+            },
+        })
+        payload_risks = scan_sqlite_payload_risks(engine._store._conn)
+        externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
+        suspicious_count = (
+            len(payload_risks["suspicious_data_uri_content_rows"])
+            + len(payload_risks["suspicious_data_uri_tool_calls_rows"])
+            + len(payload_risks["suspicious_base64_like_rows"])
+        )
+        checks.append({
+            "check": "payload_storage",
+            "status": "warn" if suspicious_count else "pass",
+            "detail": {
+                **payload_risks,
+                **externalized_stats,
+            },
+        })
+    except Exception as e:
+        checks.append({
+            "check": "payload_storage",
+            "status": "fail",
+            "detail": str(e),
+        })
+
+    # 3. FTS index sync
     try:
         msg_count = engine._store._conn.execute(
             "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)


### PR DESCRIPTION
## Summary

This hardens LCM’s SQLite write boundary so inline media/base64-ish payloads are externalized before entering `lcm.db` and FTS. It covers message content, structured multimodal content, tool results, `tool_calls`, nested function arguments, and lossless-claw/OpenClaw imports.

Recovery remains lossless through LCM externalized refs.

## Scope

This protects LCM’s `lcm.db` only. Hermes core `state.db` remains upstream/outside this patch.

Existing historical `lcm.db` rows are not rewritten here. That needs a separate backup-first cleanup or migration.

## Validation

- `git diff --check`
- `python -m pytest tests/test_ingest_protection.py -q -o 'addopts='`: 23 passed
- `python -m pytest -q -o 'addopts='`: 548 passed
- `python -m compileall -q .`
- `ruff check command.py engine.py externalize.py ingest_protection.py scripts/import_lossless_claw.py store.py tools.py tests/test_ingest_protection.py`: all checks passed
