### PR TITLE
Add opt-in path containment hardening via LCM_HERMES_BASE_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+
+# Test stubs
+agent/

--- a/command.py
+++ b/command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+import os
 import sqlite3
 from typing import Any
 
@@ -16,7 +17,18 @@ from .store import build_message_fts_spec
 def _state_db_path_for_engine(engine) -> Path:
     hermes_home = getattr(engine, "_hermes_home", "") or ""
     if hermes_home:
-        return Path(hermes_home).expanduser() / "state.db"
+        resolved = Path(hermes_home).expanduser().resolve() / "state.db"
+        # Check containment within allowed base only when restriction is active
+        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+        if env_base:
+            allowed_base = Path(env_base).expanduser().resolve()
+            try:
+                resolved.relative_to(allowed_base)
+            except ValueError:
+                raise ValueError(
+                    f"hermes_home {hermes_home} resolves to {resolved} which is not within allowed base {allowed_base}"
+                )
+        return resolved
     db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
     return db_path.parent / "state.db"
 

--- a/engine.py
+++ b/engine.py
@@ -951,11 +951,29 @@ class LCMEngine(ContextEngine):
             self._auxiliary_session_ids.discard(session_id)
         self._clear_thread_context_stateless(session_id)
 
+    def _get_allowed_hermes_base(self) -> Path | None:
+        """Get the allowed base directory for hermes_home, or None if not restricted."""
+        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+        if env_base:
+            return Path(env_base).expanduser().resolve()
+        return None  # No restriction when env var not set
+
     def _state_db_path(self, kwargs: Dict[str, Any] | None = None) -> Path:
         kwargs = kwargs or {}
         hermes_home = str(kwargs.get("hermes_home") or self._hermes_home or "")
         if hermes_home:
-            return Path(hermes_home).expanduser() / "state.db"
+            # Prevent directory traversal by resolving the path
+            path = Path(hermes_home).expanduser().resolve()
+            # Check containment within allowed base only when restriction is active
+            allowed_base = self._get_allowed_hermes_base()
+            if allowed_base is not None:
+                try:
+                    path.relative_to(allowed_base)
+                except ValueError:
+                    raise ValueError(
+                        f"hermes_home {hermes_home} resolves to {path} which is not within allowed base {allowed_base}"
+                    )
+            return path / "state.db"
         return Path(self._store.db_path).parent / "state.db"
 
     def _caller_is_auxiliary_agent_frame(self, caller_self: Any) -> bool:

--- a/externalize.py
+++ b/externalize.py
@@ -2,7 +2,7 @@
 
 Externalization started as a pre-compaction serializer guard for oversized tool
 outputs. The same durable payload format is also used by the ingest path so
-obvious oversized content can be kept out of SQLite/FTS while remaining
+obvious oversized content can be kept out of SQLite/FTS while still being
 recoverable through the LCM inspection and expansion tools.
 """
 
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -37,10 +38,27 @@ def _content_digest_prefix(content: str) -> str:
 def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool) -> Path:
     configured = getattr(config, "large_output_externalization_path", "") or ""
     if configured:
-        path = Path(configured).expanduser()
+        path = Path(configured).expanduser().resolve()
+        # Check containment for configured paths when LCM_HERMES_BASE_DIR is set
+        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+        if env_base:
+            allowed_base = Path(env_base).expanduser().resolve()
+            try:
+                path.relative_to(allowed_base)
+            except ValueError:
+                raise ValueError(f"Path {path} is not within allowed base {allowed_base}")
     else:
-        base = Path(hermes_home).expanduser() if hermes_home else Path("~/.hermes").expanduser()
+        base = Path(hermes_home).expanduser().resolve() if hermes_home else Path("~/.hermes").expanduser().resolve()
         path = base / DEFAULT_LARGE_OUTPUT_DIRNAME
+        # Check containment within allowed base for default/hermes_home-based paths
+        # Only enforced when LCM_HERMES_BASE_DIR is explicitly set
+        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+        if env_base:
+            allowed_base = Path(env_base).expanduser().resolve()
+            try:
+                path.relative_to(allowed_base)
+            except ValueError:
+                raise ValueError(f"Path {path} is not within allowed base {allowed_base}")
     if create:
         path.mkdir(parents=True, exist_ok=True)
     return path

--- a/store.py
+++ b/store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Immutable-first message store — the source of truth.
 
 Every message is persisted durably in SQLite. The normal model is append-only,
@@ -9,7 +11,9 @@ row identity (`store_id`) for DAG/source lookup.
 
 import json
 import logging
+import os
 import sqlite3
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -1,0 +1,64 @@
+"""Tests for path containment checks - validates boundary enforcement."""
+import tempfile
+from pathlib import Path
+import pytest
+
+
+def test_path_containment_within_allowed_base(monkeypatch):
+    """Test that hermes_home within allowed base is accepted."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Set allowed base to tmpdir using monkeypatch
+        monkeypatch.setenv("LCM_HERMES_BASE_DIR", tmpdir)
+
+        from hermes_lcm.command import _state_db_path_for_engine
+
+        # Create a mock engine with hermes_home inside allowed base
+        hermes_home = str(Path(tmpdir) / "hermes")
+
+        class MockEngine:
+            _hermes_home = hermes_home
+
+        engine = MockEngine()
+        # Should succeed without raising
+        path = _state_db_path_for_engine(engine)
+        assert path.is_absolute()
+        assert str(path).startswith(tmpdir)
+
+
+def test_path_containment_outside_allowed_base(monkeypatch):
+    """Test that hermes_home outside allowed base raises error."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Set allowed base to tmpdir
+        monkeypatch.setenv("LCM_HERMES_BASE_DIR", tmpdir)
+
+        from hermes_lcm.command import _state_db_path_for_engine
+
+        # Create a mock engine with hermes_home outside allowed base
+        class MockEngine:
+            _hermes_home = "/etc"
+
+        engine = MockEngine()
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="not within allowed base"):
+            _state_db_path_for_engine(engine)
+
+
+def test_engine_state_db_path_outside_allowed_base(monkeypatch):
+    """Test LCMEngine._state_db_path with engine method."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv("LCM_HERMES_BASE_DIR", tmpdir)
+
+        from hermes_lcm.engine import LCMEngine
+
+        # Create a mock store with db_path
+        class MockStore:
+            db_path = str(Path(tmpdir) / "lcm.db")
+
+        # Create engine with hermes_home outside allowed base
+        engine = LCMEngine.__new__(LCMEngine)
+        engine._hermes_home = "/etc"
+        engine._store = MockStore()
+
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="not within allowed base"):
+            engine._state_db_path()

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,0 +1,59 @@
+"""Tests for path resolution behavior."""
+import tempfile
+from pathlib import Path
+
+
+def test_state_db_path_resolves_to_absolute():
+    """Test that _state_db_path resolves to an absolute path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from hermes_lcm.command import _state_db_path_for_engine
+
+        # Create a mock engine with hermes_home in tmpdir
+        hermes_home = Path(tmpdir) / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+
+        class MockEngine:
+            _hermes_home = str(hermes_home)
+
+        engine = MockEngine()
+        path = _state_db_path_for_engine(engine)
+
+        assert path.is_absolute()
+        assert ".." not in str(path).split("/")[1:]
+
+
+def test_get_large_output_storage_dir_resolves():
+    """Test that get_large_output_storage_dir resolves paths."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from hermes_lcm.externalize import get_large_output_storage_dir
+
+        # Test with explicit path
+        configured_path = str(Path(tmpdir) / "external")
+        path = get_large_output_storage_dir(None, configured_path, create=False)
+        assert path.is_absolute()
+        assert ".." not in str(path).split("/")[1:]
+
+        # Test with hermes_home
+        hermes_home = str(Path(tmpdir) / "hermes")
+        path = get_large_output_storage_dir(None, hermes_home=hermes_home, create=False)
+        assert path.is_absolute()
+        assert ".." not in str(path).split("/")[1:]
+
+
+def test_path_escapes_via_traversal_rejected():
+    """Test that paths with ../ sequences are properly resolved."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from hermes_lcm.externalize import get_large_output_storage_dir
+
+        # Create a path with ../ sequences - should be resolved
+        base = Path(tmpdir) / "base"
+        base.mkdir(parents=True, exist_ok=True)
+        traversal_path = str(base / ".." / ".." / "etc")
+
+        # get_large_output_storage_dir should resolve this
+        path = get_large_output_storage_dir(None, hermes_home=traversal_path, create=False)
+        # The path should be absolute after resolve
+        assert path.is_absolute()
+        # No ../ segments should remain (except root)
+        parts = str(path).split("/")[1:]
+        assert ".." not in parts

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -1,0 +1,70 @@
+"""Tests for path handling security - containment validation."""
+import tempfile
+from pathlib import Path
+import os
+import pytest
+
+
+def test_configured_externalization_path_outside_allowed_base_rejected():
+    """Test that configured externalization paths outside allowed base are rejected.
+
+    When LCM_HERMES_BASE_DIR is set, config.large_output_externalization_path
+    must be validated against the allowed base.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowed_base = tmpdir
+        os.environ["LCM_HERMES_BASE_DIR"] = allowed_base
+
+        try:
+            from hermes_lcm.externalize import get_large_output_storage_dir
+
+            # Create a config with large_output_externalization_path OUTSIDE allowed base
+            class FakeConfig:
+                large_output_externalization_path = "/tmp/evil-external"
+                hermes_home = None
+
+            # This should raise ValueError because the configured path is outside allowed base
+            with pytest.raises(ValueError, match="not within allowed base"):
+                get_large_output_storage_dir(FakeConfig(), "", create=False)
+        finally:
+            del os.environ["LCM_HERMES_BASE_DIR"]
+
+
+def test_configured_externalization_path_inside_allowed_base_accepted():
+    """Test that configured externalization paths inside allowed base work."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowed_base = tmpdir
+        os.environ["LCM_HERMES_BASE_DIR"] = allowed_base
+
+        try:
+            from hermes_lcm.externalize import get_large_output_storage_dir
+
+            # Create a config with path inside allowed base
+            internal_path = Path(tmpdir) / "internal-external"
+
+            class FakeConfig:
+                large_output_externalization_path = str(internal_path)
+                hermes_home = None
+
+            path = get_large_output_storage_dir(FakeConfig(), "", create=False)
+            assert path.is_absolute()
+            assert str(path).startswith(tmpdir)
+        finally:
+            del os.environ["LCM_HERMES_BASE_DIR"]
+
+
+def test_hermes_home_outside_allowed_base_rejected(monkeypatch):
+    """Test that hermes_home outside allowed base raises ValueError."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        allowed_base = tmpdir
+        monkeypatch.setenv("LCM_HERMES_BASE_DIR", allowed_base)
+
+        from hermes_lcm.command import _state_db_path_for_engine
+
+        # Create a mock engine with hermes_home outside allowed base
+        class MockEngine:
+            _hermes_home = "/etc"
+
+        engine = MockEngine()
+        with pytest.raises(ValueError, match="not within allowed base"):
+            _state_db_path_for_engine(engine)


### PR DESCRIPTION
## Summary
Adds opt-in path containment hardening. When `LCM_HERMES_BASE_DIR` is set, all paths (hermes_home and configured externalization paths) are validated against that base directory to prevent directory escape via `../` sequences.

## Why
The original code used `Path.expanduser()` without containment checks. This commit adds explicit `.resolve()` + containment enforcement behind an environment variable, giving operators who need path restriction a way to enable it without breaking backward compatibility.

## Containment Design
- **Opt-in** via `LCM_HERMES_BASE_DIR` environment variable
- When set: all paths validated against the base directory
- When not set: backward compatible (no restriction by default) — existing behavior preserved

## Validation
- [x] pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
- [x] pytest tests/test_path_resolution.py tests/test_path_security.py tests/test_path_containment.py -q
- [x] python -m compileall -q .
- [x] bash -n scripts/install.sh scripts/update.sh
- [x] git diff --check
- [x] Rebased against main (`e0f47b6`)

## Test Results
- test_lcm_core.py: 172 passed
- test_lcm_engine.py: 360 passed  
- test_packaging_install.py: 8 passed
- test_path_resolution.py: 3 passed
- test_path_security.py: 3 passed
- test_path_containment.py: 3 passed
- CI: 596 passed

## Notes
Rate limiting and config validation handled in a separate follow-up PR to keep this focused on path containment.

Refs #162