### PR TITLE
fix: avoid union type arrays in lcm_grep schema

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -73,14 +73,14 @@ LCM_GREP = {
                 "description": "Optional raw-message role filter. When supplied, lcm_grep returns raw message hits only.",
             },
             "time_from": {
-                "type": ["number", "string"],
+                "anyOf": [{"type": "number"}, {"type": "string"}],
                 "description": (
                     "Optional inclusive minimum raw-message timestamp. Accepts Unix seconds or timezone-aware ISO 8601; "
                     "naive ISO timestamps are rejected. When supplied, lcm_grep returns raw message hits only."
                 ),
             },
             "time_to": {
-                "type": ["number", "string"],
+                "anyOf": [{"type": "number"}, {"type": "string"}],
                 "description": (
                     "Optional inclusive maximum raw-message timestamp. Accepts Unix seconds or timezone-aware ISO 8601; "
                     "naive ISO timestamps are rejected. When supplied, lcm_grep returns raw message hits only."

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -115,6 +115,18 @@ def test_install_script_refuses_to_replace_existing_non_symlink_path(tmp_path):
     assert target.is_dir()
 
 
+def test_lcm_grep_time_filters_use_anyof_not_union_type_arrays():
+    engine = _register_plugin_engine("hermes_lcm_schema_shape")
+    assert engine is not None
+    schemas = {schema["name"]: schema for schema in engine.get_tool_schemas()}
+    properties = schemas["lcm_grep"]["parameters"]["properties"]
+
+    for name in ("time_from", "time_to"):
+        field = properties[name]
+        assert field["anyOf"] == [{"type": "number"}, {"type": "string"}]
+        assert "type" not in field
+
+
 def test_plugin_entrypoint_registers_lcm_context_engine():
     engine = _register_plugin_engine("hermes_lcm_packaging_entrypoint")
 


### PR DESCRIPTION
## Summary
- Replaces `lcm_grep` timestamp schema union type arrays with `anyOf` entries.
- Adds a packaging regression that asserts `time_from` and `time_to` do not expose list-valued `type` fields.

## Why
- Kimi/Moonshot schema normalization can crash on JSON Schema `type: ["number", "string"]` because the provider adapter treats `type` as hashable scalar data.
- `anyOf` keeps the same accepted argument contract while avoiding that provider-specific failure path.

## Validation
- [x] Focused validation: `python -m pytest tests/test_packaging_install.py::test_lcm_grep_time_filters_use_anyof_not_union_type_arrays -q -o 'addopts='` -> `1 passed`
- [x] Focused validation: `python -m pytest tests/test_packaging_install.py -q -o 'addopts='` -> `9 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `569 passed`
  - [x] `pytest -q` -> `703 passed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `703 passed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- No workflow files changed.
- No runtime parsing changes, this only changes the tool schema shape exposed to model/tool adapters.

Fixes #182
