### PR TITLE
fix: keep model-switch context length authoritative

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -335,6 +335,7 @@ class LCMEngine(ContextEngine):
         self.api_mode = ""
         self.context_length = 0
         self._context_length_source = ""
+        self._update_model_pending_session_start = False
         self.threshold_tokens = 0
         self.threshold_percent = self._config.context_threshold
         self.last_prompt_tokens = 0
@@ -1447,6 +1448,12 @@ class LCMEngine(ContextEngine):
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
 
+        update_model_is_authoritative = (
+            self._context_length_source == "update_model"
+            and self.context_length > 0
+            and self._update_model_pending_session_start
+        )
+
         # Pick up context_length from kwargs if provided, but do not let stale
         # session metadata undo the authoritative runtime update_model() call.
         # Hermes Agent calls update_model() with the resolver output before it
@@ -1463,11 +1470,11 @@ class LCMEngine(ContextEngine):
                     "LCM ignored invalid session-start context_length: %r",
                     incoming_context_length,
                 )
+                self._update_model_pending_session_start = False
                 return
             if parsed_context_length <= 0:
                 if (
-                    self._context_length_source == "update_model"
-                    and self.context_length > 0
+                    update_model_is_authoritative
                     and self._session_metadata_matches_active_runtime(
                         kwargs,
                         ignore_empty_optional=True,
@@ -1479,12 +1486,13 @@ class LCMEngine(ContextEngine):
                         self.model or str(kwargs.get("model") or ""),
                         self.context_length,
                     )
+                    self._update_model_pending_session_start = False
                     return
                 self._set_context_length(parsed_context_length, source="session_start")
+                update_model_is_authoritative = False
             else:
                 if (
-                    self._context_length_source == "update_model"
-                    and self.context_length > 0
+                    update_model_is_authoritative
                     and parsed_context_length != self.context_length
                 ):
                     logger.warning(
@@ -1493,20 +1501,22 @@ class LCMEngine(ContextEngine):
                         self.model or str(kwargs.get("model") or ""),
                         self.context_length,
                     )
+                    self._update_model_pending_session_start = False
                     return
-                if self._context_length_source == "update_model" and self.context_length > 0:
+                if update_model_is_authoritative:
                     if not self._session_metadata_matches_active_runtime(kwargs):
                         logger.warning(
                             "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
                             str(kwargs.get("model") or ""),
                             self.model,
                         )
+                        self._update_model_pending_session_start = False
                         return
                 else:
                     self._set_context_length(parsed_context_length, source="session_start")
+                    update_model_is_authoritative = False
         if (
-            self._context_length_source == "update_model"
-            and self.context_length > 0
+            update_model_is_authoritative
             and not self._session_metadata_matches_active_runtime(kwargs)
         ):
             logger.warning(
@@ -1514,12 +1524,14 @@ class LCMEngine(ContextEngine):
                 str(kwargs.get("model") or ""),
                 self.model,
             )
+            self._update_model_pending_session_start = False
             return
         if "model" in kwargs:
             self.model = str(kwargs.get("model") or "")
         for key in ("base_url", "api_key", "provider", "api_mode"):
             if key in kwargs:
                 setattr(self, key, str(kwargs.get(key) or ""))
+        self._update_model_pending_session_start = False
 
     def _continue_compression_boundary(
         self,
@@ -2054,6 +2066,7 @@ class LCMEngine(ContextEngine):
         self.provider = str(provider or "")
         self.api_mode = str(api_mode or "")
         self._set_context_length(context_length, source="update_model")
+        self._update_model_pending_session_start = True
 
     def _refresh_session_filters(self) -> None:
         self._session_match_keys = build_session_match_keys(

--- a/engine.py
+++ b/engine.py
@@ -1450,7 +1450,6 @@ class LCMEngine(ContextEngine):
 
         update_model_is_authoritative = (
             self._context_length_source == "update_model"
-            and self.context_length > 0
             and self._update_model_pending_session_start
         )
 
@@ -1473,19 +1472,23 @@ class LCMEngine(ContextEngine):
                 self._update_model_pending_session_start = False
                 return
             if parsed_context_length <= 0:
-                if (
-                    update_model_is_authoritative
-                    and self._session_metadata_matches_active_runtime(
+                if update_model_is_authoritative:
+                    if self._session_metadata_matches_active_runtime(
                         kwargs,
                         ignore_empty_optional=True,
-                    )
-                ):
-                    logger.debug(
-                        "LCM ignored missing session-start context_length=%r for model=%s; active update_model context_length=%s",
-                        incoming_context_length,
-                        self.model or str(kwargs.get("model") or ""),
-                        self.context_length,
-                    )
+                    ):
+                        logger.debug(
+                            "LCM ignored missing session-start context_length=%r for model=%s; active update_model context_length=%s",
+                            incoming_context_length,
+                            self.model or str(kwargs.get("model") or ""),
+                            self.context_length,
+                        )
+                    else:
+                        logger.warning(
+                            "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                            str(kwargs.get("model") or ""),
+                            self.model,
+                        )
                     self._update_model_pending_session_start = False
                     return
                 self._set_context_length(parsed_context_length, source="session_start")

--- a/engine.py
+++ b/engine.py
@@ -389,13 +389,10 @@ class LCMEngine(ContextEngine):
         return True
 
     def _session_metadata_matches_active_runtime(self, kwargs: Dict[str, Any]) -> bool:
-        incoming_model = str(kwargs.get("model") or "")
-        if incoming_model and self.model and incoming_model != self.model:
+        if "model" in kwargs and str(kwargs.get("model") or "") != self.model:
             return False
-        for key in ("provider", "base_url", "api_mode"):
-            incoming = str(kwargs.get(key) or "")
-            active = str(getattr(self, key, "") or "")
-            if incoming and active and incoming != active:
+        for key in ("provider", "base_url", "api_key", "api_mode"):
+            if key in kwargs and str(kwargs.get(key) or "") != str(getattr(self, key, "") or ""):
                 return False
         return True
 
@@ -1468,12 +1465,27 @@ class LCMEngine(ContextEngine):
                     self.context_length,
                 )
                 return
-            if not (
-                self._context_length_source == "update_model"
-                and parsed_context_length == self.context_length
-                and self._session_metadata_matches_active_runtime(kwargs)
-            ):
+            if self._context_length_source == "update_model" and self.context_length > 0:
+                if not self._session_metadata_matches_active_runtime(kwargs):
+                    logger.warning(
+                        "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                        str(kwargs.get("model") or ""),
+                        self.model,
+                    )
+                    return
+            else:
                 self._set_context_length(parsed_context_length, source="session_start")
+        if (
+            self._context_length_source == "update_model"
+            and self.context_length > 0
+            and not self._session_metadata_matches_active_runtime(kwargs)
+        ):
+            logger.warning(
+                "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                str(kwargs.get("model") or ""),
+                self.model,
+            )
+            return
         if "model" in kwargs:
             self.model = str(kwargs.get("model") or "")
         for key in ("base_url", "api_key", "provider", "api_mode"):

--- a/engine.py
+++ b/engine.py
@@ -332,7 +332,9 @@ class LCMEngine(ContextEngine):
         self.base_url = ""
         self.api_key = ""
         self.provider = ""
+        self.api_mode = ""
         self.context_length = 0
+        self._context_length_source = ""
         self.threshold_tokens = 0
         self.threshold_percent = self._config.context_threshold
         self.last_prompt_tokens = 0
@@ -369,6 +371,33 @@ class LCMEngine(ContextEngine):
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
+
+    def _set_context_length(self, context_length: Any, *, source: str) -> bool:
+        try:
+            parsed_context_length = int(context_length)
+        except (TypeError, ValueError):
+            logger.debug("LCM ignored invalid %s context_length: %r", source, context_length)
+            return False
+        if parsed_context_length <= 0:
+            logger.debug("LCM ignored non-positive %s context_length: %r", source, context_length)
+            return False
+        self.context_length = parsed_context_length
+        self._context_length_source = source
+        self.threshold_tokens = int(
+            parsed_context_length * self._config.context_threshold
+        )
+        return True
+
+    def _session_metadata_matches_active_runtime(self, kwargs: Dict[str, Any]) -> bool:
+        incoming_model = str(kwargs.get("model") or "")
+        if incoming_model and self.model and incoming_model != self.model:
+            return False
+        for key in ("provider", "base_url", "api_mode"):
+            incoming = str(kwargs.get(key) or "")
+            active = str(getattr(self, key, "") or "")
+            if incoming and active and incoming != active:
+                return False
+        return True
 
     @property
     def name(self) -> str:
@@ -1403,12 +1432,53 @@ class LCMEngine(ContextEngine):
             self._foreground_session_platform = self._session_platform
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
-        # Pick up context_length from kwargs if provided
+
+        # Pick up context_length from kwargs if provided, but do not let stale
+        # session metadata undo the authoritative runtime update_model() call.
+        # Hermes Agent calls update_model() with the resolver output before it
+        # binds a fresh agent/session.  Older or buggy host paths can still pass
+        # a context_length copied from the previously bound runtime; treating
+        # that as authoritative makes /model switches keep compressing against
+        # the old model window.
         if "context_length" in kwargs:
-            self.context_length = kwargs["context_length"]
-            self.threshold_tokens = int(
-                self.context_length * self._config.context_threshold
-            )
+            incoming_context_length = kwargs["context_length"]
+            try:
+                parsed_context_length = int(incoming_context_length)
+            except (TypeError, ValueError):
+                logger.debug(
+                    "LCM ignored invalid session-start context_length: %r",
+                    incoming_context_length,
+                )
+                return
+            if parsed_context_length <= 0:
+                logger.debug(
+                    "LCM ignored non-positive session-start context_length: %r",
+                    incoming_context_length,
+                )
+                return
+            if (
+                self._context_length_source == "update_model"
+                and self.context_length > 0
+                and parsed_context_length != self.context_length
+            ):
+                logger.warning(
+                    "LCM ignored stale session-start context_length=%s for model=%s; active update_model context_length=%s",
+                    parsed_context_length,
+                    self.model or str(kwargs.get("model") or ""),
+                    self.context_length,
+                )
+                return
+            if not (
+                self._context_length_source == "update_model"
+                and parsed_context_length == self.context_length
+                and self._session_metadata_matches_active_runtime(kwargs)
+            ):
+                self._set_context_length(parsed_context_length, source="session_start")
+        if "model" in kwargs:
+            self.model = str(kwargs.get("model") or "")
+        for key in ("base_url", "api_key", "provider", "api_mode"):
+            if key in kwargs:
+                setattr(self, key, str(kwargs.get(key) or ""))
 
     def _continue_compression_boundary(
         self,
@@ -1937,8 +2007,12 @@ class LCMEngine(ContextEngine):
                 parent_session_id,
             )
             return
-        self.context_length = context_length
-        self.threshold_tokens = int(context_length * self._config.context_threshold)
+        self.model = str(model or "")
+        self.base_url = str(base_url or "")
+        self.api_key = str(api_key or "")
+        self.provider = str(provider or "")
+        self.api_mode = str(api_mode or "")
+        self._set_context_length(context_length, source="update_model")
 
     def _refresh_session_filters(self) -> None:
         self._session_match_keys = build_session_match_keys(

--- a/engine.py
+++ b/engine.py
@@ -395,11 +395,21 @@ class LCMEngine(ContextEngine):
         )
         return True
 
-    def _session_metadata_matches_active_runtime(self, kwargs: Dict[str, Any]) -> bool:
+    def _session_metadata_matches_active_runtime(
+        self,
+        kwargs: Dict[str, Any],
+        *,
+        ignore_empty_optional: bool = False,
+    ) -> bool:
         if "model" in kwargs and str(kwargs.get("model") or "") != self.model:
             return False
         for key in ("provider", "base_url", "api_key", "api_mode"):
-            if key in kwargs and str(kwargs.get(key) or "") != str(getattr(self, key, "") or ""):
+            if key not in kwargs:
+                continue
+            incoming = str(kwargs.get(key) or "")
+            if ignore_empty_optional and not incoming:
+                continue
+            if incoming != str(getattr(self, key, "") or ""):
                 return False
         return True
 
@@ -1455,7 +1465,14 @@ class LCMEngine(ContextEngine):
                 )
                 return
             if parsed_context_length <= 0:
-                if self._context_length_source == "update_model" and self.context_length > 0:
+                if (
+                    self._context_length_source == "update_model"
+                    and self.context_length > 0
+                    and self._session_metadata_matches_active_runtime(
+                        kwargs,
+                        ignore_empty_optional=True,
+                    )
+                ):
                     logger.debug(
                         "LCM ignored missing session-start context_length=%r for model=%s; active update_model context_length=%s",
                         incoming_context_length,

--- a/engine.py
+++ b/engine.py
@@ -379,8 +379,15 @@ class LCMEngine(ContextEngine):
             logger.debug("LCM ignored invalid %s context_length: %r", source, context_length)
             return False
         if parsed_context_length <= 0:
-            logger.debug("LCM ignored non-positive %s context_length: %r", source, context_length)
-            return False
+            logger.debug(
+                "LCM cleared non-positive %s context_length: %r",
+                source,
+                context_length,
+            )
+            self.context_length = 0
+            self._context_length_source = source
+            self.threshold_tokens = 0
+            return True
         self.context_length = parsed_context_length
         self._context_length_source = source
         self.threshold_tokens = int(
@@ -1448,33 +1455,38 @@ class LCMEngine(ContextEngine):
                 )
                 return
             if parsed_context_length <= 0:
-                logger.debug(
-                    "LCM ignored non-positive session-start context_length: %r",
-                    incoming_context_length,
-                )
-                return
-            if (
-                self._context_length_source == "update_model"
-                and self.context_length > 0
-                and parsed_context_length != self.context_length
-            ):
-                logger.warning(
-                    "LCM ignored stale session-start context_length=%s for model=%s; active update_model context_length=%s",
-                    parsed_context_length,
-                    self.model or str(kwargs.get("model") or ""),
-                    self.context_length,
-                )
-                return
-            if self._context_length_source == "update_model" and self.context_length > 0:
-                if not self._session_metadata_matches_active_runtime(kwargs):
-                    logger.warning(
-                        "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
-                        str(kwargs.get("model") or ""),
-                        self.model,
+                if self._context_length_source == "update_model" and self.context_length > 0:
+                    logger.debug(
+                        "LCM ignored missing session-start context_length=%r for model=%s; active update_model context_length=%s",
+                        incoming_context_length,
+                        self.model or str(kwargs.get("model") or ""),
+                        self.context_length,
                     )
                     return
-            else:
                 self._set_context_length(parsed_context_length, source="session_start")
+            else:
+                if (
+                    self._context_length_source == "update_model"
+                    and self.context_length > 0
+                    and parsed_context_length != self.context_length
+                ):
+                    logger.warning(
+                        "LCM ignored stale session-start context_length=%s for model=%s; active update_model context_length=%s",
+                        parsed_context_length,
+                        self.model or str(kwargs.get("model") or ""),
+                        self.context_length,
+                    )
+                    return
+                if self._context_length_source == "update_model" and self.context_length > 0:
+                    if not self._session_metadata_matches_active_runtime(kwargs):
+                        logger.warning(
+                            "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                            str(kwargs.get("model") or ""),
+                            self.model,
+                        )
+                        return
+                else:
+                    self._set_context_length(parsed_context_length, source="session_start")
         if (
             self._context_length_source == "update_model"
             and self.context_length > 0

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -383,6 +383,37 @@ def test_missing_session_start_context_length_clears_stale_update_model_window_f
     assert engine._context_length_source == "session_start"
 
 
+def test_positive_session_start_context_length_replaces_consumed_update_model_window_for_new_runtime(engine):
+    engine.update_model(
+        model="previous-resolver-model",
+        context_length=1_000_000,
+        provider="previous-provider",
+    )
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-resolver-model",
+        provider="previous-provider",
+        context_length=1_000_000,
+        conversation_id="telegram:chat-1",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="session-only-model",
+        provider="session-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "session-only-model"
+    assert engine.provider == "session-provider"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+    assert engine._context_length_source == "session_start"
+
+
 def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):
     from hermes_lcm import message_patterns as message_patterns_mod
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -302,6 +302,7 @@ def test_session_start_clears_previous_session_context_window_when_new_window_is
     assert engine.threshold_tokens == 0
     assert engine._context_length_source == "session_start"
     assert not engine.should_compress(1_000_000)
+    assert not engine._critical_budget_pressure_reached(observed_tokens=1_000_000)
 
 
 def test_missing_session_start_context_length_does_not_clear_authoritative_update_model_window(engine):
@@ -325,6 +326,61 @@ def test_missing_session_start_context_length_does_not_clear_authoritative_updat
     assert engine.context_length == 1_000_000
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
     assert engine._context_length_source == "update_model"
+
+
+def test_missing_session_start_context_length_preserves_update_model_window_with_blank_optional_fields(engine):
+    engine.update_model(
+        model="resolver-window-model",
+        context_length=1_000_000,
+        base_url="https://resolver.example/v1",
+        api_key="resolver-key",
+        provider="resolver-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="resolver-window-model",
+        base_url="",
+        api_key="",
+        provider="resolver-provider",
+        api_mode="chat_completions",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "resolver-window-model"
+    assert engine.base_url == "https://resolver.example/v1"
+    assert engine.api_key == "resolver-key"
+    assert engine.provider == "resolver-provider"
+    assert engine.api_mode == "chat_completions"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+    assert engine._context_length_source == "update_model"
+
+
+def test_missing_session_start_context_length_clears_stale_update_model_window_for_new_runtime(engine):
+    engine.update_model(
+        model="previous-resolver-model",
+        context_length=1_000_000,
+        provider="previous-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="session-only-model",
+        provider="session-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "session-only-model"
+    assert engine.provider == "session-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "session_start"
 
 
 def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -116,6 +116,86 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
 
 
+def test_update_model_updates_runtime_metadata_and_context_window(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        base_url="https://opencode.ai/zen/go",
+        api_key="test-key",
+        provider="opencode-go",
+        api_mode="anthropic_messages",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.base_url == "https://opencode.ai/zen/go"
+    assert engine.api_key == "test-key"
+    assert engine.provider == "opencode-go"
+    assert engine.api_mode == "anthropic_messages"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_overwrite_update_model_context_length_with_stale_metadata(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        provider="opencode-go",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="deepseek-v4-flash",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_overwrite_update_model_with_stale_runtime_identity(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        provider="opencode-go",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="minimax-m2.7",
+        provider="minimax",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.provider == "opencode-go"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_can_initialize_context_length_without_update_model(engine):
+    engine.model = ""
+    engine.context_length = 0
+    engine.threshold_tokens = 0
+    engine._context_length_source = ""
+
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="minimax-m2.7",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "minimax-m2.7"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+
+
 def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):
     from hermes_lcm import message_patterns as message_patterns_mod
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -366,6 +366,14 @@ def test_missing_session_start_context_length_clears_stale_update_model_window_f
         context_length=1_000_000,
         provider="previous-provider",
     )
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-resolver-model",
+        provider="previous-provider",
+        context_length=1_000_000,
+        conversation_id="telegram:chat-1",
+    )
 
     engine.on_session_start(
         "telegram:chat-1:session-2",
@@ -381,6 +389,68 @@ def test_missing_session_start_context_length_clears_stale_update_model_window_f
     assert engine.context_length == 0
     assert engine.threshold_tokens == 0
     assert engine._context_length_source == "session_start"
+
+
+def test_update_model_zero_window_ignores_stale_positive_session_metadata(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+    engine.update_model(
+        model="unknown-window-model",
+        context_length=0,
+        provider="unknown-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.provider == "unknown-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "update_model"
+
+
+def test_update_model_zero_window_ignores_stale_zero_session_metadata(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+    engine.update_model(
+        model="unknown-window-model",
+        context_length=0,
+        provider="unknown-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.provider == "unknown-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "update_model"
 
 
 def test_positive_session_start_context_length_replaces_consumed_update_model_window_for_new_runtime(engine):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -177,6 +177,87 @@ def test_session_start_does_not_overwrite_update_model_with_stale_runtime_identi
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
 
 
+def test_session_start_does_not_overwrite_update_model_identity_when_context_length_matches(engine):
+    engine.update_model(
+        model="new-model-same-window",
+        context_length=204_800,
+        base_url="https://new.example/v1",
+        api_key="new-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="old-model-same-window",
+        base_url="https://old.example/v1",
+        api_key="old-key",
+        provider="old-provider",
+        api_mode="anthropic_messages",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "new-model-same-window"
+    assert engine.base_url == "https://new.example/v1"
+    assert engine.api_key == "new-key"
+    assert engine.provider == "new-provider"
+    assert engine.api_mode == "chat_completions"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_clear_or_repopulate_update_model_identity_when_optional_fields_are_empty(engine):
+    engine.update_model(
+        model="new-model-same-window",
+        context_length=204_800,
+        base_url="https://new.example/v1",
+        api_key="new-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="new-model-same-window",
+        base_url="",
+        api_key="",
+        provider="new-provider",
+        api_mode="chat_completions",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.base_url == "https://new.example/v1"
+    assert engine.api_key == "new-key"
+
+    engine.update_model(
+        model="empty-endpoint-model",
+        context_length=204_800,
+        base_url="",
+        api_key="",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-3",
+        platform="telegram",
+        model="empty-endpoint-model",
+        base_url="https://old.example/v1",
+        api_key="old-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.base_url == ""
+    assert engine.api_key == ""
+
+
 def test_session_start_can_initialize_context_length_without_update_model(engine):
     engine.model = ""
     engine.context_length = 0

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -277,6 +277,56 @@ def test_session_start_can_initialize_context_length_without_update_model(engine
     assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
 
 
+def test_session_start_clears_previous_session_context_window_when_new_window_is_missing(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="known-window-model",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens > 0
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="unknown-window-model",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "session_start"
+    assert not engine.should_compress(1_000_000)
+
+
+def test_missing_session_start_context_length_does_not_clear_authoritative_update_model_window(engine):
+    engine.update_model(
+        model="resolver-window-model",
+        context_length=1_000_000,
+        provider="resolver-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="resolver-window-model",
+        provider="resolver-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "resolver-window-model"
+    assert engine.provider == "resolver-provider"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+    assert engine._context_length_source == "update_model"
+
+
 def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):
     from hermes_lcm import message_patterns as message_patterns_mod
 


### PR DESCRIPTION
## Summary

Fixes the LCM runtime metadata path used after model switches. `update_model()` now records the active model/runtime fields along with the resolved context window, and session-start metadata can no longer overwrite that authoritative runtime with stale values from the previous model.

It also handles missing session context telemetry explicitly. If a later session reports `context_length=0` and there is no matching fresh `update_model()` binding to preserve, LCM clears the old window and threshold instead of continuing to make compression and budget-pressure decisions with stale values.

A fresh `update_model()` binding now protects the immediately following session-start, including zero-length resolver output. After that binding is consumed, later session-start-only runtimes can replace the old model/window with their own telemetry instead of being blocked by stale resolver state.

## Why

After a mid-session `/model` switch, Hermes Agent resolves the new model context length and calls `update_model()` on the active context engine. If stale session metadata later carries the old context window or old runtime identity, LCM should keep the resolver value from `update_model()` instead of falling back to the previous model's threshold or identity.

At the same time, real missing/disabled telemetry should not inherit a previous positive session window. Zero-length `update_model()` output is also an authoritative clear for the next binding, so stale positive or stale zero session metadata from the previous runtime cannot repopulate or rename the active runtime.

## Validation

- [x] Focused metadata validation, including stale positive-window replacement and zero-window stale metadata: `19 passed, 362 deselected`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `564 passed`
  - [x] `pytest -q` -> `670 passed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] GitHub Actions on `2ccd9a8`: workflow-lint, test (3.11), test (3.12), test (3.13), test (3.14)
- [x] Read-only Codex blocker audit on the final diff: no blockers
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes

No workflow files changed. I skipped the ulimit duplicate run because the same full suite passed normally and this change does not touch fd-heavy lifecycle or packaging code.

Refs #169
