### PR TITLE
feat: add /lcm rotate for in-place tail-preserving session compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,10 +530,51 @@ Available commands:
 - `/lcm doctor source apply` - backup-first normalization of legacy blank-source rows to `unknown`
 - `/lcm doctor retention` - read-only retention analysis
 - `/lcm backup` - timestamped SQLite backup
+- `/lcm rotate` - read-only preview of an in-place tail-preserving compact of the active session
+- `/lcm rotate apply` - backup-first rotate that advances the lifecycle frontier past pre-tail raw messages
 - `/lcm help` - command help
 
 Apply paths are intentionally narrow and backup-first. Start with diagnostics
 before cleanup or repair.
+
+### Rotate: in-place compact without changing session identity
+
+`/lcm rotate` lets an operator compact a long-running session in place without
+changing `session_id` or `conversation_id`. It is the in-session counterpart to
+Hermes-level `/new` (which starts a new session) and to `/lcm doctor clean`
+(which prunes whole junk sessions).
+
+What rotate does:
+
+- preserves the live tail (`LCM_FRESH_TAIL_COUNT` most-recent messages)
+- advances the lifecycle frontier marker past every raw message before the tail,
+  so subsequent bootstrap stops replaying them into the active prompt
+- writes a rolling `*-rotate-latest.sqlite3` backup under the same backup
+  directory as `/lcm backup`, overwriting the previous rotate slot atomically
+  so disk usage stays bounded across repeated rotates
+
+What rotate does not do:
+
+- it does not delete raw messages — pre-tail rows remain in the SQLite store
+  and stay recoverable through `lcm_load_session` and `lcm_expand`, preserving
+  the lossless raw recovery contract
+- it does not invoke the summarization model — rotate is a frontier and backup
+  operation, not a synthesis step. Pre-tail content that was not yet covered by
+  a summary node remains accessible only as raw rows; trigger normal compaction
+  first if you want the pre-tail range covered by summary nodes before rotating
+- it does not change session or conversation identity, run on stateless
+  sessions (`LCM_STATELESS_SESSION_PATTERNS`), or run on ignored sessions
+  (`LCM_IGNORE_SESSION_PATTERNS`) — rotate refuses on both with a clear reason
+
+`lcm_status` and `/lcm status` surface `last_rotate_at` (epoch float, or `null`
+when no rotate has happened) and the rolling backup path so operators can see
+when rotate last ran. The mtime of the rolling backup file is the source of
+truth — no new lifecycle column is added by this feature.
+
+Re-running `/lcm rotate apply` on a session whose frontier is already at or
+ahead of the target boundary reports `status: noop` and is safe to retry.
+A no-op apply does not write a new rolling backup, so the previous
+known-good `*-rotate-latest.sqlite3` snapshot survives idempotent retries.
 
 ## How It Works
 

--- a/command.py
+++ b/command.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import os
 import sqlite3
@@ -92,6 +92,8 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm doctor source apply: backup-first normalization of legacy blank-source rows to unknown",
         "- /lcm doctor retention: read-only retention analysis for stored session footprint and age",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
+        "- /lcm rotate: preview a tail-preserving in-place compact of the active session (read-only)",
+        "- /lcm rotate apply: backup-first rotate that advances the lifecycle frontier past pre-tail raw messages",
         "- /lcm help: show this help",
     ])
     return "\n".join(lines)
@@ -159,6 +161,20 @@ def _status_text(engine) -> str:
         f"source_legacy_blank_messages: {source_stats['legacy_blank_source_messages']}",
         f"source_effective_unknown_messages: {source_stats['effective_unknown_messages']}",
     ]
+
+    last_rotate_at = status.get("last_rotate_at")
+    if last_rotate_at:
+        lines.append(
+            f"last_rotate_at: "
+            f"{datetime.fromtimestamp(float(last_rotate_at), tz=timezone.utc).isoformat(timespec='seconds')}"
+        )
+        rotate_backup_size = int(status.get("rotate_backup_size", 0) or 0)
+        if rotate_backup_size:
+            lines.append(f"rotate_backup_size: {_fmt_size(rotate_backup_size)}")
+    else:
+        lines.append("last_rotate_at: (never)")
+    if status.get("rotate_backup_path"):
+        lines.append(f"rotate_backup_path: {status['rotate_backup_path']}")
 
     if session_bound:
         lines.extend([
@@ -423,6 +439,20 @@ def _scan_retention_candidates(engine) -> dict[str, Any]:
     }
 
 
+def _flush_engine_connections(engine) -> None:
+    """Commit pending writes on every SQLite connection the engine owns.
+
+    Shared by ``_backup_database`` (timestamped backup) and
+    ``_rotate_backup_database`` (rolling backup) so the connection-flush
+    contract stays in one place.
+    """
+    engine._store._conn.commit()
+    engine._dag._conn.commit()
+    lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
+    if lifecycle_conn is not None:
+        lifecycle_conn.commit()
+
+
 def _backup_database(engine) -> dict[str, Any]:
     db_path = Path(engine._store.db_path)
     if not db_path.exists():
@@ -432,18 +462,13 @@ def _backup_database(engine) -> dict[str, Any]:
             "error": "database file does not exist",
         }
 
-    backup_root = Path(engine._hermes_home).expanduser() if getattr(engine, "_hermes_home", "") else db_path.parent
-    backup_dir = backup_root / "backups" / "lcm"
+    backup_dir = engine.backup_dir()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = backup_dir / f"{db_path.stem}-{timestamp}.sqlite3"
 
     try:
         backup_dir.mkdir(parents=True, exist_ok=True)
-        engine._store._conn.commit()
-        engine._dag._conn.commit()
-        lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
-        if lifecycle_conn is not None:
-            lifecycle_conn.commit()
+        _flush_engine_connections(engine)
 
         dest = sqlite3.connect(str(backup_path))
         try:
@@ -464,6 +489,180 @@ def _backup_database(engine) -> dict[str, Any]:
         "backup_path": backup_path,
         "backup_size": backup_size,
     }
+
+
+def _rotate_backup_database(engine) -> dict[str, Any]:
+    """Write a rolling rotate-latest SQLite snapshot of the LCM store.
+
+    Atomic via tmp-then-rename so the slot is never half-written. Unlike
+    ``_backup_database`` which produces timestamped files, this overwrites a
+    single rolling slot so disk usage stays bounded across repeated rotates.
+    """
+    db_path = Path(engine._store.db_path)
+    if not db_path.exists():
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "error": "database file does not exist",
+        }
+
+    backup_path = engine.rotate_backup_path()
+    backup_dir = backup_path.parent
+    tmp_path = backup_path.with_name(backup_path.name + ".tmp")
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        _flush_engine_connections(engine)
+
+        if tmp_path.exists():
+            tmp_path.unlink()
+        dest = sqlite3.connect(str(tmp_path))
+        try:
+            engine._store._conn.backup(dest)
+        finally:
+            dest.close()
+        # Atomic replace so the rolling slot is never half-written.
+        tmp_path.replace(backup_path)
+    except (OSError, sqlite3.Error) as exc:
+        # Best-effort cleanup of the tmp file if something failed midway.
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "backup_path": backup_path,
+            "error": str(exc),
+        }
+
+    backup_size = backup_path.stat().st_size if backup_path.exists() else 0
+    return {
+        "ok": True,
+        "db_path": db_path,
+        "backup_path": backup_path,
+        "backup_size": backup_size,
+    }
+
+
+def _rotate_text(engine) -> str:
+    preview = engine.rotate_active_session(apply=False)
+    if not preview.get("ok"):
+        reason = preview.get("reason", "unknown")
+        lines = [
+            "LCM rotate",
+            "status: refused",
+            f"reason: {reason}",
+        ]
+        session_id = preview.get("session_id")
+        if session_id:
+            lines.append(f"session_id: {session_id}")
+        lines.append("note: read-only preview — no changes were made")
+        return "\n".join(lines)
+
+    backup_path = engine.rotate_backup_path()
+    lines = [
+        "LCM rotate",
+        f"status: {'noop' if preview.get('noop') else 'preview'}",
+        f"session_id: {preview['session_id']}",
+        f"conversation_id: {preview['conversation_id']}",
+        f"total_message_count: {preview['total_message_count']}",
+        f"fresh_tail_count: {preview['fresh_tail_count']}",
+        f"pre_tail_message_count: {preview.get('pre_tail_message_count', 0)}",
+        f"current_frontier_store_id: {preview['current_frontier_store_id']}",
+        f"new_frontier_store_id: {preview['new_frontier_store_id']}",
+        f"rotate_backup_path: {backup_path}",
+    ]
+    if preview.get("noop"):
+        lines.append(f"reason: {preview.get('reason', 'no_change')}")
+        lines.append("note: read-only preview — rotate apply would be a no-op for this session")
+    else:
+        lines.append("note: read-only preview — use `/lcm rotate apply` to advance the frontier (backup-first)")
+        lines.append("note: pre-tail raw messages remain in the store and recoverable via lcm_load_session")
+    return "\n".join(lines)
+
+
+def _rotate_apply_text(engine) -> str:
+    # Pre-flight refusal AND noop check before touching disk. This avoids
+    # both writing a backup for a session that would refuse and overwriting
+    # the previous known-good rolling backup when the apply would be a no-op
+    # (e.g., idempotent rerun on an already-rotated session).
+    pre = engine.rotate_active_session(apply=False)
+    if not pre.get("ok"):
+        reason = pre.get("reason", "unknown")
+        lines = [
+            "LCM rotate apply",
+            "status: refused",
+            f"reason: {reason}",
+        ]
+        session_id = pre.get("session_id")
+        if session_id:
+            lines.append(f"session_id: {session_id}")
+        lines.append("note: rotate apply refused; no backup was created and no lifecycle state was changed")
+        return "\n".join(lines)
+
+    if pre.get("noop"):
+        # Surface the same shape as a successful apply but with status:noop so
+        # operators get the standard fields without a fresh backup write
+        # destroying the previous known-good snapshot.
+        lines = [
+            "LCM rotate apply",
+            "status: noop",
+            f"session_id: {pre['session_id']}",
+            f"conversation_id: {pre['conversation_id']}",
+            f"total_message_count: {pre['total_message_count']}",
+            f"fresh_tail_count: {pre['fresh_tail_count']}",
+            f"pre_tail_message_count: {pre.get('pre_tail_message_count', 0)}",
+            f"previous_frontier_store_id: {pre['current_frontier_store_id']}",
+            f"new_frontier_store_id: {pre['new_frontier_store_id']}",
+            f"reason: {pre.get('reason', 'no_change')}",
+            "note: rotate is a no-op; rolling backup was not written so the previous rotate-latest snapshot is preserved",
+        ]
+        return "\n".join(lines)
+
+    backup = _rotate_backup_database(engine)
+    if not backup["ok"]:
+        return "\n".join([
+            "LCM rotate apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"error: backup failed: {backup['error']}",
+            "note: rotate apply aborted before any lifecycle mutation",
+        ])
+
+    result = engine.rotate_active_session(apply=True)
+    if not result.get("ok"):
+        return "\n".join([
+            "LCM rotate apply",
+            "status: refused",
+            f"reason: {result.get('reason', 'unknown')}",
+            f"rotate_backup_path: {backup['backup_path']}",
+            f"rotate_backup_size: {_fmt_size(int(backup['backup_size']))}",
+            "note: backup was created before rotate refused; lifecycle state unchanged",
+        ])
+
+    is_noop = bool(result.get("noop"))
+    lines = [
+        "LCM rotate apply",
+        f"status: {'noop' if is_noop else 'ok'}",
+        f"session_id: {result['session_id']}",
+        f"conversation_id: {result['conversation_id']}",
+        f"rotate_backup_path: {backup['backup_path']}",
+        f"rotate_backup_size: {_fmt_size(int(backup['backup_size']))}",
+        f"total_message_count: {result['total_message_count']}",
+        f"fresh_tail_count: {result['fresh_tail_count']}",
+        f"pre_tail_message_count: {result.get('pre_tail_message_count', 0)}",
+        f"previous_frontier_store_id: {result['current_frontier_store_id']}",
+        f"new_frontier_store_id: {result.get('applied_frontier_store_id', result['new_frontier_store_id'])}",
+    ]
+    if is_noop:
+        lines.append(f"reason: {result.get('reason', 'no_change')}")
+        lines.append("note: lifecycle state already at or ahead of the target frontier")
+    else:
+        lines.append("note: pre-tail raw messages remain in the store and recoverable via lcm_load_session")
+        lines.append("note: rolling backup overwrites the previous rotate-latest slot")
+    return "\n".join(lines)
 
 
 def _scan_fts_repair(engine) -> dict[str, Any]:
@@ -1197,6 +1396,13 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
         if rest:
             return _help_text("`/lcm backup` does not accept extra arguments.")
         return _backup_text(engine)
+
+    if head == "rotate":
+        if not rest:
+            return _rotate_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "apply":
+            return _rotate_apply_text(engine)
+        return _help_text("`/lcm rotate` accepts an optional `apply` subcommand.")
 
     if head == "help":
         return _help_text()

--- a/engine.py
+++ b/engine.py
@@ -2016,6 +2016,26 @@ class LCMEngine(ContextEngine):
             )
         except Exception as exc:  # pragma: no cover - defensive
             status["lifecycle_fragmentation"] = {"error": str(exc), "read_only": True}
+        try:
+            rotate_backup_path = self.rotate_backup_path()
+            status["rotate_backup_path"] = str(rotate_backup_path)
+            # Single stat() to avoid a TOCTOU window where the rolling slot
+            # could be atomically replaced between separate mtime and size reads.
+            try:
+                rotate_stat = rotate_backup_path.stat()
+            except FileNotFoundError:
+                rotate_stat = None
+            if rotate_stat is not None:
+                status["last_rotate_at"] = rotate_stat.st_mtime
+                status["rotate_backup_size"] = rotate_stat.st_size
+            else:
+                status["last_rotate_at"] = None
+                status["rotate_backup_size"] = 0
+        except Exception as exc:  # pragma: no cover - defensive
+            status["rotate_backup_path"] = None
+            status["last_rotate_at"] = None
+            status["rotate_backup_size"] = 0
+            status["rotate_backup_error"] = str(exc)
         if session_id:
             status["store_messages"] = self._store.get_session_count(session_id)
             status["dag_nodes"] = len(self._dag.get_session_nodes(session_id))
@@ -3605,6 +3625,163 @@ class LCMEngine(ContextEngine):
             # Take first line only
             return hint.split("\n")[0].strip()
         return ""
+
+    # -- Rotate ------------------------------------------------------------
+
+    def backup_dir(self) -> Path:
+        """Return the directory where LCM backup snapshots are written.
+
+        Centralized so the timestamped ``/lcm backup`` slot and the rolling
+        ``/lcm rotate apply`` slot share the same directory derivation.
+        """
+        db_path = Path(self._store.db_path)
+        backup_root = (
+            Path(self._hermes_home).expanduser()
+            if getattr(self, "_hermes_home", "")
+            else db_path.parent
+        )
+        return backup_root / "backups" / "lcm"
+
+    def rotate_backup_path(self) -> Path:
+        """Return the rolling rotate-latest SQLite backup path for this engine.
+
+        Centralized so command.py (which writes the backup) and get_status()
+        (which reads its mtime to surface last_rotate_at) cannot drift.
+        """
+        db_path = Path(self._store.db_path)
+        return self.backup_dir() / f"{db_path.stem}-rotate-latest.sqlite3"
+
+    def rotate_active_session(
+        self,
+        *,
+        apply: bool = False,
+    ) -> dict[str, Any]:
+        """Compact the active session in-place without changing identity.
+
+        Read-only by default (``apply=False``). Returns a preview describing
+        what would change. When ``apply=True``, advances the lifecycle frontier
+        marker past the pre-tail raw messages so they are no longer replayed
+        into active context on subsequent bootstrap. Raw messages remain in
+        the SQLite store and are recoverable through ``lcm_load_session`` and
+        ``lcm_expand`` — the lossless raw recovery contract is preserved.
+
+        Refuses on sessions that are unbound, ignored, or stateless.
+
+        Refusal/no-op reason codes (returned as ``reason``):
+
+        - ``no_active_session``: engine has no bound session or conversation.
+        - ``session_ignored``: foreground session matched
+          ``LCM_IGNORE_SESSION_PATTERNS``.
+        - ``session_stateless``: foreground session matched
+          ``LCM_STATELESS_SESSION_PATTERNS``.
+        - ``no_pre_tail_content``: total stored messages do not exceed
+          ``fresh_tail_count``; nothing to rotate.
+        - ``empty_tail``: tail query returned no rows despite a non-zero
+          count (concurrent deletion race); rotate cannot compute a boundary.
+        - ``frontier_already_ahead``: lifecycle frontier is already at or
+          past the proposed new frontier; rotate is a no-op.
+        - ``stale_lifecycle_state``: apply requested but lifecycle's
+          ``current_session_id`` did not match this engine's session, so
+          ``advance_frontier`` did not persist the change.
+        """
+        session_id = self._session_id
+        conversation_id = self._conversation_id
+
+        if not session_id or not conversation_id:
+            return {"ok": False, "reason": "no_active_session"}
+        if self._session_ignored:
+            return {"ok": False, "reason": "session_ignored", "session_id": session_id}
+        if self._session_stateless:
+            return {"ok": False, "reason": "session_stateless", "session_id": session_id}
+
+        fresh_tail_count = max(1, int(self._config.fresh_tail_count))
+        total_count = int(self._store.get_session_count(session_id))
+
+        state = self._lifecycle.get_by_conversation(conversation_id)
+        current_frontier = int(state.current_frontier_store_id) if state else 0
+
+        base = {
+            "ok": True,
+            "session_id": session_id,
+            "conversation_id": conversation_id,
+            "total_message_count": total_count,
+            "fresh_tail_count": fresh_tail_count,
+            "current_frontier_store_id": current_frontier,
+            "mode": "apply" if apply else "preview",
+        }
+
+        if total_count <= fresh_tail_count:
+            return {
+                **base,
+                "noop": True,
+                "reason": "no_pre_tail_content",
+                "pre_tail_message_count": 0,
+                "new_frontier_store_id": current_frontier,
+            }
+
+        tail = self._store.get_session_tail(session_id, fresh_tail_count)
+        if not tail:
+            # Concurrent deletion can empty the tail after the count check.
+            # Surface the same shape callers expect for any other no-op so
+            # downstream formatters can render it without KeyError.
+            return {
+                **base,
+                "noop": True,
+                "reason": "empty_tail",
+                "pre_tail_message_count": 0,
+                "new_frontier_store_id": current_frontier,
+            }
+
+        smallest_tail_store_id = int(tail[0].get("store_id") or 0)
+        new_frontier = max(0, smallest_tail_store_id - 1)
+        pre_tail_count = max(0, total_count - len(tail))
+
+        is_noop = new_frontier <= current_frontier
+        result = {
+            **base,
+            "pre_tail_message_count": pre_tail_count,
+            "new_frontier_store_id": new_frontier,
+            "noop": is_noop,
+        }
+        if is_noop:
+            # Set the reason for both preview and apply so downstream
+            # formatters can render a stable explanation. Preview previously
+            # omitted the reason, which left _rotate_apply_text's preflight
+            # check unable to distinguish frontier-already-ahead from other
+            # no-ops.
+            result["reason"] = "frontier_already_ahead"
+
+        if not apply:
+            return result
+
+        if is_noop:
+            return result
+
+        new_state = self._lifecycle.advance_frontier(
+            conversation_id,
+            session_id,
+            new_frontier,
+        )
+        # advance_frontier silently returns the unchanged state when its
+        # session_id check fails (lifecycle_state.py:557-559). Detect that
+        # by checking whether the persisted frontier actually advanced; only
+        # promote the in-process marker on a confirmed persist.
+        persisted_frontier = (
+            int(new_state.current_frontier_store_id) if new_state else current_frontier
+        )
+        if persisted_frontier < new_frontier:
+            return {
+                **{k: v for k, v in result.items() if k != "ok"},
+                "ok": False,
+                "noop": False,
+                "reason": "stale_lifecycle_state",
+                "applied_frontier_store_id": persisted_frontier,
+            }
+        self._last_compacted_store_id = max(
+            self._last_compacted_store_id, persisted_frontier
+        )
+        result["applied_frontier_store_id"] = persisted_frontier
+        return result
 
     # -- Lifecycle ---------------------------------------------------------
 

--- a/engine.py
+++ b/engine.py
@@ -3667,6 +3667,27 @@ class LCMEngine(ContextEngine):
 
         Refuses on sessions that are unbound, ignored, or stateless.
 
+        Two frontier markers are intentionally kept separate:
+
+        - The **persisted lifecycle frontier**
+          (``lifecycle_state.current_frontier_store_id``) is the
+          bootstrap signal — on next session start, raw rows at or
+          below it are not replayed into the active context. Rotate
+          advances this marker.
+        - The **in-process source-mapping marker**
+          (``self._last_compacted_store_id``) tracks raw rows that the
+          *current process* has already moved into summary DAG nodes.
+          ``_get_store_ids_for_messages`` uses it to filter candidates
+          when mapping in-memory active messages back to ``store_id``.
+          Rotate deliberately does NOT advance this marker: pre-tail
+          raw messages remain in the in-memory active context until
+          the host rebuilds it, so a normal ``compress()`` later in
+          the same process can still summarize them with correct
+          ``source_ids`` lineage. On next process start,
+          ``_bind_lifecycle_state`` reads the persisted frontier into
+          the in-process marker — at that point the active context is
+          being built from scratch, so the contract holds.
+
         Refusal/no-op reason codes (returned as ``reason``):
 
         - ``no_active_session``: engine has no bound session or conversation.
@@ -3777,9 +3798,18 @@ class LCMEngine(ContextEngine):
                 "reason": "stale_lifecycle_state",
                 "applied_frontier_store_id": persisted_frontier,
             }
-        self._last_compacted_store_id = max(
-            self._last_compacted_store_id, persisted_frontier
-        )
+        # Deliberately do NOT touch self._last_compacted_store_id here.
+        # The in-process source-mapping marker must stay aligned with the
+        # in-memory active context the host is still using. Pre-tail raw
+        # messages remain in that active context until the host rebuilds
+        # it; advancing the marker would make
+        # _get_store_ids_for_messages filter out those rows on the next
+        # in-process compress(), producing summary nodes whose text
+        # covers pre-rotate messages but whose source_ids reference only
+        # post-rotate rows. The persisted lifecycle frontier we just
+        # advanced is the bootstrap signal for the next process start,
+        # where _bind_lifecycle_state will read it into the marker
+        # against a freshly-built active context.
         result["applied_frontier_store_id"] = persisted_frontier
         return result
 

--- a/schemas.py
+++ b/schemas.py
@@ -244,10 +244,13 @@ LCM_STATUS = {
     "description": (
         "Get a quick health overview of the LCM engine for the current session. "
         "Shows compression count, store size, DAG depth distribution, context usage, "
-        "active configuration, and session/message filter state. Use this to "
-        "understand how much history has been compacted, how the engine is "
-        "performing, whether the current session is matched by ignore or stateless "
-        "session patterns, and which message noise-suppression patterns are loaded."
+        "active configuration, session/message filter state, and rotate snapshot "
+        "state (last_rotate_at, rotate_backup_path, rotate_backup_size when a "
+        "/lcm rotate apply has been run). Use this to understand how much history "
+        "has been compacted, how the engine is performing, whether the current "
+        "session is matched by ignore or stateless session patterns, which message "
+        "noise-suppression patterns are loaded, and when the rolling rotate "
+        "backup was last written."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_lcm_rotate.py
+++ b/tests/test_lcm_rotate.py
@@ -1,5 +1,6 @@
 """Tests for /lcm rotate command surface and engine rotate path."""
 
+import importlib
 import os
 import re
 from pathlib import Path
@@ -102,8 +103,14 @@ def test_rotate_apply_advances_frontier_and_writes_rolling_backup(tmp_path):
     state = engine._lifecycle.get_by_conversation(engine._conversation_id)
     assert state is not None
     assert state.current_frontier_store_id == 7
-    # Engine in-process marker should also move forward.
-    assert engine._last_compacted_store_id >= 7
+    # The in-process source-mapping marker must NOT advance here. Pre-tail
+    # raw messages may still be present in the host's in-memory active
+    # context; advancing the marker would break source_ids lineage on the
+    # next in-process compress(). The persisted lifecycle frontier is the
+    # bootstrap signal; the in-process marker is only updated by actual
+    # compaction inside this process. See the regression at
+    # test_rotate_apply_does_not_corrupt_source_lineage_on_next_compress.
+    assert engine._last_compacted_store_id == 0
 
 
 def test_rotate_apply_preserves_raw_messages_for_lossless_recovery(tmp_path):
@@ -372,6 +379,97 @@ def test_rotate_apply_reports_stale_lifecycle_state_when_session_drifts(tmp_path
     state = engine._lifecycle.get_by_conversation(engine._conversation_id)
     assert state is not None
     assert state.current_frontier_store_id == 0
+
+
+def test_rotate_apply_does_not_corrupt_source_lineage_on_next_compress(tmp_path, monkeypatch):
+    """Regression for the issue Tosko4 surfaced on PR #176.
+
+    After /lcm rotate apply, the in-memory active context still holds the
+    pre-rotate raw messages until the host rebuilds it. A normal compress()
+    later in the same process must produce a DAG node whose source_ids
+    reference the same raw rows it summarized — not just the post-rotate
+    tail. Advancing the in-process source-mapping marker on rotate would
+    cause _get_store_ids_for_messages to filter out the pre-rotate rows,
+    producing a poisoned node (text covers msg-0..msg-7, source_ids = [9]).
+    """
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_rotate_lineage.db")
+    config.fresh_tail_count = 3
+    config.leaf_chunk_tokens = 10
+    config.context_threshold = 0.001
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session", conversation_id="live-session")
+    engine.context_length = 200000
+    engine.threshold_tokens = int(200000 * config.context_threshold)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    for i in range(10):
+        messages.append({"role": "user", "content": f"msg-{i} " + "x" * 200})
+    for msg in messages[1:]:
+        engine._store.append(engine._session_id, msg, source="test")
+    engine._store._conn.commit()
+
+    # Apply rotate. The persisted frontier moves to 8 (store_id of msg-8,
+    # the second-to-last message; tail keeps the last 3 store rows). The
+    # host's in-memory active context still holds system + msg-0..msg-9.
+    rotate_result = engine.rotate_active_session(apply=True)
+    assert rotate_result["ok"] is True
+    assert rotate_result["noop"] is False
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == rotate_result["new_frontier_store_id"]
+    # Critical invariant: the in-process source-mapping marker must NOT
+    # have advanced. If it did, _get_store_ids_for_messages would filter
+    # out the pre-rotate raw rows on the next compress() and the resulting
+    # summary node would have source_ids referencing only post-frontier
+    # rows while its text covered pre-frontier content.
+    assert engine._last_compacted_store_id == 0
+
+    # Host appends a new assistant turn, simulating Hermes continuing in
+    # the same process. The in-memory active context still has all the
+    # pre-rotate messages.
+    messages.append({"role": "assistant", "content": "ack-msg-9"})
+    engine._store.append(engine._session_id, messages[-1], source="test")
+    engine._store._conn.commit()
+
+    # Stub the summarizer so the test is deterministic and we can verify
+    # exactly which raw messages get compacted.
+    lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+    monkeypatch.setattr(
+        lcm_engine_module,
+        "summarize_with_escalation",
+        lambda **kwargs: ("Summary of pre-tail messages.\nExpand for details about: msg-0..msg-7", 1),
+    )
+
+    engine.compress(messages)
+
+    nodes = engine._dag.get_session_nodes(engine._session_id)
+    assert nodes, "compress() should have produced at least one summary node"
+    summary_node = nodes[0]
+
+    # source_ids must reference the actual raw rows the summary covers.
+    # Empty or post-frontier-only source_ids would mean the lineage was
+    # severed by the in-process marker filter.
+    assert summary_node.source_ids, (
+        f"summary_node.source_ids is empty — _get_store_ids_for_messages "
+        f"likely filtered out the pre-rotate rows. Marker was {engine._last_compacted_store_id}, "
+        f"compacted msgs first/last: msg-0..msg-7."
+    )
+    # Source rows must come from the pre-tail range (store_id <= rotate
+    # frontier). If source_ids only contained post-frontier rows (the
+    # original bug shape: source_ids == [9]), this assertion fails.
+    rotate_frontier = rotate_result["new_frontier_store_id"]
+    pre_frontier_sources = [
+        sid for sid in summary_node.source_ids if sid <= rotate_frontier
+    ]
+    assert pre_frontier_sources, (
+        f"summary covers pre-rotate messages but source_ids "
+        f"({summary_node.source_ids}) contains no rows at or below the "
+        f"rotate frontier ({rotate_frontier}). Source lineage is severed."
+    )
 
 
 def test_rotate_backup_path_falls_back_to_db_sibling_when_hermes_home_unset(tmp_path):

--- a/tests/test_lcm_rotate.py
+++ b/tests/test_lcm_rotate.py
@@ -1,0 +1,391 @@
+"""Tests for /lcm rotate command surface and engine rotate path."""
+
+import os
+import re
+from pathlib import Path
+
+from hermes_lcm.command import handle_lcm_command
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _build_engine(tmp_path, *, fresh_tail_count: int = 3) -> LCMEngine:
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_rotate_test.db")
+    config.fresh_tail_count = fresh_tail_count
+    hermes_home = tmp_path / "hermes_home"
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session", conversation_id="live-session")
+    engine.context_length = 200000
+    engine.threshold_tokens = int(200000 * config.context_threshold)
+    return engine
+
+
+def _seed_messages(engine: LCMEngine, count: int) -> None:
+    for index in range(count):
+        engine._store.append(
+            engine._session_id,
+            {"role": "user", "content": f"message-{index}"},
+            source="test",
+        )
+    engine._store._conn.commit()
+
+
+def _extract_field(result: str, key: str) -> str:
+    line = next(
+        (line for line in result.splitlines() if line.startswith(f"{key}: ")),
+        None,
+    )
+    assert line is not None, f"expected {key} in output:\n{result}"
+    return line.split(": ", 1)[1]
+
+
+def test_rotate_preview_reports_planned_frontier_without_mutating(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "LCM rotate" in result
+    assert "status: preview" in result
+    assert "total_message_count: 10" in result
+    assert "fresh_tail_count: 3" in result
+    assert "pre_tail_message_count: 7" in result
+    assert "current_frontier_store_id: 0" in result
+    # New frontier should be store_id of last pre-tail message (7).
+    assert "new_frontier_store_id: 7" in result
+    assert "rotate_backup_path:" in result
+    assert "note: read-only preview" in result
+
+    # Confirm no mutation: frontier still 0 in lifecycle state.
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+    # Confirm no backup was written.
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_preview_reports_noop_when_total_messages_within_tail(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=5)
+    _seed_messages(engine, count=3)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: noop" in result
+    assert "reason: no_pre_tail_content" in result
+    assert "total_message_count: 3" in result
+
+
+def test_rotate_apply_advances_frontier_and_writes_rolling_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "LCM rotate apply" in result
+    assert "status: ok" in result
+    assert "previous_frontier_store_id: 0" in result
+    assert "new_frontier_store_id: 7" in result
+    assert "note: rolling backup overwrites the previous rotate-latest slot" in result
+    backup_path = Path(_extract_field(result, "rotate_backup_path"))
+    assert backup_path.exists()
+    assert backup_path.name.endswith("-rotate-latest.sqlite3")
+    # Backup size line uses _fmt_size formatting (e.g. "12.0 KB"); assert
+    # it exists and is non-empty rather than pinning the exact representation.
+    backup_size_str = _extract_field(result, "rotate_backup_size")
+    assert backup_size_str.strip()
+
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 7
+    # Engine in-process marker should also move forward.
+    assert engine._last_compacted_store_id >= 7
+
+
+def test_rotate_apply_preserves_raw_messages_for_lossless_recovery(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=2)
+    _seed_messages(engine, count=8)
+
+    handle_lcm_command("rotate apply", engine)
+
+    # All 8 raw messages remain in the store after rotate — frontier only
+    # changes the bootstrap replay boundary, never deletes raw history.
+    assert engine._store.get_session_count(engine._session_id) == 8
+    tail = engine._store.get_session_tail(engine._session_id, limit=2)
+    assert [row.get("content") for row in tail] == ["message-6", "message-7"]
+
+
+def test_rotate_apply_rerun_is_idempotent_and_preserves_existing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    first = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in first
+    first_backup = Path(_extract_field(first, "rotate_backup_path"))
+    assert first_backup.exists()
+    first_size = first_backup.stat().st_size
+    first_mtime = first_backup.stat().st_mtime
+
+    second = handle_lcm_command("rotate apply", engine)
+    assert "status: noop" in second
+    assert "reason: frontier_already_ahead" in second
+    assert (
+        "rolling backup was not written so the previous rotate-latest snapshot is preserved"
+        in second
+    )
+
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 7
+
+    # The previous known-good rolling backup must survive a noop rerun. Both
+    # mtime and size are unchanged because the noop short-circuit happens
+    # before any disk write.
+    assert first_backup.exists()
+    assert first_backup.stat().st_mtime == first_mtime
+    assert first_backup.stat().st_size == first_size
+
+
+def test_rotate_apply_rolling_backup_overwrites_prior_slot_on_actual_rotate(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    first = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in first
+    first_backup = Path(_extract_field(first, "rotate_backup_path"))
+    assert first_backup.exists()
+    first_mtime = first_backup.stat().st_mtime
+
+    # Add more messages so the second apply has new content to rotate past
+    # the now-advanced frontier (not a noop).
+    _seed_messages(engine, count=5)
+
+    # Force a measurable mtime delta — SQLite backup() inside the same second
+    # can land on the same mtime granularity on some filesystems.
+    older = first_mtime - 5.0
+    os.utime(first_backup, (older, older))
+
+    second = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in second
+    second_backup = Path(_extract_field(second, "rotate_backup_path"))
+    assert second_backup == first_backup, "rotate should reuse the rolling slot, not create a new file"
+    assert second_backup.stat().st_mtime > older, "rolling slot mtime should advance on re-rotate"
+
+    # Ensure only one rotate backup exists in the directory — disk usage bounded.
+    rotate_backups = list(first_backup.parent.glob("*-rotate-latest.sqlite3"))
+    assert rotate_backups == [first_backup]
+
+
+def test_rotate_refuses_on_ignored_session(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_ignored = True
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_ignored" in result
+
+
+def test_rotate_refuses_on_stateless_session(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_stateless = True
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_stateless" in result
+
+
+def test_rotate_apply_refuses_on_ignored_session_without_writing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_ignored = True
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_ignored" in result
+    # Backup must not be written when the rotate is refused.
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_apply_refuses_on_stateless_session_without_writing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_stateless = True
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_stateless" in result
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_refuses_when_no_session_bound(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    engine._session_id = ""
+    engine._conversation_id = ""
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: no_active_session" in result
+
+
+def test_rotate_help_rejects_unknown_subcommand(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+
+    result = handle_lcm_command("rotate something-else", engine)
+
+    # Soft assertion — exact wording may evolve; verify the help text
+    # mentions rotate and rejects the bogus subcommand.
+    assert "rotate" in result
+    assert "apply" in result
+
+
+def test_lcm_status_reports_last_rotate_at_after_apply(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    before = handle_lcm_command("status", engine)
+    assert "last_rotate_at: (never)" in before
+
+    handle_lcm_command("rotate apply", engine)
+
+    after = handle_lcm_command("status", engine)
+    # Pin the format: UTC ISO-8601 with seconds precision and +00:00 offset.
+    assert re.search(
+        r"last_rotate_at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00", after
+    ), f"expected UTC ISO timestamp in status output:\n{after}"
+    assert "last_rotate_at: (never)" not in after
+    # Backup size field is rendered with _fmt_size formatting; assert presence
+    # and non-empty content, not exact bytes.
+    assert "rotate_backup_size: " in after
+    assert "rotate_backup_path:" in after
+
+
+def test_lcm_help_lists_rotate_subcommands(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    result = handle_lcm_command("help", engine)
+    assert "/lcm rotate" in result
+    assert "/lcm rotate apply" in result
+
+
+def test_rotate_handles_session_with_exactly_fresh_tail_count_messages(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=3)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: noop" in result
+    assert "reason: no_pre_tail_content" in result
+    assert "total_message_count: 3" in result
+    assert "pre_tail_message_count: 0" in result
+
+
+def test_rotate_empty_tail_branch_returns_noop_shape_without_keyerror(tmp_path):
+    """Concurrent deletion can empty the tail after the count check. The
+    formatter must render a no-op without KeyError.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Force the count-vs-tail mismatch the real concurrent-delete race
+    # would produce: total_count reports 10, but get_session_tail returns
+    # empty. Patch the bound method on this engine's store instance only.
+    original_get_session_tail = engine._store.get_session_tail
+    try:
+        engine._store.get_session_tail = lambda session_id, limit=1000: []  # type: ignore[method-assign]
+        result = handle_lcm_command("rotate", engine)
+    finally:
+        engine._store.get_session_tail = original_get_session_tail  # type: ignore[method-assign]
+
+    assert "status: noop" in result
+    assert "reason: empty_tail" in result
+    # Required fields must be present so command-layer formatters do not crash.
+    assert "pre_tail_message_count: 0" in result
+    assert "new_frontier_store_id: 0" in result
+
+
+def test_rotate_apply_aborts_and_preserves_state_when_backup_write_fails(tmp_path):
+    """Backup-first contract: if the rolling backup write fails, rotate apply
+    must return status:error and leave lifecycle frontier untouched.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Pre-create the backup directory as a regular file so mkdir / write fails.
+    backup_path = engine.rotate_backup_path()
+    backup_dir = backup_path.parent
+    backup_dir.parent.mkdir(parents=True, exist_ok=True)
+    # Replace the would-be backup directory with a regular file to force OSError
+    # on mkdir(parents=True, exist_ok=True) inside _rotate_backup_database.
+    backup_dir.write_text("not a directory")
+
+    try:
+        result = handle_lcm_command("rotate apply", engine)
+    finally:
+        # Clean up the sentinel file so later tests in the same tmp_path do
+        # not interfere — though pytest gives each test its own tmp_path.
+        if backup_dir.exists() and backup_dir.is_file():
+            backup_dir.unlink()
+
+    assert "LCM rotate apply" in result
+    assert "status: error" in result
+    assert "error: backup failed:" in result
+    assert "note: rotate apply aborted before any lifecycle mutation" in result
+
+    # Critical safety guarantee: lifecycle frontier is unchanged.
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+
+def test_rotate_apply_reports_stale_lifecycle_state_when_session_drifts(tmp_path):
+    """advance_frontier silently returns the unchanged state when the lifecycle
+    row's current_session_id no longer matches this engine's session. rotate
+    apply must detect that and surface status:refused reason:stale_lifecycle_state
+    rather than reporting status:ok with a fabricated frontier.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Simulate session drift: another flow bound a different session id to
+    # this conversation. _bind_lifecycle_state would have updated the row.
+    engine._lifecycle.bind_session("other-session", conversation_id=engine._conversation_id)
+    # Engine's local _session_id stays on the original "live-session".
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: stale_lifecycle_state" in result
+
+    # The rolling backup WAS written (we passed preflight) — that's expected
+    # with the current ordering. Lifecycle frontier should NOT have advanced
+    # for "live-session".
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+
+def test_rotate_backup_path_falls_back_to_db_sibling_when_hermes_home_unset(tmp_path):
+    """The hermes_home-unset branch in rotate_backup_path puts the rolling
+    backup beside the LCM database. Cover the branch so a regression there
+    is visible.
+    """
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_no_home.db")
+    config.fresh_tail_count = 3
+    engine = LCMEngine(config=config, hermes_home="")
+    try:
+        path = engine.rotate_backup_path()
+        assert path == tmp_path / "backups" / "lcm" / "lcm_no_home-rotate-latest.sqlite3"
+        assert engine.backup_dir() == tmp_path / "backups" / "lcm"
+    finally:
+        engine.shutdown()


### PR DESCRIPTION
## Summary

- Adds `/lcm rotate` (read-only preview) and `/lcm rotate apply`
  (backup-first mutation) on the existing slash-command surface.
  Rotate advances the lifecycle frontier marker past pre-tail raw
  messages without changing `session_id` or `conversation_id`. Raw
  messages remain in the SQLite store and stay recoverable through
  `lcm_load_session` and `lcm_expand` so the lossless raw recovery
  contract is preserved.
- Rolling `{db_stem}-rotate-latest.sqlite3` snapshot written
  atomically via tmp + `Path.replace`. No-op rerun short-circuits
  before any disk write so the previous known-good snapshot is
  preserved across idempotent retries.
- `lcm_status` / `/lcm status` surface `last_rotate_at` (UTC ISO-8601
  with explicit `+00:00`), `rotate_backup_path`, and
  `rotate_backup_size`. `LCM_STATUS` tool schema description updated.

## Why

`hermes-lcm` is positioned as inspired by `lossless-claw`, which has
`/lcm rotate` for the in-session compact case. Operators running
heavy interactive sessions today have no deterministic way to compact
an active session in place: automatic compaction is timing-driven,
`/new` at the Hermes layer loses in-session continuity, and
`/lcm doctor clean` targets junk sessions, not an in-place compact of
an active one. This closes that gap with a backup-first, refusal-aware
command that follows the existing `/lcm doctor *` pattern.

Refs #175 for the full problem framing, alternatives considered, and
backward-compatibility notes.

## Validation

- [x] Focused validation: `pytest tests/test_lcm_rotate.py -q` -> `19 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `564 passed`
  - [x] `pytest -q` -> `695 passed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `695 passed`
  - [x] `python -m compileall -q .` -> `OK`
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> `OK`
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> `OK`
  - [x] `git diff --check` -> `clean`
- [ ] Workflow validation, if workflows changed: `actionlint` (n/a — no workflow changes)

## Notes

**Scope discipline.** I deliberately constrained this PR to the rotate
surface and the smallest engine and command-side additions needed to
support it. Refusal/no-op reason codes are documented on
`rotate_active_session` so future readers do not have to grep for the
bare strings.

**Refusal codes covered:** `no_active_session`, `session_ignored`,
`session_stateless`, `no_pre_tail_content`, `empty_tail`,
`frontier_already_ahead`, `stale_lifecycle_state`. The
`stale_lifecycle_state` code surfaces when `advance_frontier` returns
the unchanged state because the row's `current_session_id` no longer
matches this engine; rotate detects that case explicitly rather than
masking it as a successful frontier advance.

**Internals consolidated, no behavior change for existing callers:**

- `engine.backup_dir()` centralizes the backup directory derivation
  so the timestamped `/lcm backup` slot and the new rolling rotate
  slot cannot drift on `hermes_home` or `db_path` changes
- `command._flush_engine_connections()` extracted to share the
  three-connection commit between `/lcm backup` and `/lcm rotate apply`
- `get_status()` uses a single `stat()` on the rolling backup path,
  avoiding a TOCTOU window between separate mtime and size reads

**Pre-existing concerns surfaced during review, intentionally out of scope:**

- `lifecycle_state.advance_frontier` does a non-atomic read-then-update
  under autocommit (`lifecycle_state.py:549-572`). Pre-existing, not
  introduced by this PR, but rotate adds another caller. Happy to
  file a separate follow-up PR converting it to a single-statement
  `MAX()` update if you would like that addressed independently.
- `last_rotate_at` is derived from the rolling backup's mtime and is
  therefore spoofable by anything that touches the file. The README
  documents this; persisting the timestamp in `lcm_lifecycle_state`
  is a defensible follow-up if operational pain shows up.

**Multi-reviewer pass.** Before opening the PR I ran correctness,
testing, maintainability, project-standards, security, adversarial,
and python-idioms reviews on the working diff. All actionable findings
were addressed: `empty_tail` KeyError safety, persist-then-mutate
order for the in-process `_last_compacted_store_id` marker,
backup-only-after-noop-check (so idempotent rerun does not destroy the
previous known-good snapshot), standardized `rotate_backup_path` key
name across preview/apply/status surfaces, timezone-aware UTC
formatting on `last_rotate_at`, `pathlib`-native `Path.replace` for
the atomic rename, single `stat()` call in `get_status` for the
rolling backup, and refusal-codes documented on the engine method.

**No agent-tool surface change.** No new agent tool is added, no
existing tool schema parameters change. The `LCM_STATUS` description
is widened to mention the new fields so the model understands what
it sees.

Refs #175