### PR TITLE
fix: suppress preflight compression when LCM would noop

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -537,6 +537,8 @@ class LCMEngine(ContextEngine):
             eligible, reason = self._leaf_compaction_candidate_status(messages)
             if eligible:
                 return True
+            if self._should_run_deferred_maintenance(messages, observed_tokens=rough):
+                return True
             self._last_compression_status = "noop"
             self._last_compression_noop_reason = reason
             logger.info("LCM preflight compression no-op: %s", reason)

--- a/engine.py
+++ b/engine.py
@@ -534,9 +534,54 @@ class LCMEngine(ContextEngine):
         if self._should_force_overflow_recovery(observed_tokens=rough):
             return True
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
-            return True
+            eligible, reason = self._leaf_compaction_candidate_status(messages)
+            if eligible:
+                return True
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = reason
+            logger.info("LCM preflight compression no-op: %s", reason)
+            return False
         self._refresh_raw_backlog_debt(messages, observed_tokens=rough)
         return self._should_run_deferred_maintenance(messages, observed_tokens=rough)
+
+    def _leaf_compaction_candidate_status(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        force_overflow: bool = False,
+    ) -> tuple[bool, str]:
+        """Return whether a normal leaf compaction pass can actually run.
+
+        The host asks ``should_compress_preflight`` before it emits user-visible
+        compression status. A session can be over the global context threshold
+        while all pressure sits in the protected fresh tail, or while the raw
+        backlog outside that tail is still smaller than the configured leaf
+        chunk. In that case ``compress()`` would immediately no-op, so preflight
+        should not advertise a compaction attempt yet.
+        """
+        if not messages:
+            return False, "empty message list"
+        n = len(messages)
+        fresh_tail_start = max(0, n - self._config.fresh_tail_count)
+        leading_anchor_count = self._leading_anchor_count(messages)
+        if fresh_tail_start <= leading_anchor_count:
+            return False, "no eligible raw backlog outside fresh tail"
+
+        candidate_raw = messages[leading_anchor_count:fresh_tail_start]
+        if not candidate_raw:
+            return False, "no eligible raw backlog outside fresh tail"
+
+        if force_overflow:
+            return True, "forced overflow recovery"
+
+        raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
+        if self._config.dynamic_leaf_chunk_enabled:
+            working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
+        else:
+            working_leaf_chunk_tokens = self._config.leaf_chunk_tokens
+        if raw_tokens_outside_tail < working_leaf_chunk_tokens:
+            return False, "raw backlog outside fresh tail is below leaf chunk threshold"
+        return True, "eligible raw backlog outside fresh tail"
 
     def _working_leaf_chunk_tokens(self, raw_tokens_outside_tail: int) -> int:
         base = max(1, self._config.leaf_chunk_tokens)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -951,6 +951,42 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_preflight_requests_compaction_for_deferred_maintenance_under_critical_pressure(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_deferred_critical.db"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=100,
+            deferred_maintenance_enabled=True,
+            critical_budget_pressure_ratio=0.50,
+        )
+        instance = LCMEngine(config=config)
+        instance._bind_lifecycle_state("test-session")
+        instance.context_length = 200
+        instance.threshold_tokens = 100
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "tiny old backlog"},
+            {"role": "assistant", "content": "tiny old answer"},
+            {"role": "user", "content": "fresh " + "x" * 500},
+            {"role": "assistant", "content": "fresh " + "y" * 500},
+            {"role": "user", "content": "fresh " + "z" * 500},
+        ]
+        try:
+            rough = count_messages_tokens(messages)
+            assert rough >= instance.threshold_tokens
+            eligible, reason = instance._leaf_compaction_candidate_status(messages)
+            assert not eligible
+            assert "below leaf chunk threshold" in reason
+            instance._lifecycle.record_debt(
+                instance._conversation_id,
+                kind="raw_backlog",
+                size_estimate=instance._raw_backlog_tokens(messages),
+            )
+            assert instance._should_run_deferred_maintenance(messages, observed_tokens=rough)
+            assert instance.should_compress_preflight(messages)
+        finally:
+            instance.shutdown()
+
     def test_preflight_requests_compaction_when_old_backlog_has_leaf_chunk(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_preflight_leaf_chunk.db"),

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -925,6 +925,56 @@ class TestEngineABC:
 
         assert instance.should_compress(90)
 
+    def test_preflight_does_not_request_compaction_when_only_fresh_tail_is_over_threshold(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_fresh_tail.db"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=100,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        instance.context_length = 1000
+        instance.threshold_tokens = 100
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "tiny old backlog"},
+            {"role": "assistant", "content": "tiny old answer"},
+            {"role": "user", "content": "fresh " + "x" * 500},
+            {"role": "assistant", "content": "fresh " + "y" * 500},
+            {"role": "user", "content": "fresh " + "z" * 500},
+        ]
+        try:
+            assert count_messages_tokens(messages) >= instance.threshold_tokens
+            assert not instance.should_compress_preflight(messages)
+            assert instance._last_compression_status == "noop"
+            assert "below leaf chunk threshold" in instance._last_compression_noop_reason
+        finally:
+            instance.shutdown()
+
+    def test_preflight_requests_compaction_when_old_backlog_has_leaf_chunk(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_leaf_chunk.db"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=20,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        instance.context_length = 1000
+        instance.threshold_tokens = 100
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old backlog " + "x" * 200},
+            {"role": "assistant", "content": "old answer " + "y" * 200},
+            {"role": "user", "content": "fresh " + "a" * 200},
+            {"role": "assistant", "content": "fresh " + "b" * 200},
+            {"role": "user", "content": "fresh " + "c" * 200},
+        ]
+        try:
+            assert count_messages_tokens(messages) >= instance.threshold_tokens
+            assert instance.should_compress_preflight(messages)
+        finally:
+            instance.shutdown()
+
     def test_update_from_response(self, engine):
         engine.update_from_response({
             "prompt_tokens": 5000,


### PR DESCRIPTION
## Summary
- Adds a preflight eligibility check before LCM reports that compression should run.
- Suppresses preflight compression when the active context is over the global threshold but the only available raw backlog is protected by the fresh tail or smaller than the leaf chunk threshold.
- Preserves normal preflight compression when an eligible old raw leaf chunk exists.
- Preserves deferred/emergency maintenance preflight eligibility when existing raw-backlog debt is under critical budget pressure, matching `compress()`.

## Why
- Hermes can emit a user-visible "Compacting context" status before calling `compress()`.
- If LCM then immediately no-ops with `raw backlog outside fresh tail is below leaf chunk threshold`, the session can stay above threshold and repeatedly show compaction status without any compaction happening.
- The previous guard also suppressed deferred/emergency maintenance when raw backlog was below the leaf chunk threshold even though `compress()` would still compact under deferred maintenance debt plus critical budget pressure.
- This makes preflight match `compress()` instead of blocking a real maintenance compaction path.

## Validation
- [x] Focused preflight validation: `python -m pytest tests/test_lcm_engine.py::TestEngineABC::test_preflight_does_not_request_compaction_when_only_fresh_tail_is_over_threshold tests/test_lcm_engine.py::TestEngineABC::test_preflight_requests_compaction_for_deferred_maintenance_under_critical_pressure tests/test_lcm_engine.py::TestEngineABC::test_preflight_requests_compaction_when_old_backlog_has_leaf_chunk -q -o 'addopts='` -> `3 passed`
- [x] `python -m compileall -q engine.py tests/test_lcm_engine.py` -> passed
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> earlier local macOS run: `565 passed, 1 skipped, 1 failed` due to existing SQLite lock timing assertion (`elapsed < 0.3`)
  - [ ] `pytest -q` -> earlier local macOS run: `695 passed, 1 skipped, 3 failed`; failures appeared unrelated to this patch: the SQLite lock timing assertion above and two `/var` vs `/private/var` temp path string-prefix assertions
  - [ ] Latest `python -m pytest tests/test_lcm_engine.py -q -o 'addopts='` -> `383 passed, 1 skipped, 1 failed`; same SQLite lock timing assertion (`elapsed < 0.3`, observed `0.376s`) reproduced locally on macOS
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'` -> not run
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed earlier
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed earlier
  - [x] `git diff --check` -> passed earlier
- [ ] Workflow validation, if workflows changed: not applicable, no workflow changes

## Notes
- Code intentionally stays minimal: preflight now mirrors `compress()` at both boundaries: normal leaf eligibility and deferred maintenance under critical budget pressure.

Refs #