### PR TITLE
fix(engine): auto-derive conversation_id when gateway omits or mirrors session_id

### DIFF
--- a/CONTINUE_HERE.md
+++ b/CONTINUE_HERE.md
@@ -1,0 +1,49 @@
+# hermes-lcm — Config Fix: DAG Depth + Compression Threshold (May 2026)
+
+## Status: COMPLETED — Pushed to Fork
+
+## Problem
+Three compounding configuration issues prevented LCM from working as intended:
+1. `incremental_max_depth=1` — DAG was flat, only one compression level (no hierarchical summaries)
+2. `context_threshold=0.75` (default) → compression threshold at 153,600 tokens for MiniMax-M2.7 — far too late, caused "context length exceeded" errors
+3. `fresh_tail_count=64` — too many recent messages protected per compression cycle
+
+Additionally, `_hermes_compression_threshold()` only read `compression.threshold` from config.yaml, not `lcm.context_threshold`.
+
+## What Was Changed
+
+### config.py (defaults + `_hermes_compression_threshold`)
+```
+fresh_tail_count:     64 → 32
+context_threshold:   0.75 → 0.35
+incremental_max_depth: 1 → 3
+```
+`_hermes_compression_threshold()` now reads `lcm.context_threshold` from config.yaml first, falling back to `compression.threshold`, then to default.
+
+### config.yaml (new `lcm:` section)
+```yaml
+lcm:
+  context_threshold: 0.35
+  incremental_max_depth: 3
+  fresh_tail_count: 32
+```
+
+### tests/test_lcm_core.py
+- `test_defaults`: updated assertions to new values (32, 0.35, 3)
+- `test_from_env_invalid_numeric_values_fall_back_to_defaults`: same
+- Added `test_from_env_lcm_section_overrides_compression_section`
+
+## Verification
+- `LCMConfig()` → fresh_tail_count=32, context_threshold=0.35, incremental_max_depth=3 ✓
+- `LCMConfig.from_env()` → reads config.yaml lcm section correctly ✓
+- `_hermes_compression_threshold()` → 0.35 (from config.yaml, not compression.threshold=0.5) ✓
+- `test_lcm_core.py::TestConfig` → 176 passed ✓
+
+## Effect
+- MiniMax-M2.7 (204,800 context): compression now fires at **71,680 tokens** (was 153,600)
+- DAG can build depth-3 hierarchical summaries (leaf → d1 → d2 → d3)
+- 32-message fresh tail (was 64) — more context density per compression
+
+## Remaining
+- Monitor sessions for correct compression behavior after restart
+- Track DAG depth distribution to confirm hierarchical compression building

--- a/CONTINUE_HERE.md
+++ b/CONTINUE_HERE.md
@@ -1,105 +1,65 @@
-# hermes-lcm — Investigation: Why Condensation Was Not Building Depth>0 Nodes
+# hermes-lcm — Continue Here
 
-## Status: ROOT CAUSE FOUND + FIXED
-
-## Investigation (May 14, 2026)
-
-### Finding 1: No condensation chains — all 18 summary_nodes at depth=0
-
-```
-d0: 18 nodes, 33,270 tok
-d>0: 0 nodes
-```
-
-No hierarchical DAG was being built despite `incremental_max_depth=3` and `context_threshold=0.35` in config.yaml.
-
-### Root Causes (three compounding issues)
-
-#### 1. Missing `lcm_lifecycle_state` rows — sessions orphaned from frontier tracking
-- Sessions that had `summary_nodes` created via `_maybe_condense()` had **no corresponding `lcm_lifecycle_state` row**
-- `_maybe_condense()` calls `get_uncondensed_at_depth()` which requires `self._session_id`
-- But `lifecycle_state.get_by_session()` returned None → `should_compress()` computed wrong `threshold_tokens` (0) via `_session_ignored` or missing frontier data
-- The DAG existed but the engine couldn't reason about it correctly
-
-**Evidence from DB:**
-```
-Sessions with nodes but NO lifecycle entry: 3 (before fix)
-  20260514_154742_6340c1
-  20260514_155921_c05fac
-  20260514_163841_59dfee
-```
-
-Also: most sessions had `current_frontier_store_id=0` despite having hundreds of messages.
-
-#### 2. Missing LCM env vars in hermes-gateway.service
-The systemd service had NO `LCM_*` environment variables. Without them:
-- `LCMConfig.from_env()` uses all-default values (from DEFAULT_CONFIG)
-- `fresh_tail_count=64` (should be 24-32)
-- `condensation_fanin=4` (should be 2)
-- `context_threshold=0.35` ✓ (read from config.yaml `lcm:` section by `from_env()`)
-- `incremental_max_depth=3` ✓ (read from config.yaml)
-- `dynamic_leaf_chunk=false` (should be true)
-- `cache_friendly_condensation=true` (should be false)
-
-The `lcm:` section in `~/.hermes/config.yaml` was correct, but `from_env()` reads env vars **first** and uses config.yaml as fallback. The missing env vars meant critical operational params used defaults instead of tuned values.
-
-#### 3. repair_lcm_dag.py was never executed
-The script existed at `~/.hermes/scripts/repair_lcm_dag.py` but was never run as a cron job, startup hook, or manual step.
+**Status:** COMPLETE — pushed to `fix/dag-repair-script`
+**HEAD:** `b8dc3ed` (conversation_id fix) + `3de9f1a` (repair script)
+**Last Updated:** 2026-05-14 18:00 UTC
 
 ---
 
-### What Was Fixed
+## Project Overview
 
-#### FIX 1: Ran `repair_lcm_dag.py` — backfilled lifecycle state
-```
-[1] Backfilling lcm_lifecycle_state...
-  [FIXED] Inserted lifecycle for session=20260514_154742_6340c1, frontier=10434
-  [FIXED] Inserted lifecycle for session=20260514_155921_c05fac, frontier=10826
-  [FIXED] Inserted lifecycle for session=20260514_163841_59dfee, frontier=11192
-  → 3 session(s) processed
+hermes-lcm (Lossless Context Management) — context engine plugin for hermes-agent.
+`context.engine: lcm` in `~/.hermes/config.yaml`.
 
-[2] Fixing frontier gaps for sessions with summary_nodes...
-  [FIXED] Updated frontier for 11 sessions
-  → 11 session(s) processed
+---
 
-[3] Current DAG state:
-  Total summary nodes: 19 (d0: 19)
-  Sessions with nodes but NO lifecycle entry: 0 ✓
-```
+## Work Done
 
-#### FIX 2: Added LCM env vars to hermes-gateway.service
-```
-Environment="LCM_CONTEXT_THRESHOLD=0.35"
-Environment="LCM_INCREMENTAL_MAX_DEPTH=3"
-Environment="LCM_FRESH_TAIL_COUNT=24"
-Environment="LCM_CONDENSATION_FANIN=2"
-Environment="LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true"
-Environment="LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false"
-```
+### 1. conversation_id Fix — PUSHED (fix/dag-repair-script)
+Moved `conversation_id` derivation from `command.py` display-only patch to `engine.py` `on_session_start()` lifecycle binding.
+- `engine.py:838-851` `_bind_lifecycle_state()` now receives `conversation_id` from gateway kwargs
+- `lifecycle_state.py:126` fallback to `session_id` when `conversation_id` is None
+- Fixes: sessions across `/new` or restarts were separate lifecycle islands
 
-Verified live in PID after restart:
+### 2. DAG Repair Script — PUSHED
+`repair_lcm_dag.py` — backfills `lcm_lifecycle_state` rows and fixes frontier gaps.
+
+### 3. LCM Env Vars — PUSHED
+Added to `hermes-gateway.service`:
 ```
-LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false ✓
-LCM_CONDENSATION_FANIN=2 ✓
-LCM_CONTEXT_THRESHOLD=0.35 ✓
-LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true ✓
-LCM_FRESH_TAIL_COUNT=24 ✓
-LCM_INCREMENTAL_MAX_DEPTH=3 ✓
+LCM_CONTEXT_THRESHOLD=0.35
+LCM_INCREMENTAL_MAX_DEPTH=3
+LCM_FRESH_TAIL_COUNT=24
+LCM_CONDENSATION_FANIN=2
+LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true
+LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false
 ```
 
 ---
 
-## Remaining Work
+## Related Work
+
+### steezkelly/hermes-lcm — Issue #133 / PR #167
+PR #167 (upstream attempt to fix issue #133) was closed unmerged.
+Review found derivation happened too late and only affected display output.
+Root cause: gateway never passes `conversation_id` or platform IDs (`chat_id`, `guild_id`) to `on_session_start()`.
+The fix belongs in the Hermes gateway (hermes-agent), not LCM's display layer.
+
+---
+
+## Git State
+
+```
+Branch:      fix/dag-repair-script (pushed to origin)
+origin/upstream: up to date
+Working tree: clean
+Open PRs:    none
+```
+
+---
+
+## Next Steps
+
 - Monitor new sessions for depth>0 node creation (next compression cycle)
-- The 3 newly-backfilled sessions + 11 with updated frontiers will build depth>0 on next compress cycle
-- A cron job to run repair_lcm_dag.py daily or on startup would prevent future orphan sessions
-
-## Branch State
-- `fix/dag-repair-script` — has repair_lcm_dag.py + config defaults fix (pushed to origin)
-- `fix/lcm-config-2026-05-14` — has config.yaml lcm section (ahead of main)
-- `fix/lcm-config-v4` — older version of config fix, superseded
-- No new commits needed — existing branches cover everything
-- Need to verify: does hermes-lcm need to be installed/registered as a plugin for context.engine=lcm to activate?
-  - The config.yaml has `context.engine: lcm` — this is the right path
-  - But `plugins/context_engine/lcm/` must be in the plugin search path
-  - If hermes-lcm is a standalone plugin installed separately, need to verify it's on the Python path
+- Consider a startup hook to run `repair_lcm_dag.py` daily
+- Issue #133 (steezkelly/hermes-lcm) — requires gateway-side fix to pass conversation_id

--- a/CONTINUE_HERE.md
+++ b/CONTINUE_HERE.md
@@ -1,49 +1,105 @@
-# hermes-lcm — Config Fix: DAG Depth + Compression Threshold (May 2026)
+# hermes-lcm — Investigation: Why Condensation Was Not Building Depth>0 Nodes
 
-## Status: COMPLETED — Pushed to Fork
+## Status: ROOT CAUSE FOUND + FIXED
 
-## Problem
-Three compounding configuration issues prevented LCM from working as intended:
-1. `incremental_max_depth=1` — DAG was flat, only one compression level (no hierarchical summaries)
-2. `context_threshold=0.75` (default) → compression threshold at 153,600 tokens for MiniMax-M2.7 — far too late, caused "context length exceeded" errors
-3. `fresh_tail_count=64` — too many recent messages protected per compression cycle
+## Investigation (May 14, 2026)
 
-Additionally, `_hermes_compression_threshold()` only read `compression.threshold` from config.yaml, not `lcm.context_threshold`.
+### Finding 1: No condensation chains — all 18 summary_nodes at depth=0
 
-## What Was Changed
-
-### config.py (defaults + `_hermes_compression_threshold`)
 ```
-fresh_tail_count:     64 → 32
-context_threshold:   0.75 → 0.35
-incremental_max_depth: 1 → 3
-```
-`_hermes_compression_threshold()` now reads `lcm.context_threshold` from config.yaml first, falling back to `compression.threshold`, then to default.
-
-### config.yaml (new `lcm:` section)
-```yaml
-lcm:
-  context_threshold: 0.35
-  incremental_max_depth: 3
-  fresh_tail_count: 32
+d0: 18 nodes, 33,270 tok
+d>0: 0 nodes
 ```
 
-### tests/test_lcm_core.py
-- `test_defaults`: updated assertions to new values (32, 0.35, 3)
-- `test_from_env_invalid_numeric_values_fall_back_to_defaults`: same
-- Added `test_from_env_lcm_section_overrides_compression_section`
+No hierarchical DAG was being built despite `incremental_max_depth=3` and `context_threshold=0.35` in config.yaml.
 
-## Verification
-- `LCMConfig()` → fresh_tail_count=32, context_threshold=0.35, incremental_max_depth=3 ✓
-- `LCMConfig.from_env()` → reads config.yaml lcm section correctly ✓
-- `_hermes_compression_threshold()` → 0.35 (from config.yaml, not compression.threshold=0.5) ✓
-- `test_lcm_core.py::TestConfig` → 176 passed ✓
+### Root Causes (three compounding issues)
 
-## Effect
-- MiniMax-M2.7 (204,800 context): compression now fires at **71,680 tokens** (was 153,600)
-- DAG can build depth-3 hierarchical summaries (leaf → d1 → d2 → d3)
-- 32-message fresh tail (was 64) — more context density per compression
+#### 1. Missing `lcm_lifecycle_state` rows — sessions orphaned from frontier tracking
+- Sessions that had `summary_nodes` created via `_maybe_condense()` had **no corresponding `lcm_lifecycle_state` row**
+- `_maybe_condense()` calls `get_uncondensed_at_depth()` which requires `self._session_id`
+- But `lifecycle_state.get_by_session()` returned None → `should_compress()` computed wrong `threshold_tokens` (0) via `_session_ignored` or missing frontier data
+- The DAG existed but the engine couldn't reason about it correctly
 
-## Remaining
-- Monitor sessions for correct compression behavior after restart
-- Track DAG depth distribution to confirm hierarchical compression building
+**Evidence from DB:**
+```
+Sessions with nodes but NO lifecycle entry: 3 (before fix)
+  20260514_154742_6340c1
+  20260514_155921_c05fac
+  20260514_163841_59dfee
+```
+
+Also: most sessions had `current_frontier_store_id=0` despite having hundreds of messages.
+
+#### 2. Missing LCM env vars in hermes-gateway.service
+The systemd service had NO `LCM_*` environment variables. Without them:
+- `LCMConfig.from_env()` uses all-default values (from DEFAULT_CONFIG)
+- `fresh_tail_count=64` (should be 24-32)
+- `condensation_fanin=4` (should be 2)
+- `context_threshold=0.35` ✓ (read from config.yaml `lcm:` section by `from_env()`)
+- `incremental_max_depth=3` ✓ (read from config.yaml)
+- `dynamic_leaf_chunk=false` (should be true)
+- `cache_friendly_condensation=true` (should be false)
+
+The `lcm:` section in `~/.hermes/config.yaml` was correct, but `from_env()` reads env vars **first** and uses config.yaml as fallback. The missing env vars meant critical operational params used defaults instead of tuned values.
+
+#### 3. repair_lcm_dag.py was never executed
+The script existed at `~/.hermes/scripts/repair_lcm_dag.py` but was never run as a cron job, startup hook, or manual step.
+
+---
+
+### What Was Fixed
+
+#### FIX 1: Ran `repair_lcm_dag.py` — backfilled lifecycle state
+```
+[1] Backfilling lcm_lifecycle_state...
+  [FIXED] Inserted lifecycle for session=20260514_154742_6340c1, frontier=10434
+  [FIXED] Inserted lifecycle for session=20260514_155921_c05fac, frontier=10826
+  [FIXED] Inserted lifecycle for session=20260514_163841_59dfee, frontier=11192
+  → 3 session(s) processed
+
+[2] Fixing frontier gaps for sessions with summary_nodes...
+  [FIXED] Updated frontier for 11 sessions
+  → 11 session(s) processed
+
+[3] Current DAG state:
+  Total summary nodes: 19 (d0: 19)
+  Sessions with nodes but NO lifecycle entry: 0 ✓
+```
+
+#### FIX 2: Added LCM env vars to hermes-gateway.service
+```
+Environment="LCM_CONTEXT_THRESHOLD=0.35"
+Environment="LCM_INCREMENTAL_MAX_DEPTH=3"
+Environment="LCM_FRESH_TAIL_COUNT=24"
+Environment="LCM_CONDENSATION_FANIN=2"
+Environment="LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true"
+Environment="LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false"
+```
+
+Verified live in PID after restart:
+```
+LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false ✓
+LCM_CONDENSATION_FANIN=2 ✓
+LCM_CONTEXT_THRESHOLD=0.35 ✓
+LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true ✓
+LCM_FRESH_TAIL_COUNT=24 ✓
+LCM_INCREMENTAL_MAX_DEPTH=3 ✓
+```
+
+---
+
+## Remaining Work
+- Monitor new sessions for depth>0 node creation (next compression cycle)
+- The 3 newly-backfilled sessions + 11 with updated frontiers will build depth>0 on next compress cycle
+- A cron job to run repair_lcm_dag.py daily or on startup would prevent future orphan sessions
+
+## Branch State
+- `fix/dag-repair-script` — has repair_lcm_dag.py + config defaults fix (pushed to origin)
+- `fix/lcm-config-2026-05-14` — has config.yaml lcm section (ahead of main)
+- `fix/lcm-config-v4` — older version of config fix, superseded
+- No new commits needed — existing branches cover everything
+- Need to verify: does hermes-lcm need to be installed/registered as a plugin for context.engine=lcm to activate?
+  - The config.yaml has `context.engine: lcm` — this is the right path
+  - But `plugins/context_engine/lcm/` must be in the plugin search path
+  - If hermes-lcm is a standalone plugin installed separately, need to verify it's on the Python path

--- a/README.md
+++ b/README.md
@@ -530,10 +530,51 @@ Available commands:
 - `/lcm doctor source apply` - backup-first normalization of legacy blank-source rows to `unknown`
 - `/lcm doctor retention` - read-only retention analysis
 - `/lcm backup` - timestamped SQLite backup
+- `/lcm rotate` - read-only preview of an in-place tail-preserving compact of the active session
+- `/lcm rotate apply` - backup-first rotate that advances the lifecycle frontier past pre-tail raw messages
 - `/lcm help` - command help
 
 Apply paths are intentionally narrow and backup-first. Start with diagnostics
 before cleanup or repair.
+
+### Rotate: in-place compact without changing session identity
+
+`/lcm rotate` lets an operator compact a long-running session in place without
+changing `session_id` or `conversation_id`. It is the in-session counterpart to
+Hermes-level `/new` (which starts a new session) and to `/lcm doctor clean`
+(which prunes whole junk sessions).
+
+What rotate does:
+
+- preserves the live tail (`LCM_FRESH_TAIL_COUNT` most-recent messages)
+- advances the lifecycle frontier marker past every raw message before the tail,
+  so subsequent bootstrap stops replaying them into the active prompt
+- writes a rolling `*-rotate-latest.sqlite3` backup under the same backup
+  directory as `/lcm backup`, overwriting the previous rotate slot atomically
+  so disk usage stays bounded across repeated rotates
+
+What rotate does not do:
+
+- it does not delete raw messages — pre-tail rows remain in the SQLite store
+  and stay recoverable through `lcm_load_session` and `lcm_expand`, preserving
+  the lossless raw recovery contract
+- it does not invoke the summarization model — rotate is a frontier and backup
+  operation, not a synthesis step. Pre-tail content that was not yet covered by
+  a summary node remains accessible only as raw rows; trigger normal compaction
+  first if you want the pre-tail range covered by summary nodes before rotating
+- it does not change session or conversation identity, run on stateless
+  sessions (`LCM_STATELESS_SESSION_PATTERNS`), or run on ignored sessions
+  (`LCM_IGNORE_SESSION_PATTERNS`) — rotate refuses on both with a clear reason
+
+`lcm_status` and `/lcm status` surface `last_rotate_at` (epoch float, or `null`
+when no rotate has happened) and the rolling backup path so operators can see
+when rotate last ran. The mtime of the rolling backup file is the source of
+truth — no new lifecycle column is added by this feature.
+
+Re-running `/lcm rotate apply` on a session whose frontier is already at or
+ahead of the target boundary reports `status: noop` and is safe to retry.
+A no-op apply does not write a new rolling backup, so the previous
+known-good `*-rotate-latest.sqlite3` snapshot survives idempotent retries.
 
 ## How It Works
 

--- a/command.py
+++ b/command.py
@@ -105,6 +105,24 @@ def _status_text(engine) -> str:
     session_bound = bool(engine.current_session_id)
     source_stats = status.get("source_lineage") or {}
     runtime_identity = status.get("runtime_identity") or {}
+
+    # Auto-derive conversation_id when gateway omits it or mirrors session_id
+    # Fixes https://github.com/stephenschoettler/hermes-lcm/issues/133
+    current_conv_id = runtime_identity.get('conversation_id')
+    if current_conv_id is None or current_conv_id == '' or current_conv_id == engine.current_session_id:
+        platform = engine.current_session_platform or 'unknown'
+        if platform == 'discord':
+            guild_id = runtime_identity.get('guild_id', 'unknown')
+            channel_id = runtime_identity.get('channel_id', 'unknown')
+            user_id = runtime_identity.get('user_id', 'unknown')
+            current_conv_id = f"discord:{guild_id}:{channel_id}:{user_id}"
+        elif platform == 'telegram':
+            chat_id = runtime_identity.get('chat_id', 'unknown')
+            current_conv_id = f"telegram:{chat_id}"
+        else:
+            current_conv_id = f"{platform}:{engine.current_session_id}"
+        runtime_identity['conversation_id'] = current_conv_id
+
     source_stats = {
         "messages_total": int(source_stats.get("messages_total", 0) or 0),
         "attributed_messages": int(source_stats.get("attributed_messages", 0) or 0),

--- a/command.py
+++ b/command.py
@@ -106,23 +106,6 @@ def _status_text(engine) -> str:
     source_stats = status.get("source_lineage") or {}
     runtime_identity = status.get("runtime_identity") or {}
 
-    # Auto-derive conversation_id when gateway omits it or mirrors session_id
-    # Fixes https://github.com/stephenschoettler/hermes-lcm/issues/133
-    current_conv_id = runtime_identity.get('conversation_id')
-    if current_conv_id is None or current_conv_id == '' or current_conv_id == engine.current_session_id:
-        platform = engine.current_session_platform or 'unknown'
-        if platform == 'discord':
-            guild_id = runtime_identity.get('guild_id', 'unknown')
-            channel_id = runtime_identity.get('channel_id', 'unknown')
-            user_id = runtime_identity.get('user_id', 'unknown')
-            current_conv_id = f"discord:{guild_id}:{channel_id}:{user_id}"
-        elif platform == 'telegram':
-            chat_id = runtime_identity.get('chat_id', 'unknown')
-            current_conv_id = f"telegram:{chat_id}"
-        else:
-            current_conv_id = f"{platform}:{engine.current_session_id}"
-        runtime_identity['conversation_id'] = current_conv_id
-
     source_stats = {
         "messages_total": int(source_stats.get("messages_total", 0) or 0),
         "attributed_messages": int(source_stats.get("attributed_messages", 0) or 0),

--- a/command.py
+++ b/command.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import os
 import sqlite3
@@ -92,6 +92,8 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm doctor source apply: backup-first normalization of legacy blank-source rows to unknown",
         "- /lcm doctor retention: read-only retention analysis for stored session footprint and age",
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
+        "- /lcm rotate: preview a tail-preserving in-place compact of the active session (read-only)",
+        "- /lcm rotate apply: backup-first rotate that advances the lifecycle frontier past pre-tail raw messages",
         "- /lcm help: show this help",
     ])
     return "\n".join(lines)
@@ -160,6 +162,20 @@ def _status_text(engine) -> str:
         f"source_legacy_blank_messages: {source_stats['legacy_blank_source_messages']}",
         f"source_effective_unknown_messages: {source_stats['effective_unknown_messages']}",
     ]
+
+    last_rotate_at = status.get("last_rotate_at")
+    if last_rotate_at:
+        lines.append(
+            f"last_rotate_at: "
+            f"{datetime.fromtimestamp(float(last_rotate_at), tz=timezone.utc).isoformat(timespec='seconds')}"
+        )
+        rotate_backup_size = int(status.get("rotate_backup_size", 0) or 0)
+        if rotate_backup_size:
+            lines.append(f"rotate_backup_size: {_fmt_size(rotate_backup_size)}")
+    else:
+        lines.append("last_rotate_at: (never)")
+    if status.get("rotate_backup_path"):
+        lines.append(f"rotate_backup_path: {status['rotate_backup_path']}")
 
     if session_bound:
         lines.extend([
@@ -424,6 +440,20 @@ def _scan_retention_candidates(engine) -> dict[str, Any]:
     }
 
 
+def _flush_engine_connections(engine) -> None:
+    """Commit pending writes on every SQLite connection the engine owns.
+
+    Shared by ``_backup_database`` (timestamped backup) and
+    ``_rotate_backup_database`` (rolling backup) so the connection-flush
+    contract stays in one place.
+    """
+    engine._store._conn.commit()
+    engine._dag._conn.commit()
+    lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
+    if lifecycle_conn is not None:
+        lifecycle_conn.commit()
+
+
 def _backup_database(engine) -> dict[str, Any]:
     db_path = Path(engine._store.db_path)
     if not db_path.exists():
@@ -433,18 +463,13 @@ def _backup_database(engine) -> dict[str, Any]:
             "error": "database file does not exist",
         }
 
-    backup_root = Path(engine._hermes_home).expanduser() if getattr(engine, "_hermes_home", "") else db_path.parent
-    backup_dir = backup_root / "backups" / "lcm"
+    backup_dir = engine.backup_dir()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = backup_dir / f"{db_path.stem}-{timestamp}.sqlite3"
 
     try:
         backup_dir.mkdir(parents=True, exist_ok=True)
-        engine._store._conn.commit()
-        engine._dag._conn.commit()
-        lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
-        if lifecycle_conn is not None:
-            lifecycle_conn.commit()
+        _flush_engine_connections(engine)
 
         dest = sqlite3.connect(str(backup_path))
         try:
@@ -465,6 +490,180 @@ def _backup_database(engine) -> dict[str, Any]:
         "backup_path": backup_path,
         "backup_size": backup_size,
     }
+
+
+def _rotate_backup_database(engine) -> dict[str, Any]:
+    """Write a rolling rotate-latest SQLite snapshot of the LCM store.
+
+    Atomic via tmp-then-rename so the slot is never half-written. Unlike
+    ``_backup_database`` which produces timestamped files, this overwrites a
+    single rolling slot so disk usage stays bounded across repeated rotates.
+    """
+    db_path = Path(engine._store.db_path)
+    if not db_path.exists():
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "error": "database file does not exist",
+        }
+
+    backup_path = engine.rotate_backup_path()
+    backup_dir = backup_path.parent
+    tmp_path = backup_path.with_name(backup_path.name + ".tmp")
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        _flush_engine_connections(engine)
+
+        if tmp_path.exists():
+            tmp_path.unlink()
+        dest = sqlite3.connect(str(tmp_path))
+        try:
+            engine._store._conn.backup(dest)
+        finally:
+            dest.close()
+        # Atomic replace so the rolling slot is never half-written.
+        tmp_path.replace(backup_path)
+    except (OSError, sqlite3.Error) as exc:
+        # Best-effort cleanup of the tmp file if something failed midway.
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        return {
+            "ok": False,
+            "db_path": db_path,
+            "backup_path": backup_path,
+            "error": str(exc),
+        }
+
+    backup_size = backup_path.stat().st_size if backup_path.exists() else 0
+    return {
+        "ok": True,
+        "db_path": db_path,
+        "backup_path": backup_path,
+        "backup_size": backup_size,
+    }
+
+
+def _rotate_text(engine) -> str:
+    preview = engine.rotate_active_session(apply=False)
+    if not preview.get("ok"):
+        reason = preview.get("reason", "unknown")
+        lines = [
+            "LCM rotate",
+            "status: refused",
+            f"reason: {reason}",
+        ]
+        session_id = preview.get("session_id")
+        if session_id:
+            lines.append(f"session_id: {session_id}")
+        lines.append("note: read-only preview — no changes were made")
+        return "\n".join(lines)
+
+    backup_path = engine.rotate_backup_path()
+    lines = [
+        "LCM rotate",
+        f"status: {'noop' if preview.get('noop') else 'preview'}",
+        f"session_id: {preview['session_id']}",
+        f"conversation_id: {preview['conversation_id']}",
+        f"total_message_count: {preview['total_message_count']}",
+        f"fresh_tail_count: {preview['fresh_tail_count']}",
+        f"pre_tail_message_count: {preview.get('pre_tail_message_count', 0)}",
+        f"current_frontier_store_id: {preview['current_frontier_store_id']}",
+        f"new_frontier_store_id: {preview['new_frontier_store_id']}",
+        f"rotate_backup_path: {backup_path}",
+    ]
+    if preview.get("noop"):
+        lines.append(f"reason: {preview.get('reason', 'no_change')}")
+        lines.append("note: read-only preview — rotate apply would be a no-op for this session")
+    else:
+        lines.append("note: read-only preview — use `/lcm rotate apply` to advance the frontier (backup-first)")
+        lines.append("note: pre-tail raw messages remain in the store and recoverable via lcm_load_session")
+    return "\n".join(lines)
+
+
+def _rotate_apply_text(engine) -> str:
+    # Pre-flight refusal AND noop check before touching disk. This avoids
+    # both writing a backup for a session that would refuse and overwriting
+    # the previous known-good rolling backup when the apply would be a no-op
+    # (e.g., idempotent rerun on an already-rotated session).
+    pre = engine.rotate_active_session(apply=False)
+    if not pre.get("ok"):
+        reason = pre.get("reason", "unknown")
+        lines = [
+            "LCM rotate apply",
+            "status: refused",
+            f"reason: {reason}",
+        ]
+        session_id = pre.get("session_id")
+        if session_id:
+            lines.append(f"session_id: {session_id}")
+        lines.append("note: rotate apply refused; no backup was created and no lifecycle state was changed")
+        return "\n".join(lines)
+
+    if pre.get("noop"):
+        # Surface the same shape as a successful apply but with status:noop so
+        # operators get the standard fields without a fresh backup write
+        # destroying the previous known-good snapshot.
+        lines = [
+            "LCM rotate apply",
+            "status: noop",
+            f"session_id: {pre['session_id']}",
+            f"conversation_id: {pre['conversation_id']}",
+            f"total_message_count: {pre['total_message_count']}",
+            f"fresh_tail_count: {pre['fresh_tail_count']}",
+            f"pre_tail_message_count: {pre.get('pre_tail_message_count', 0)}",
+            f"previous_frontier_store_id: {pre['current_frontier_store_id']}",
+            f"new_frontier_store_id: {pre['new_frontier_store_id']}",
+            f"reason: {pre.get('reason', 'no_change')}",
+            "note: rotate is a no-op; rolling backup was not written so the previous rotate-latest snapshot is preserved",
+        ]
+        return "\n".join(lines)
+
+    backup = _rotate_backup_database(engine)
+    if not backup["ok"]:
+        return "\n".join([
+            "LCM rotate apply",
+            "status: error",
+            f"database_path: {backup['db_path']}",
+            f"error: backup failed: {backup['error']}",
+            "note: rotate apply aborted before any lifecycle mutation",
+        ])
+
+    result = engine.rotate_active_session(apply=True)
+    if not result.get("ok"):
+        return "\n".join([
+            "LCM rotate apply",
+            "status: refused",
+            f"reason: {result.get('reason', 'unknown')}",
+            f"rotate_backup_path: {backup['backup_path']}",
+            f"rotate_backup_size: {_fmt_size(int(backup['backup_size']))}",
+            "note: backup was created before rotate refused; lifecycle state unchanged",
+        ])
+
+    is_noop = bool(result.get("noop"))
+    lines = [
+        "LCM rotate apply",
+        f"status: {'noop' if is_noop else 'ok'}",
+        f"session_id: {result['session_id']}",
+        f"conversation_id: {result['conversation_id']}",
+        f"rotate_backup_path: {backup['backup_path']}",
+        f"rotate_backup_size: {_fmt_size(int(backup['backup_size']))}",
+        f"total_message_count: {result['total_message_count']}",
+        f"fresh_tail_count: {result['fresh_tail_count']}",
+        f"pre_tail_message_count: {result.get('pre_tail_message_count', 0)}",
+        f"previous_frontier_store_id: {result['current_frontier_store_id']}",
+        f"new_frontier_store_id: {result.get('applied_frontier_store_id', result['new_frontier_store_id'])}",
+    ]
+    if is_noop:
+        lines.append(f"reason: {result.get('reason', 'no_change')}")
+        lines.append("note: lifecycle state already at or ahead of the target frontier")
+    else:
+        lines.append("note: pre-tail raw messages remain in the store and recoverable via lcm_load_session")
+        lines.append("note: rolling backup overwrites the previous rotate-latest slot")
+    return "\n".join(lines)
 
 
 def _scan_fts_repair(engine) -> dict[str, Any]:
@@ -1198,6 +1397,13 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
         if rest:
             return _help_text("`/lcm backup` does not accept extra arguments.")
         return _backup_text(engine)
+
+    if head == "rotate":
+        if not rest:
+            return _rotate_text(engine)
+        if len(rest) == 1 and rest[0].lower() == "apply":
+            return _rotate_apply_text(engine)
+        return _help_text("`/lcm rotate` accepts an optional `apply` subcommand.")
 
     if head == "help":
         return _help_text()

--- a/config.py
+++ b/config.py
@@ -46,7 +46,10 @@ def _parse_bool_env(key: str, default: bool) -> bool:
 
 
 def _hermes_compression_threshold(default: float) -> float:
-    """Read Hermes compression.threshold when no LCM env override is present.
+    """Read Hermes compression.threshold or lcm.context_threshold from config.yaml.
+
+    Priority: LCM_CONTEXT_THRESHOLD env var > lcm.context_threshold (config.yaml)
+              > compression.threshold (config.yaml) > default.
 
     Hermes gateways may load ``~/.hermes/config.yaml`` without exporting every
     setting into the process environment. Falling back to the main Hermes
@@ -59,19 +62,28 @@ def _hermes_compression_threshold(default: float) -> float:
         text = cfg_path.read_text()
         if yaml is not None:
             cfg = yaml.safe_load(text) or {}
-            value = (cfg.get("compression") or {}).get("threshold")
-            if value is None:
-                return default
-            return float(value)
+            # lcm.context_threshold takes priority over compression.threshold
+            lcm_val = (cfg.get("lcm") or {}).get("context_threshold")
+            if lcm_val is not None:
+                return float(lcm_val)
+            comp_val = (cfg.get("compression") or {}).get("threshold")
+            if comp_val is not None:
+                return float(comp_val)
+            return default
 
+        in_lcm = False
         in_compression = False
         for raw_line in text.splitlines():
             line = raw_line.split("#", 1)[0].rstrip()
             if not line.strip():
                 continue
             if not line.startswith((" ", "\t")):
-                in_compression = line.strip() == "compression:"
+                stripped = line.strip()
+                in_lcm = stripped == "lcm:"
+                in_compression = stripped == "compression:"
                 continue
+            if in_lcm and line.strip().startswith("context_threshold:"):
+                return float(line.split(":", 1)[1].strip().strip("'\""))
             if in_compression and line.strip().startswith("threshold:"):
                 return float(line.split(":", 1)[1].strip().strip("'\""))
         return default
@@ -84,15 +96,15 @@ class LCMConfig:
     """All tunables for the LCM engine."""
 
     # -- Fresh tail: recent messages never compacted ---
-    fresh_tail_count: int = 64
+    fresh_tail_count: int = 32
 
     # -- Compaction thresholds ---
     # Max source tokens in a leaf chunk before summarization triggers
     leaf_chunk_tokens: int = 20_000
     # Fraction of context window that triggers compaction (0.0–1.0)
-    context_threshold: float = 0.75
+    context_threshold: float = 0.35
     # Max condensation depth (-1 = unlimited, 0 = leaf only)
-    incremental_max_depth: int = 1
+    incremental_max_depth: int = 3
     # How many same-depth summaries trigger condensation
     condensation_fanin: int = 4
     # When enabled, leaf compaction may use a larger working chunk size based on backlog pressure

--- a/engine.py
+++ b/engine.py
@@ -881,12 +881,42 @@ class LCMEngine(ContextEngine):
 
     # -- ContextEngine optional methods ------------------------------------
 
+    def _derive_conversation_id(self, session_id: str, kwargs: Dict[str, Any]) -> str:
+        """Derive a conversation_id from platform metadata when gateway doesn't provide one.
+
+        Called when the gateway passes conversation_id equal to session_id or None
+        (the common case for Telegram multi-session scenarios). Derives the real
+        conversation identifier from platform-level metadata passed in kwargs.
+
+        Returns the derived conversation_id or session_id as fallback.
+        """
+        explicit = kwargs.get("conversation_id")
+        if explicit and explicit != session_id:
+            return explicit
+        platform = str(kwargs.get("platform") or self._session_platform or "")
+        if platform == "telegram":
+            chat_id = kwargs.get("chat_id")
+            if chat_id:
+                return f"telegram:{chat_id}"
+        elif platform == "discord":
+            guild_id = kwargs.get("guild_id")
+            channel_id = kwargs.get("channel_id")
+            user_id = kwargs.get("user_id")
+            if guild_id and channel_id:
+                identifier = f"discord:{guild_id}:{channel_id}"
+                if user_id:
+                    identifier += f":{user_id}"
+                return identifier
+        return session_id
+
     def _bind_lifecycle_state(
         self,
         session_id: str,
         *,
         conversation_id: str | None = None,
     ) -> None:
+        if not conversation_id or conversation_id == session_id:
+            conversation_id = self._derive_conversation_id(session_id, {})
         state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
         self._conversation_id = state.conversation_id
         self._last_compacted_store_id = state.current_frontier_store_id
@@ -1513,9 +1543,15 @@ class LCMEngine(ContextEngine):
             self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
             self._apply_session_start_metadata(session_id, kwargs)
+            # Derive conversation_id when gateway omits or mirrors session_id
+            explicit_conv_id = kwargs.get("conversation_id")
+            if not explicit_conv_id or explicit_conv_id == session_id:
+                derived_conv_id = self._derive_conversation_id(session_id, kwargs)
+            else:
+                derived_conv_id = explicit_conv_id
             self._bind_lifecycle_state(
                 session_id,
-                conversation_id=kwargs.get("conversation_id"),
+                conversation_id=derived_conv_id,
             )
             self._clear_pending_reset_boundary()
             self._log_session_filter_diagnostics()
@@ -1574,9 +1610,15 @@ class LCMEngine(ContextEngine):
             self._last_overflow_recovery_failed = False
             self._last_condensation_suppressed_reason = ""
         self._apply_session_start_metadata(session_id, kwargs)
+        # Derive conversation_id when gateway omits or mirrors session_id
+        explicit_conv_id = kwargs.get("conversation_id")
+        if not explicit_conv_id or explicit_conv_id == session_id:
+            derived_conv_id = self._derive_conversation_id(session_id, kwargs)
+        else:
+            derived_conv_id = explicit_conv_id
         self._bind_lifecycle_state(
             session_id,
-            conversation_id=kwargs.get("conversation_id"),
+            conversation_id=derived_conv_id,
         )
         self._schedule_ingest_cursor_reconciliation()
         self._log_session_filter_diagnostics()

--- a/engine.py
+++ b/engine.py
@@ -944,20 +944,42 @@ class LCMEngine(ContextEngine):
         explicit = kwargs.get("conversation_id")
         if explicit and explicit != session_id:
             return explicit
+        
         platform = str(kwargs.get("platform") or self._session_platform or "")
+        
         if platform == "telegram":
             chat_id = kwargs.get("chat_id")
-            if chat_id:
+            if not chat_id:
+                return session_id if fallback_to_session else None
+            
+            # Include topic/thread discriminator if available
+            thread_id = kwargs.get("message_thread_id")
+            if thread_id:
+                return f"telegram:{chat_id}:{thread_id}"
+            else:
                 return f"telegram:{chat_id}"
+        
         elif platform == "discord":
             guild_id = kwargs.get("guild_id")
             channel_id = kwargs.get("channel_id")
+            if not guild_id or not channel_id:
+                return session_id if fallback_to_session else None
+            
+            # Build base identifier
+            identifier = f"discord:{guild_id}:{channel_id}"
+            
+            # Include user_id if available
             user_id = kwargs.get("user_id")
-            if guild_id and channel_id:
-                identifier = f"discord:{guild_id}:{channel_id}"
-                if user_id:
-                    identifier += f":{user_id}"
-                return identifier
+            if user_id:
+                identifier += f":{user_id}"
+            
+            # Include thread discriminator if available
+            thread_id = kwargs.get("thread_id")
+            if thread_id:
+                identifier += f":{thread_id}"
+            
+            return identifier
+        
         return session_id if fallback_to_session else None
 
     def _bind_lifecycle_state(

--- a/engine.py
+++ b/engine.py
@@ -2065,6 +2065,26 @@ class LCMEngine(ContextEngine):
             )
         except Exception as exc:  # pragma: no cover - defensive
             status["lifecycle_fragmentation"] = {"error": str(exc), "read_only": True}
+        try:
+            rotate_backup_path = self.rotate_backup_path()
+            status["rotate_backup_path"] = str(rotate_backup_path)
+            # Single stat() to avoid a TOCTOU window where the rolling slot
+            # could be atomically replaced between separate mtime and size reads.
+            try:
+                rotate_stat = rotate_backup_path.stat()
+            except FileNotFoundError:
+                rotate_stat = None
+            if rotate_stat is not None:
+                status["last_rotate_at"] = rotate_stat.st_mtime
+                status["rotate_backup_size"] = rotate_stat.st_size
+            else:
+                status["last_rotate_at"] = None
+                status["rotate_backup_size"] = 0
+        except Exception as exc:  # pragma: no cover - defensive
+            status["rotate_backup_path"] = None
+            status["last_rotate_at"] = None
+            status["rotate_backup_size"] = 0
+            status["rotate_backup_error"] = str(exc)
         if session_id:
             status["store_messages"] = self._store.get_session_count(session_id)
             status["dag_nodes"] = len(self._dag.get_session_nodes(session_id))
@@ -3654,6 +3674,193 @@ class LCMEngine(ContextEngine):
             # Take first line only
             return hint.split("\n")[0].strip()
         return ""
+
+    # -- Rotate ------------------------------------------------------------
+
+    def backup_dir(self) -> Path:
+        """Return the directory where LCM backup snapshots are written.
+
+        Centralized so the timestamped ``/lcm backup`` slot and the rolling
+        ``/lcm rotate apply`` slot share the same directory derivation.
+        """
+        db_path = Path(self._store.db_path)
+        backup_root = (
+            Path(self._hermes_home).expanduser()
+            if getattr(self, "_hermes_home", "")
+            else db_path.parent
+        )
+        return backup_root / "backups" / "lcm"
+
+    def rotate_backup_path(self) -> Path:
+        """Return the rolling rotate-latest SQLite backup path for this engine.
+
+        Centralized so command.py (which writes the backup) and get_status()
+        (which reads its mtime to surface last_rotate_at) cannot drift.
+        """
+        db_path = Path(self._store.db_path)
+        return self.backup_dir() / f"{db_path.stem}-rotate-latest.sqlite3"
+
+    def rotate_active_session(
+        self,
+        *,
+        apply: bool = False,
+    ) -> dict[str, Any]:
+        """Compact the active session in-place without changing identity.
+
+        Read-only by default (``apply=False``). Returns a preview describing
+        what would change. When ``apply=True``, advances the lifecycle frontier
+        marker past the pre-tail raw messages so they are no longer replayed
+        into active context on subsequent bootstrap. Raw messages remain in
+        the SQLite store and are recoverable through ``lcm_load_session`` and
+        ``lcm_expand`` — the lossless raw recovery contract is preserved.
+
+        Refuses on sessions that are unbound, ignored, or stateless.
+
+        Two frontier markers are intentionally kept separate:
+
+        - The **persisted lifecycle frontier**
+          (``lifecycle_state.current_frontier_store_id``) is the
+          bootstrap signal — on next session start, raw rows at or
+          below it are not replayed into the active context. Rotate
+          advances this marker.
+        - The **in-process source-mapping marker**
+          (``self._last_compacted_store_id``) tracks raw rows that the
+          *current process* has already moved into summary DAG nodes.
+          ``_get_store_ids_for_messages`` uses it to filter candidates
+          when mapping in-memory active messages back to ``store_id``.
+          Rotate deliberately does NOT advance this marker: pre-tail
+          raw messages remain in the in-memory active context until
+          the host rebuilds it, so a normal ``compress()`` later in
+          the same process can still summarize them with correct
+          ``source_ids`` lineage. On next process start,
+          ``_bind_lifecycle_state`` reads the persisted frontier into
+          the in-process marker — at that point the active context is
+          being built from scratch, so the contract holds.
+
+        Refusal/no-op reason codes (returned as ``reason``):
+
+        - ``no_active_session``: engine has no bound session or conversation.
+        - ``session_ignored``: foreground session matched
+          ``LCM_IGNORE_SESSION_PATTERNS``.
+        - ``session_stateless``: foreground session matched
+          ``LCM_STATELESS_SESSION_PATTERNS``.
+        - ``no_pre_tail_content``: total stored messages do not exceed
+          ``fresh_tail_count``; nothing to rotate.
+        - ``empty_tail``: tail query returned no rows despite a non-zero
+          count (concurrent deletion race); rotate cannot compute a boundary.
+        - ``frontier_already_ahead``: lifecycle frontier is already at or
+          past the proposed new frontier; rotate is a no-op.
+        - ``stale_lifecycle_state``: apply requested but lifecycle's
+          ``current_session_id`` did not match this engine's session, so
+          ``advance_frontier`` did not persist the change.
+        """
+        session_id = self._session_id
+        conversation_id = self._conversation_id
+
+        if not session_id or not conversation_id:
+            return {"ok": False, "reason": "no_active_session"}
+        if self._session_ignored:
+            return {"ok": False, "reason": "session_ignored", "session_id": session_id}
+        if self._session_stateless:
+            return {"ok": False, "reason": "session_stateless", "session_id": session_id}
+
+        fresh_tail_count = max(1, int(self._config.fresh_tail_count))
+        total_count = int(self._store.get_session_count(session_id))
+
+        state = self._lifecycle.get_by_conversation(conversation_id)
+        current_frontier = int(state.current_frontier_store_id) if state else 0
+
+        base = {
+            "ok": True,
+            "session_id": session_id,
+            "conversation_id": conversation_id,
+            "total_message_count": total_count,
+            "fresh_tail_count": fresh_tail_count,
+            "current_frontier_store_id": current_frontier,
+            "mode": "apply" if apply else "preview",
+        }
+
+        if total_count <= fresh_tail_count:
+            return {
+                **base,
+                "noop": True,
+                "reason": "no_pre_tail_content",
+                "pre_tail_message_count": 0,
+                "new_frontier_store_id": current_frontier,
+            }
+
+        tail = self._store.get_session_tail(session_id, fresh_tail_count)
+        if not tail:
+            # Concurrent deletion can empty the tail after the count check.
+            # Surface the same shape callers expect for any other no-op so
+            # downstream formatters can render it without KeyError.
+            return {
+                **base,
+                "noop": True,
+                "reason": "empty_tail",
+                "pre_tail_message_count": 0,
+                "new_frontier_store_id": current_frontier,
+            }
+
+        smallest_tail_store_id = int(tail[0].get("store_id") or 0)
+        new_frontier = max(0, smallest_tail_store_id - 1)
+        pre_tail_count = max(0, total_count - len(tail))
+
+        is_noop = new_frontier <= current_frontier
+        result = {
+            **base,
+            "pre_tail_message_count": pre_tail_count,
+            "new_frontier_store_id": new_frontier,
+            "noop": is_noop,
+        }
+        if is_noop:
+            # Set the reason for both preview and apply so downstream
+            # formatters can render a stable explanation. Preview previously
+            # omitted the reason, which left _rotate_apply_text's preflight
+            # check unable to distinguish frontier-already-ahead from other
+            # no-ops.
+            result["reason"] = "frontier_already_ahead"
+
+        if not apply:
+            return result
+
+        if is_noop:
+            return result
+
+        new_state = self._lifecycle.advance_frontier(
+            conversation_id,
+            session_id,
+            new_frontier,
+        )
+        # advance_frontier silently returns the unchanged state when its
+        # session_id check fails (lifecycle_state.py:557-559). Detect that
+        # by checking whether the persisted frontier actually advanced; only
+        # promote the in-process marker on a confirmed persist.
+        persisted_frontier = (
+            int(new_state.current_frontier_store_id) if new_state else current_frontier
+        )
+        if persisted_frontier < new_frontier:
+            return {
+                **{k: v for k, v in result.items() if k != "ok"},
+                "ok": False,
+                "noop": False,
+                "reason": "stale_lifecycle_state",
+                "applied_frontier_store_id": persisted_frontier,
+            }
+        # Deliberately do NOT touch self._last_compacted_store_id here.
+        # The in-process source-mapping marker must stay aligned with the
+        # in-memory active context the host is still using. Pre-tail raw
+        # messages remain in that active context until the host rebuilds
+        # it; advancing the marker would make
+        # _get_store_ids_for_messages filter out those rows on the next
+        # in-process compress(), producing summary nodes whose text
+        # covers pre-rotate messages but whose source_ids reference only
+        # post-rotate rows. The persisted lifecycle frontier we just
+        # advanced is the bootstrap signal for the next process start,
+        # where _bind_lifecycle_state will read it into the marker
+        # against a freshly-built active context.
+        result["applied_frontier_store_id"] = persisted_frontier
+        return result
 
     # -- Lifecycle ---------------------------------------------------------
 

--- a/engine.py
+++ b/engine.py
@@ -332,7 +332,10 @@ class LCMEngine(ContextEngine):
         self.base_url = ""
         self.api_key = ""
         self.provider = ""
+        self.api_mode = ""
         self.context_length = 0
+        self._context_length_source = ""
+        self._update_model_pending_session_start = False
         self.threshold_tokens = 0
         self.threshold_percent = self._config.context_threshold
         self.last_prompt_tokens = 0
@@ -369,6 +372,47 @@ class LCMEngine(ContextEngine):
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
+
+    def _set_context_length(self, context_length: Any, *, source: str) -> bool:
+        try:
+            parsed_context_length = int(context_length)
+        except (TypeError, ValueError):
+            logger.debug("LCM ignored invalid %s context_length: %r", source, context_length)
+            return False
+        if parsed_context_length <= 0:
+            logger.debug(
+                "LCM cleared non-positive %s context_length: %r",
+                source,
+                context_length,
+            )
+            self.context_length = 0
+            self._context_length_source = source
+            self.threshold_tokens = 0
+            return True
+        self.context_length = parsed_context_length
+        self._context_length_source = source
+        self.threshold_tokens = int(
+            parsed_context_length * self._config.context_threshold
+        )
+        return True
+
+    def _session_metadata_matches_active_runtime(
+        self,
+        kwargs: Dict[str, Any],
+        *,
+        ignore_empty_optional: bool = False,
+    ) -> bool:
+        if "model" in kwargs and str(kwargs.get("model") or "") != self.model:
+            return False
+        for key in ("provider", "base_url", "api_key", "api_mode"):
+            if key not in kwargs:
+                continue
+            incoming = str(kwargs.get(key) or "")
+            if ignore_empty_optional and not incoming:
+                continue
+            if incoming != str(getattr(self, key, "") or ""):
+                return False
+        return True
 
     @property
     def name(self) -> str:
@@ -1440,12 +1484,94 @@ class LCMEngine(ContextEngine):
             self._foreground_session_platform = self._session_platform
         if "hermes_home" in kwargs:
             self._hermes_home = kwargs["hermes_home"]
-        # Pick up context_length from kwargs if provided
+
+        update_model_is_authoritative = (
+            self._context_length_source == "update_model"
+            and self._update_model_pending_session_start
+        )
+
+        # Pick up context_length from kwargs if provided, but do not let stale
+        # session metadata undo the authoritative runtime update_model() call.
+        # Hermes Agent calls update_model() with the resolver output before it
+        # binds a fresh agent/session.  Older or buggy host paths can still pass
+        # a context_length copied from the previously bound runtime; treating
+        # that as authoritative makes /model switches keep compressing against
+        # the old model window.
         if "context_length" in kwargs:
-            self.context_length = kwargs["context_length"]
-            self.threshold_tokens = int(
-                self.context_length * self._config.context_threshold
+            incoming_context_length = kwargs["context_length"]
+            try:
+                parsed_context_length = int(incoming_context_length)
+            except (TypeError, ValueError):
+                logger.debug(
+                    "LCM ignored invalid session-start context_length: %r",
+                    incoming_context_length,
+                )
+                self._update_model_pending_session_start = False
+                return
+            if parsed_context_length <= 0:
+                if update_model_is_authoritative:
+                    if self._session_metadata_matches_active_runtime(
+                        kwargs,
+                        ignore_empty_optional=True,
+                    ):
+                        logger.debug(
+                            "LCM ignored missing session-start context_length=%r for model=%s; active update_model context_length=%s",
+                            incoming_context_length,
+                            self.model or str(kwargs.get("model") or ""),
+                            self.context_length,
+                        )
+                    else:
+                        logger.warning(
+                            "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                            str(kwargs.get("model") or ""),
+                            self.model,
+                        )
+                    self._update_model_pending_session_start = False
+                    return
+                self._set_context_length(parsed_context_length, source="session_start")
+                update_model_is_authoritative = False
+            else:
+                if (
+                    update_model_is_authoritative
+                    and parsed_context_length != self.context_length
+                ):
+                    logger.warning(
+                        "LCM ignored stale session-start context_length=%s for model=%s; active update_model context_length=%s",
+                        parsed_context_length,
+                        self.model or str(kwargs.get("model") or ""),
+                        self.context_length,
+                    )
+                    self._update_model_pending_session_start = False
+                    return
+                if update_model_is_authoritative:
+                    if not self._session_metadata_matches_active_runtime(kwargs):
+                        logger.warning(
+                            "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                            str(kwargs.get("model") or ""),
+                            self.model,
+                        )
+                        self._update_model_pending_session_start = False
+                        return
+                else:
+                    self._set_context_length(parsed_context_length, source="session_start")
+                    update_model_is_authoritative = False
+        if (
+            update_model_is_authoritative
+            and not self._session_metadata_matches_active_runtime(kwargs)
+        ):
+            logger.warning(
+                "LCM ignored stale session-start runtime metadata for model=%s; active update_model model=%s",
+                str(kwargs.get("model") or ""),
+                self.model,
             )
+            self._update_model_pending_session_start = False
+            return
+        if "model" in kwargs:
+            self.model = str(kwargs.get("model") or "")
+        for key in ("base_url", "api_key", "provider", "api_mode"):
+            if key in kwargs:
+                setattr(self, key, str(kwargs.get(key) or ""))
+        self._update_model_pending_session_start = False
 
     def _continue_compression_boundary(
         self,
@@ -1986,8 +2112,13 @@ class LCMEngine(ContextEngine):
                 parent_session_id,
             )
             return
-        self.context_length = context_length
-        self.threshold_tokens = int(context_length * self._config.context_threshold)
+        self.model = str(model or "")
+        self.base_url = str(base_url or "")
+        self.api_key = str(api_key or "")
+        self.provider = str(provider or "")
+        self.api_mode = str(api_mode or "")
+        self._set_context_length(context_length, source="update_model")
+        self._update_model_pending_session_start = True
 
     def _refresh_session_filters(self) -> None:
         self._session_match_keys = build_session_match_keys(

--- a/engine.py
+++ b/engine.py
@@ -881,14 +881,21 @@ class LCMEngine(ContextEngine):
 
     # -- ContextEngine optional methods ------------------------------------
 
-    def _derive_conversation_id(self, session_id: str, kwargs: Dict[str, Any]) -> str:
+    def _derive_conversation_id(self, session_id: str, kwargs: Dict[str, Any], *, fallback_to_session: bool = True) -> str | None:
         """Derive a conversation_id from platform metadata when gateway doesn't provide one.
 
         Called when the gateway passes conversation_id equal to session_id or None
         (the common case for Telegram multi-session scenarios). Derives the real
         conversation identifier from platform-level metadata passed in kwargs.
 
-        Returns the derived conversation_id or session_id as fallback.
+        Args:
+            session_id: The session_id to use as final fallback.
+            kwargs: Keyword arguments from the original call (may be empty dict).
+            fallback_to_session: If True, return session_id when no platform data found.
+                                 If False, return None (caller handles None explicitly).
+
+        Returns:
+            The derived conversation_id, session_id, or None.
         """
         explicit = kwargs.get("conversation_id")
         if explicit and explicit != session_id:
@@ -907,7 +914,7 @@ class LCMEngine(ContextEngine):
                 if user_id:
                     identifier += f":{user_id}"
                 return identifier
-        return session_id
+        return session_id if fallback_to_session else None
 
     def _bind_lifecycle_state(
         self,

--- a/schemas.py
+++ b/schemas.py
@@ -244,10 +244,13 @@ LCM_STATUS = {
     "description": (
         "Get a quick health overview of the LCM engine for the current session. "
         "Shows compression count, store size, DAG depth distribution, context usage, "
-        "active configuration, and session/message filter state. Use this to "
-        "understand how much history has been compacted, how the engine is "
-        "performing, whether the current session is matched by ignore or stateless "
-        "session patterns, and which message noise-suppression patterns are loaded."
+        "active configuration, session/message filter state, and rotate snapshot "
+        "state (last_rotate_at, rotate_backup_path, rotate_backup_size when a "
+        "/lcm rotate apply has been run). Use this to understand how much history "
+        "has been compacted, how the engine is performing, whether the current "
+        "session is matched by ignore or stateless session patterns, which message "
+        "noise-suppression patterns are loaded, and when the rolling rotate "
+        "backup was last written."
     ),
     "parameters": {
         "type": "object",

--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -37,6 +37,8 @@ def _ensure_local_package_importable() -> None:
 _ensure_local_package_importable()
 
 from hermes_lcm.config import LCMConfig  # noqa: E402
+from hermes_lcm.dag import build_nodes_fts_spec  # noqa: E402
+from hermes_lcm.db_bootstrap import ensure_external_content_fts  # noqa: E402
 from hermes_lcm.ingest_protection import protect_message_for_ingest  # noqa: E402
 from hermes_lcm.message_content import normalize_content_value  # noqa: E402
 from hermes_lcm.store import MessageStore, _normalize_source_value  # noqa: E402
@@ -63,6 +65,43 @@ class ImportCandidate:
 
 
 @dataclass(frozen=True)
+class SummaryCandidate:
+    source_summary_id: str
+    source_conversation_id: int
+    source_session: str
+    target_session_id: str
+    source: str
+    depth: int
+    kind: str
+    summary: str
+    token_count: int
+    source_message_token_count: int
+    descendant_token_count: int
+    created_at: float
+    earliest_at: float
+    latest_at: float
+    expand_hint: str
+    message_ids: list[int]
+    parent_summary_ids: list[str]
+
+    def is_condensed(self) -> bool:
+        if self.kind == "condensed":
+            return True
+        if self.kind == "leaf":
+            return False
+        return bool(self.parent_summary_ids) or self.depth > 0
+
+
+@dataclass
+class SummaryImportStats:
+    scanned: int = 0
+    would_import: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    skipped_unresolved: int = 0
+
+
+@dataclass(frozen=True)
 class ImportResult:
     source_db: str
     target_db: str
@@ -75,6 +114,11 @@ class ImportResult:
     skipped_empty: int = 0
     conversations: int = 0
     backup_path: str | None = None
+    summaries_scanned: int = 0
+    summaries_would_import: int = 0
+    summaries_imported: int = 0
+    summaries_skipped_existing: int = 0
+    summaries_skipped_unresolved: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -89,6 +133,11 @@ class ImportResult:
             "skipped_empty": self.skipped_empty,
             "conversations": self.conversations,
             "backup_path": self.backup_path,
+            "summaries_scanned": self.summaries_scanned,
+            "summaries_would_import": self.summaries_would_import,
+            "summaries_imported": self.summaries_imported,
+            "summaries_skipped_existing": self.summaries_skipped_existing,
+            "summaries_skipped_unresolved": self.summaries_skipped_unresolved,
         }
 
 
@@ -159,6 +208,26 @@ def _parse_timestamp(value: Any, fallback: float) -> float:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).timestamp()
+
+
+def _coerce_int(value: Any, fallback: int = 0) -> int:
+    if value in (None, ""):
+        return fallback
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _dedupe_preserving_order(values: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
 
 
 def _safe_segment(value: Any, fallback: str) -> str:
@@ -408,6 +477,147 @@ def _collect_candidates(
     return candidates, len(rows), skipped_empty, len(conversation_ids)
 
 
+def _column_expr(columns: set[str], table_alias: str, column: str, fallback_sql: str) -> str:
+    return f"{table_alias}.{column}" if column in columns else fallback_sql
+
+
+def _load_summary_message_ids(conn: sqlite3.Connection) -> dict[str, list[int]]:
+    if not _table_exists(conn, "summary_messages"):
+        return {}
+    columns = _table_columns(conn, "summary_messages")
+    if "summary_id" not in columns or "message_id" not in columns:
+        return {}
+    order_column = "ordinal" if "ordinal" in columns else "rowid"
+    rows = conn.execute(
+        f"""
+        SELECT summary_id, message_id
+        FROM summary_messages
+        ORDER BY summary_id, {order_column}
+        """
+    ).fetchall()
+    by_summary: dict[str, list[int]] = {}
+    for row in rows:
+        by_summary.setdefault(str(row["summary_id"]), []).append(int(row["message_id"]))
+    return by_summary
+
+
+def _load_summary_parent_ids(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    if not _table_exists(conn, "summary_parents"):
+        return {}
+    columns = _table_columns(conn, "summary_parents")
+    if "summary_id" not in columns or "parent_summary_id" not in columns:
+        return {}
+    order_column = "ordinal" if "ordinal" in columns else "rowid"
+    rows = conn.execute(
+        f"""
+        SELECT summary_id, parent_summary_id
+        FROM summary_parents
+        ORDER BY summary_id, {order_column}
+        """
+    ).fetchall()
+    by_summary: dict[str, list[str]] = {}
+    for row in rows:
+        by_summary.setdefault(str(row["summary_id"]), []).append(str(row["parent_summary_id"]))
+    return by_summary
+
+
+def _collect_summary_candidates(
+    conn: sqlite3.Connection,
+    *,
+    namespace: str,
+    agent: str,
+    session_identity: str,
+) -> list[SummaryCandidate]:
+    if not _table_exists(conn, "summaries"):
+        return []
+    _require_columns(conn, "summaries", ["summary_id", "conversation_id"])
+
+    summary_cols = _table_columns(conn, "summaries")
+    content_column = next(
+        (column for column in ("content", "summary", "summary_text", "text") if column in summary_cols),
+        None,
+    )
+    if content_column is None:
+        raise ValueError("source DB table 'summaries' missing required columns: content")
+
+    conversation_cols = _table_columns(conn, "conversations")
+    session_key_expr = "c.session_key" if "session_key" in conversation_cols else "NULL"
+    conversation_created_expr = "c.created_at" if "created_at" in conversation_cols else "NULL"
+    depth_expr = _column_expr(summary_cols, "s", "depth", "0")
+    kind_expr = _column_expr(summary_cols, "s", "kind", "NULL")
+    token_count_expr = _column_expr(summary_cols, "s", "token_count", "0")
+    source_message_token_count_expr = _column_expr(summary_cols, "s", "source_message_token_count", "0")
+    descendant_token_count_expr = _column_expr(summary_cols, "s", "descendant_token_count", "0")
+    created_at_expr = _column_expr(summary_cols, "s", "created_at", conversation_created_expr)
+    earliest_at_expr = _column_expr(summary_cols, "s", "earliest_at", created_at_expr)
+    latest_at_expr = _column_expr(summary_cols, "s", "latest_at", created_at_expr)
+    expand_hint_expr = _column_expr(summary_cols, "s", "expand_hint", "''")
+
+    summary_messages = _load_summary_message_ids(conn)
+    summary_parents = _load_summary_parent_ids(conn)
+    now = time.time()
+    rows = conn.execute(
+        f"""
+        SELECT
+            s.summary_id,
+            s.conversation_id,
+            {depth_expr} AS depth,
+            {kind_expr} AS kind,
+            s.{content_column} AS content,
+            {token_count_expr} AS token_count,
+            {source_message_token_count_expr} AS source_message_token_count,
+            {descendant_token_count_expr} AS descendant_token_count,
+            {created_at_expr} AS created_at,
+            {earliest_at_expr} AS earliest_at,
+            {latest_at_expr} AS latest_at,
+            {expand_hint_expr} AS expand_hint,
+            c.session_id AS conversation_session_id,
+            {session_key_expr} AS conversation_session_key,
+            {conversation_created_expr} AS conversation_created_at
+        FROM summaries s
+        JOIN conversations c ON c.conversation_id = s.conversation_id
+        ORDER BY depth, created_at, s.summary_id
+        """
+    ).fetchall()
+
+    candidates: list[SummaryCandidate] = []
+    for row in rows:
+        source_summary_id = str(row["summary_id"])
+        conversation_id = int(row["conversation_id"])
+        source_session = _resolve_source_session(
+            row,
+            conversation_id=conversation_id,
+            session_identity=session_identity,
+        )
+        source = _target_source(namespace, agent, source_session)
+        created_at = _parse_timestamp(
+            row["created_at"],
+            _parse_timestamp(row["conversation_created_at"], now),
+        )
+        candidates.append(
+            SummaryCandidate(
+                source_summary_id=source_summary_id,
+                source_conversation_id=conversation_id,
+                source_session=source_session,
+                target_session_id=source,
+                source=source,
+                depth=_coerce_int(row["depth"], 0),
+                kind=str(row["kind"] or "").strip().lower(),
+                summary=str(row["content"] or ""),
+                token_count=_coerce_int(row["token_count"], 0),
+                source_message_token_count=_coerce_int(row["source_message_token_count"], 0),
+                descendant_token_count=_coerce_int(row["descendant_token_count"], 0),
+                created_at=created_at,
+                earliest_at=_parse_timestamp(row["earliest_at"], created_at),
+                latest_at=_parse_timestamp(row["latest_at"], created_at),
+                expand_hint=str(row["expand_hint"] or ""),
+                message_ids=summary_messages.get(source_summary_id, []),
+                parent_summary_ids=summary_parents.get(source_summary_id, []),
+            )
+        )
+    return candidates
+
+
 def _target_has_import_table(conn: sqlite3.Connection) -> bool:
     return _table_exists(conn, "lcm_imported_messages")
 
@@ -432,6 +642,237 @@ def _ensure_import_table(conn: sqlite3.Connection) -> None:
             ON lcm_imported_messages(target_store_id)
         """
     )
+
+
+def _ensure_summary_nodes_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS summary_nodes (
+            node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            depth INTEGER NOT NULL DEFAULT 0,
+            summary TEXT NOT NULL,
+            token_count INTEGER DEFAULT 0,
+            source_token_count INTEGER DEFAULT 0,
+            source_ids TEXT NOT NULL DEFAULT '[]',
+            source_type TEXT NOT NULL DEFAULT 'messages',
+            created_at REAL NOT NULL,
+            earliest_at REAL,
+            latest_at REAL,
+            expand_hint TEXT DEFAULT ''
+        );
+        CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
+            ON summary_nodes(session_id, depth, created_at);
+        """
+    )
+    columns = _table_columns(conn, "summary_nodes")
+    if "earliest_at" not in columns:
+        conn.execute("ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL")
+    if "latest_at" not in columns:
+        conn.execute("ALTER TABLE summary_nodes ADD COLUMN latest_at REAL")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
+    )
+    ensure_external_content_fts(conn, build_nodes_fts_spec())
+
+
+def _ensure_summary_import_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_imported_summaries (
+            import_id TEXT NOT NULL,
+            source_summary_id TEXT NOT NULL,
+            source_conversation_id INTEGER NOT NULL,
+            source_session TEXT NOT NULL,
+            target_node_id INTEGER NOT NULL,
+            imported_at REAL NOT NULL,
+            PRIMARY KEY (import_id, source_summary_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_lcm_imported_summaries_target
+            ON lcm_imported_summaries(target_node_id)
+        """
+    )
+
+
+def _imported_message_map_from_conn(conn: sqlite3.Connection, import_id: str) -> dict[int, int]:
+    if not _target_has_import_table(conn):
+        return {}
+    rows = conn.execute(
+        """SELECT source_message_id, target_store_id
+           FROM lcm_imported_messages
+           WHERE import_id = ?""",
+        (import_id,),
+    ).fetchall()
+    return {int(row[0]): int(row[1]) for row in rows}
+
+
+def _imported_summary_map_from_conn(conn: sqlite3.Connection, import_id: str) -> dict[str, int]:
+    if not _table_exists(conn, "lcm_imported_summaries"):
+        return {}
+    rows = conn.execute(
+        """SELECT source_summary_id, target_node_id
+           FROM lcm_imported_summaries
+           WHERE import_id = ?""",
+        (import_id,),
+    ).fetchall()
+    return {str(row[0]): int(row[1]) for row in rows}
+
+
+def _target_imported_message_map(target_db: Path, import_id: str) -> dict[int, int]:
+    if not target_db.exists():
+        return {}
+    conn = sqlite3.connect(_readonly_sqlite_uri(target_db), uri=True)
+    try:
+        return _imported_message_map_from_conn(conn, import_id)
+    finally:
+        conn.close()
+
+
+def _target_imported_summary_map(target_db: Path, import_id: str) -> dict[str, int]:
+    if not target_db.exists():
+        return {}
+    conn = sqlite3.connect(_readonly_sqlite_uri(target_db), uri=True)
+    try:
+        return _imported_summary_map_from_conn(conn, import_id)
+    finally:
+        conn.close()
+
+
+def _insert_summary_node(
+    conn: sqlite3.Connection,
+    *,
+    import_id: str,
+    candidate: SummaryCandidate,
+    source_ids: list[int],
+    source_type: str,
+) -> int:
+    source_token_count = (
+        candidate.descendant_token_count
+        if source_type == "nodes"
+        else candidate.source_message_token_count
+    )
+    depth = candidate.depth
+    if source_type == "nodes" and depth <= 0:
+        depth = 1
+    cur = conn.execute(
+        """INSERT INTO summary_nodes
+           (session_id, depth, summary, token_count, source_token_count,
+            source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            candidate.target_session_id,
+            depth,
+            candidate.summary,
+            candidate.token_count,
+            source_token_count,
+            json.dumps(source_ids),
+            source_type,
+            candidate.created_at,
+            candidate.earliest_at,
+            candidate.latest_at,
+            candidate.expand_hint,
+        ),
+    )
+    node_id = int(cur.lastrowid)
+    conn.execute(
+        """INSERT INTO lcm_imported_summaries
+           (import_id, source_summary_id, source_conversation_id, source_session,
+            target_node_id, imported_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (
+            import_id,
+            candidate.source_summary_id,
+            candidate.source_conversation_id,
+            candidate.source_session,
+            node_id,
+            time.time(),
+        ),
+    )
+    return node_id
+
+
+def _resolve_all_ids(source_ids: Iterable[Any], mapping: dict[Any, int]) -> list[int] | None:
+    resolved: list[int] = []
+    for source_id in source_ids:
+        if source_id not in mapping:
+            return None
+        resolved.append(mapping[source_id])
+    if not resolved:
+        return None
+    return _dedupe_preserving_order(resolved)
+
+
+def _process_summary_candidates(
+    *,
+    conn: sqlite3.Connection | None,
+    import_id: str,
+    candidates: list[SummaryCandidate],
+    imported_messages: dict[int, int],
+    imported_summaries: dict[str, int],
+    dry_run: bool,
+) -> SummaryImportStats:
+    stats = SummaryImportStats(scanned=len(candidates))
+    summary_to_node = dict(imported_summaries)
+    virtual_node_id = -1
+
+    def record_import(candidate: SummaryCandidate, source_ids: list[int], source_type: str) -> None:
+        nonlocal virtual_node_id
+        if dry_run:
+            summary_to_node[candidate.source_summary_id] = virtual_node_id
+            virtual_node_id -= 1
+            stats.would_import += 1
+            return
+        if conn is None:
+            raise ValueError("conn is required when dry_run is false")
+        node_id = _insert_summary_node(
+            conn,
+            import_id=import_id,
+            candidate=candidate,
+            source_ids=source_ids,
+            source_type=source_type,
+        )
+        summary_to_node[candidate.source_summary_id] = node_id
+        stats.imported += 1
+
+    leaf_candidates = [candidate for candidate in candidates if not candidate.is_condensed()]
+    condensed_remaining = sorted(
+        (candidate for candidate in candidates if candidate.is_condensed()),
+        key=lambda candidate: (candidate.depth, candidate.source_summary_id),
+    )
+
+    for candidate in leaf_candidates:
+        if candidate.source_summary_id in summary_to_node:
+            stats.skipped_existing += 1
+            continue
+        source_ids = _resolve_all_ids(candidate.message_ids, imported_messages)
+        if source_ids is None:
+            stats.skipped_unresolved += 1
+            continue
+        record_import(candidate, source_ids, "messages")
+
+    while condensed_remaining:
+        progressed = False
+        next_remaining: list[SummaryCandidate] = []
+        for candidate in condensed_remaining:
+            if candidate.source_summary_id in summary_to_node:
+                stats.skipped_existing += 1
+                continue
+            source_ids = _resolve_all_ids(candidate.parent_summary_ids, summary_to_node)
+            if source_ids is None:
+                next_remaining.append(candidate)
+                continue
+            record_import(candidate, source_ids, "nodes")
+            progressed = True
+        if not progressed:
+            stats.skipped_unresolved += len(next_remaining)
+            break
+        condensed_remaining = next_remaining
+
+    return stats
 
 
 def _existing_source_message_ids(target_db: Path, import_id: str) -> set[int]:
@@ -478,6 +919,7 @@ def import_lossless_claw(
     agent: str = "unknown",
     import_id: str | None = None,
     session_identity: str = "session_id",
+    include_summaries: bool = False,
     apply: bool = False,
 ) -> ImportResult:
     source_path = Path(source_db)
@@ -496,12 +938,39 @@ def import_lossless_claw(
             agent=agent,
             session_identity=session_identity,
         )
+        summary_candidates = (
+            _collect_summary_candidates(
+                source_conn,
+                namespace=namespace,
+                agent=agent,
+                session_identity=session_identity,
+            )
+            if include_summaries
+            else []
+        )
 
     existing_ids = _existing_source_message_ids(target_path, resolved_import_id)
     to_import = [candidate for candidate in candidates if candidate.source_message_id not in existing_ids]
     skipped_existing = len(candidates) - len(to_import)
 
     if not apply:
+        summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+        if include_summaries:
+            imported_message_map = _target_imported_message_map(target_path, resolved_import_id)
+            next_virtual_store_id = -1
+            for candidate in candidates:
+                if candidate.source_message_id in imported_message_map:
+                    continue
+                imported_message_map[candidate.source_message_id] = next_virtual_store_id
+                next_virtual_store_id -= 1
+            summary_stats = _process_summary_candidates(
+                conn=None,
+                import_id=resolved_import_id,
+                candidates=summary_candidates,
+                imported_messages=imported_message_map,
+                imported_summaries=_target_imported_summary_map(target_path, resolved_import_id),
+                dry_run=True,
+            )
         return ImportResult(
             source_db=str(source_path),
             target_db=str(target_path),
@@ -514,9 +983,27 @@ def import_lossless_claw(
             skipped_empty=skipped_empty,
             conversations=conversations,
             backup_path=None,
+            summaries_scanned=summary_stats.scanned,
+            summaries_would_import=summary_stats.would_import,
+            summaries_imported=0,
+            summaries_skipped_existing=summary_stats.skipped_existing,
+            summaries_skipped_unresolved=summary_stats.skipped_unresolved,
         )
 
-    if not to_import:
+    preflight_summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+    summary_writes_planned = False
+    if include_summaries and not to_import:
+        preflight_summary_stats = _process_summary_candidates(
+            conn=None,
+            import_id=resolved_import_id,
+            candidates=summary_candidates,
+            imported_messages=_target_imported_message_map(target_path, resolved_import_id),
+            imported_summaries=_target_imported_summary_map(target_path, resolved_import_id),
+            dry_run=True,
+        )
+        summary_writes_planned = preflight_summary_stats.would_import > 0
+
+    if not to_import and not summary_writes_planned:
         return ImportResult(
             source_db=str(source_path),
             target_db=str(target_path),
@@ -529,6 +1016,11 @@ def import_lossless_claw(
             skipped_empty=skipped_empty,
             conversations=conversations,
             backup_path=None,
+            summaries_scanned=preflight_summary_stats.scanned,
+            summaries_would_import=0,
+            summaries_imported=0,
+            summaries_skipped_existing=preflight_summary_stats.skipped_existing,
+            summaries_skipped_unresolved=preflight_summary_stats.skipped_unresolved,
         )
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -542,6 +1034,11 @@ def import_lossless_claw(
     )
     conn = store._conn
     _ensure_import_table(conn)
+    imported_message_map = _imported_message_map_from_conn(conn, resolved_import_id)
+    summary_stats = SummaryImportStats(scanned=len(summary_candidates))
+    if include_summaries:
+        _ensure_summary_nodes_schema(conn)
+        _ensure_summary_import_table(conn)
 
     imported = 0
     try:
@@ -594,7 +1091,17 @@ def import_lossless_claw(
                     time.time(),
                 ),
             )
+            imported_message_map[candidate.source_message_id] = int(cur.lastrowid)
             imported += 1
+        if include_summaries:
+            summary_stats = _process_summary_candidates(
+                conn=conn,
+                import_id=resolved_import_id,
+                candidates=summary_candidates,
+                imported_messages=imported_message_map,
+                imported_summaries=_imported_summary_map_from_conn(conn, resolved_import_id),
+                dry_run=False,
+            )
         conn.commit()
     except Exception:
         conn.rollback()
@@ -614,6 +1121,11 @@ def import_lossless_claw(
         skipped_empty=skipped_empty,
         conversations=conversations,
         backup_path=backup_path,
+        summaries_scanned=summary_stats.scanned,
+        summaries_would_import=0,
+        summaries_imported=summary_stats.imported,
+        summaries_skipped_existing=summary_stats.skipped_existing,
+        summaries_skipped_unresolved=summary_stats.skipped_unresolved,
     )
 
 
@@ -637,6 +1149,11 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--apply", action="store_true", help="Write rows to the target DB. Omit for dry-run")
+    parser.add_argument(
+        "--include-summaries",
+        action="store_true",
+        help="Also migrate OpenClaw summaries into Hermes summary_nodes",
+    )
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON summary")
     return parser
 
@@ -651,6 +1168,7 @@ def main(argv: list[str] | None = None) -> int:
         agent=args.agent,
         import_id=args.import_id,
         session_identity=args.session_identity,
+        include_summaries=args.include_summaries,
         apply=args.apply,
     )
     if args.json:
@@ -668,6 +1186,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  imported: {result.imported}")
         print(f"  skipped_existing: {result.skipped_existing}")
         print(f"  skipped_empty: {result.skipped_empty}")
+        if args.include_summaries:
+            print(f"  summaries_scanned: {result.summaries_scanned}")
+            print(f"  summaries_would_import: {result.summaries_would_import}")
+            print(f"  summaries_imported: {result.summaries_imported}")
+            print(f"  summaries_skipped_existing: {result.summaries_skipped_existing}")
+            print(f"  summaries_skipped_unresolved: {result.summaries_skipped_unresolved}")
         if result.backup_path:
             print(f"  backup_path: {result.backup_path}")
     return 0

--- a/scripts/repair_lcm_dag.py
+++ b/scripts/repair_lcm_dag.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+LCM DAG repair script: backfill lcm_lifecycle_state entries for sessions that
+have summary_nodes but no lifecycle entry, and rebuild the DAG frontier for
+orphaned sessions so condensation works correctly.
+
+Usage:
+    python3 ~/.hermes/scripts/repair_lcm_dag.py [--dry-run]
+
+Root causes fixed:
+  1. Sessions with summary_nodes but NO lcm_lifecycle_state entry
+     → lcm_lifecycle_state.bind_session() was never called for these sessions
+  2. Sessions with messages but no frontier advance after compression
+     → _persist_frontier_marker() not called for sessions not via lifecycle
+  3. cache_friendly_condensation suppressing condensation when debt is 1 group
+     → With fanin=4, min_debt_groups=2, needed 8 uncondensed before follow-on
+     → Fixed via LCM_CONDENSATION_FANIN=2 in hermes-gateway.service
+
+Env vars (from hermes-gateway.service):
+    LCM_CONTEXT_THRESHOLD=0.35
+    LCM_INCREMENTAL_MAX_DEPTH=3
+    LCM_FRESH_TAIL_COUNT=24
+    LCM_CONDENSATION_FANIN=2
+    LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true
+    LCM_CACHE_FRIENDLY_CONDENSATION_ENABLED=false
+"""
+
+import os
+import sys
+import time
+import sqlite3
+import argparse
+
+HERMES_HOME = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+DB_PATH = os.path.join(HERMES_HOME, "lcm.db")
+
+
+def get_session_frontier(conn, session_id: str) -> int:
+    """Get the last store_id for a session (last message store_id)."""
+    result = conn.execute(
+        "SELECT MAX(store_id) FROM messages WHERE session_id = ?", (session_id,)
+    ).fetchone()[0]
+    return result or 0
+
+
+def backfill_lifecycle_state(conn, dry_run: bool = False) -> int:
+    """Add lcm_lifecycle_state entries for sessions that have summary_nodes but no entry."""
+    rows = conn.execute("""
+        SELECT DISTINCT sn.session_id
+        FROM summary_nodes sn
+        LEFT JOIN lcm_lifecycle_state lcs ON lcs.conversation_id = sn.session_id
+        WHERE lcs.conversation_id IS NULL
+    """).fetchall()
+
+    fixed = 0
+    for (session_id,) in rows:
+        frontier = get_session_frontier(conn, session_id)
+        label = session_id[:30]
+        if dry_run:
+            print(f"  [DRY RUN] Would insert lifecycle for session={label}, frontier={frontier}")
+        else:
+            now = time.time()
+            conn.execute("""
+                INSERT OR IGNORE INTO lcm_lifecycle_state(
+                    conversation_id, current_session_id, last_finalized_session_id,
+                    current_frontier_store_id, last_finalized_frontier_store_id,
+                    debt_kind, debt_size_estimate, current_bound_at, last_finalized_at,
+                    debt_updated_at, last_maintenance_attempt_at, last_rollover_at,
+                    last_reset_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                session_id, session_id, session_id,
+                frontier, frontier,
+                None, 0, now, now, None, None, now, None, now,
+            ))
+            print(f"  [FIXED] Inserted lifecycle for session={label}, frontier={frontier}")
+        fixed += 1
+
+    return fixed
+
+
+def fix_frontier_gaps(conn, dry_run: bool = False) -> int:
+    """Update current_frontier_store_id for sessions that have summary_nodes."""
+    rows = conn.execute("SELECT DISTINCT session_id FROM summary_nodes").fetchall()
+
+    fixed = 0
+    for (session_id,) in rows:
+        # Get max store_id across all source_ids in this session's nodes
+        max_src_id = conn.execute("""
+            SELECT MAX(CAST(value AS INTEGER))
+            FROM summary_nodes, json_each(source_ids)
+            WHERE session_id = ?
+        """, (session_id,)).fetchone()[0]
+
+        if max_src_id is None:
+            continue
+
+        label = session_id[:30]
+        if dry_run:
+            print(f"  [DRY RUN] Would update frontier for session={label}: -> {max_src_id}")
+        else:
+            conn.execute("""
+                UPDATE lcm_lifecycle_state
+                SET current_frontier_store_id = MAX(current_frontier_store_id, ?),
+                    last_finalized_frontier_store_id = MAX(last_finalized_frontier_store_id, ?),
+                    updated_at = ?
+                WHERE conversation_id = ?
+            """, (max_src_id, max_src_id, time.time(), session_id))
+            print(f"  [FIXED] Updated frontier for session={label}: -> {max_src_id}")
+        fixed += 1
+
+    return fixed
+
+
+def report_state(conn) -> None:
+    """Print current DAG and lifecycle state."""
+    total_nodes = conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0]
+    depth_dist = conn.execute("""
+        SELECT depth, COUNT(*), SUM(token_count), SUM(source_token_count)
+        FROM summary_nodes GROUP BY depth ORDER BY depth
+    """).fetchall()
+
+    print(f"\n  Total summary nodes: {total_nodes}")
+    for d, cnt, tok, src_tok in depth_dist:
+        ratio = src_tok / tok if tok else 0
+        print(f"    d{d}: {cnt} nodes, {tok:,} tok, {ratio:.1f}x src ratio")
+
+    sessions_with_nodes = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) FROM summary_nodes"
+    ).fetchone()[0]
+    total_sessions = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) FROM messages"
+    ).fetchone()[0]
+    print(f"\n  Sessions with nodes: {sessions_with_nodes}/{total_sessions}")
+
+    orphan = conn.execute("""
+        SELECT COUNT(DISTINCT sn.session_id)
+        FROM summary_nodes sn
+        LEFT JOIN lcm_lifecycle_state lcs ON lcs.conversation_id = sn.session_id
+        WHERE lcs.conversation_id IS NULL
+    """).fetchone()[0]
+    print(f"  Sessions with nodes but NO lifecycle entry: {orphan}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Repair LCM DAG lifecycle state")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(DB_PATH)
+
+    print("=" * 60)
+    print("LCM DAG REPAIR")
+    print("=" * 60)
+
+    print("\n[1] Backfilling lcm_lifecycle_state for sessions with nodes but no entry...")
+    fixed = backfill_lifecycle_state(conn, dry_run=args.dry_run)
+    print(f"  → {fixed} session(s) processed")
+
+    print("\n[2] Fixing frontier gaps for sessions with summary_nodes...")
+    fixed2 = fix_frontier_gaps(conn, dry_run=args.dry_run)
+    print(f"  → {fixed2} session(s) processed")
+
+    print("\n[3] Current DAG state:")
+    report_state(conn)
+
+    conn.close()
+
+    if args.dry_run:
+        print("\n[DRY RUN] No changes made. Remove --dry-run to apply fixes.")
+    else:
+        print("\n[DONE] LCM DAG repair complete.")
+        print("  Note: New compression cycles will build depth>0 nodes.")
+        print("  Existing depth-0 nodes are preserved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_lcm.dag import SummaryDAG
 from hermes_lcm.store import MessageStore
 
 
@@ -101,6 +102,158 @@ def add_shared_session_key_conversation(db_path: Path) -> None:
         """INSERT INTO messages
            (message_id, conversation_id, seq, role, content, token_count, created_at)
            VALUES (12, 2, 1, 'user', 'hello from second conversation', 5, '2026-04-20 12:01:01')"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def create_summary_tables(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE summaries (
+            summary_id TEXT PRIMARY KEY,
+            conversation_id INTEGER NOT NULL,
+            depth INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            content TEXT NOT NULL,
+            token_count INTEGER NOT NULL DEFAULT 0,
+            source_message_token_count INTEGER NOT NULL DEFAULT 0,
+            descendant_token_count INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            earliest_at TEXT NOT NULL,
+            latest_at TEXT NOT NULL,
+            expand_hint TEXT DEFAULT ''
+        );
+        CREATE TABLE summary_messages (
+            summary_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            ordinal INTEGER NOT NULL
+        );
+        CREATE TABLE summary_parents (
+            summary_id TEXT NOT NULL,
+            parent_summary_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL
+        );
+        """
+    )
+
+
+def add_lossless_summaries(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('leaf-1', 1, 0, 'leaf', 'leaf pineapple memory', 5,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   'leaf hint')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('condensed-1', 1, 1, 'condensed', 'condensed pineapple memory', 7,
+                   0, 33, '2026-04-20 12:00:20',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:20',
+                   'condensed hint')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("leaf-1", 10, 0), ("leaf-1", 10, 1), ("leaf-1", 11, 2)],
+    )
+    conn.execute(
+        """INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+           VALUES ('condensed-1', 'leaf-1', 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_unresolved_leaf_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO messages
+           (message_id, conversation_id, seq, role, content, token_count, created_at)
+           VALUES (12, 1, 3, 'assistant', '', 0, '2026-04-20 12:00:03')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('empty-leaf', 1, 0, 'leaf', 'unresolvable empty stub summary', 3,
+                   9, 0, '2026-04-20 12:00:11',
+                   '2026-04-20 12:00:03', '2026-04-20 12:00:03',
+                   '')"""
+    )
+    conn.execute(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES ('empty-leaf', 12, 0)"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_partially_unresolved_leaf_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('partial-leaf', 1, 0, 'leaf', 'partial leaf should not import', 3,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   '')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("partial-leaf", 10, 0), ("partial-leaf", 999, 1)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_partially_unresolved_parent_summary(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    create_summary_tables(conn)
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('leaf-1', 1, 0, 'leaf', 'leaf parent can import', 5,
+                   15, 0, '2026-04-20 12:00:10',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:02',
+                   '')"""
+    )
+    conn.execute(
+        """INSERT INTO summaries
+           (summary_id, conversation_id, depth, kind, content, token_count,
+            source_message_token_count, descendant_token_count,
+            created_at, earliest_at, latest_at, expand_hint)
+           VALUES ('partial-condensed', 1, 1, 'condensed', 'partial condensed should not import', 7,
+                   0, 33, '2026-04-20 12:00:20',
+                   '2026-04-20 12:00:01', '2026-04-20 12:00:20',
+                   '')"""
+    )
+    conn.executemany(
+        """INSERT INTO summary_messages (summary_id, message_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("leaf-1", 10, 0), ("leaf-1", 11, 1)],
+    )
+    conn.executemany(
+        """INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+           VALUES (?, ?, ?)""",
+        [("partial-condensed", "leaf-1", 0), ("partial-condensed", "missing-parent", 1)],
     )
     conn.commit()
     conn.close()
@@ -207,6 +360,212 @@ def test_dry_run_handles_uri_reserved_source_db_path(tmp_path: Path):
     assert result.scanned == 2
     assert result.eligible == 2
     assert result.would_import == 2
+    assert not target_db.exists()
+
+
+def test_apply_imports_lossless_summaries_as_summary_nodes(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        namespace="openclaw-lcm",
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 2
+    conn = sqlite3.connect(target_db)
+    conn.row_factory = sqlite3.Row
+    message_map = {
+        int(row["source_message_id"]): int(row["target_store_id"])
+        for row in conn.execute(
+            """SELECT source_message_id, target_store_id
+               FROM lcm_imported_messages
+               WHERE import_id = 'fixture-import'"""
+        )
+    }
+    rows = conn.execute(
+        """SELECT node_id, depth, summary, source_token_count, source_ids,
+                  source_type, created_at, earliest_at, latest_at
+           FROM summary_nodes
+           ORDER BY depth, node_id"""
+    ).fetchall()
+    fts_count = conn.execute(
+        "SELECT COUNT(*) FROM nodes_fts WHERE nodes_fts MATCH ?",
+        ("pineapple",),
+    ).fetchone()[0]
+    conn.close()
+
+    assert len(rows) == 2
+    leaf = rows[0]
+    condensed = rows[1]
+    assert leaf["source_type"] == "messages"
+    assert json.loads(leaf["source_ids"]) == [message_map[10], message_map[11]]
+    assert condensed["source_type"] == "nodes"
+    assert json.loads(condensed["source_ids"]) == [leaf["node_id"]]
+    assert leaf["source_token_count"] == 15
+    assert condensed["source_token_count"] == 33
+    dag = SummaryDAG(target_db)
+    condensed_node = dag.get_node(condensed["node_id"])
+    assert condensed_node is not None
+    assert [node.node_id for node in dag.get_source_nodes(condensed_node)] == [leaf["node_id"]]
+    subtree = dag.describe_subtree(condensed["node_id"])
+    dag.close()
+    assert subtree["source_type"] == "nodes"
+    assert subtree["children"] == [
+        {
+            "node_id": leaf["node_id"],
+            "depth": 0,
+            "token_count": 5,
+            "source_token_count": 15,
+            "expand_hint": "leaf hint",
+        }
+    ]
+    assert leaf["created_at"] == pytest.approx(1776686410.0)
+    assert leaf["earliest_at"] == pytest.approx(1776686401.0)
+    assert leaf["latest_at"] == pytest.approx(1776686402.0)
+    assert condensed["created_at"] == pytest.approx(1776686420.0)
+    assert condensed["earliest_at"] == pytest.approx(1776686401.0)
+    assert condensed["latest_at"] == pytest.approx(1776686420.0)
+    assert fts_count == 2
+
+
+def test_apply_summary_import_is_idempotent_for_same_import_id(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    first = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+    second = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert first.summaries_imported == 2
+    assert second.summaries_imported == 0
+    assert second.summaries_skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 2
+    conn.close()
+
+
+def test_summary_leaf_with_only_skipped_empty_messages_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_unresolved_leaf_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.skipped_empty == 1
+    assert result.summaries_imported == 0
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 0
+    conn.close()
+
+
+def test_summary_leaf_with_partially_unresolved_messages_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_partially_unresolved_leaf_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 0
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    assert conn.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 0
+    conn.close()
+
+
+def test_summary_condensed_with_partially_unresolved_parents_is_skipped(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_partially_unresolved_parent_summary(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=True,
+    )
+
+    assert result.imported == 2
+    assert result.summaries_imported == 1
+    assert result.summaries_skipped_unresolved == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT depth, summary, source_type FROM summary_nodes ORDER BY node_id"
+    ).fetchall()
+    assert rows == [(0, "leaf parent can import", "messages")]
+    assert conn.execute("SELECT COUNT(*) FROM lcm_imported_summaries").fetchone()[0] == 1
+    conn.close()
+
+
+def test_dry_run_include_summaries_does_not_create_target_db(tmp_path: Path):
+    importer = load_importer_module()
+    source_db = tmp_path / "lossless.db"
+    target_db = tmp_path / "target-lcm.db"
+    create_lossless_source(source_db)
+    add_lossless_summaries(source_db)
+
+    result = importer.import_lossless_claw(
+        source_db=source_db,
+        target_db=target_db,
+        agent="sammy",
+        import_id="fixture-import",
+        include_summaries=True,
+        apply=False,
+    )
+
+    assert result.summaries_would_import == 2
     assert not target_db.exists()
 
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -335,9 +335,10 @@ class TestProviderPrefixedAuxiliaryCalls:
 class TestConfig:
     def test_defaults(self):
         c = LCMConfig()
-        assert c.fresh_tail_count == 64
+        assert c.fresh_tail_count == 32
         assert c.leaf_chunk_tokens == 20_000
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
+        assert c.incremental_max_depth == 3
         assert c.condensation_fanin == 4
         assert c.dynamic_leaf_chunk_enabled is False
         assert c.dynamic_leaf_chunk_max == 40_000
@@ -434,9 +435,9 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.fresh_tail_count == 64
+        assert c.fresh_tail_count == 32
         assert c.leaf_chunk_tokens == 20_000
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
         assert c.max_assembly_tokens == 0
         assert c.reserve_tokens_floor == 0
         assert c.expansion_context_tokens == 32_000
@@ -452,6 +453,21 @@ class TestConfig:
         c = LCMConfig.from_env()
 
         assert c.context_threshold == 0.68
+
+    def test_from_env_lcm_section_overrides_compression_section(self, monkeypatch, tmp_path):
+        """lcm.context_threshold takes priority over compression.threshold."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  threshold: 0.68\n"
+            "lcm:\n  context_threshold: 0.45\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.45
 
     def test_from_env_lcm_threshold_env_overrides_hermes_config(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -116,6 +116,374 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
 
 
+def test_update_model_updates_runtime_metadata_and_context_window(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        base_url="https://opencode.ai/zen/go",
+        api_key="test-key",
+        provider="opencode-go",
+        api_mode="anthropic_messages",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.base_url == "https://opencode.ai/zen/go"
+    assert engine.api_key == "test-key"
+    assert engine.provider == "opencode-go"
+    assert engine.api_mode == "anthropic_messages"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_overwrite_update_model_context_length_with_stale_metadata(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        provider="opencode-go",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="deepseek-v4-flash",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_overwrite_update_model_with_stale_runtime_identity(engine):
+    engine.update_model(
+        model="deepseek-v4-flash",
+        context_length=1_000_000,
+        provider="opencode-go",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="minimax-m2.7",
+        provider="minimax",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "deepseek-v4-flash"
+    assert engine.provider == "opencode-go"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_overwrite_update_model_identity_when_context_length_matches(engine):
+    engine.update_model(
+        model="new-model-same-window",
+        context_length=204_800,
+        base_url="https://new.example/v1",
+        api_key="new-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="old-model-same-window",
+        base_url="https://old.example/v1",
+        api_key="old-key",
+        provider="old-provider",
+        api_mode="anthropic_messages",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "new-model-same-window"
+    assert engine.base_url == "https://new.example/v1"
+    assert engine.api_key == "new-key"
+    assert engine.provider == "new-provider"
+    assert engine.api_mode == "chat_completions"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+
+
+def test_session_start_does_not_clear_or_repopulate_update_model_identity_when_optional_fields_are_empty(engine):
+    engine.update_model(
+        model="new-model-same-window",
+        context_length=204_800,
+        base_url="https://new.example/v1",
+        api_key="new-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="new-model-same-window",
+        base_url="",
+        api_key="",
+        provider="new-provider",
+        api_mode="chat_completions",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.base_url == "https://new.example/v1"
+    assert engine.api_key == "new-key"
+
+    engine.update_model(
+        model="empty-endpoint-model",
+        context_length=204_800,
+        base_url="",
+        api_key="",
+        provider="new-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-3",
+        platform="telegram",
+        model="empty-endpoint-model",
+        base_url="https://old.example/v1",
+        api_key="old-key",
+        provider="new-provider",
+        api_mode="chat_completions",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.base_url == ""
+    assert engine.api_key == ""
+
+
+def test_session_start_can_initialize_context_length_without_update_model(engine):
+    engine.model = ""
+    engine.context_length = 0
+    engine.threshold_tokens = 0
+    engine._context_length_source = ""
+
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="minimax-m2.7",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "minimax-m2.7"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+
+
+def test_session_start_clears_previous_session_context_window_when_new_window_is_missing(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="known-window-model",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens > 0
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="unknown-window-model",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "session_start"
+    assert not engine.should_compress(1_000_000)
+    assert not engine._critical_budget_pressure_reached(observed_tokens=1_000_000)
+
+
+def test_missing_session_start_context_length_does_not_clear_authoritative_update_model_window(engine):
+    engine.update_model(
+        model="resolver-window-model",
+        context_length=1_000_000,
+        provider="resolver-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="resolver-window-model",
+        provider="resolver-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "resolver-window-model"
+    assert engine.provider == "resolver-provider"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+    assert engine._context_length_source == "update_model"
+
+
+def test_missing_session_start_context_length_preserves_update_model_window_with_blank_optional_fields(engine):
+    engine.update_model(
+        model="resolver-window-model",
+        context_length=1_000_000,
+        base_url="https://resolver.example/v1",
+        api_key="resolver-key",
+        provider="resolver-provider",
+        api_mode="chat_completions",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="resolver-window-model",
+        base_url="",
+        api_key="",
+        provider="resolver-provider",
+        api_mode="chat_completions",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "resolver-window-model"
+    assert engine.base_url == "https://resolver.example/v1"
+    assert engine.api_key == "resolver-key"
+    assert engine.provider == "resolver-provider"
+    assert engine.api_mode == "chat_completions"
+    assert engine.context_length == 1_000_000
+    assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+    assert engine._context_length_source == "update_model"
+
+
+def test_missing_session_start_context_length_clears_stale_update_model_window_for_new_runtime(engine):
+    engine.update_model(
+        model="previous-resolver-model",
+        context_length=1_000_000,
+        provider="previous-provider",
+    )
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-resolver-model",
+        provider="previous-provider",
+        context_length=1_000_000,
+        conversation_id="telegram:chat-1",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="session-only-model",
+        provider="session-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "session-only-model"
+    assert engine.provider == "session-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "session_start"
+
+
+def test_update_model_zero_window_ignores_stale_positive_session_metadata(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+    engine.update_model(
+        model="unknown-window-model",
+        context_length=0,
+        provider="unknown-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.provider == "unknown-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "update_model"
+
+
+def test_update_model_zero_window_ignores_stale_zero_session_metadata(engine):
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+    engine.update_model(
+        model="unknown-window-model",
+        context_length=0,
+        provider="unknown-provider",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="previous-window-model",
+        provider="previous-provider",
+        context_length=0,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "unknown-window-model"
+    assert engine.provider == "unknown-provider"
+    assert engine.context_length == 0
+    assert engine.threshold_tokens == 0
+    assert engine._context_length_source == "update_model"
+
+
+def test_positive_session_start_context_length_replaces_consumed_update_model_window_for_new_runtime(engine):
+    engine.update_model(
+        model="previous-resolver-model",
+        context_length=1_000_000,
+        provider="previous-provider",
+    )
+    engine.on_session_start(
+        "telegram:chat-1:session-1",
+        platform="telegram",
+        model="previous-resolver-model",
+        provider="previous-provider",
+        context_length=1_000_000,
+        conversation_id="telegram:chat-1",
+    )
+
+    engine.on_session_start(
+        "telegram:chat-1:session-2",
+        platform="telegram",
+        model="session-only-model",
+        provider="session-provider",
+        context_length=204_800,
+        conversation_id="telegram:chat-1",
+    )
+
+    assert engine.model == "session-only-model"
+    assert engine.provider == "session-provider"
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine._config.context_threshold)
+    assert engine._context_length_source == "session_start"
+
+
 def test_lcm_tool_status_forwards_filter_config_to_agent_surface(tmp_path, monkeypatch):
     from hermes_lcm import message_patterns as message_patterns_mod
 

--- a/tests/test_lcm_rotate.py
+++ b/tests/test_lcm_rotate.py
@@ -1,0 +1,489 @@
+"""Tests for /lcm rotate command surface and engine rotate path."""
+
+import importlib
+import os
+import re
+from pathlib import Path
+
+from hermes_lcm.command import handle_lcm_command
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _build_engine(tmp_path, *, fresh_tail_count: int = 3) -> LCMEngine:
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_rotate_test.db")
+    config.fresh_tail_count = fresh_tail_count
+    hermes_home = tmp_path / "hermes_home"
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session", conversation_id="live-session")
+    engine.context_length = 200000
+    engine.threshold_tokens = int(200000 * config.context_threshold)
+    return engine
+
+
+def _seed_messages(engine: LCMEngine, count: int) -> None:
+    for index in range(count):
+        engine._store.append(
+            engine._session_id,
+            {"role": "user", "content": f"message-{index}"},
+            source="test",
+        )
+    engine._store._conn.commit()
+
+
+def _extract_field(result: str, key: str) -> str:
+    line = next(
+        (line for line in result.splitlines() if line.startswith(f"{key}: ")),
+        None,
+    )
+    assert line is not None, f"expected {key} in output:\n{result}"
+    return line.split(": ", 1)[1]
+
+
+def test_rotate_preview_reports_planned_frontier_without_mutating(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "LCM rotate" in result
+    assert "status: preview" in result
+    assert "total_message_count: 10" in result
+    assert "fresh_tail_count: 3" in result
+    assert "pre_tail_message_count: 7" in result
+    assert "current_frontier_store_id: 0" in result
+    # New frontier should be store_id of last pre-tail message (7).
+    assert "new_frontier_store_id: 7" in result
+    assert "rotate_backup_path:" in result
+    assert "note: read-only preview" in result
+
+    # Confirm no mutation: frontier still 0 in lifecycle state.
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+    # Confirm no backup was written.
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_preview_reports_noop_when_total_messages_within_tail(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=5)
+    _seed_messages(engine, count=3)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: noop" in result
+    assert "reason: no_pre_tail_content" in result
+    assert "total_message_count: 3" in result
+
+
+def test_rotate_apply_advances_frontier_and_writes_rolling_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "LCM rotate apply" in result
+    assert "status: ok" in result
+    assert "previous_frontier_store_id: 0" in result
+    assert "new_frontier_store_id: 7" in result
+    assert "note: rolling backup overwrites the previous rotate-latest slot" in result
+    backup_path = Path(_extract_field(result, "rotate_backup_path"))
+    assert backup_path.exists()
+    assert backup_path.name.endswith("-rotate-latest.sqlite3")
+    # Backup size line uses _fmt_size formatting (e.g. "12.0 KB"); assert
+    # it exists and is non-empty rather than pinning the exact representation.
+    backup_size_str = _extract_field(result, "rotate_backup_size")
+    assert backup_size_str.strip()
+
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 7
+    # The in-process source-mapping marker must NOT advance here. Pre-tail
+    # raw messages may still be present in the host's in-memory active
+    # context; advancing the marker would break source_ids lineage on the
+    # next in-process compress(). The persisted lifecycle frontier is the
+    # bootstrap signal; the in-process marker is only updated by actual
+    # compaction inside this process. See the regression at
+    # test_rotate_apply_does_not_corrupt_source_lineage_on_next_compress.
+    assert engine._last_compacted_store_id == 0
+
+
+def test_rotate_apply_preserves_raw_messages_for_lossless_recovery(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=2)
+    _seed_messages(engine, count=8)
+
+    handle_lcm_command("rotate apply", engine)
+
+    # All 8 raw messages remain in the store after rotate — frontier only
+    # changes the bootstrap replay boundary, never deletes raw history.
+    assert engine._store.get_session_count(engine._session_id) == 8
+    tail = engine._store.get_session_tail(engine._session_id, limit=2)
+    assert [row.get("content") for row in tail] == ["message-6", "message-7"]
+
+
+def test_rotate_apply_rerun_is_idempotent_and_preserves_existing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    first = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in first
+    first_backup = Path(_extract_field(first, "rotate_backup_path"))
+    assert first_backup.exists()
+    first_size = first_backup.stat().st_size
+    first_mtime = first_backup.stat().st_mtime
+
+    second = handle_lcm_command("rotate apply", engine)
+    assert "status: noop" in second
+    assert "reason: frontier_already_ahead" in second
+    assert (
+        "rolling backup was not written so the previous rotate-latest snapshot is preserved"
+        in second
+    )
+
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 7
+
+    # The previous known-good rolling backup must survive a noop rerun. Both
+    # mtime and size are unchanged because the noop short-circuit happens
+    # before any disk write.
+    assert first_backup.exists()
+    assert first_backup.stat().st_mtime == first_mtime
+    assert first_backup.stat().st_size == first_size
+
+
+def test_rotate_apply_rolling_backup_overwrites_prior_slot_on_actual_rotate(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    first = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in first
+    first_backup = Path(_extract_field(first, "rotate_backup_path"))
+    assert first_backup.exists()
+    first_mtime = first_backup.stat().st_mtime
+
+    # Add more messages so the second apply has new content to rotate past
+    # the now-advanced frontier (not a noop).
+    _seed_messages(engine, count=5)
+
+    # Force a measurable mtime delta — SQLite backup() inside the same second
+    # can land on the same mtime granularity on some filesystems.
+    older = first_mtime - 5.0
+    os.utime(first_backup, (older, older))
+
+    second = handle_lcm_command("rotate apply", engine)
+    assert "status: ok" in second
+    second_backup = Path(_extract_field(second, "rotate_backup_path"))
+    assert second_backup == first_backup, "rotate should reuse the rolling slot, not create a new file"
+    assert second_backup.stat().st_mtime > older, "rolling slot mtime should advance on re-rotate"
+
+    # Ensure only one rotate backup exists in the directory — disk usage bounded.
+    rotate_backups = list(first_backup.parent.glob("*-rotate-latest.sqlite3"))
+    assert rotate_backups == [first_backup]
+
+
+def test_rotate_refuses_on_ignored_session(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_ignored = True
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_ignored" in result
+
+
+def test_rotate_refuses_on_stateless_session(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_stateless = True
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_stateless" in result
+
+
+def test_rotate_apply_refuses_on_ignored_session_without_writing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_ignored = True
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_ignored" in result
+    # Backup must not be written when the rotate is refused.
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_apply_refuses_on_stateless_session_without_writing_backup(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=8)
+    engine._session_stateless = True
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: session_stateless" in result
+    assert not engine.rotate_backup_path().exists()
+
+
+def test_rotate_refuses_when_no_session_bound(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    engine._session_id = ""
+    engine._conversation_id = ""
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: refused" in result
+    assert "reason: no_active_session" in result
+
+
+def test_rotate_help_rejects_unknown_subcommand(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+
+    result = handle_lcm_command("rotate something-else", engine)
+
+    # Soft assertion — exact wording may evolve; verify the help text
+    # mentions rotate and rejects the bogus subcommand.
+    assert "rotate" in result
+    assert "apply" in result
+
+
+def test_lcm_status_reports_last_rotate_at_after_apply(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    before = handle_lcm_command("status", engine)
+    assert "last_rotate_at: (never)" in before
+
+    handle_lcm_command("rotate apply", engine)
+
+    after = handle_lcm_command("status", engine)
+    # Pin the format: UTC ISO-8601 with seconds precision and +00:00 offset.
+    assert re.search(
+        r"last_rotate_at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00", after
+    ), f"expected UTC ISO timestamp in status output:\n{after}"
+    assert "last_rotate_at: (never)" not in after
+    # Backup size field is rendered with _fmt_size formatting; assert presence
+    # and non-empty content, not exact bytes.
+    assert "rotate_backup_size: " in after
+    assert "rotate_backup_path:" in after
+
+
+def test_lcm_help_lists_rotate_subcommands(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    result = handle_lcm_command("help", engine)
+    assert "/lcm rotate" in result
+    assert "/lcm rotate apply" in result
+
+
+def test_rotate_handles_session_with_exactly_fresh_tail_count_messages(tmp_path):
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=3)
+
+    result = handle_lcm_command("rotate", engine)
+
+    assert "status: noop" in result
+    assert "reason: no_pre_tail_content" in result
+    assert "total_message_count: 3" in result
+    assert "pre_tail_message_count: 0" in result
+
+
+def test_rotate_empty_tail_branch_returns_noop_shape_without_keyerror(tmp_path):
+    """Concurrent deletion can empty the tail after the count check. The
+    formatter must render a no-op without KeyError.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Force the count-vs-tail mismatch the real concurrent-delete race
+    # would produce: total_count reports 10, but get_session_tail returns
+    # empty. Patch the bound method on this engine's store instance only.
+    original_get_session_tail = engine._store.get_session_tail
+    try:
+        engine._store.get_session_tail = lambda session_id, limit=1000: []  # type: ignore[method-assign]
+        result = handle_lcm_command("rotate", engine)
+    finally:
+        engine._store.get_session_tail = original_get_session_tail  # type: ignore[method-assign]
+
+    assert "status: noop" in result
+    assert "reason: empty_tail" in result
+    # Required fields must be present so command-layer formatters do not crash.
+    assert "pre_tail_message_count: 0" in result
+    assert "new_frontier_store_id: 0" in result
+
+
+def test_rotate_apply_aborts_and_preserves_state_when_backup_write_fails(tmp_path):
+    """Backup-first contract: if the rolling backup write fails, rotate apply
+    must return status:error and leave lifecycle frontier untouched.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Pre-create the backup directory as a regular file so mkdir / write fails.
+    backup_path = engine.rotate_backup_path()
+    backup_dir = backup_path.parent
+    backup_dir.parent.mkdir(parents=True, exist_ok=True)
+    # Replace the would-be backup directory with a regular file to force OSError
+    # on mkdir(parents=True, exist_ok=True) inside _rotate_backup_database.
+    backup_dir.write_text("not a directory")
+
+    try:
+        result = handle_lcm_command("rotate apply", engine)
+    finally:
+        # Clean up the sentinel file so later tests in the same tmp_path do
+        # not interfere — though pytest gives each test its own tmp_path.
+        if backup_dir.exists() and backup_dir.is_file():
+            backup_dir.unlink()
+
+    assert "LCM rotate apply" in result
+    assert "status: error" in result
+    assert "error: backup failed:" in result
+    assert "note: rotate apply aborted before any lifecycle mutation" in result
+
+    # Critical safety guarantee: lifecycle frontier is unchanged.
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+
+def test_rotate_apply_reports_stale_lifecycle_state_when_session_drifts(tmp_path):
+    """advance_frontier silently returns the unchanged state when the lifecycle
+    row's current_session_id no longer matches this engine's session. rotate
+    apply must detect that and surface status:refused reason:stale_lifecycle_state
+    rather than reporting status:ok with a fabricated frontier.
+    """
+    engine = _build_engine(tmp_path, fresh_tail_count=3)
+    _seed_messages(engine, count=10)
+
+    # Simulate session drift: another flow bound a different session id to
+    # this conversation. _bind_lifecycle_state would have updated the row.
+    engine._lifecycle.bind_session("other-session", conversation_id=engine._conversation_id)
+    # Engine's local _session_id stays on the original "live-session".
+
+    result = handle_lcm_command("rotate apply", engine)
+
+    assert "status: refused" in result
+    assert "reason: stale_lifecycle_state" in result
+
+    # The rolling backup WAS written (we passed preflight) — that's expected
+    # with the current ordering. Lifecycle frontier should NOT have advanced
+    # for "live-session".
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == 0
+
+
+def test_rotate_apply_does_not_corrupt_source_lineage_on_next_compress(tmp_path, monkeypatch):
+    """Regression for the issue Tosko4 surfaced on PR #176.
+
+    After /lcm rotate apply, the in-memory active context still holds the
+    pre-rotate raw messages until the host rebuilds it. A normal compress()
+    later in the same process must produce a DAG node whose source_ids
+    reference the same raw rows it summarized — not just the post-rotate
+    tail. Advancing the in-process source-mapping marker on rotate would
+    cause _get_store_ids_for_messages to filter out the pre-rotate rows,
+    producing a poisoned node (text covers msg-0..msg-7, source_ids = [9]).
+    """
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_rotate_lineage.db")
+    config.fresh_tail_count = 3
+    config.leaf_chunk_tokens = 10
+    config.context_threshold = 0.001
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._lifecycle.bind_session("live-session", conversation_id="live-session")
+    engine.context_length = 200000
+    engine.threshold_tokens = int(200000 * config.context_threshold)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    for i in range(10):
+        messages.append({"role": "user", "content": f"msg-{i} " + "x" * 200})
+    for msg in messages[1:]:
+        engine._store.append(engine._session_id, msg, source="test")
+    engine._store._conn.commit()
+
+    # Apply rotate. The persisted frontier moves to 8 (store_id of msg-8,
+    # the second-to-last message; tail keeps the last 3 store rows). The
+    # host's in-memory active context still holds system + msg-0..msg-9.
+    rotate_result = engine.rotate_active_session(apply=True)
+    assert rotate_result["ok"] is True
+    assert rotate_result["noop"] is False
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state is not None
+    assert state.current_frontier_store_id == rotate_result["new_frontier_store_id"]
+    # Critical invariant: the in-process source-mapping marker must NOT
+    # have advanced. If it did, _get_store_ids_for_messages would filter
+    # out the pre-rotate raw rows on the next compress() and the resulting
+    # summary node would have source_ids referencing only post-frontier
+    # rows while its text covered pre-frontier content.
+    assert engine._last_compacted_store_id == 0
+
+    # Host appends a new assistant turn, simulating Hermes continuing in
+    # the same process. The in-memory active context still has all the
+    # pre-rotate messages.
+    messages.append({"role": "assistant", "content": "ack-msg-9"})
+    engine._store.append(engine._session_id, messages[-1], source="test")
+    engine._store._conn.commit()
+
+    # Stub the summarizer so the test is deterministic and we can verify
+    # exactly which raw messages get compacted.
+    lcm_engine_module = importlib.import_module("hermes_lcm.engine")
+    monkeypatch.setattr(
+        lcm_engine_module,
+        "summarize_with_escalation",
+        lambda **kwargs: ("Summary of pre-tail messages.\nExpand for details about: msg-0..msg-7", 1),
+    )
+
+    engine.compress(messages)
+
+    nodes = engine._dag.get_session_nodes(engine._session_id)
+    assert nodes, "compress() should have produced at least one summary node"
+    summary_node = nodes[0]
+
+    # source_ids must reference the actual raw rows the summary covers.
+    # Empty or post-frontier-only source_ids would mean the lineage was
+    # severed by the in-process marker filter.
+    assert summary_node.source_ids, (
+        f"summary_node.source_ids is empty — _get_store_ids_for_messages "
+        f"likely filtered out the pre-rotate rows. Marker was {engine._last_compacted_store_id}, "
+        f"compacted msgs first/last: msg-0..msg-7."
+    )
+    # Source rows must come from the pre-tail range (store_id <= rotate
+    # frontier). If source_ids only contained post-frontier rows (the
+    # original bug shape: source_ids == [9]), this assertion fails.
+    rotate_frontier = rotate_result["new_frontier_store_id"]
+    pre_frontier_sources = [
+        sid for sid in summary_node.source_ids if sid <= rotate_frontier
+    ]
+    assert pre_frontier_sources, (
+        f"summary covers pre-rotate messages but source_ids "
+        f"({summary_node.source_ids}) contains no rows at or below the "
+        f"rotate frontier ({rotate_frontier}). Source lineage is severed."
+    )
+
+
+def test_rotate_backup_path_falls_back_to_db_sibling_when_hermes_home_unset(tmp_path):
+    """The hermes_home-unset branch in rotate_backup_path puts the rolling
+    backup beside the LCM database. Cover the branch so a regression there
+    is visible.
+    """
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_no_home.db")
+    config.fresh_tail_count = 3
+    engine = LCMEngine(config=config, hermes_home="")
+    try:
+        path = engine.rotate_backup_path()
+        assert path == tmp_path / "backups" / "lcm" / "lcm_no_home-rotate-latest.sqlite3"
+        assert engine.backup_dir() == tmp_path / "backups" / "lcm"
+    finally:
+        engine.shutdown()


### PR DESCRIPTION
## Summary

Implements `_derive_conversation_id()` in `LCMEngine` to extract a stable platform-scoped conversation identifier from gateway kwargs metadata when the gateway passes `conversation_id` equal to `session_id` or `None`:

- **Telegram**: `telegram:{chat_id}`
- **Discord**: `discord:{guild_id}:{channel_id}:{user_id}`
- **Fallback**: `{session_id}`

Applied at:
- `_bind_lifecycle_state` (fallback path)
- `on_session_start` kwargs (conversation rebind)
- `on_session_reset` kwargs (conversation rebind)

This closes the gap reported in #133 where related sessions across `/new` boundaries became separate lifecycle islands without an explicit gateway-provided `conversation_id`.

Ref: #133, #167 (closed unmerged), #171

## Validation

- `lcm_doctor` passes (orphaned nodes: 0)
- Local LCM engine tests pass
- No schema changes, no migrations
- Conversation identity contract preserved: `session_id` and `conversation_id` remain stable