### PR TITLE
fix: refresh plugin metadata from manifest on status reads

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -84,10 +84,12 @@ def _strip_metadata_scalar(value: str) -> str:
 
 
 def _plugin_metadata() -> dict[str, str]:
-    """Return plugin identity from the loaded code tree."""
+    """Return plugin identity from the loaded code tree.
+
+    Always re-read the manifest from disk when available so status tools reflect
+    hot-updated plugin checkouts even in long-lived Hermes processes.
+    """
     global _PLUGIN_METADATA
-    if _PLUGIN_METADATA is not None:
-        return dict(_PLUGIN_METADATA)
 
     metadata = {"name": "hermes-lcm", "version": "unknown"}
     manifest = _PLUGIN_ROOT / "plugin.yaml"
@@ -99,10 +101,13 @@ def _plugin_metadata() -> dict[str, str]:
             key = key.strip()
             if key in {"name", "version"}:
                 metadata[key] = _strip_metadata_scalar(raw_value)
+        _PLUGIN_METADATA = metadata
+        return dict(metadata)
     except OSError:
         logger.debug("LCM plugin manifest not readable at %s", manifest)
 
-    _PLUGIN_METADATA = metadata
+    if _PLUGIN_METADATA is not None:
+        return dict(_PLUGIN_METADATA)
     return dict(metadata)
 
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -194,6 +194,55 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
 
 
+def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
+    import hermes_lcm.engine as engine_mod
+
+    repo_root = Path(engine_mod.__file__).resolve().parent
+    manifest = repo_root / "plugin.yaml"
+    original = manifest.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(engine_mod, "_PLUGIN_METADATA", None)
+
+    initial = engine_mod._plugin_metadata()
+    assert initial["name"] == "hermes-lcm"
+    assert initial["version"] == "0.10.2"
+
+    updated = original.replace('version: "0.10.2"', 'version: "9.9.9-test"')
+    if updated == original:
+        updated = original.replace('version: 0.10.2', 'version: 9.9.9-test')
+    assert updated != original
+
+    try:
+        manifest.write_text(updated, encoding="utf-8")
+        refreshed = engine_mod._plugin_metadata()
+        assert refreshed == {"name": "hermes-lcm", "version": "9.9.9-test"}
+
+        manifest.unlink()
+        fallback = engine_mod._plugin_metadata()
+        assert fallback == {"name": "hermes-lcm", "version": "9.9.9-test"}
+    finally:
+        manifest.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(engine_mod, "_PLUGIN_METADATA", None)
+
+
+def test_plugin_metadata_defaults_when_manifest_missing_before_first_read(tmp_path, monkeypatch):
+    import hermes_lcm.engine as engine_mod
+
+    repo_root = Path(engine_mod.__file__).resolve().parent
+    manifest = repo_root / "plugin.yaml"
+    original = manifest.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(engine_mod, "_PLUGIN_METADATA", None)
+
+    try:
+        manifest.unlink()
+        metadata = engine_mod._plugin_metadata()
+        assert metadata == {"name": "hermes-lcm", "version": "unknown"}
+    finally:
+        manifest.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(engine_mod, "_PLUGIN_METADATA", None)
+
+
 def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 


### PR DESCRIPTION
Summary
- refresh hermes-lcm plugin metadata from plugin.yaml on status reads
- make runtime status tools reflect hot-updated plugin checkouts in long-lived Hermes processes
- retain cached metadata only as a fallback when the manifest is not readable

Why
lcm_status.runtime_identity.plugin_version could stay stale after a plugin repo hot-update because _plugin_metadata() returned cached values once initialized. Refreshing metadata from plugin.yaml keeps runtime status aligned with the actual checked-out plugin version.

Validation
- restarted the gateway and confirmed runtime_identity.plugin_version updated to 0.10.2
- confirmed hermes plugins list shows hermes-lcm 0.10.2
- ran:
  `PYTHONPATH=/root/.hermes/hermes-agent python3 -m pytest tests/test_lcm_engine.py -q -o addopts=`
- result: 360 passed
