### PR TITLE
fix: route custom LCM models and report no-ops

### DIFF
--- a/command.py
+++ b/command.py
@@ -120,6 +120,8 @@ def _status_text(engine) -> str:
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"compression_count: {engine.compression_count}",
+        f"last_compression_status: {status.get('last_compression_status', 'idle')}",
+        f"last_compression_noop_reason: {status.get('last_compression_noop_reason', '') or '(none)'}",
         f"threshold_tokens: {engine.threshold_tokens if session_bound else '(uninitialized)'}",
         f"cache_metrics_available: {_fmt_bool(status.get('cache_metrics_available'))}",
         f"last_input_tokens: {status.get('last_input_tokens', 0)}",

--- a/engine.py
+++ b/engine.py
@@ -344,6 +344,8 @@ class LCMEngine(ContextEngine):
         self.summary_model = self._config.summary_model
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
+        self._last_compression_status = "idle"
+        self._last_compression_noop_reason = ""
         # Temporary source window used only while compress() assembles context.
         # _assemble_context also serves tests and recovery paths directly, so
         # keep anchoring opt-in rather than changing its public behavior.
@@ -607,14 +609,28 @@ class LCMEngine(ContextEngine):
         5. Assemble new active context: summaries + fresh tail
         """
         if not messages:
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = "empty message list"
             return messages
 
+        self._last_compression_status = "running"
+        self._last_compression_noop_reason = ""
+
         if self._session_ignored or self._session_stateless or self._thread_context_stateless():
+            reason = (
+                "auxiliary thread context"
+                if self._thread_context_stateless()
+                else "ignored session"
+                if self._session_ignored
+                else "stateless session"
+            )
             logger.debug(
                 "LCM compress bypassed for %s session %s",
                 "auxiliary" if self._thread_context_stateless() else "ignored" if self._session_ignored else "stateless",
                 self._thread_context_session_id() or self._session_id or "(unknown)",
             )
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = f"bypassed: {reason}"
             return messages
 
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
@@ -659,6 +675,7 @@ class LCMEngine(ContextEngine):
             if observed_prompt_tokens is not None and observed_prompt_tokens > 0
             else count_messages_tokens(messages)
         )
+        noop_reason = "no eligible raw backlog outside fresh tail"
 
         while leaf_passes < max_leaf_passes:
             n = len(working_messages)
@@ -668,12 +685,14 @@ class LCMEngine(ContextEngine):
             # prompt, but Hermes gateway sessions may pass only conversation
             # messages here, so index 0 can be a user message.
             if fresh_tail_start <= 1:
+                noop_reason = "no eligible raw backlog outside fresh tail"
                 break
 
             # Skip the leading anchor, candidate raw backlog is indices
             # 1..fresh_tail_start.
             candidate_raw = working_messages[1:fresh_tail_start]
             if not candidate_raw:
+                noop_reason = "no eligible raw backlog outside fresh tail"
                 break
 
             raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
@@ -681,6 +700,9 @@ class LCMEngine(ContextEngine):
                 working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
                 if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
                     if not (deferred_maintenance_active and critical_budget_pressure):
+                        noop_reason = (
+                            "raw backlog outside fresh tail is below leaf chunk threshold"
+                        )
                         break
                 if force_overflow:
                     to_compact = candidate_raw
@@ -689,10 +711,14 @@ class LCMEngine(ContextEngine):
             else:
                 if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
                     if not (deferred_maintenance_active and critical_budget_pressure):
+                        noop_reason = (
+                            "raw backlog outside fresh tail is below leaf chunk threshold"
+                        )
                         break
                 to_compact = candidate_raw
 
             if not to_compact:
+                noop_reason = "no eligible leaf chunk selected"
                 break
 
             # Pre-compaction extraction: best-effort, never blocks compaction
@@ -767,12 +793,19 @@ class LCMEngine(ContextEngine):
                 messages,
                 insert_missing_tool_stubs=False,
             )
-            if len(sanitized_messages) != len(messages):
+            if sanitized_messages != messages:
                 # _ingest_messages() already advanced the cursor to the original
-                # active-context length. If the host continues from the shorter
-                # sanitized context, keeping the old cursor would make the next
-                # appended messages look already ingested.
+                # active-context length. If the host continues from a sanitized
+                # context, keeping the old cursor could make the next appended
+                # messages look already ingested. This applies to content-only
+                # cleanup as well as dropped-message cleanup.
                 self._ingest_cursor = len(sanitized_messages)
+                self._last_compression_status = "sanitized"
+                self._last_compression_noop_reason = ""
+            else:
+                self._last_compression_status = "noop"
+                self._last_compression_noop_reason = noop_reason
+                logger.info("LCM compression no-op: %s", noop_reason)
             return sanitized_messages
 
         # Step 6: Check if condensation is needed
@@ -798,6 +831,8 @@ class LCMEngine(ContextEngine):
         finally:
             self._pending_context_anchor_messages = None
         self.compression_count += 1
+        self._last_compression_status = "compacted"
+        self._last_compression_noop_reason = ""
         if recovery_assembly_cap is None:
             self._last_overflow_recovery_failed = False
         else:
@@ -1320,6 +1355,8 @@ class LCMEngine(ContextEngine):
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
+        self._last_compression_status = "idle"
+        self._last_compression_noop_reason = ""
 
     def _apply_session_start_metadata(self, session_id: str, kwargs: Dict[str, Any]) -> None:
         self._session_id = session_id
@@ -1801,6 +1838,8 @@ class LCMEngine(ContextEngine):
             "cache_read_ratio": round(self.cache_read_ratio, 4),
             "context_length": self.context_length,
             "threshold_tokens": self.threshold_tokens,
+            "last_compression_status": self._last_compression_status,
+            "last_compression_noop_reason": self._last_compression_noop_reason,
         })
         session_id = self.current_session_id
         conversation_id = self.current_conversation_id
@@ -3165,12 +3204,19 @@ class LCMEngine(ContextEngine):
         assembly_cap_override: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         if compressed != original_messages:
+            self._last_compression_status = "overflow_recovery"
+            self._last_compression_noop_reason = ""
             self._ingest_cursor = len(compressed)
             self._ingest_cursor_needs_reconcile = False
             logger.info(
                 "LCM assembly guardrail recovery: %d messages → %d (no new summary node)",
                 len(original_messages),
                 len(compressed),
+            )
+        else:
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = (
+                "forced overflow recovery found no droppable active-context messages"
             )
 
         effective_cap = (

--- a/model_routing.py
+++ b/model_routing.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -19,15 +22,22 @@ ProviderResolver = Callable[[str], bool]
 # named custom providers from the Hermes config are safe to split; registry-only
 # providers still need an allowlist because many provider IDs are also valid
 # OpenRouter model namespaces, for example ``anthropic/...``, ``google/...``
-# and ``x-ai/...``. ``custom:`` prefixes are intentionally not split here until
-# the Hermes auxiliary resolver supports them end-to-end.
+# and ``x-ai/...``. ``custom:<name>/...`` is accepted for non-canonical named
+# custom providers because Hermes auxiliary routing normalizes ``provider`` the
+# same way, but canonical built-ins such as ``custom:openai-codex/...`` remain
+# model-only to avoid accidentally selecting the built-in provider.
 _PROVIDER_PREFIXES = frozenset({"cerebras"})
 
 
 def _provider_route_is_resolvable(provider: str) -> bool:
     """Return whether Hermes can route an explicit auxiliary provider."""
-    if provider.startswith("custom:"):
+    provider = (provider or "").strip().lower()
+    if not provider:
         return False
+    if provider.startswith("custom:"):
+        provider = provider.split(":", 1)[1].strip()
+        if not provider:
+            return False
 
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY
@@ -68,9 +78,12 @@ def parse_lcm_model_override(
     provider, sep, rest = model.partition("/")
     provider = provider.strip().lower()
     rest = rest.strip()
+    route_provider = provider
+    if provider.startswith("custom:"):
+        route_provider = provider.split(":", 1)[1].strip()
     can_resolve_provider = provider_resolver or _provider_route_is_resolvable
-    if sep and rest and can_resolve_provider(provider):
-        return ModelRoute(provider=provider, model=rest)
+    if sep and rest and route_provider and can_resolve_provider(route_provider):
+        return ModelRoute(provider=route_provider, model=rest)
 
     return ModelRoute(provider=None, model=model)
 
@@ -82,3 +95,10 @@ def apply_lcm_model_route(call_kwargs: dict, model: str | None) -> None:
         call_kwargs["provider"] = route.provider
     if route.model:
         call_kwargs["model"] = route.model
+    if model and route.model:
+        logger.debug(
+            "LCM auxiliary model override routed: raw=%r provider=%s model=%s",
+            model,
+            route.provider or "(task default)",
+            route.model,
+        )

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -36,8 +36,23 @@ def test_lcm_status_default_reports_current_session(engine):
     assert "cache_metrics_available: no" in result
     assert "last_cache_read_tokens: 0" in result
     assert "last_cache_write_tokens: 0" in result
+    assert "last_compression_status: idle" in result
+    assert "last_compression_noop_reason: (none)" in result
     assert "store_messages: 0" in result
     assert "dag_nodes: 0" in result
+
+
+def test_lcm_status_reports_last_compression_noop_reason(engine):
+    engine._last_compression_status = "noop"
+    engine._last_compression_noop_reason = "no eligible raw backlog outside fresh tail"
+
+    result = handle_lcm_command("status", engine)
+
+    assert "last_compression_status: noop" in result
+    assert (
+        "last_compression_noop_reason: no eligible raw backlog outside fresh tail"
+        in result
+    )
 
 
 def test_lcm_status_reports_cache_usage_metrics_when_host_provides_them(engine):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -129,6 +129,20 @@ class TestModelRouting:
         assert route.provider == "my-provider"
         assert route.model == "model-a"
 
+    def test_custom_prefixed_named_provider_is_split_when_provider_resolves(self, monkeypatch):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        self._install_fake_provider_modules(
+            monkeypatch,
+            named_custom={"lcpp": {"base_url": "http://127.0.0.1:8081/v1"}},
+            registry={"openai-codex": object()},
+        )
+
+        route = parse_lcm_model_override("custom:LCPP/4B-Qwen3-2507-compressor")
+
+        assert route.provider == "lcpp"
+        assert route.model == "4B-Qwen3-2507-compressor"
+
     def test_openrouter_organization_slug_stays_model_only(self):
         from hermes_lcm.model_routing import parse_lcm_model_override
 
@@ -237,6 +251,43 @@ class TestProviderPrefixedAuxiliaryCalls:
 
         assert "provider" not in seen
         assert seen["model"] == "meta-llama/Llama-3.3-70B-Instruct"
+
+    def test_summary_call_passes_custom_prefixed_provider_and_stripped_model(self, monkeypatch):
+        from hermes_lcm.escalation import _call_llm_for_summary
+
+        seen = {}
+
+        def fake_call_llm(**kwargs):
+            seen.update(kwargs)
+            return self._fake_response("summary")
+
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
+
+        hermes_cli = ModuleType("hermes_cli")
+        hermes_cli.__path__ = []
+        runtime_provider = ModuleType("hermes_cli.runtime_provider")
+        runtime_provider._get_named_custom_provider = (
+            lambda provider: {"name": "LCPP", "base_url": "http://127.0.0.1:8081/v1"}
+            if provider == "lcpp"
+            else None
+        )
+        auth = ModuleType("hermes_cli.auth")
+        auth.PROVIDER_REGISTRY = {}
+        hermes_cli.runtime_provider = runtime_provider
+        hermes_cli.auth = auth
+        monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", runtime_provider)
+        monkeypatch.setitem(sys.modules, "hermes_cli.auth", auth)
+
+        result = _call_llm_for_summary(
+            "summarize",
+            200,
+            model="custom:LCPP/4B-Qwen3-2507-compressor",
+        )
+
+        assert result == "summary"
+        assert seen["provider"] == "lcpp"
+        assert seen["model"] == "4B-Qwen3-2507-compressor"
 
     def test_extraction_call_passes_provider_and_stripped_model(self, monkeypatch):
         from hermes_lcm.extraction import _call_extraction_llm

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -110,6 +110,8 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["last_cache_write_tokens"] == 50
     assert payload["last_reasoning_tokens"] == 30
     assert payload["cache_read_ratio"] == 0.381
+    assert payload["last_compression_status"] == "idle"
+    assert payload["last_compression_noop_reason"] == ""
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
 
@@ -2764,14 +2766,35 @@ class TestEngineCompress:
         assert "stale orphan args" not in serialized
 
     def test_compress_short_conversation_noop(self, engine):
-        """Short conversations should pass through unchanged."""
+        """Short conversations should pass through unchanged with an explicit reason."""
         messages = [
             {"role": "system", "content": "You are helpful"},
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
         ]
         result = engine.compress(messages)
+        assert result == messages
+        assert engine._last_compression_status == "noop"
+        assert "eligible raw backlog" in engine._last_compression_noop_reason
+
+        status = engine.get_status()
+        assert status["last_compression_status"] == "noop"
+        assert "eligible raw backlog" in status["last_compression_noop_reason"]
+
+    def test_compress_short_conversation_sanitized_content_is_not_noop(self, engine):
+        """Content-only active-context cleanup should report sanitized, not noop."""
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "<think>internal</think>Visible answer"},
+        ]
+
+        result = engine.compress(messages)
+
         assert len(result) == len(messages)
+        assert result[-1]["content"] == "Visible answer"
+        assert engine._last_compression_status == "sanitized"
+        assert engine._last_compression_noop_reason == ""
 
     def test_compress_handles_multimodal_first_user_message_without_system(self, engine, monkeypatch):
         """Gateway sessions may pass conversation messages without a leading system prompt."""

--- a/tools.py
+++ b/tools.py
@@ -1457,6 +1457,8 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     return json.dumps({
         "session_id": session_id,
         "compression_count": engine.compression_count,
+        "last_compression_status": full_status.get("last_compression_status", "idle"),
+        "last_compression_noop_reason": full_status.get("last_compression_noop_reason", ""),
         "context_length": engine.context_length,
         "threshold_tokens": engine.threshold_tokens,
         "last_prompt_tokens": engine.last_prompt_tokens,


### PR DESCRIPTION
## Summary
- Fix LCM model override parsing so `custom:<named-provider>/<model>` works for resolvable named custom providers.
- Preserve canonical built-in provider safeguards when splitting provider/model overrides.
- Track compression status/no-op reasons and surface them through `/lcm status` and the `lcm_status` tool.
- Prevent sanitized active-context cleanup from being misreported as a no-op.

## Why
- Local llama.cpp deployments can hot-swap models by the `model` field, but LCM was not routing `custom:LCPP/...` overrides the same way Hermes auxiliary compression does.
- Manual and automatic compression no-ops were hard to diagnose because the public status surfaces did not explain why compression skipped work.
- Content-only sanitization can change active context without changing message count, so length-only no-op detection was wrong.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_lcm_command.py -q -o addopts=''` -> `582 passed, 40 warnings`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> covered by focused superset above
  - [x] `pytest -q` -> `592 passed, 40 warnings`
  - [x] `ulimit -n 1024; python -m pytest -q -o addopts=''` -> `592 passed, 40 warnings`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- No workflow files changed, so `actionlint` was not run.
- Also ran an added-line static scan for obvious secret, shell, eval/exec, pickle, and SQL injection patterns: passed.
- Independent review: approved.

Refs #
