### PR TITLE
fix: treat numeric zero as disabled compression

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,8 +48,16 @@ def _parse_bool_env(key: str, default: bool) -> bool:
 def _config_bool_disabled(value) -> bool:
     if isinstance(value, bool):
         return value is False
+    if isinstance(value, (int, float)):
+        return value == 0
     if isinstance(value, str):
-        return value.strip().lower() in {"0", "false", "no", "off"}
+        normalized = value.strip().lower()
+        if normalized in {"0", "false", "no", "off"}:
+            return True
+        try:
+            return float(normalized) == 0
+        except ValueError:
+            return False
     return False
 
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -477,6 +477,45 @@ class TestConfig:
 
         assert c.context_threshold == 0.75
 
+    def test_from_env_ignores_numeric_zero_disabled_hermes_threshold(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: 0\n  threshold: 0.50\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.75
+
+    def test_from_env_ignores_numeric_zero_float_disabled_hermes_threshold(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: 0.0\n  threshold: 0.50\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.75
+
+    def test_from_env_numeric_one_keeps_hermes_threshold_fallback(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: 1\n  threshold: 0.50\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.50
+
     def test_from_env_ignores_disabled_hermes_threshold_without_pyyaml(self, monkeypatch, tmp_path):
         import hermes_lcm.config as config_mod
 
@@ -492,6 +531,38 @@ class TestConfig:
         c = LCMConfig.from_env()
 
         assert c.context_threshold == 0.75
+
+    def test_from_env_ignores_numeric_zero_float_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: 0.0\n  threshold: '0.50'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.75
+
+    def test_from_env_numeric_one_float_keeps_threshold_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: 1.0\n  threshold: '0.50'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.50
 
     def test_from_env_reads_hermes_threshold_without_pyyaml(self, monkeypatch, tmp_path):
         import hermes_lcm.config as config_mod


### PR DESCRIPTION
## Summary

`compression.enabled: 0` is loaded by PyYAML as numeric zero, not as a string. The disabled-compression fallback added in #191 only handled booleans and strings, so the PyYAML path still treated numeric zero as enabled and inherited `compression.threshold`.

This updates the disabled check to treat numeric zero values as disabled too, including string-y zero values from the minimal YAML parser. Nonzero numeric values still keep the existing Hermes threshold fallback.

## Validation

```text
python -m pytest tests/test_lcm_core.py::TestConfig -q
13 passed

python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
576 passed

python -m pytest -q
726 passed

ulimit -n 1024 && python -m pytest -q
726 passed

python -m compileall -q .
python -m py_compile scripts/import_lossless_claw.py
bash -n scripts/install.sh scripts/update.sh
git diff --check origin/main...HEAD
```

Refs #191.
