### PR TITLE
fix: avoid data URI scaffold false positives

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -541,28 +541,38 @@ def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
         """,
         (limit,),
     ).fetchall()
-    data_uri_content = conn.execute(
+    candidate_cap = max(limit * 20, limit)
+    # Pre-filter broadly in SQL, then apply the same conservative Python regex
+    # used by ingest externalization. This avoids false positives from code or
+    # doctor text that quotes scaffolds such as "data:%;base64,%" or
+    # `DATA_URI = "data:image/png;base64," + DATA_PAYLOAD`.
+    data_uri_content_candidates = conn.execute(
         """
         SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
         FROM messages
-        WHERE content LIKE '%data:%;base64,%'
+        WHERE lower(content) GLOB '*data:*;base64,*'
         ORDER BY content_len DESC
         LIMIT ?
         """,
-        (limit,),
+        (candidate_cap,),
     ).fetchall()
-    data_uri_tool_calls = conn.execute(
+    data_uri_tool_call_candidates = conn.execute(
         """
         SELECT store_id, session_id, source, role, COALESCE(length(tool_calls), 0) AS tool_calls_len, tool_calls
         FROM messages
-        WHERE tool_calls LIKE '%data:%;base64,%'
+        WHERE lower(tool_calls) GLOB '*data:*;base64,*'
         ORDER BY tool_calls_len DESC
         LIMIT ?
         """,
-        (limit,),
+        (candidate_cap,),
     ).fetchall()
+    data_uri_content = [
+        row for row in data_uri_content_candidates if isinstance(row[-1], str) and contains_data_uri_base64(row[-1])
+    ][:limit]
+    data_uri_tool_calls = [
+        row for row in data_uri_tool_call_candidates if isinstance(row[-1], str) and contains_data_uri_base64(row[-1])
+    ][:limit]
 
-    candidate_cap = max(limit * 20, limit)
     generic_rows = []
     for store_id, session_id, source, role, content, tool_calls in conn.execute(
         """

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1234,6 +1234,63 @@ def test_lcm_doctor_reports_largest_and_suspicious_payload_rows(tmp_path):
     assert "suspicious_base64_like_rows:" in result
 
 
+def test_lcm_doctor_ignores_literal_data_uri_like_scaffold(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "diagnostic pattern: data:%;base64,%",
+            None,
+            json.dumps([{"function": {"arguments": "LIKE pattern data:%;base64,%"}}]),
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    json_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+
+    payload_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
+    assert payload_check["status"] == "pass"
+    assert payload_check["detail"]["suspicious_data_uri_content_rows"] == []
+    assert payload_check["detail"]["suspicious_data_uri_tool_calls_rows"] == []
+
+
+def test_lcm_doctor_ignores_code_data_uri_prefix_without_payload(tmp_path):
+    engine = _engine(tmp_path)
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "tool",
+            'DATA_URI = "data:image/png;base64," + DATA_PAYLOAD',
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    json_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+
+    payload_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
+    assert payload_check["status"] == "pass"
+    assert payload_check["detail"]["suspicious_data_uri_content_rows"] == []
+
+
 def test_lcm_doctor_reports_embedded_generic_base64_without_raw_preview(tmp_path):
     engine = _engine(tmp_path)
     engine._store._conn.execute(


### PR DESCRIPTION
## Summary
- Avoid treating literal diagnostic scaffolds like `data:%;base64,%` as real inline data URIs in `lcm_doctor` payload checks.
- Avoid treating code examples like `DATA_URI = "data:image/png;base64," + DATA_PAYLOAD` as real inline data URI payloads.
- Pre-filter broadly in SQL, then apply the existing conservative Python data-URI regex used by ingest externalization.
- Add regression tests for both harmless scaffold text and code-prefix-only examples.

## Why
Doctor/tool output and tests can include diagnostic/code strings that mention a data URI prefix without embedding an actual payload. If those strings are re-ingested, broad SQL matching can make the warning self-reproducing even though there is no inline media payload to externalize.

## Test Plan
- `python -m pytest tests/test_ingest_protection.py::test_lcm_doctor_reports_largest_and_suspicious_payload_rows tests/test_ingest_protection.py::test_lcm_doctor_ignores_literal_data_uri_like_scaffold tests/test_ingest_protection.py::test_lcm_doctor_ignores_code_data_uri_prefix_without_payload -q`
