### PR TITLE
fix: rebind storage when Hermes home changes

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -413,6 +413,10 @@ class LCMEngine(ContextEngine):
         self._session_ignored = False
         self._session_stateless = False
         self._clear_pending_reset_boundary()
+        with self._auxiliary_session_lock:
+            self._auxiliary_session_ids.clear()
+            self._auxiliary_lineage_session_ids.clear()
+        self._clear_thread_context_stateless()
         self._reset_session_scoped_runtime_state()
 
     def _rebind_storage_for_home(self, hermes_home: str = "") -> bool:
@@ -426,8 +430,17 @@ class LCMEngine(ContextEngine):
         if not hermes_home:
             return False
         if self._config.database_path:
+            current_home = str(self._hermes_home or "")
+            current_store_home = str(getattr(getattr(self, "_store", None), "_hermes_home", "") or "")
+            if current_home == str(hermes_home) and current_store_home == str(hermes_home):
+                return False
             self._hermes_home = hermes_home
-            return False
+            store = getattr(self, "_store", None)
+            if store is not None:
+                store._hermes_home = hermes_home
+            self._reset_profile_runtime_state()
+            logger.info("LCM rebound Hermes home for configured database path %s", hermes_home)
+            return True
 
         db_path = self._resolve_db_path(hermes_home)
         current_db = Path(getattr(getattr(self, "_store", None), "db_path", ""))

--- a/engine.py
+++ b/engine.py
@@ -272,17 +272,8 @@ class LCMEngine(ContextEngine):
         self._config = config or LCMConfig.from_env()
         self._hermes_home = hermes_home
 
-        # Resolve DB path
-        if self._config.database_path:
-            db_path = Path(self._config.database_path)
-        elif hermes_home:
-            db_path = Path(hermes_home) / "lcm.db"
-        else:
-            db_path = Path.home() / ".hermes" / "lcm.db"
-
-        self._store = MessageStore(db_path, ingest_protection_config=self._config, hermes_home=hermes_home)
-        self._dag = SummaryDAG(db_path)
-        self._lifecycle = LifecycleStateStore(db_path)
+        db_path = self._resolve_db_path(hermes_home)
+        self._bind_storage(db_path, hermes_home)
 
         self._session_id: str = ""
         self._session_platform: str = ""
@@ -380,6 +371,75 @@ class LCMEngine(ContextEngine):
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
+
+    def _resolve_db_path(self, hermes_home: str = "") -> Path:
+        """Resolve the SQLite path for the active Hermes profile/home."""
+        if self._config.database_path:
+            return Path(self._config.database_path)
+        if hermes_home:
+            return Path(hermes_home) / "lcm.db"
+        return Path.home() / ".hermes" / "lcm.db"
+
+    def _bind_storage(self, db_path: str | Path, hermes_home: str = "") -> None:
+        """Bind store/DAG/lifecycle helpers to one SQLite database."""
+        self._store = MessageStore(
+            db_path,
+            ingest_protection_config=self._config,
+            hermes_home=hermes_home,
+        )
+        self._dag = SummaryDAG(db_path)
+        self._lifecycle = LifecycleStateStore(db_path)
+
+    def _close_storage(self) -> None:
+        """Best-effort close of currently bound SQLite helpers."""
+        for attr in ("_store", "_dag", "_lifecycle"):
+            helper = getattr(self, attr, None)
+            close = getattr(helper, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    logger.debug("LCM failed closing %s during profile rebind", attr, exc_info=True)
+
+    def _reset_profile_runtime_state(self) -> None:
+        """Clear process-local session state that cannot cross profile homes."""
+        self._session_id = ""
+        self._session_platform = ""
+        self._foreground_session_id = ""
+        self._foreground_session_platform = ""
+        self._foreground_conversation_id = ""
+        self._conversation_id = ""
+        self._session_match_keys = []
+        self._session_ignored = False
+        self._session_stateless = False
+        self._clear_pending_reset_boundary()
+        self._reset_session_scoped_runtime_state()
+
+    def _rebind_storage_for_home(self, hermes_home: str = "") -> bool:
+        """Switch SQLite-backed state when a reused engine serves another profile.
+
+        Hermes core passes the active ``hermes_home`` on session start.  Older
+        Hermes versions may still reuse the same plugin/context-engine object
+        after ``HERMES_HOME`` changes, so the plugin must not assume the store
+        captured during ``register()`` is still correct.
+        """
+        if not hermes_home:
+            return False
+        if self._config.database_path:
+            self._hermes_home = hermes_home
+            return False
+
+        db_path = self._resolve_db_path(hermes_home)
+        current_db = Path(getattr(getattr(self, "_store", None), "db_path", ""))
+        if current_db == db_path and str(self._hermes_home or "") == str(hermes_home):
+            return False
+
+        self._close_storage()
+        self._hermes_home = hermes_home
+        self._bind_storage(db_path, hermes_home)
+        self._reset_profile_runtime_state()
+        logger.info("LCM rebound storage for Hermes home %s", hermes_home)
+        return True
 
     def _set_context_length(self, context_length: Any, *, source: str) -> bool:
         try:
@@ -1735,6 +1795,9 @@ class LCMEngine(ContextEngine):
         self._log_session_filter_diagnostics()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
+        if "hermes_home" in kwargs:
+            self._rebind_storage_for_home(str(kwargs.get("hermes_home") or ""))
+
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -102,6 +102,71 @@ def test_reused_engine_rebinds_storage_when_hermes_home_changes(tmp_path):
         engine.shutdown()
 
 
+def test_profile_rebind_clears_old_auxiliary_session_state(tmp_path):
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    config = LCMConfig(database_path="")
+    engine = LCMEngine(config=config, hermes_home=str(home_a))
+    try:
+        engine.on_session_start(
+            "session-a",
+            hermes_home=str(home_a),
+            platform="cli",
+            context_length=200000,
+        )
+        engine._mark_thread_context_stateless("old-profile-aux")
+        assert engine._has_auxiliary_lineage_session("old-profile-aux")
+        assert engine._thread_context_stateless()
+
+        engine.on_session_start(
+            "session-b",
+            hermes_home=str(home_b),
+            platform="cli",
+            parent_session_id="old-profile-aux",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "session-b"
+        assert not engine._has_auxiliary_lineage_session("old-profile-aux")
+        assert not engine._thread_context_stateless()
+    finally:
+        engine.shutdown()
+
+
+def test_config_database_path_profile_rebind_updates_externalization_home(tmp_path):
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    config = LCMConfig(
+        database_path=str(tmp_path / "shared-lcm.db"),
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=10,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(home_a))
+    try:
+        engine.on_session_start(
+            "session-a",
+            hermes_home=str(home_a),
+            platform="cli",
+            context_length=200000,
+        )
+        engine._ingest_messages([{"role": "assistant", "content": "profile-a " + "A" * 32}])
+        assert len(list((home_a / "lcm-large-outputs").glob("*.json"))) == 1
+
+        engine.on_session_start(
+            "session-b",
+            hermes_home=str(home_b),
+            platform="cli",
+            context_length=200000,
+        )
+        assert engine._store._hermes_home == str(home_b)
+        engine._ingest_messages([{"role": "assistant", "content": "profile-b " + "B" * 32}])
+
+        assert len(list((home_a / "lcm-large-outputs").glob("*.json"))) == 1
+        assert len(list((home_b / "lcm-large-outputs").glob("*.json"))) == 1
+    finally:
+        engine.shutdown()
+
+
 def test_lcm_tool_status_reports_lifecycle_fragmentation_summary(engine, tmp_path):
     engine._hermes_home = str(tmp_path / "hermes_home")
     state_db = tmp_path / "hermes_home" / "state.db"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -59,6 +59,49 @@ def test_engine_deallocation_releases_sqlite_fds_without_gc(tmp_path):
     assert after <= before + 2
 
 
+def test_reused_engine_rebinds_storage_when_hermes_home_changes(tmp_path):
+    """Plugin-side guard for Hermes hosts that reuse one engine across profiles."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    config = LCMConfig(database_path="")
+    engine = LCMEngine(config=config, hermes_home=str(home_a))
+    try:
+        engine.context_length = 200000
+        engine.threshold_tokens = int(200000 * config.context_threshold)
+
+        engine.on_session_start(
+            "session-a",
+            hermes_home=str(home_a),
+            platform="cli",
+            context_length=200000,
+        )
+        assert Path(engine._store.db_path) == home_a / "lcm.db"
+        engine._ingest_messages([{"role": "user", "content": "message from profile a"}])
+        assert engine._store.get_session_count("session-a") == 1
+
+        engine.on_session_start(
+            "session-b",
+            hermes_home=str(home_b),
+            platform="cli",
+            context_length=200000,
+        )
+        assert Path(engine._store.db_path) == home_b / "lcm.db"
+        assert engine._session_id == "session-b"
+        assert engine._store.get_session_count("session-a") == 0
+        engine._ingest_messages([{"role": "user", "content": "message from profile b"}])
+        assert engine._store.get_session_count("session-b") == 1
+
+        with sqlite3.connect(home_a / "lcm.db") as conn_a:
+            rows_a = conn_a.execute("SELECT session_id, content FROM messages").fetchall()
+        with sqlite3.connect(home_b / "lcm.db") as conn_b:
+            rows_b = conn_b.execute("SELECT session_id, content FROM messages").fetchall()
+
+        assert rows_a == [("session-a", "message from profile a")]
+        assert rows_b == [("session-b", "message from profile b")]
+    finally:
+        engine.shutdown()
+
+
 def test_lcm_tool_status_reports_lifecycle_fragmentation_summary(engine, tmp_path):
     engine._hermes_home = str(tmp_path / "hermes_home")
     state_db = tmp_path / "hermes_home" / "state.db"


### PR DESCRIPTION
## Summary

This keeps a reused `LCMEngine` from leaking profile-bound state when Hermes starts a session with a different `hermes_home`.

The branch now handles both profile-home storage modes:

- default profile DBs are rebound to the active profile's `lcm.db`
- explicit `config.database_path` keeps the shared DB but moves `MessageStore`'s `hermes_home`, so ingest externalization writes under the active profile
- profile switches clear foreground/session state plus auxiliary lineage and thread-local auxiliary markers

## Why

Hermes can keep a plugin/context-engine object alive in a long-running process while switching profiles. Since Hermes already passes the active profile home to `on_session_start`, LCM can keep storage and process-local state aligned with that profile instead of carrying old-profile DB paths or auxiliary markers forward.

## Validation

```text
python -m pytest tests/test_lcm_engine.py::test_reused_engine_rebinds_storage_when_hermes_home_changes tests/test_lcm_engine.py::test_profile_rebind_clears_old_auxiliary_session_state tests/test_lcm_engine.py::test_config_database_path_profile_rebind_updates_externalization_home -q
3 passed

python -m pytest tests/test_lcm_engine.py -q
388 passed

python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_ingest_protection.py tests/test_packaging_install.py -q
630 passed

python -m pytest -q
729 passed

ulimit -n 1024 && python -m pytest -q
729 passed

python -m compileall -q .
python -m py_compile scripts/import_lossless_claw.py
bash -n scripts/install.sh scripts/update.sh
git diff --check upstream/main...HEAD
```
