### PR TITLE
fix: mark LCM automatic compaction as silent

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -252,6 +252,10 @@ def _is_synthetic_assistant_noise(content: str) -> bool:
 class LCMEngine(ContextEngine):
     """Lossless Context Management engine.
 
+    Automatic LCM compaction is routine background maintenance. Hosts that
+    support user-visible compaction status opt-outs should keep successful
+    automatic LCM passes silent unless the user explicitly asks for diagnostics.
+
     Architecture:
       1. Every message is persisted verbatim in an immutable MessageStore
       2. When context pressure builds, older messages outside the fresh tail
@@ -354,7 +358,11 @@ class LCMEngine(ContextEngine):
         # run_agent.py reads these for context probing
         self._context_probed = False
         self._context_probe_persistable = False
-        self.quiet_mode = False
+        # Host compatibility: LCM treats successful automatic compaction as
+        # silent maintenance. Manual /lcm diagnostics and warning/error paths
+        # remain explicit.
+        self.emit_automatic_compaction_status = False
+        self.quiet_mode = True
         self.summary_model = self._config.summary_model
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -27,6 +27,11 @@ def engine(tmp_path):
     return e
 
 
+def test_lcm_engine_declares_automatic_compaction_silent(engine):
+    assert engine.emit_automatic_compaction_status is False
+    assert engine.quiet_mode is True
+
+
 def test_lcm_status_default_reports_current_session(engine):
     result = handle_lcm_command("", engine)
 


### PR DESCRIPTION
## Summary

LCM now explicitly marks successful automatic compaction as silent background maintenance. This gives compatible Hermes hosts a clear signal not to show generic compression or compaction status text for normal LCM maintenance, while keeping manual `/lcm` diagnostics and warning/error paths explicit.

The visible `📦 Preflight compression...` and `🗜️ Compacting context...` messages are emitted by Hermes Agent core, not by LCM itself, so this PR keeps the change on the LCM side as an engine contract rather than patching the host text directly.

## Why

In an LCM backed session, successful automatic compaction is expected maintenance, not something the user needs to see on every turn. Surfacing generic compression status in chat makes a healthy LCM session look like it is repeatedly falling back to lossy compression or stuck in a fault state.

This change keeps that routine path quiet for users, while preserving the debug surfaces operators need: logs, `lcm_status`, `/lcm status`, `last_compression_status`, and `last_compression_noop_reason` still carry the diagnostic trail.

Refs #168.

## Validation

`python -m pytest`

704 passed.
