### PR TITLE
fix: ignore disabled Hermes compression threshold

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,13 +45,22 @@ def _parse_bool_env(key: str, default: bool) -> bool:
     return default
 
 
+def _config_bool_disabled(value) -> bool:
+    if isinstance(value, bool):
+        return value is False
+    if isinstance(value, str):
+        return value.strip().lower() in {"0", "false", "no", "off"}
+    return False
+
+
 def _hermes_compression_threshold(default: float) -> float:
     """Read Hermes compression.threshold when no LCM env override is present.
 
     Hermes gateways may load ``~/.hermes/config.yaml`` without exporting every
     setting into the process environment. Falling back to the main Hermes
     compression threshold keeps LCM aligned with the active agent config while
-    still allowing ``LCM_CONTEXT_THRESHOLD`` to override it explicitly.
+    still allowing ``LCM_CONTEXT_THRESHOLD`` to override it explicitly. Disabled
+    Hermes compression should not leak its threshold into LCM.
     """
     home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
     cfg_path = home / "config.yaml"
@@ -59,22 +68,42 @@ def _hermes_compression_threshold(default: float) -> float:
         text = cfg_path.read_text()
         if yaml is not None:
             cfg = yaml.safe_load(text) or {}
-            value = (cfg.get("compression") or {}).get("threshold")
+            compression = cfg.get("compression") or {}
+            if _config_bool_disabled(compression.get("enabled")):
+                return default
+            value = compression.get("threshold")
             if value is None:
                 return default
             return float(value)
 
         in_compression = False
+        direct_indent = None
+        compression_disabled = False
+        threshold_value = None
         for raw_line in text.splitlines():
             line = raw_line.split("#", 1)[0].rstrip()
             if not line.strip():
                 continue
             if not line.startswith((" ", "\t")):
                 in_compression = line.strip() == "compression:"
+                direct_indent = None
                 continue
-            if in_compression and line.strip().startswith("threshold:"):
-                return float(line.split(":", 1)[1].strip().strip("'\""))
-        return default
+            if not in_compression:
+                continue
+            indent = len(line) - len(line.lstrip(" \t"))
+            if direct_indent is None:
+                direct_indent = indent
+            if indent != direct_indent or ":" not in line:
+                continue
+            key, raw_value = line.strip().split(":", 1)
+            value = raw_value.strip().strip("'\"")
+            if key == "enabled" and _config_bool_disabled(value):
+                compression_disabled = True
+            elif key == "threshold":
+                threshold_value = value
+        if compression_disabled or threshold_value is None:
+            return default
+        return float(threshold_value)
     except Exception:
         return default
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -464,6 +464,35 @@ class TestConfig:
 
         assert c.context_threshold == 0.82
 
+    def test_from_env_ignores_disabled_hermes_compression_threshold(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: false\n  threshold: 0.50\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.75
+
+    def test_from_env_ignores_disabled_hermes_threshold_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: false\n  threshold: '0.50'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.75
+
     def test_from_env_reads_hermes_threshold_without_pyyaml(self, monkeypatch, tmp_path):
         import hermes_lcm.config as config_mod
 


### PR DESCRIPTION
## Summary
- Ignore Hermes `compression.threshold` as an LCM fallback when `compression.enabled: false`.
- Preserve the existing fallback when Hermes compression is enabled or unspecified and `LCM_CONTEXT_THRESHOLD` is missing.
- Add regression coverage for the normal PyYAML path and the minimal no-PyYAML parser path.

## Why
- A disabled Hermes compressor should not pull LCM's `context_threshold` down to the disabled host compression threshold.
- This prevents premature LCM compaction in configurations that explicitly disable host compression and rely on LCM's own default or `LCM_CONTEXT_THRESHOLD`.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_core.py::TestConfig -q` -> `8 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `571 passed`
  - [x] `pytest -q` -> `706 passed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'` -> not run, local execution policy denied lowering the fd limit
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- Regression tests were written first and failed as expected before the fix: the disabled Hermes threshold still produced `context_threshold == 0.5`.
- No workflow files changed.

Fixes #187
