### PR TITLE
feat: add deterministic LCM benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 
 # Test stubs
 agent/
+
+# Benchmark outputs
+benchmarks/runs/
+*.lcm-benchmark-result.json

--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,0 +1,10 @@
+"""Deterministic benchmark harness for model-aware LCM preset tuning."""
+
+from .types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics
+
+__all__ = [
+    "Canary",
+    "LCMPolicy",
+    "ReplayFixture",
+    "ReplayMetrics",
+]

--- a/benchmarking/fixtures.py
+++ b/benchmarking/fixtures.py
@@ -1,0 +1,87 @@
+"""Fixture loading and deterministic fixture generation for LCM benchmarks."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from .types import ReplayFixture
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _resolve_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _REPO_ROOT / candidate
+
+
+def fixture_from_dict(data: Mapping[str, object]) -> ReplayFixture:
+    missing = [key for key in ("name", "messages") if key not in data]
+    if missing:
+        raise ValueError(f"fixture missing required key(s): {', '.join(missing)}")
+    if not isinstance(data["messages"], list):
+        raise ValueError("fixture messages must be a list")
+    return ReplayFixture.from_dict(data)
+
+
+def load_fixture(path: str | Path) -> ReplayFixture:
+    """Load one benchmark fixture JSON file."""
+    fixture_path = _resolve_path(path)
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError(f"fixture must contain a JSON object: {fixture_path}")
+    return fixture_from_dict(data)
+
+
+def load_fixtures(paths: Iterable[str | Path]) -> list[ReplayFixture]:
+    return [load_fixture(path) for path in paths]
+
+
+def iter_fixture_files(directory: str | Path = "benchmarks/fixtures") -> list[Path]:
+    fixture_dir = _resolve_path(directory)
+    return sorted(fixture_dir.glob("*.json"))
+
+
+def _canary_prefix(name: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").upper()
+    return normalized or "SYNTHETIC"
+
+
+def make_synthetic_fixture(
+    *,
+    name: str = "synthetic_long_history",
+    message_pairs: int = 12,
+    canary_count: int = 3,
+    filler_words: int = 40,
+) -> ReplayFixture:
+    """Build a deterministic synthetic long-session fixture.
+
+    The generator avoids randomness so benchmark tests and smoke runs can compare
+    exact metrics across policy changes.
+    """
+    prefix = _canary_prefix(name)
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": "You are a deterministic LCM benchmark agent."}
+    ]
+    canaries = []
+    filler = " ".join(f"{prefix.lower()}_filler_{idx}" for idx in range(filler_words))
+    for idx in range(message_pairs):
+        content = f"Turn {idx:04d}. {filler}"
+        if idx < canary_count:
+            canary_id = f"CANARY_{prefix}_{idx:04d}"
+            value = f"VALUE_{prefix}_{idx:04d}"
+            content = f"{canary_id} = {value}. {content}"
+            canaries.append({"id": canary_id, "value": value, "expected_query": canary_id})
+        messages.append({"role": "user", "content": content})
+        messages.append({"role": "assistant", "content": f"Acknowledged turn {idx:04d}."})
+    return ReplayFixture.from_dict({
+        "name": name,
+        "messages": messages,
+        "canaries": canaries,
+        "tags": ["synthetic", "deterministic"],
+    })

--- a/benchmarking/metrics.py
+++ b/benchmarking/metrics.py
@@ -1,0 +1,40 @@
+"""Metric helpers for deterministic LCM benchmark replays."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .types import Canary
+
+
+def normalize_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                value = item.get("text") or item.get("content") or ""
+                parts.append(str(value))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return str(content)
+
+
+def messages_text(messages: Iterable[dict[str, Any]]) -> str:
+    return "\n".join(normalize_message_content(message.get("content")) for message in messages)
+
+
+def canary_present(text: str, canary: Canary) -> bool:
+    return canary.id in text and canary.value in text
+
+
+def count_canary_hits(text: str, canaries: Iterable[Canary]) -> int:
+    return sum(1 for canary in canaries if canary_present(text, canary))
+
+
+def count_active_canaries(messages: Iterable[dict[str, Any]], canaries: Iterable[Canary]) -> int:
+    return count_canary_hits(messages_text(messages), canaries)

--- a/benchmarking/policies.py
+++ b/benchmarking/policies.py
@@ -14,6 +14,16 @@ except Exception:  # pragma: no cover - optional dependency
     yaml = None
 
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _resolve_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _REPO_ROOT / candidate
+
+
 def builtin_policies() -> list[LCMPolicy]:
     """Return the zero-config policy set used by the skeleton harness."""
     return [
@@ -94,7 +104,7 @@ def _load_mapping(path: Path) -> Mapping[str, Any]:
 
 def load_policy(path: str | Path) -> LCMPolicy:
     """Load one policy from JSON or flat YAML."""
-    return LCMPolicy.from_dict(_load_mapping(Path(path)))
+    return LCMPolicy.from_dict(_load_mapping(_resolve_path(path)))
 
 
 def load_policies(paths: Iterable[str | Path] | None = None) -> list[LCMPolicy]:

--- a/benchmarking/policies.py
+++ b/benchmarking/policies.py
@@ -1,0 +1,105 @@
+"""Policy loading for model-aware LCM benchmark replays."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .types import LCMPolicy
+
+try:  # pragma: no cover - exercised when PyYAML is installed
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+def builtin_policies() -> list[LCMPolicy]:
+    """Return the zero-config policy set used by the skeleton harness."""
+    return [
+        LCMPolicy(
+            name="baseline_272k",
+            context_length=272_000,
+            context_threshold=0.75,
+            fresh_tail_count=64,
+            leaf_chunk_tokens=20_000,
+            notes="Current long-context baseline: 64-message fresh tail, 20k leaf chunks.",
+        ),
+        LCMPolicy(
+            name="codex_gpt_long_context_candidate",
+            context_length=272_000,
+            context_threshold=0.75,
+            fresh_tail_count=24,
+            leaf_chunk_tokens=8_000,
+            target_after_compaction=0.55,
+            notes="Initial deterministic GPT/Codex long-context candidate.",
+        ),
+    ]
+
+
+def _parse_scalar(raw: str) -> Any:
+    value = raw.strip().strip("'\"")
+    lower = value.lower()
+    if lower in {"true", "yes", "on"}:
+        return True
+    if lower in {"false", "no", "off"}:
+        return False
+    if lower in {"null", "none", "~"}:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _minimal_yaml_mapping(text: str) -> dict[str, Any]:
+    """Parse the flat key/value YAML shape used by benchmark policies.
+
+    This is deliberately tiny. It keeps policy loading dependency-light while
+    still allowing `.yaml` policy files in minimal installs without PyYAML.
+    """
+    result: dict[str, Any] = {}
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if ":" not in line:
+            raise ValueError(f"unsupported policy YAML line {line_no}: {raw_line!r}")
+        key, value = line.split(":", 1)
+        result[key.strip()] = _parse_scalar(value)
+    return result
+
+
+def _load_mapping(path: Path) -> Mapping[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    if yaml is not None:
+        loaded = yaml.safe_load(text)
+        if not isinstance(loaded, Mapping):
+            raise ValueError(f"policy file must contain a mapping: {path}")
+        return loaded
+    try:
+        loaded = json.loads(text)
+    except json.JSONDecodeError:
+        loaded = _minimal_yaml_mapping(text)
+    if not isinstance(loaded, Mapping):
+        raise ValueError(f"policy file must contain a mapping: {path}")
+    return loaded
+
+
+def load_policy(path: str | Path) -> LCMPolicy:
+    """Load one policy from JSON or flat YAML."""
+    return LCMPolicy.from_dict(_load_mapping(Path(path)))
+
+
+def load_policies(paths: Iterable[str | Path] | None = None) -> list[LCMPolicy]:
+    """Load policies from paths, or return built-ins when no paths are supplied."""
+    selected = list(paths or [])
+    if not selected:
+        return builtin_policies()
+    return [load_policy(path) for path in selected]

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -1,0 +1,262 @@
+"""Deterministic LCM replay runner for benchmark-driven preset tuning."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from .metrics import canary_present, count_active_canaries, normalize_message_content
+from .types import LCMPolicy, ReplayFixture, ReplayMetrics
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANARY_LINE_RE = re.compile(r"\b(CANARY_[A-Z0-9_]+)\s*=\s*([A-Z0-9_:-]+)")
+
+
+def _ensure_hermes_lcm_package() -> None:
+    """Make this source checkout importable as `hermes_lcm` without plugin registration."""
+    if "hermes_lcm" in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(
+        "hermes_lcm",
+        _REPO_ROOT / "__init__.py",
+        submodule_search_locations=[str(_REPO_ROOT)],
+    )
+    if spec is None:
+        raise RuntimeError("could not create hermes_lcm package spec")
+    module = importlib.util.module_from_spec(spec)
+    module.__path__ = [str(_REPO_ROOT)]
+    module.__package__ = "hermes_lcm"
+    sys.modules["hermes_lcm"] = module
+
+
+def _safe_name(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-._")
+    return safe or "replay"
+
+
+def deterministic_summary(
+    *,
+    text: str,
+    source_tokens: int,
+    token_budget: int,
+    depth: int,
+    max_canaries: int = 1,
+    **_: Any,
+) -> tuple[str, int]:
+    """Return a deterministic summary that preserves bounded canary facts."""
+    preserved: list[str] = []
+    seen: set[str] = set()
+    for match in _CANARY_LINE_RE.finditer(text):
+        canary_id, value = match.groups()
+        if canary_id in seen:
+            continue
+        seen.add(canary_id)
+        preserved.append(f"{canary_id} = {value}")
+        if len(preserved) >= max_canaries:
+            break
+    lines = [
+        "Deterministic benchmark summary.",
+        f"source_tokens={source_tokens}",
+        f"token_budget={token_budget}",
+        f"depth={depth}",
+    ]
+    if preserved:
+        lines.append("Preserved canaries:")
+        lines.extend(f"- {line}" for line in preserved)
+    return "\n".join(lines), 1
+
+
+@contextmanager
+def patched_deterministic_summarizer(max_canaries: int = 1) -> Iterator[None]:
+    """Patch LCM summarization inside a fail-closed deterministic context."""
+    _ensure_hermes_lcm_package()
+    import hermes_lcm.engine as lcm_engine
+
+    original = lcm_engine.summarize_with_escalation
+
+    def _stub(**kwargs: Any) -> tuple[str, int]:
+        return deterministic_summary(max_canaries=max_canaries, **kwargs)
+
+    lcm_engine.summarize_with_escalation = _stub
+    try:
+        yield
+    finally:
+        lcm_engine.summarize_with_escalation = original
+
+
+def _config_from_policy(policy: LCMPolicy, database_path: Path):
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.config import LCMConfig
+
+    return LCMConfig(
+        fresh_tail_count=policy.fresh_tail_count,
+        leaf_chunk_tokens=policy.leaf_chunk_tokens,
+        context_threshold=policy.context_threshold,
+        incremental_max_depth=policy.incremental_max_depth,
+        condensation_fanin=policy.condensation_fanin,
+        dynamic_leaf_chunk_enabled=policy.dynamic_leaf_chunk_enabled,
+        database_path=str(database_path),
+    )
+
+
+def _new_engine(policy: LCMPolicy, run_dir: Path):
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.engine import LCMEngine
+
+    db_path = run_dir / f"{_safe_name(policy.name)}.lcm.db"
+    hermes_home = run_dir / "hermes-home"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config = _config_from_policy(policy, db_path)
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    session_id = f"bench-{_safe_name(policy.name)}"
+    conversation_id = f"bench-{_safe_name(policy.name)}"
+    engine.on_session_start(
+        session_id,
+        platform="benchmark",
+        conversation_id=conversation_id,
+        model="benchmark-model",
+        provider="benchmark",
+        context_length=policy.context_length,
+    )
+    engine.update_model(
+        model="benchmark-model",
+        context_length=policy.context_length,
+        provider="benchmark",
+    )
+    return engine
+
+
+def _grep_canary(engine: Any, canary: Any) -> bool:
+    query = canary.expected_query or canary.id
+    try:
+        grep_payload = json.loads(engine.handle_tool_call("lcm_grep", {"query": query, "limit": 5}))
+    except Exception:
+        return False
+    for hit in grep_payload.get("results", []):
+        hit_text = "\n".join(
+            str(hit.get(key, "")) for key in ("snippet", "content", "summary")
+        )
+        if canary_present(hit_text, canary):
+            return True
+        store_id = hit.get("store_id")
+        if store_id is None:
+            continue
+        try:
+            expanded = json.loads(
+                engine.handle_tool_call(
+                    "lcm_expand",
+                    {"store_id": int(store_id), "max_tokens": 100_000},
+                )
+            )
+        except Exception:
+            continue
+        expanded_text = normalize_message_content(expanded.get("content"))
+        if canary_present(expanded_text, canary):
+            return True
+    return False
+
+
+def _count_retrieval_canaries(engine: Any, fixture: ReplayFixture) -> int:
+    return sum(1 for canary in fixture.canaries if _grep_canary(engine, canary))
+
+
+def run_replay(
+    fixture: ReplayFixture,
+    policy: LCMPolicy,
+    *,
+    output_dir: str | Path,
+    max_summary_canaries: int = 1,
+) -> ReplayMetrics:
+    """Replay one fixture against one LCM policy with deterministic summarization."""
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.tokens import count_messages_tokens
+
+    root_dir = Path(output_dir)
+    run_dir = root_dir / _safe_name(fixture.name)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    engine = _new_engine(policy, run_dir)
+    start = time.perf_counter()
+    failures: list[str] = []
+    messages = [dict(message) for message in fixture.messages]
+    compressed_messages = messages
+    compaction_attempts = 0
+    before = count_messages_tokens(messages)
+    try:
+        should_compress = engine.should_compress_preflight(messages)
+        if should_compress:
+            compaction_attempts = 1
+            with patched_deterministic_summarizer(max_canaries=max_summary_canaries):
+                compressed_messages = engine.compress(messages, current_tokens=before)
+        after = count_messages_tokens(compressed_messages)
+        active_canaries = count_active_canaries(compressed_messages, fixture.canaries)
+        retrieval_canaries = _count_retrieval_canaries(engine, fixture)
+        status = engine.get_status()
+        metrics = ReplayMetrics(
+            policy_name=policy.name,
+            fixture_name=fixture.name,
+            prompt_tokens_before=before,
+            prompt_tokens_after=after,
+            threshold_tokens=engine.threshold_tokens,
+            compression_count=engine.compression_count,
+            compaction_attempts=compaction_attempts,
+            post_compaction_headroom_tokens=engine.threshold_tokens - after,
+            active_canaries_found=active_canaries,
+            retrieval_canaries_found=retrieval_canaries,
+            total_canaries=len(fixture.canaries),
+            failures=failures,
+            database_path=str(engine._store.db_path),
+            hermes_home=str(engine._hermes_home),
+            active_message_count=len(compressed_messages),
+            store_messages=int(status.get("store_messages", 0) or 0),
+            dag_nodes=int(status.get("dag_nodes", 0) or 0),
+            elapsed_ms=round((time.perf_counter() - start) * 1000, 3),
+        )
+    except Exception as exc:
+        failures.append(f"{type(exc).__name__}: {exc}")
+        after = count_messages_tokens(compressed_messages)
+        metrics = ReplayMetrics(
+            policy_name=policy.name,
+            fixture_name=fixture.name,
+            prompt_tokens_before=before,
+            prompt_tokens_after=after,
+            threshold_tokens=engine.threshold_tokens,
+            compression_count=engine.compression_count,
+            compaction_attempts=compaction_attempts,
+            post_compaction_headroom_tokens=engine.threshold_tokens - after,
+            active_canaries_found=0,
+            retrieval_canaries_found=0,
+            total_canaries=len(fixture.canaries),
+            failures=failures,
+            database_path=str(engine._store.db_path),
+            hermes_home=str(engine._hermes_home),
+            active_message_count=len(compressed_messages),
+            elapsed_ms=round((time.perf_counter() - start) * 1000, 3),
+        )
+    finally:
+        engine.shutdown()
+
+    metrics_path = run_dir / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return metrics
+
+
+def run_replays(
+    fixtures: list[ReplayFixture],
+    policies: list[LCMPolicy],
+    *,
+    output_dir: str | Path,
+) -> list[ReplayMetrics]:
+    metrics: list[ReplayMetrics] = []
+    root = Path(output_dir)
+    for fixture in fixtures:
+        for policy in policies:
+            suite_dir = root / f"{_safe_name(fixture.name)}__{_safe_name(policy.name)}"
+            metrics.append(run_replay(fixture, policy, output_dir=suite_dir))
+    return metrics

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -1,0 +1,48 @@
+"""Report output helpers for deterministic LCM benchmark runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import mean
+from typing import Iterable
+
+from .types import ReplayMetrics
+
+
+def summarize_metrics(metrics: Iterable[ReplayMetrics]) -> dict[str, object]:
+    rows = list(metrics)
+    if not rows:
+        return {"benchmark_version": "1", "runs": 0, "policies": [], "fixtures": []}
+    return {
+        "benchmark_version": "1",
+        "runs": len(rows),
+        "policies": sorted({row.policy_name for row in rows}),
+        "fixtures": sorted({row.fixture_name for row in rows}),
+        "total_failures": sum(len(row.failures) for row in rows),
+        "compression_count": sum(row.compression_count for row in rows),
+        "compaction_attempts": sum(row.compaction_attempts for row in rows),
+        "avg_prompt_tokens_before": mean(row.prompt_tokens_before for row in rows),
+        "avg_prompt_tokens_after": mean(row.prompt_tokens_after for row in rows),
+        "total_active_canaries_found": sum(row.active_canaries_found for row in rows),
+        "total_retrieval_canaries_found": sum(row.retrieval_canaries_found for row in rows),
+        "total_canaries": sum(row.total_canaries for row in rows),
+        "metrics": [row.to_dict() for row in rows],
+    }
+
+
+def write_metrics_jsonl(path: str | Path, metrics: Iterable[ReplayMetrics]) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        for row in metrics:
+            handle.write(json.dumps(row.to_dict(), sort_keys=True) + "\n")
+
+
+def write_summary(path: str | Path, metrics: Iterable[ReplayMetrics]) -> dict[str, object]:
+    rows = list(metrics)
+    summary = summarize_metrics(rows)
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary

--- a/benchmarking/types.py
+++ b/benchmarking/types.py
@@ -1,0 +1,144 @@
+"""Serializable types for deterministic LCM benchmark replays."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+@dataclass(frozen=True)
+class LCMPolicy:
+    name: str
+    context_length: int
+    context_threshold: float
+    fresh_tail_count: int
+    leaf_chunk_tokens: int
+    condensation_fanin: int = 4
+    incremental_max_depth: int = 1
+    dynamic_leaf_chunk_enabled: bool = False
+    target_after_compaction: float | None = None
+    min_turns_between_compactions: int = 0
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LCMPolicy":
+        return cls(
+            name=str(data["name"]),
+            context_length=int(data["context_length"]),
+            context_threshold=float(data["context_threshold"]),
+            fresh_tail_count=int(data["fresh_tail_count"]),
+            leaf_chunk_tokens=int(data["leaf_chunk_tokens"]),
+            condensation_fanin=int(data.get("condensation_fanin", 4)),
+            incremental_max_depth=int(data.get("incremental_max_depth", 1)),
+            dynamic_leaf_chunk_enabled=_as_bool(data.get("dynamic_leaf_chunk_enabled", False)),
+            target_after_compaction=(
+                None
+                if data.get("target_after_compaction") is None
+                else float(data["target_after_compaction"])
+            ),
+            min_turns_between_compactions=int(data.get("min_turns_between_compactions", 0)),
+            notes=str(data.get("notes", "")),
+        )
+
+
+@dataclass(frozen=True)
+class Canary:
+    id: str
+    value: str
+    expected_query: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Canary":
+        canary_id = str(data["id"])
+        return cls(
+            id=canary_id,
+            value=str(data["value"]),
+            expected_query=str(data.get("expected_query") or canary_id),
+        )
+
+
+@dataclass(frozen=True)
+class ReplayFixture:
+    name: str
+    messages: list[dict[str, Any]]
+    canaries: list[Canary] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "messages": list(self.messages),
+            "canaries": [canary.to_dict() for canary in self.canaries],
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReplayFixture":
+        return cls(
+            name=str(data["name"]),
+            messages=[dict(message) for message in data["messages"]],
+            canaries=[Canary.from_dict(item) for item in data.get("canaries", [])],
+            tags=[str(tag) for tag in data.get("tags", [])],
+        )
+
+
+@dataclass
+class ReplayMetrics:
+    policy_name: str
+    fixture_name: str
+    prompt_tokens_before: int
+    prompt_tokens_after: int
+    threshold_tokens: int
+    compression_count: int
+    compaction_attempts: int
+    post_compaction_headroom_tokens: int
+    active_canaries_found: int
+    retrieval_canaries_found: int
+    total_canaries: int
+    failures: list[str] = field(default_factory=list)
+    database_path: str = ""
+    hermes_home: str = ""
+    active_message_count: int = 0
+    store_messages: int = 0
+    dag_nodes: int = 0
+    elapsed_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReplayMetrics":
+        return cls(
+            policy_name=str(data["policy_name"]),
+            fixture_name=str(data["fixture_name"]),
+            prompt_tokens_before=int(data["prompt_tokens_before"]),
+            prompt_tokens_after=int(data["prompt_tokens_after"]),
+            threshold_tokens=int(data["threshold_tokens"]),
+            compression_count=int(data["compression_count"]),
+            compaction_attempts=int(data["compaction_attempts"]),
+            post_compaction_headroom_tokens=int(data["post_compaction_headroom_tokens"]),
+            active_canaries_found=int(data["active_canaries_found"]),
+            retrieval_canaries_found=int(data["retrieval_canaries_found"]),
+            total_canaries=int(data["total_canaries"]),
+            failures=[str(item) for item in data.get("failures", [])],
+            database_path=str(data.get("database_path", "")),
+            hermes_home=str(data.get("hermes_home", "")),
+            active_message_count=int(data.get("active_message_count", 0)),
+            store_messages=int(data.get("store_messages", 0)),
+            dag_nodes=int(data.get("dag_nodes", 0)),
+            elapsed_ms=float(data.get("elapsed_ms", 0.0)),
+        )

--- a/benchmarks/fixtures/long_history_canaries.json
+++ b/benchmarks/fixtures/long_history_canaries.json
@@ -1,0 +1,19 @@
+{
+  "name": "long_history_canaries",
+  "tags": ["long_history", "exact_recall", "synthetic"],
+  "messages": [
+    {"role": "system", "content": "You are a deterministic LCM benchmark agent."},
+    {"role": "user", "content": "CANARY_ALPHA = VALUE_ALPHA. Early project invariant: alpha routing must remain recoverable."},
+    {"role": "assistant", "content": "Acknowledged alpha invariant."},
+    {"role": "user", "content": "Routine discussion about implementation details, tests, and release order."},
+    {"role": "assistant", "content": "Acknowledged."},
+    {"role": "user", "content": "CANARY_BETA = VALUE_BETA. Second old fact should be searchable after compaction."},
+    {"role": "assistant", "content": "Acknowledged beta invariant."},
+    {"role": "user", "content": "Later noisy turn with unrelated status updates and validation notes."},
+    {"role": "assistant", "content": "Acknowledged."}
+  ],
+  "canaries": [
+    {"id": "CANARY_ALPHA", "value": "VALUE_ALPHA", "expected_query": "CANARY_ALPHA"},
+    {"id": "CANARY_BETA", "value": "VALUE_BETA", "expected_query": "CANARY_BETA"}
+  ]
+}

--- a/benchmarks/fixtures/repeated_compaction_chatter.json
+++ b/benchmarks/fixtures/repeated_compaction_chatter.json
@@ -1,0 +1,18 @@
+{
+  "name": "repeated_compaction_chatter",
+  "tags": ["compaction_chatter", "synthetic"],
+  "messages": [
+    {"role": "system", "content": "You are a deterministic LCM benchmark agent."},
+    {"role": "user", "content": "CANARY_CHATTER = VALUE_CHATTER. This fact anchors the chatter replay."},
+    {"role": "assistant", "content": "Acknowledged chatter anchor."},
+    {"role": "user", "content": "Large-ish but deterministic backlog segment one. filler filler filler filler filler filler filler filler filler filler."},
+    {"role": "assistant", "content": "Acknowledged segment one."},
+    {"role": "user", "content": "Large-ish but deterministic backlog segment two. filler filler filler filler filler filler filler filler filler filler."},
+    {"role": "assistant", "content": "Acknowledged segment two."},
+    {"role": "user", "content": "Recent user turn should remain in the fresh tail."},
+    {"role": "assistant", "content": "Recent assistant turn should remain in the fresh tail."}
+  ],
+  "canaries": [
+    {"id": "CANARY_CHATTER", "value": "VALUE_CHATTER", "expected_query": "CANARY_CHATTER"}
+  ]
+}

--- a/benchmarks/policies/baseline.yaml
+++ b/benchmarks/policies/baseline.yaml
@@ -1,0 +1,11 @@
+name: baseline_272k
+context_length: 272000
+context_threshold: 0.75
+fresh_tail_count: 64
+leaf_chunk_tokens: 20000
+condensation_fanin: 4
+incremental_max_depth: 1
+dynamic_leaf_chunk_enabled: false
+target_after_compaction: null
+min_turns_between_compactions: 0
+notes: "Current long-context baseline: 64-message fresh tail, 20k leaf chunks."

--- a/scripts/lcm_benchmark.py
+++ b/scripts/lcm_benchmark.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run deterministic hermes-lcm benchmark replays."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarking.fixtures import load_fixtures
+from benchmarking.policies import load_policies
+from benchmarking.replay import run_replays
+from benchmarking.report import write_metrics_jsonl, write_summary
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", action="append", default=[], help="Fixture JSON path. Repeatable.")
+    parser.add_argument("--policy", action="append", default=[], help="Policy JSON/YAML path. Repeatable.")
+    parser.add_argument("--output", required=True, help="Benchmark output directory.")
+    parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
+    parser.add_argument(
+        "--allow-external-output",
+        action="store_true",
+        help="Allow --output outside this repository.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_output_path(path: Path, *, allow_external: bool) -> Path:
+    resolved = path.resolve()
+    repo_root = REPO_ROOT.resolve()
+    if not allow_external and not resolved.is_relative_to(repo_root):
+        raise SystemExit(
+            f"Refusing output outside repo: {resolved}. "
+            "Pass --allow-external-output to override."
+        )
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    output_dir = _validate_output_path(Path(args.output), allow_external=args.allow_external_output)
+    if not args.fixture:
+        raise SystemExit("At least one --fixture path is required")
+    fixtures = load_fixtures(args.fixture)
+    policies = load_policies(args.policy)
+    metrics = run_replays(fixtures, policies, output_dir=output_dir)
+    write_metrics_jsonl(output_dir / "metrics.jsonl", metrics)
+    summary = write_summary(output_dir / "summary.json", metrics)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmarking_fixtures.py
+++ b/tests/test_benchmarking_fixtures.py
@@ -1,0 +1,67 @@
+"""Tests for benchmark fixture loading and deterministic generation."""
+
+import json
+
+import pytest
+
+from benchmarking.fixtures import load_fixture, make_synthetic_fixture
+
+
+def test_load_fixture_parses_canaries(tmp_path):
+    path = tmp_path / "fixture.json"
+    path.write_text(json.dumps({
+        "name": "long_history_canaries",
+        "tags": ["long_history", "exact_recall"],
+        "messages": [
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "CANARY_ALPHA = VALUE_ALPHA"},
+        ],
+        "canaries": [
+            {"id": "CANARY_ALPHA", "value": "VALUE_ALPHA", "expected_query": "CANARY_ALPHA"},
+        ],
+    }))
+
+    fixture = load_fixture(path)
+
+    assert fixture.name == "long_history_canaries"
+    assert fixture.tags == ["long_history", "exact_recall"]
+    assert fixture.canaries[0].value == "VALUE_ALPHA"
+
+
+def test_load_fixture_rejects_missing_required_keys(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps({"name": "bad"}))
+
+    with pytest.raises(ValueError, match="messages"):
+        load_fixture(path)
+
+
+def test_make_synthetic_fixture_is_deterministic():
+    first = make_synthetic_fixture(
+        name="deterministic",
+        message_pairs=4,
+        canary_count=2,
+        filler_words=6,
+    )
+    second = make_synthetic_fixture(
+        name="deterministic",
+        message_pairs=4,
+        canary_count=2,
+        filler_words=6,
+    )
+
+    assert first == second
+    assert len(first.messages) == 9  # system plus four user/assistant pairs
+    assert [canary.id for canary in first.canaries] == [
+        "CANARY_DETERMINISTIC_0000",
+        "CANARY_DETERMINISTIC_0001",
+    ]
+    assert "CANARY_DETERMINISTIC_0000 = VALUE_DETERMINISTIC_0000" in first.messages[1]["content"]
+
+
+def test_committed_long_history_fixture_loads():
+    fixture = load_fixture("benchmarks/fixtures/long_history_canaries.json")
+
+    assert fixture.name == "long_history_canaries"
+    assert fixture.canaries
+    assert fixture.messages[0]["role"] == "system"

--- a/tests/test_benchmarking_replay.py
+++ b/tests/test_benchmarking_replay.py
@@ -1,0 +1,114 @@
+"""Tests for deterministic LCM benchmark replay."""
+
+import json
+from pathlib import Path
+
+import hermes_lcm.engine as lcm_engine
+
+from benchmarking.fixtures import make_synthetic_fixture
+from benchmarking.replay import run_replay
+from benchmarking.types import Canary, LCMPolicy, ReplayFixture
+
+
+def _small_policy(**overrides):
+    values = {
+        "name": "small_policy",
+        "context_length": 400,
+        "context_threshold": 0.20,
+        "fresh_tail_count": 1,
+        "leaf_chunk_tokens": 20,
+        "condensation_fanin": 4,
+        "incremental_max_depth": 1,
+        "dynamic_leaf_chunk_enabled": False,
+    }
+    values.update(overrides)
+    return LCMPolicy(**values)
+
+
+def test_replay_below_threshold_does_not_compress(tmp_path):
+    fixture = ReplayFixture(
+        name="tiny_fixture",
+        messages=[
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "small hello"},
+        ],
+    )
+    policy = _small_policy(context_length=10_000, context_threshold=0.90)
+
+    metrics = run_replay(fixture, policy, output_dir=tmp_path)
+
+    assert metrics.compaction_attempts == 0
+    assert metrics.compression_count == 0
+    assert metrics.prompt_tokens_before == metrics.prompt_tokens_after
+    assert Path(metrics.database_path).is_relative_to(tmp_path)
+
+
+def test_replay_above_threshold_compresses_and_reports_canary_recall(tmp_path):
+    fixture = make_synthetic_fixture(
+        name="pressure",
+        message_pairs=8,
+        canary_count=2,
+        filler_words=80,
+    )
+    policy = _small_policy()
+
+    metrics = run_replay(fixture, policy, output_dir=tmp_path)
+
+    assert metrics.compaction_attempts == 1
+    assert metrics.compression_count >= 1
+    assert metrics.prompt_tokens_before > metrics.prompt_tokens_after
+    assert metrics.active_canaries_found >= 1
+    assert metrics.retrieval_canaries_found == metrics.total_canaries == 2
+    assert metrics.failures == []
+
+
+def test_replay_restores_summarizer_patch(tmp_path):
+    original = lcm_engine.summarize_with_escalation
+    fixture = make_synthetic_fixture(
+        name="restore",
+        message_pairs=6,
+        canary_count=1,
+        filler_words=80,
+    )
+
+    run_replay(fixture, _small_policy(), output_dir=tmp_path)
+
+    assert lcm_engine.summarize_with_escalation is original
+
+
+def test_replay_uses_output_directory_for_state_and_not_home(tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake-home"
+    output_dir = tmp_path / "benchmark-output"
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("HERMES_HOME", str(fake_home / ".hermes"))
+    fixture = make_synthetic_fixture(
+        name="sandbox",
+        message_pairs=6,
+        canary_count=1,
+        filler_words=80,
+    )
+
+    metrics = run_replay(fixture, _small_policy(), output_dir=output_dir)
+
+    assert Path(metrics.database_path).is_relative_to(output_dir)
+    assert Path(metrics.hermes_home).is_relative_to(output_dir)
+    assert not (fake_home / ".hermes" / "lcm.db").exists()
+
+
+def test_replay_retrieval_expands_raw_hits(tmp_path):
+    fixture = ReplayFixture(
+        name="raw_hit",
+        messages=[
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "CANARY_RAW = VALUE_RAW " + ("filler " * 120)},
+            {"role": "assistant", "content": "Acknowledged."},
+        ],
+        canaries=[Canary(id="CANARY_RAW", value="VALUE_RAW", expected_query="CANARY_RAW")],
+    )
+
+    metrics = run_replay(fixture, _small_policy(), output_dir=tmp_path)
+    raw_metrics = json.loads((tmp_path / "raw_hit" / "metrics.json").read_text())
+
+    assert metrics.retrieval_canaries_found == 1
+    assert raw_metrics["retrieval_canaries_found"] == 1
+    assert raw_metrics["database_path"] == metrics.database_path

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -1,0 +1,93 @@
+"""Tests for model-aware benchmark data structures and policies."""
+
+import json
+
+from benchmarking.policies import builtin_policies, load_policy
+from benchmarking.types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics
+
+
+def test_policy_round_trips_through_json_mapping():
+    policy = LCMPolicy(
+        name="codex_gpt_272k",
+        context_length=272_000,
+        context_threshold=0.75,
+        fresh_tail_count=24,
+        leaf_chunk_tokens=8_000,
+        target_after_compaction=0.55,
+        notes="dry-run candidate",
+    )
+
+    restored = LCMPolicy.from_dict(json.loads(json.dumps(policy.to_dict())))
+
+    assert restored == policy
+
+
+def test_fixture_round_trips_nested_canaries():
+    fixture = ReplayFixture(
+        name="long_history_canaries",
+        messages=[{"role": "user", "content": "CANARY_ALPHA = VALUE_ALPHA"}],
+        canaries=[Canary(id="CANARY_ALPHA", value="VALUE_ALPHA", expected_query="CANARY_ALPHA")],
+        tags=["exact_recall"],
+    )
+
+    restored = ReplayFixture.from_dict(json.loads(json.dumps(fixture.to_dict())))
+
+    assert restored == fixture
+    assert restored.canaries[0].expected_query == "CANARY_ALPHA"
+
+
+def test_metrics_round_trips_with_failure_list():
+    metrics = ReplayMetrics(
+        policy_name="baseline_272k",
+        fixture_name="long_history_canaries",
+        prompt_tokens_before=100,
+        prompt_tokens_after=80,
+        threshold_tokens=75,
+        compression_count=1,
+        compaction_attempts=1,
+        post_compaction_headroom_tokens=-5,
+        active_canaries_found=1,
+        retrieval_canaries_found=2,
+        total_canaries=2,
+        failures=["headroom below zero"],
+    )
+
+    restored = ReplayMetrics.from_dict(json.loads(json.dumps(metrics.to_dict())))
+
+    assert restored == metrics
+
+
+def test_builtin_policies_include_baseline_and_codex_candidate():
+    policies = {policy.name: policy for policy in builtin_policies()}
+
+    assert policies["baseline_272k"].context_length == 272_000
+    assert policies["baseline_272k"].fresh_tail_count == 64
+    assert policies["codex_gpt_long_context_candidate"].leaf_chunk_tokens == 8_000
+    assert policies["codex_gpt_long_context_candidate"].target_after_compaction == 0.55
+
+
+def test_load_policy_accepts_json_and_minimal_yaml(tmp_path):
+    json_path = tmp_path / "policy.json"
+    json_path.write_text(json.dumps({
+        "name": "json_policy",
+        "context_length": 1000,
+        "context_threshold": 0.7,
+        "fresh_tail_count": 8,
+        "leaf_chunk_tokens": 100,
+    }))
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text("""
+name: yaml_policy
+context_length: 2000
+context_threshold: 0.8
+fresh_tail_count: 12
+leaf_chunk_tokens: 250
+dynamic_leaf_chunk_enabled: false
+target_after_compaction: 0.55
+""".strip())
+
+    assert load_policy(json_path).name == "json_policy"
+    yaml_policy = load_policy(yaml_path)
+    assert yaml_policy.name == "yaml_policy"
+    assert yaml_policy.dynamic_leaf_chunk_enabled is False
+    assert yaml_policy.target_after_compaction == 0.55

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -91,3 +91,11 @@ target_after_compaction: 0.55
     assert yaml_policy.name == "yaml_policy"
     assert yaml_policy.dynamic_leaf_chunk_enabled is False
     assert yaml_policy.target_after_compaction == 0.55
+
+
+def test_load_policy_resolves_repo_relative_paths_from_external_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    policy = load_policy("benchmarks/policies/baseline.yaml")
+
+    assert policy.name == "baseline_272k"


### PR DESCRIPTION
## Summary
- Adds a deterministic, no-network benchmark harness for replaying LCM fixtures against policy candidates.
- Adds serializable benchmark types, policy loading, fixture loading/generation, replay metrics, report output helpers, and a `scripts/lcm_benchmark.py` entrypoint.
- Adds initial synthetic fixtures and a `baseline_272k` policy, with benchmark run outputs ignored.
- Resolves repo-relative fixture and policy paths from the repository root so the benchmark CLI can be invoked from outside the checkout.

## Why
- Enables model-aware LCM preset tuning without live provider calls, user API keys, or live Hermes config mutation.
- Sets up the GPT/Codex long-context tuning path from #189 while keeping runtime `engine.py` and `config.py` unchanged.

## Validation
- [x] RED check for Codex finding: `pytest tests/test_benchmarking_types.py::test_load_policy_resolves_repo_relative_paths_from_external_cwd -q` -> failed with `FileNotFoundError` before the fix
- [x] Focused validation: `pytest tests/test_benchmarking_types.py tests/test_benchmarking_fixtures.py tests/test_benchmarking_replay.py -q` -> `15 passed`
- [x] Benchmark smoke: `python /home/w0lf/hermes-lcm-model-presets/scripts/lcm_benchmark.py --fixture benchmarks/fixtures/long_history_canaries.json --policy benchmarks/policies/baseline.yaml --output /tmp/hermes-lcm-policy-path-smoke --allow-external-output --json` -> exited 0 from outside the repo CWD and wrote `summary.json` / `metrics.jsonl`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `569 passed`
  - [x] `pytest -q` -> `719 passed`
  - [x] `ulimit -n 1024 && pytest -q` -> `719 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- No workflow files changed.
- No runtime compression behavior changed.
- No live provider calls are made by the benchmark harness.
- Benchmark artifacts are written under the requested output directory; `benchmarks/runs/` is ignored.
- Latest validated head: `dbdd739`.

Refs #189
