### PR TITLE
Import OpenClaw summaries into summary_nodes

### DIFF
--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -37,6 +37,8 @@ def _ensure_local_package_importable() -> None:
 _ensure_local_package_importable()
 
 from hermes_lcm.config import LCMConfig  # noqa: E402
+from hermes_lcm.dag import build_nodes_fts_spec  # noqa: E402
+from hermes_lcm.db_bootstrap import ensure_external_content_fts  # noqa: E402
 from hermes_lcm.ingest_protection import protect_message_for_ingest  # noqa: E402
 from hermes_lcm.message_content import normalize_content_value  # noqa: E402
 from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
@@ -63,6 +65,43 @@ class ImportCandidate:
 
 
 @dataclass(frozen=True)
+class SummaryCandidate:
+    source_summary_id: str
+    source_conversation_id: int
+    source_session: str
+    target_session_id: str
+    source: str
+    depth: int
+    kind: str
+    summary: str
+    token_count: int
+    source_message_token_count: int
+    descendant_token_count: int
+    created_at: float
+    earliest_at: float
+    latest_at: float
+    expand_hint: str
+    message_ids: list[int]
+    parent_summary_ids: list[str]
+
+    def is_condensed(self) -> bool:
+        if self.kind == "condensed":
+            return True
+        if self.kind == "leaf":
+            return False
+        return bool(self.parent_summary_ids) or self.depth > 0
+
+
+@dataclass
+class SummaryImportStats:
+    scanned: int = 0
+    would_import: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    skipped_unresolved: int = 0
+
+
+@dataclass(frozen=True)
 class ImportResult:
     source_db: str
     target_db: str
@@ -75,6 +114,11 @@ class ImportResult:
     skipped_empty: int = 0
     conversations: int = 0
     backup_path: str | None = None
+    summaries_scanned: int = 0
+    summaries_would_import: int = 0
+    summaries_imported: int = 0
+    summaries_skipped_existing: int = 0
+    summaries_skipped_unresolved: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -89,6 +133,11 @@ class ImportResult:
             "skipped_empty": self.skipped_empty,
             "conversations": self.conversations,
             "backup_path": self.backup_path,
+            "summaries_scanned": self.summaries_scanned,
+            "summaries_would_import": self.summaries_would_import,
+            "summaries_imported": self.summaries_imported,
+            "summaries_skipped_existing": self.summaries_skipped_existing,
+            "summaries_skipped_unresolved": self.summaries_skipped_unresolved,
         }
 
 
@@ -159,6 +208,26 @@ def _parse_timestamp(value: Any, fallback: float) -> float:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).timestamp()
+
+
+def _coerce_int(value: Any, fallback: int = 0) -> int:
+    if value in (None, ""):
+        return fallback
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _dedupe_preserving_order(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
 
 
 def _safe_segment(value: Any, fallback: str) -> str:
@@ -408,6 +477,147 @@ def _collect_candidates(
     return candidates, len(rows), skipped_empty, len(conversation_ids)
 
 
+def _column_expr(columns: set[str], table_alias: str, column: str, fallback_sql: str) -> str:
+    return f"{table_alias}.{column}" if column in columns else fallback_sql
+
+
+def _load_summary_message_ids(conn: sqlite3.Connection) -> dict[str, list[int]]:
+    if not _table_exists(conn, "summary_messages"):
+        return {}
+    columns = _table_columns(conn, "summary_messages")
+    if "summary_id" not in columns or "message_id" not in columns:
+        return {}
+    order_column = "ordinal" if "ordinal" in columns else "rowid"
+    rows = conn.execute(
+        f"""
+        SELECT summary_id, message_id
+        FROM summary_messages
+        ORDER BY summary_id, {order_column}
+        """
+    ).fetchall()
+    by_summary: dict[str, list[int]] = {}
+    for row in rows:
+        by_summary.setdefault(str(row["summary_id"]), []).append(int(row["message_id"]))
+    return by_summary
+
+
+def _load_summary_parent_ids(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    if not _table_exists(conn, "summary_parents"):
+        return {}
+    columns = _table_columns(conn, "summary_parents")
+    if "summary_id" not in columns or "parent_summary_id" not in columns:
+        return {}
+    order_column = "ordinal" if "ordinal" in columns else "rowid"
+    rows = conn.execute(
+        f"""
+        SELECT summary_id, parent_summary_id
+        FROM summary_parents
+        ORDER BY summary_id, {order_column}
+        """
+    ).fetchall()
+    by_summary: dict[str, list[str]] = {}
+    for row in rows:
+        by_summary.setdefault(str(row["summary_id"]), []).append(str(row["parent_summary_id"]))
+    return by_summary
+
+
+def _collect_summary_candidates(
+    conn: sqlite3.Connection,
+    *,
+    namespace: str,
+    agent: str,
+    session_identity: str,
+) -> list[SummaryCandidate]:
+    if not _table_exists(conn, "summaries"):
+        return []
+    _require_columns(conn, "summaries", ["summary_id", "conversation_id"])
+
+    summary_cols = _table_columns(conn, "summaries")
+    content_column = next(
+        (column for column in ("content", "summary", "summary_text", "text") if column in summary_cols),
+        None,
+    )
+    if content_column is None:
+        raise ValueError("source DB table 'summaries' missing required columns: content")
+
+    conversation_cols = _table_columns(conn, "conversations")
+    session_key_expr = "c.session_key" if "session_key" in conversation_cols else "NULL"
+    conversation_created_expr = "c.created_at" if "created_at" in conversation_cols else "NULL"
+    depth_expr = _column_expr(summary_cols, "s", "depth", "0")
+    kind_expr = _column_expr(summary_cols, "s", "kind", "NULL")
+    token_count_expr = _column_expr(summary_cols, "s", "token_count", "0")
+    source_message_token_count_expr = _column_expr(summary_cols, "s", "source_message_token_count", "0")
+    descendant_token_count_expr = _column_expr(summary_cols, "s", "descendant_token_count", "0")
+    created_at_expr = _column_expr(summary_cols, "s", "created_at", conversation_created_expr)
+    earliest_at_expr = _column_expr(summary_cols, "s", "earliest_at", created_at_expr)
+    latest_at_expr = _column_expr(summary_cols, "s", "latest_at", created_at_expr)
+    expand_hint_expr = _column_expr(summary_cols, "s", "expand_hint", "''")
+
+    summary_messages = _load_summary_message_ids(conn)
+    summary_parents = _load_summary_parent_ids(conn)
+    now = time.time()
+    rows = conn.execute(
+        f"""
+        SELECT
+            s.summary_id,
+            s.conversation_id,
+            {depth_expr} AS depth,
+            {kind_expr} AS kind,
+            s.{content_column} AS content,
+            {token_count_expr} AS token_count,
+            {source_message_token_count_expr} AS source_message_token_count,
+            {descendant_token_count_expr} AS descendant_token_count,
+            {created_at_expr} AS created_at,
+            {earliest_at_expr} AS earliest_at,
+            {latest_at_expr} AS latest_at,
+            {expand_hint_expr} AS expand_hint,
+            c.session_id AS conversation_session_id,
+            {session_key_expr} AS conversation_session_key,
+            {conversation_created_expr} AS conversation_created_at
+        FROM summaries s
+        JOIN conversations c ON c.conversation_id = s.conversation_id
+        ORDER BY depth, created_at, s.summary_id
+        """
+    ).fetchall()
+
+    candidates: list[SummaryCandidate] = []
+    for row in rows:
+        source_summary_id = str(row["summary_id"])
+        conversation_id = int(row["conversation_id"])
+        source_session = _resolve_source_session(
+            row,
+            conversation_id=conversation_id,
+            session_identity=session_identity,
+        )
+        source = _target_source(namespace, agent, source_session)
+        created_at = _parse_timestamp(
+            row["created_at"],
+            _parse_timestamp(row["conversation_created_at"], now),
+        )
+        candidates.append(
+            SummaryCandidate(
+                source_summary_id=source_summary_id,
+                source_conversation_id=conversation_id,
+                source_session=source_session,
+                target_session_id=source,
+                source=source,
+                depth=_coerce_int(row["depth"], 0),
+                kind=str(row["kind"] or "").strip().lower(),
+                summary=str(row["content"] or ""),
+                token_count=_coerce_int(row["token_count"], 0),
+                source_message_token_count=_coerce_int(row["source_message_token_count"], 0),
+                descendant_token_count=_coerce_int(row["descendant_token_count"], 0),
+                created_at=created_at,
+                earliest_at=_parse_timestamp(row["earliest_at"], created_at),
+                latest_at=_parse_timestamp(row["latest_at"], created_at),
+                expand_hint=str(row["expand_hint"] or ""),
+                message_ids=summary_messages.get(source_summary_id, []),
+                parent_summary_ids=summary_parents.get(source_summary_id, []),
+            )
+        )
+    return candidates
+
+
 def _target_has_import_table(conn: sqlite3.Connection) -> bool:
     return _table_exists(conn, "lcm_imported_messages")
 
@@ -432,6 +642,237 @@ def _ensure_import_table(conn: sqlite3.Connection) -> None:
             ON lcm_imported_messages(target_store_id)
         """
     )
+
+
+def _ensure_summary_nodes_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS summary_nodes (
+            node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            depth INTEGER NOT NULL DEFAULT 0,
+            summary TEXT NOT NULL,
+            token_count INTEGER DEFAULT 0,
+            source_token_count INTEGER DEFAULT 0,
+            source_ids TEXT NOT NULL DEFAULT '[]',
+            source_type TEXT NOT NULL DEFAULT 'messages',
+            created_at REAL NOT NULL,
+            earliest_at REAL,
+            latest_at REAL,
+            expand_hint TEXT DEFAULT ''
+        );
+        CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
+            ON summary_nodes(session_id, depth, created_at);
+        """
+    )
+    columns = _table_columns(conn, "summary_nodes")
+    if "earliest_at" not in columns:
+        conn.execute("ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL")
+    if "latest_at" not in columns:
+        conn.execute("ALTER TABLE summary_nodes ADD COLUMN latest_at REAL")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
+    )
+    ensure_external_content_fts(conn, build_nodes_fts_spec())
+
+
+def _ensure_summary_import_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_imported_summaries (
+            import_id TEXT NOT NULL,
+            source_summary_id TEXT NOT NULL,
+            source_conversation_id INTEGER NOT NULL,
+            source_session TEXT NOT NULL,
+            target_node_id INTEGER NOT NULL,
+            imported_at REAL NOT NULL,
+            PRIMARY KEY (import_id, source_summary_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_lcm_imported_summaries_target
+            ON lcm_imported_summaries(target_node_id)
+        """
+    )
+
+
+def _imported_message_map_from_conn(conn: sqlite3.Connection, import_id: str) -> dict[int, int]:
+    if not _target_has_import_table(conn):
+        return {}
+    rows = conn.execute(
+        """SELECT source_message_id, target_store_id
+           FROM lcm_imported_messages
+           WHERE import_id = ?""",
+        (import_id,),
+    ).fetchall()
+    return {int(row[0]): int(row[1]) for row in rows}
+
+
+def _imported_summary_map_from_conn(conn: sqlite3.Connection, import_id: str) -> dict[str, int]:
+    if not _table_exists(conn, "lcm_imported_summaries"):
+        return {}
+    rows = conn.execute(
+        """SELECT source_summary_id, target_node_id
+           FROM lcm_imported_summaries
+           WHERE import_id = ?""",
+        (import_id,),
+    ).fetchall()
+    return {str(row[0]): int(row[1]) for row in rows}
+
+
+def _target_imported_message_map(target_db: Path, import_id: str) -> dict[int, int]:
+    if not target_db.exists():
+        return {}
+    conn = sqlite3.connect(_readonly_sqlite_uri(target_db), uri=True)
+    try:
+        return _imported_message_map_from_conn(conn, import_id)
+    finally:
+        conn.close()
+
+
+def _target_imported_summary_map(target_db: Path, import_id: str) -> dict[str, int]:
+    if not target_db.exists():
+        return {}
+    conn = sqlite3.connect(_readonly_sqlite_uri(target_db), uri=True)
+    try:
+        return _imported_summary_map_from_conn(conn, import_id)
+    finally:
+        conn.close()
+
+
+def _insert_summary_node(
+    conn: sqlite3.Connection,
+    *,
+    import_id: str,
+    candidate: SummaryCandidate,
+    source_ids: list[int],
+    source_type: str,
+) -> int:
+    source_token_count = (
+        candidate.descendant_token_count
+        if source_type == "nodes"
+        else candidate.source_message_token_count
+    )
+    depth = candidate.depth
+    if source_type == "nodes" and depth <= 0:
+        depth = 1
+    cur = conn.execute(
+        """INSERT INTO summary_nodes
+           (session_id, depth, summary, token_count, source_token_count,
+            source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            candidate.target_session_id,
+            depth,
+            candidate.summary,
+            candidate.token_count,
+            source_token_count,
+            json.dumps(source_ids),
+            source_type,
+            candidate.created_at,
+            candidate.earliest_at,
+            candidate.latest_at,
+            candidate.expand_hint,
+        ),
+    )
+    node_id = int(cur.lastrowid)
+    conn.execute(
+        """INSERT INTO lcm_imported_summaries
+           (import_id, source_summary_id, source_conversation_id, source_session,
+            target_node_id, imported_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            import_id,
+            candidate.source_summary_id,
+            candidate.source_conversation_id,
+            candidate.source_session,
+            node_id,
+            time.time(),
+        ),
+    )
+    return node_id
+
+
+def _resolve_all_ids(source_ids: Iterable[Any], mapping: dict[Any, int]) -> list[int] | None:
+    resolved: list[int] = []
+    for source_id in source_ids:
+        if source_id not in mapping:
+            return None
+        resolved.append(mapping[source_id])
+    if not resolved:
+        return None
+    return _dedupe_preserving_order(resolved)
+
+
+def _process_summary_candidates(
+    *,
+    conn: sqlite3.Connection | None,
+    import_id: str,
+    candidates: list[SummaryCandidate],
+    imported_messages: dict[int, int],
+    imported_summaries: dict[str, int],
+    dry_run: bool,
+) -> SummaryImportStats:
+    stats = SummaryImportStats(scanned=len(candidates))
+    summary_to_node = dict(imported_summaries)
+    virtual_node_id = -1
+
+    def record_import(candidate: SummaryCandidate, source_ids: list[int], source_type: str) -> None:
+        nonlocal virtual_node_id
+        if dry_run:
+            summary_to_node[candidate.source_summary_id] = virtual_node_id
+            virtual_node_id -= 1
+            stats.would_import += 1
+            return
+        if conn is None:
+            raise ValueError("conn is required when dry_run is false")
+        node_id = _insert_summary_node(
+            conn,
+            import_id=import_id,
+            candidate=candidate,
+            source_ids=source_ids,
+            source_type=source_type,
+        )
+        summary_to_node[candidate.source_summary_id] = node_id
+        stats.imported += 1
+
+    leaf_candidates = [candidate for candidate in candidates if not candidate.is_condensed()]
+    condensed_remaining = sorted(
+        (candidate for candidate in candidates if candidate.is_condensed()),
+        key=lambda candidate: (candidate.depth, candidate.source_summary_id),
+    )
+
+    for candidate in leaf_candidates:
+        if candidate.source_summary_id in summary_to_node:
+            stats.skipped_existing += 1
+            continue
+        source_ids = _resolve_all_ids(candidate.message_ids, imported_messages)
+        if source_ids is None:
+            stats.skipped_unresolved += 1
+            continue
+        record_import(candidate, source_ids, "messages")
+
+    while condensed_remaining:
+        progressed = False
+        next_remaining: list[SummaryCandidate] = []
+        for candidate in condensed_remaining:
+            if candidate.source_summary_id in summary_to_node:
+                stats.skipped_existing += 1
+                continue
+            source_ids = _resolve_all_ids(candidate.parent_summary_ids, summary_to_node)
+            if source_ids is None:
+                next_remaining.append(candidate)
+                continue
+            record_import(candidate, source_ids, "nodes")
+            progressed = True
+        if not progressed:
+            stats.skipped_unresolved += len(next_remaining)
+            break
+        condensed_remaining = next_remaining
+
+    return stats
 
 
 def _existing_source_message_ids(target_db: Path, import_id: str) -> set[int]:
@@ -478,6 +919,7 @@ def import_lossless_claw(
     agent: str = "unknown",
     import_id: str | None = None,
     session_identity: str = "session_id",
+    include_summaries: bool = False,
     apply: bool = False,
 ) -> ImportResult:
     source_path = Path(source_db)
@@ -496,12 +938,39 @@ def import_lossless_claw(
             agent=agent,
             session_identity=session_identity,
         )
+        summary_candidates = (
+            _collect_summary_candidates(
+                source_conn,
+                namespace=namespace,
+                agent=agent,
+                session_identity=session_identity,
+            )
+            if include_summaries
+            else []
+        )
 
     existing_ids = _existing_source_message_ids(target_path, resolved_import_id)
     to_import = [candidate for candidate in candidates if candidate.source_message_id not in existing_ids]
     skipped_existing = len(candidates) - len(to_import)
 
     if not apply:
+        summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+        if include_summaries:
+            imported_message_map = _target_imported_message_map(target_path, resolved_import_id)
+            next_virtual_store_id = -1
+            for candidate in candidates:
+                if candidate.source_message_id in imported_message_map:
+                    continue
+                imported_message_map[candidate.source_message_id] = next_virtual_store_id
+                next_virtual_store_id -= 1
+            summary_stats = _process_summary_candidates(
+                conn=None,
+                import_id=resolved_import_id,
+                candidates=summary_candidates,
+                imported_messages=imported_message_map,
+                imported_summaries=_target_imported_summary_map(target_path, resolved_import_id),
+                dry_run=True,
+            )
         return ImportResult(
             source_db=str(source_path),
             target_db=str(target_path),
@@ -514,9 +983,27 @@ def import_lossless_claw(
             skipped_empty=skipped_empty,
             conversations=conversations,
             backup_path=None,
+            summaries_scanned=summary_stats.scanned,
+            summaries_would_import=summary_stats.would_import,
+            summaries_imported=0,
+            summaries_skipped_existing=summary_stats.skipped_existing,
+            summaries_skipped_unresolved=summary_stats.skipped_unresolved,
         )
 
-    if not to_import:
+    preflight_summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+    summary_writes_planned = False
+    if include_summaries and not to_import:
+        preflight_summary_stats = _process_summary_candidates(
+            conn=None,
+            import_id=resolved_import_id,
+            candidates=summary_candidates,
+            imported_messages=_target_imported_message_map(target_path, resolved_import_id),
+            imported_summaries=_target_imported_summary_map(target_path, resolved_import_id),
+            dry_run=True,
+        )
+        summary_writes_planned = preflight_summary_stats.would_import > 0
+
+    if not to_import and not summary_writes_planned:
         return ImportResult(
             source_db=str(source_path),
             target_db=str(target_path),
@@ -529,6 +1016,11 @@ def import_lossless_claw(
             skipped_empty=skipped_empty,
             conversations=conversations,
             backup_path=None,
+            summaries_scanned=preflight_summary_stats.scanned,
+            summaries_would_import=0,
+            summaries_imported=0,
+            summaries_skipped_existing=preflight_summary_stats.skipped_existing,
+            summaries_skipped_unresolved=preflight_summary_stats.skipped_unresolved,
         )
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -542,6 +1034,11 @@ def import_lossless_claw(
     )
     conn = store._conn
     _ensure_import_table(conn)
+    imported_message_map = _imported_message_map_from_conn(conn, resolved_import_id)
+    summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+    if include_summaries:
+        _ensure_summary_nodes_schema(conn)
+        _ensure_summary_import_table(conn)
 
     imported = 0
     try:
@@ -594,7 +1091,17 @@ def import_lossless_claw(
                     time.time(),
                 ),
             )
+            imported_message_map[candidate.source_message_id] = int(cur.lastrowid)
             imported += 1
+        if include_summaries:
+            summary_stats = _process_summary_candidates(
+                conn=conn,
+                import_id=resolved_import_id,
+                candidates=summary_candidates,
+                imported_messages=imported_message_map,
+                imported_summaries=_imported_summary_map_from_conn(conn, resolved_import_id),
+                dry_run=False,
+            )
         conn.commit()
     except Exception:
         conn.rollback()
@@ -614,6 +1121,11 @@ def import_lossless_claw(
         skipped_empty=skipped_empty,
         conversations=conversations,
         backup_path=backup_path,
+        summaries_scanned=summary_stats.scanned,
+        summaries_would_import=0,
+        summaries_imported=summary_stats.imported,
+        summaries_skipped_existing=summary_stats.skipped_existing,
+        summaries_skipped_unresolved=summary_stats.skipped_unresolved,
     )
 
 
@@ -637,6 +1149,11 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--apply", action="store_true", help="Write rows to the target DB. Omit for dry-run")
+    parser.add_argument(
+        "--include-summaries",
+        action="store_true",
+        help="Also migrate OpenClaw summaries into Hermes summary_nodes",
+    )
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON summary")
     return parser
 
@@ -651,6 +1168,7 @@ def main(argv: list[str] | None = None) -> int:
         agent=args.agent,
         import_id=args.import_id,
         session_identity=args.session_identity,
+        include_summaries=args.include_summaries,
         apply=args.apply,
     )
     if args.json:
@@ -668,6 +1186,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  imported: {result.imported}")
         print(f"  skipped_existing: {result.skipped_existing}")
         print(f"  skipped_empty: {result.skipped_empty}")
+        if args.include_summaries:
+            print(f"  summaries_scanned: {result.summaries_scanned}")
+            print(f"  summaries_would_import: {result.summaries_would_import}")
+            print(f"  summaries_imported: {result.summaries_imported}")
+            print(f"  summaries_skipped_existing: {result.summaries_skipped_existing}")
+            print(f"  summaries_skipped_unresolved: {result.summaries_skipped_unresolved}")
         if result.backup_path:
             print(f"  backup_path: {result.backup_path}")
     return 0

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_lcm.dag import SummaryDAG
 from hermes_lcm.store import MessageStore
 
 
@@ -101,6 +102,158 @@ def add_shared_session_key_conversation(db_path: Path) -> None:
         """INSERT INTO messages
            (message_id, conversation_id, seq, role, content, token_count, created_at)
            VALUES (12, 2, 1, 'user', 'hello from second conversation', 5, '2026-04-20 12:01:01')"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def create_summary_tables(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE summaries (
+            summary_id TEXT PRIMARY KEY,
+            conversation_id INTEGER NOT NULL,
+            depth INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            content TEXT NOT NULL,
+            token_count INTEGER NOT NULL DEFAULT 0,
+            source_message_token_count INTEGER NOT NULL DEFAULT 0,
+            descendant_token_count INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            earliest_at TEXT NOT NULL,
+            latest_at TEXT NOT NULL,
+            expand_hint TEXT DEFAULT ''
+        );
+        CREATE TABLE summary_messages (
+            summary_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            ordinal INTEGER NOT NULL
+        );
+        CREATE TABLE summary_parents (
+            summary_id TEXT NOT NULL,
+            parent_summary_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL
+        );
+        """
+    )
+
+
+def add_lossless_summaries(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('leaf-1', 1, 0, 'leaf', 'leaf pineapple memory', 5,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   'leaf hint')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('condensed-1', 1, 1, 'condensed', 'condensed pineapple memory', 7,
+                   0, 33, '2026-04-20 12:00:20',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:20',
+                   'condensed hint')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("leaf-1", 10, 0), ("leaf-1", 10, 1), ("leaf-1", 11, 2)],
+    )
+    conn.execute(
+        """INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+           VALUES ('condensed-1', 'leaf-1', 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_unresolved_leaf_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (12, 1, 3, 'assistant', '', 0, '2026-04-20 12:00:03')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('empty-leaf', 1, 0, 'leaf', 'unresolvable empty stub summary', 3,
+                   9, 0, '2026-04-20 12:00:11',
+                   '2026-04-20 12:00:03', '2026-04-20 12:00:03',
+                   '')"""
+    )
+    conn.execute(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES ('empty-leaf', 12, 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_partially_unresolved_leaf_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('partial-leaf', 1, 0, 'leaf', 'partial leaf should not import', 3,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   '')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("partial-leaf", 10, 0), ("partial-leaf", 999, 1)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_partially_unresolved_parent_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('leaf-1', 1, 0, 'leaf', 'leaf parent can import', 5,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   '')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('partial-condensed', 1, 1, 'condensed', 'partial condensed should not import', 7,
+                   0, 33, '2026-04-20 12:00:20',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:20',
+                   '')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("leaf-1", 10, 0), ("leaf-1", 11, 1)],
+    )
+    conn.executemany(
+        """INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("partial-condensed", "leaf-1", 0), ("partial-condensed", "missing-parent", 1)],
     )
     conn.commit()
     conn.close()
@@ -207,6 +360,212 @@ def test_dry_run_handles_uri_reserved_source_db_path(tmp_path: Path):
     assert result.scanned == 2
     assert result.eligible == 2
     assert result.would_import == 2
+    assert not target_db.exists()
+
+
+def test_apply_imports_lossless_summaries_as_summary_nodes(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 2
+    conn = sqlite3.connect(target_db)
+    conn.row_factory = sqlite3.Row
+    message_map = {
+        int(row["source_message_id"]): int(row["target_store_id"])
+        for row in conn.execute(
+            """SELECT source_message_id, target_store_id
+               FROM lcm_imported_messages
+               WHERE import_id = 'fixture-import'"""
+        )
+    }
+    rows = conn.execute(
+        """SELECT node_id, depth, summary, source_token_count, source_ids,
+                  source_type, created_at, earliest_at, latest_at
+           FROM summary_nodes
+           ORDER BY depth, node_id"""
+    ).fetchall()
+    fts_count = conn.execute(
+        "SELECT COUNT(*) FROM nodes_fts WHERE nodes_fts MATCH ?",
+        ("pineapple",),
+    ).fetchone()[0]
+    conn.close()
+
+    assert len(rows) == 2
+    leaf = rows[0]
+    condensed = rows[1]
+    assert leaf["source_type"] == "messages"
+    assert json.loads(leaf["source_ids"]) == [message_map[10], message_map[11]]
+    assert condensed["source_type"] == "nodes"
+    assert json.loads(condensed["source_ids"]) == [leaf["node_id"]]
+    assert leaf["source_token_count"] == 15
+    assert condensed["source_token_count"] == 33
+    dag = SummaryDAG(target_db)
+    condensed_node = dag.get_node(condensed["node_id"])
+    assert condensed_node is not None
+    assert [node.node_id for node in dag.get_source_nodes(condensed_node)] == [leaf["node_id"]]
+    subtree = dag.describe_subtree(condensed["node_id"])
+    dag.close()
+    assert subtree["source_type"] == "nodes"
+    assert subtree["children"] == [
+        {
+            "node_id": leaf["node_id"],
+            "depth": 0,
+            "token_count": 5,
+            "source_token_count": 15,
+            "expand_hint": "leaf hint",
+        }
+    ]
+    assert leaf["created_at"] == pytest.approx(1776686410.0)
+    assert leaf["earliest_at"] == pytest.approx(1776686401.0)
+    assert leaf["latest_at"] == pytest.approx(1776686402.0)
+    assert condensed["created_at"] == pytest.approx(1776686420.0)
+    assert condensed["earliest_at"] == pytest.approx(1776686401.0)
+    assert condensed["latest_at"] == pytest.approx(1776686420.0)
+    assert fts_count == 2
+
+
+def test_apply_summary_import_is_idempotent_for_same_import_id(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    first = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+    second = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert first.summaries_imported == 2
+    assert second.summaries_imported == 0
+    assert second.summaries_skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 2
+    conn.close()
+
+
+def test_summary_leaf_with_only_skipped_empty_messages_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_unresolved_leaf_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.skipped_empty == 1
+    assert result.summaries_imported == 0
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 0
+    conn.close()
+
+
+def test_summary_leaf_with_partially_unresolved_messages_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_partially_unresolved_leaf_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 0
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 0
+    conn.close()
+
+
+def test_summary_condensed_with_partially_unresolved_parents_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_partially_unresolved_parent_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 1
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT depth, summary, source_type FROM summary_nodes ORDER BY node_id"
+    ).fetchall()
+    assert rows == [(0, "leaf parent can import", "messages")]
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 1
+    conn.close()
+
+
+def test_dry_run_include_summaries_does_not_create_target_db(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=False,
+    )
+
+    assert result.summaries_would_import == 2
     assert not target_db.exists()
 
 


### PR DESCRIPTION
## Summary
- Adds optional OpenClaw summary migration to `scripts/import_lossless_claw.py` behind `--include-summaries`.
- Imports leaf summaries after resolving every referenced source message through `lcm_imported_messages`.
- Imports condensed summaries depth by depth after resolving parent summaries into their new Hermes `node_id` values.
- Tracks imported summaries in `lcm_imported_summaries` so reruns stay idempotent.

## Why
- OpenClaw migrations currently preserve raw messages but drop the compressed summary DAG.
- Without those nodes, old sessions are searchable as transcripts but lose the drill-down memory structure that makes LCM useful for recall.
- Migrating summaries into `summary_nodes` lets imported sessions keep their existing compressed context instead of rebuilding it from scratch.

## Validation
- [x] Focused validation: `pytest tests/test_import_lossless_claw.py -q` -> `16 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `564 passed`
  - [x] `pytest -q` -> `676 passed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `676 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Read-only Codex blocker audit after the partial resolution fix: no blockers.

## Notes
- Condensed nodes intentionally use `source_type="nodes"`, not `"summaries"`, because that is the contract `SummaryDAG` traversal expects for node to node edges.
- Code unchanged after Stephen's template request.

Closes #170.
