### PR TITLE
feat: add benchmark policy comparison metrics

### DIFF
--- a/benchmarking/policies.py
+++ b/benchmarking/policies.py
@@ -42,7 +42,18 @@ def builtin_policies() -> list[LCMPolicy]:
             fresh_tail_count=24,
             leaf_chunk_tokens=8_000,
             target_after_compaction=0.55,
+            policy_version="1",
             notes="Initial deterministic GPT/Codex long-context candidate.",
+        ),
+        LCMPolicy(
+            name="pressure_smoke",
+            context_length=300,
+            context_threshold=0.30,
+            fresh_tail_count=2,
+            leaf_chunk_tokens=24,
+            target_after_compaction=0.55,
+            policy_version="1",
+            notes="Small deterministic pressure policy for benchmark chatter/headroom validation only.",
         ),
     ]
 

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -167,6 +167,12 @@ def _count_retrieval_canaries(engine: Any, fixture: ReplayFixture) -> int:
     return sum(1 for canary in fixture.canaries if _grep_canary(engine, canary))
 
 
+def _ratio(numerator: int | float, denominator: int | float) -> float:
+    if not denominator:
+        return 0.0
+    return numerator / denominator
+
+
 def run_replay(
     fixture: ReplayFixture,
     policy: LCMPolicy,
@@ -197,19 +203,34 @@ def run_replay(
         after = count_messages_tokens(compressed_messages)
         active_canaries = count_active_canaries(compressed_messages, fixture.canaries)
         retrieval_canaries = _count_retrieval_canaries(engine, fixture)
+        tail_count = min(max(policy.fresh_tail_count, 0), len(compressed_messages))
+        fresh_tail = compressed_messages[-tail_count:] if tail_count else []
+        fresh_tail_tokens = count_messages_tokens(fresh_tail)
+        estimated_next_turn_tokens = count_messages_tokens(messages[-2:]) if messages else 0
+        headroom_tokens = engine.threshold_tokens - after
         status = engine.get_status()
         metrics = ReplayMetrics(
             policy_name=policy.name,
+            policy_version=policy.policy_version,
             fixture_name=fixture.name,
+            fixture_tags=list(fixture.tags),
             prompt_tokens_before=before,
             prompt_tokens_after=after,
             threshold_tokens=engine.threshold_tokens,
             compression_count=engine.compression_count,
             compaction_attempts=compaction_attempts,
-            post_compaction_headroom_tokens=engine.threshold_tokens - after,
+            post_compaction_headroom_tokens=headroom_tokens,
+            post_compaction_headroom_ratio=_ratio(headroom_tokens, engine.threshold_tokens),
+            fresh_tail_message_count=tail_count,
+            fresh_tail_tokens=fresh_tail_tokens,
+            fresh_tail_pressure_ratio=_ratio(fresh_tail_tokens, engine.threshold_tokens),
+            estimated_next_turn_tokens=estimated_next_turn_tokens,
+            repeated_compaction_risk=bool(compaction_attempts and headroom_tokens <= estimated_next_turn_tokens),
             active_canaries_found=active_canaries,
             retrieval_canaries_found=retrieval_canaries,
             total_canaries=len(fixture.canaries),
+            active_canary_recall=_ratio(active_canaries, len(fixture.canaries)) if fixture.canaries else 1.0,
+            retrieval_canary_recall=_ratio(retrieval_canaries, len(fixture.canaries)) if fixture.canaries else 1.0,
             failures=failures,
             database_path=str(engine._store.db_path),
             hermes_home=str(engine._hermes_home),
@@ -221,18 +242,33 @@ def run_replay(
     except Exception as exc:
         failures.append(f"{type(exc).__name__}: {exc}")
         after = count_messages_tokens(compressed_messages)
+        tail_count = min(max(policy.fresh_tail_count, 0), len(compressed_messages))
+        fresh_tail = compressed_messages[-tail_count:] if tail_count else []
+        fresh_tail_tokens = count_messages_tokens(fresh_tail)
+        estimated_next_turn_tokens = count_messages_tokens(messages[-2:]) if messages else 0
+        headroom_tokens = engine.threshold_tokens - after
         metrics = ReplayMetrics(
             policy_name=policy.name,
+            policy_version=policy.policy_version,
             fixture_name=fixture.name,
+            fixture_tags=list(fixture.tags),
             prompt_tokens_before=before,
             prompt_tokens_after=after,
             threshold_tokens=engine.threshold_tokens,
             compression_count=engine.compression_count,
             compaction_attempts=compaction_attempts,
-            post_compaction_headroom_tokens=engine.threshold_tokens - after,
+            post_compaction_headroom_tokens=headroom_tokens,
+            post_compaction_headroom_ratio=_ratio(headroom_tokens, engine.threshold_tokens),
+            fresh_tail_message_count=tail_count,
+            fresh_tail_tokens=fresh_tail_tokens,
+            fresh_tail_pressure_ratio=_ratio(fresh_tail_tokens, engine.threshold_tokens),
+            estimated_next_turn_tokens=estimated_next_turn_tokens,
+            repeated_compaction_risk=bool(compaction_attempts and headroom_tokens <= estimated_next_turn_tokens),
             active_canaries_found=0,
             retrieval_canaries_found=0,
             total_canaries=len(fixture.canaries),
+            active_canary_recall=0.0 if fixture.canaries else 1.0,
+            retrieval_canary_recall=0.0 if fixture.canaries else 1.0,
             failures=failures,
             database_path=str(engine._store.db_path),
             hermes_home=str(engine._hermes_home),

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -41,6 +41,10 @@ def _safe_name(value: str) -> str:
     return safe or "replay"
 
 
+def _policy_run_key(policy: LCMPolicy) -> str:
+    return f"{_safe_name(policy.name)}__v{_safe_name(policy.policy_version)}"
+
+
 def deterministic_summary(
     *,
     text: str,
@@ -110,13 +114,14 @@ def _new_engine(policy: LCMPolicy, run_dir: Path):
     _ensure_hermes_lcm_package()
     from hermes_lcm.engine import LCMEngine
 
-    db_path = run_dir / f"{_safe_name(policy.name)}.lcm.db"
+    policy_key = _policy_run_key(policy)
+    db_path = run_dir / f"{policy_key}.lcm.db"
     hermes_home = run_dir / "hermes-home"
     hermes_home.mkdir(parents=True, exist_ok=True)
     config = _config_from_policy(policy, db_path)
     engine = LCMEngine(config=config, hermes_home=str(hermes_home))
-    session_id = f"bench-{_safe_name(policy.name)}"
-    conversation_id = f"bench-{_safe_name(policy.name)}"
+    session_id = f"bench-{policy_key}"
+    conversation_id = f"bench-{policy_key}"
     engine.on_session_start(
         session_id,
         platform="benchmark",
@@ -185,7 +190,7 @@ def run_replay(
     from hermes_lcm.tokens import count_messages_tokens
 
     root_dir = Path(output_dir)
-    run_dir = root_dir / _safe_name(fixture.name)
+    run_dir = root_dir / f"{_safe_name(fixture.name)}__{_policy_run_key(policy)}"
     run_dir.mkdir(parents=True, exist_ok=True)
     engine = _new_engine(policy, run_dir)
     start = time.perf_counter()
@@ -293,6 +298,5 @@ def run_replays(
     root = Path(output_dir)
     for fixture in fixtures:
         for policy in policies:
-            suite_dir = root / f"{_safe_name(fixture.name)}__{_safe_name(policy.name)}"
-            metrics.append(run_replay(fixture, policy, output_dir=suite_dir))
+            metrics.append(run_replay(fixture, policy, output_dir=root))
     return metrics

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -3,22 +3,151 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
+from datetime import UTC, datetime
 from pathlib import Path
 from statistics import mean
-from typing import Iterable
+from typing import Any, Iterable
 
 from .types import ReplayMetrics
+
+BENCHMARK_VERSION = "2"
+FRESH_TAIL_PRESSURE_THRESHOLD = 0.30
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _safe_mean(values: Iterable[int | float]) -> float:
+    selected = list(values)
+    return mean(selected) if selected else 0.0
+
+
+def _safe_ratio(numerator: int | float, denominator: int | float, *, default: float = 0.0) -> float:
+    if not denominator:
+        return default
+    return numerator / denominator
+
+
+def _fixture_suite(rows: list[ReplayMetrics]) -> list[dict[str, object]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        entry = grouped.setdefault(
+            row.fixture_name,
+            {"name": row.fixture_name, "runs": 0, "tags": set()},
+        )
+        entry["runs"] += 1
+        entry["tags"].update(row.fixture_tags)
+    return [
+        {"name": name, "runs": entry["runs"], "tags": sorted(entry["tags"])}
+        for name, entry in sorted(grouped.items())
+    ]
+
+
+def _policy_versions(rows: list[ReplayMetrics]) -> dict[str, str | list[str]]:
+    versions_by_policy: dict[str, set[str]] = defaultdict(set)
+    for row in rows:
+        versions_by_policy[row.policy_name].add(row.policy_version)
+    return {
+        policy_name: versions[0] if len(versions) == 1 else versions
+        for policy_name, raw_versions in sorted(versions_by_policy.items())
+        for versions in [sorted(raw_versions)]
+    }
+
+
+def _metric_summary(rows: list[ReplayMetrics]) -> dict[str, object]:
+    total_canaries = sum(row.total_canaries for row in rows)
+    return {
+        "total_failures": sum(len(row.failures) for row in rows),
+        "compression_count": sum(row.compression_count for row in rows),
+        "compaction_attempts": sum(row.compaction_attempts for row in rows),
+        "repeated_compaction_risk_count": sum(1 for row in rows if row.repeated_compaction_risk),
+        "fresh_tail_pressure_events": sum(
+            1 for row in rows if row.fresh_tail_pressure_ratio >= FRESH_TAIL_PRESSURE_THRESHOLD
+        ),
+        "avg_prompt_tokens_before": _safe_mean(row.prompt_tokens_before for row in rows),
+        "avg_prompt_tokens_after": _safe_mean(row.prompt_tokens_after for row in rows),
+        "avg_post_compaction_headroom_tokens": _safe_mean(
+            row.post_compaction_headroom_tokens for row in rows
+        ),
+        "min_post_compaction_headroom_tokens": min(
+            (row.post_compaction_headroom_tokens for row in rows), default=0
+        ),
+        "total_active_canaries_found": sum(row.active_canaries_found for row in rows),
+        "total_retrieval_canaries_found": sum(row.retrieval_canaries_found for row in rows),
+        "total_canaries": total_canaries,
+        "active_canary_recall": _safe_ratio(
+            sum(row.active_canaries_found for row in rows), total_canaries, default=1.0
+        ),
+        "retrieval_canary_recall": _safe_ratio(
+            sum(row.retrieval_canaries_found for row in rows), total_canaries, default=1.0
+        ),
+    }
+
+
+def compare_policies(metrics: Iterable[ReplayMetrics]) -> list[dict[str, object]]:
+    """Return ranked aggregate policy comparison rows."""
+    grouped: dict[tuple[str, str], list[ReplayMetrics]] = defaultdict(list)
+    for row in metrics:
+        grouped[(row.policy_name, row.policy_version)].append(row)
+
+    comparison: list[dict[str, object]] = []
+    for (policy_name, policy_version), rows in grouped.items():
+        summary = _metric_summary(rows)
+        runs = len(rows)
+        failure_count = int(summary["total_failures"])
+        risk_count = int(summary["repeated_compaction_risk_count"])
+        pressure_events = int(summary["fresh_tail_pressure_events"])
+        active_recall = float(summary["active_canary_recall"])
+        retrieval_recall = float(summary["retrieval_canary_recall"])
+        stability = 1.0 - _safe_ratio(risk_count, runs)
+        recall_score = (retrieval_recall * 0.70) + (active_recall * 0.30)
+        score = round(
+            (recall_score * 100.0)
+            + (stability * 20.0)
+            - (failure_count * 100.0)
+            - (pressure_events * 5.0),
+            3,
+        )
+        comparison.append({
+            "policy_name": policy_name,
+            "policy_version": policy_version,
+            "policy_key": f"{policy_name}@{policy_version}",
+            "runs": runs,
+            "score": score,
+            **summary,
+        })
+
+    return sorted(
+        comparison,
+        key=lambda row: (-float(row["score"]), str(row["policy_key"])),
+    )
 
 
 def summarize_metrics(metrics: Iterable[ReplayMetrics]) -> dict[str, object]:
     rows = list(metrics)
     if not rows:
-        return {"benchmark_version": "1", "runs": 0, "policies": [], "fixtures": []}
+        return {
+            "benchmark_version": BENCHMARK_VERSION,
+            "generated_at_utc": _utc_timestamp(),
+            "runs": 0,
+            "policies": [],
+            "policy_versions": {},
+            "fixtures": [],
+            "fixture_suite": [],
+            "metric_summary": _metric_summary([]),
+            "policy_comparison": [],
+            "metrics": [],
+        }
     return {
-        "benchmark_version": "1",
+        "benchmark_version": BENCHMARK_VERSION,
+        "generated_at_utc": _utc_timestamp(),
         "runs": len(rows),
         "policies": sorted({row.policy_name for row in rows}),
+        "policy_versions": _policy_versions(rows),
         "fixtures": sorted({row.fixture_name for row in rows}),
+        "fixture_suite": _fixture_suite(rows),
         "total_failures": sum(len(row.failures) for row in rows),
         "compression_count": sum(row.compression_count for row in rows),
         "compaction_attempts": sum(row.compaction_attempts for row in rows),
@@ -27,6 +156,8 @@ def summarize_metrics(metrics: Iterable[ReplayMetrics]) -> dict[str, object]:
         "total_active_canaries_found": sum(row.active_canaries_found for row in rows),
         "total_retrieval_canaries_found": sum(row.retrieval_canaries_found for row in rows),
         "total_canaries": sum(row.total_canaries for row in rows),
+        "metric_summary": _metric_summary(rows),
+        "policy_comparison": compare_policies(rows),
         "metrics": [row.to_dict() for row in rows],
     }
 

--- a/benchmarking/types.py
+++ b/benchmarking/types.py
@@ -26,6 +26,7 @@ class LCMPolicy:
     dynamic_leaf_chunk_enabled: bool = False
     target_after_compaction: float | None = None
     min_turns_between_compactions: int = 0
+    policy_version: str = "1"
     notes: str = ""
 
     def to_dict(self) -> dict[str, Any]:
@@ -48,6 +49,7 @@ class LCMPolicy:
                 else float(data["target_after_compaction"])
             ),
             min_turns_between_compactions=int(data.get("min_turns_between_compactions", 0)),
+            policy_version=str(data.get("policy_version", "1")),
             notes=str(data.get("notes", "")),
         )
 
@@ -110,6 +112,16 @@ class ReplayMetrics:
     retrieval_canaries_found: int
     total_canaries: int
     failures: list[str] = field(default_factory=list)
+    policy_version: str = "1"
+    fixture_tags: list[str] = field(default_factory=list)
+    post_compaction_headroom_ratio: float = 0.0
+    fresh_tail_message_count: int = 0
+    fresh_tail_tokens: int = 0
+    fresh_tail_pressure_ratio: float = 0.0
+    estimated_next_turn_tokens: int = 0
+    repeated_compaction_risk: bool = False
+    active_canary_recall: float = 0.0
+    retrieval_canary_recall: float = 0.0
     database_path: str = ""
     hermes_home: str = ""
     active_message_count: int = 0
@@ -135,6 +147,16 @@ class ReplayMetrics:
             retrieval_canaries_found=int(data["retrieval_canaries_found"]),
             total_canaries=int(data["total_canaries"]),
             failures=[str(item) for item in data.get("failures", [])],
+            policy_version=str(data.get("policy_version", "1")),
+            fixture_tags=[str(item) for item in data.get("fixture_tags", [])],
+            post_compaction_headroom_ratio=float(data.get("post_compaction_headroom_ratio", 0.0)),
+            fresh_tail_message_count=int(data.get("fresh_tail_message_count", 0)),
+            fresh_tail_tokens=int(data.get("fresh_tail_tokens", 0)),
+            fresh_tail_pressure_ratio=float(data.get("fresh_tail_pressure_ratio", 0.0)),
+            estimated_next_turn_tokens=int(data.get("estimated_next_turn_tokens", 0)),
+            repeated_compaction_risk=_as_bool(data.get("repeated_compaction_risk", False)),
+            active_canary_recall=float(data.get("active_canary_recall", 0.0)),
+            retrieval_canary_recall=float(data.get("retrieval_canary_recall", 0.0)),
             database_path=str(data.get("database_path", "")),
             hermes_home=str(data.get("hermes_home", "")),
             active_message_count=int(data.get("active_message_count", 0)),

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,72 @@
+# hermes-lcm deterministic benchmarks
+
+This directory contains deterministic replay fixtures and policy files for benchmark-driven LCM preset work.
+
+The benchmark harness is offline by default:
+
+- no live provider calls
+- deterministic summarization stub
+- no live Hermes config mutation
+- writes isolated to the requested output directory
+
+## Run the default replay suite
+
+```bash
+python scripts/lcm_benchmark.py \
+  --fixture benchmarks/fixtures/long_history_canaries.json \
+  --fixture benchmarks/fixtures/repeated_compaction_chatter.json \
+  --output benchmarks/runs/local-smoke \
+  --json
+```
+
+Use `--allow-external-output` when writing outside the repository:
+
+```bash
+python scripts/lcm_benchmark.py \
+  --fixture benchmarks/fixtures/repeated_compaction_chatter.json \
+  --output /tmp/hermes-lcm-benchmark \
+  --allow-external-output \
+  --json
+```
+
+When no `--policy` is supplied, the harness loads built-in policies:
+
+- `baseline_272k`, current long-context baseline
+- `codex_gpt_long_context_candidate`, initial Codex/GPT long-context candidate
+- `pressure_smoke`, a deliberately small benchmark-only policy that proves pressure/chatter metrics trigger compaction
+
+`pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
+
+## Output files
+
+The harness writes:
+
+- `metrics.jsonl`, one serialized replay result per fixture/policy pair
+- `summary.json`, aggregate provenance, metric summary, and ranked policy comparison
+- per-run `metrics.json` files under fixture/policy output directories
+
+Summary metadata includes:
+
+- `benchmark_version`
+- `generated_at_utc`
+- `fixture_suite`
+- `policy_versions`
+- `metric_summary`
+- `policy_comparison`
+
+The comparison score is intentionally conservative. It rewards canary recall and stability, then penalizes failures, repeated-compaction risk, and excessive fresh-tail pressure. Treat it as a harness signal, not as proof that a policy is ready to become `preset: auto`.
+
+## Metrics added for preset research
+
+Each replay records:
+
+- `post_compaction_headroom_tokens`
+- `post_compaction_headroom_ratio`
+- `fresh_tail_tokens`
+- `fresh_tail_pressure_ratio`
+- `estimated_next_turn_tokens`
+- `repeated_compaction_risk`
+- `active_canary_recall`
+- `retrieval_canary_recall`
+
+These are the first benchmark-quality signals for issue #189. Runtime preset selection, `/lcm preset suggest`, `/lcm preset apply`, live-provider tuning, and automatic config edits remain out of scope.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -43,7 +43,7 @@ The harness writes:
 
 - `metrics.jsonl`, one serialized replay result per fixture/policy pair
 - `summary.json`, aggregate provenance, metric summary, and ranked policy comparison
-- per-run `metrics.json` files under fixture/policy output directories
+- per-run `metrics.json` files under fixture/policy-version output directories, for example `fixture__policy__v1/metrics.json`
 
 Summary metadata includes:
 

--- a/benchmarks/policies/baseline.yaml
+++ b/benchmarks/policies/baseline.yaml
@@ -8,4 +8,5 @@ incremental_max_depth: 1
 dynamic_leaf_chunk_enabled: false
 target_after_compaction: null
 min_turns_between_compactions: 0
+policy_version: "1"
 notes: "Current long-context baseline: 64-message fresh tail, 20k leaf chunks."

--- a/benchmarks/policies/pressure_smoke.yaml
+++ b/benchmarks/policies/pressure_smoke.yaml
@@ -1,0 +1,12 @@
+name: pressure_smoke
+context_length: 300
+context_threshold: 0.30
+fresh_tail_count: 2
+leaf_chunk_tokens: 24
+condensation_fanin: 4
+incremental_max_depth: 1
+dynamic_leaf_chunk_enabled: false
+target_after_compaction: 0.55
+min_turns_between_compactions: 0
+policy_version: "1"
+notes: "Small deterministic pressure policy for benchmark chatter/headroom validation only."

--- a/tests/test_benchmarking_fixtures.py
+++ b/tests/test_benchmarking_fixtures.py
@@ -5,6 +5,8 @@ import json
 import pytest
 
 from benchmarking.fixtures import load_fixture, make_synthetic_fixture
+from benchmarking.policies import load_policy
+from benchmarking.replay import run_replay
 
 
 def test_load_fixture_parses_canaries(tmp_path):
@@ -65,3 +67,16 @@ def test_committed_long_history_fixture_loads():
     assert fixture.name == "long_history_canaries"
     assert fixture.canaries
     assert fixture.messages[0]["role"] == "system"
+
+
+def test_committed_chatter_fixture_with_pressure_policy_compacts(tmp_path):
+    fixture = load_fixture("benchmarks/fixtures/repeated_compaction_chatter.json")
+    policy = load_policy("benchmarks/policies/pressure_smoke.yaml")
+
+    metrics = run_replay(fixture, policy, output_dir=tmp_path)
+
+    assert fixture.tags == ["compaction_chatter", "synthetic"]
+    assert policy.name == "pressure_smoke"
+    assert metrics.compaction_attempts == 1
+    assert metrics.compression_count >= 1
+    assert metrics.repeated_compaction_risk is True

--- a/tests/test_benchmarking_replay.py
+++ b/tests/test_benchmarking_replay.py
@@ -112,3 +112,25 @@ def test_replay_retrieval_expands_raw_hits(tmp_path):
     assert metrics.retrieval_canaries_found == 1
     assert raw_metrics["retrieval_canaries_found"] == 1
     assert raw_metrics["database_path"] == metrics.database_path
+
+
+def test_replay_reports_headroom_fresh_tail_and_chatter_risk_metrics(tmp_path):
+    fixture = make_synthetic_fixture(
+        name="pressure_metrics",
+        message_pairs=8,
+        canary_count=2,
+        filler_words=80,
+    )
+
+    metrics = run_replay(fixture, _small_policy(), output_dir=tmp_path)
+    raw_metrics = json.loads((tmp_path / "pressure_metrics" / "metrics.json").read_text())
+
+    assert metrics.fresh_tail_message_count == 1
+    assert metrics.fresh_tail_tokens > 0
+    assert metrics.fresh_tail_pressure_ratio > 0
+    assert metrics.estimated_next_turn_tokens > 0
+    assert metrics.post_compaction_headroom_ratio == metrics.post_compaction_headroom_tokens / metrics.threshold_tokens
+    assert metrics.active_canary_recall == metrics.active_canaries_found / metrics.total_canaries
+    assert metrics.retrieval_canary_recall == 1.0
+    assert metrics.repeated_compaction_risk is True
+    assert raw_metrics["repeated_compaction_risk"] is True

--- a/tests/test_benchmarking_replay.py
+++ b/tests/test_benchmarking_replay.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import hermes_lcm.engine as lcm_engine
 
 from benchmarking.fixtures import make_synthetic_fixture
-from benchmarking.replay import run_replay
+from benchmarking.replay import run_replay, run_replays
 from benchmarking.types import Canary, LCMPolicy, ReplayFixture
 
 
@@ -95,6 +95,27 @@ def test_replay_uses_output_directory_for_state_and_not_home(tmp_path, monkeypat
     assert not (fake_home / ".hermes" / "lcm.db").exists()
 
 
+def test_run_replays_isolates_same_name_policy_versions(tmp_path):
+    fixture = ReplayFixture(
+        name="versioned_fixture",
+        messages=[
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "small hello"},
+        ],
+    )
+    policies = [
+        _small_policy(name="candidate", policy_version="1", context_length=10_000, context_threshold=0.90),
+        _small_policy(name="candidate", policy_version="2", context_length=10_000, context_threshold=0.90),
+    ]
+
+    metrics = run_replays([fixture], policies, output_dir=tmp_path)
+
+    assert [row.policy_version for row in metrics] == ["1", "2"]
+    assert len({row.database_path for row in metrics}) == 2
+    assert (tmp_path / "versioned_fixture__candidate__v1" / "metrics.json").exists()
+    assert (tmp_path / "versioned_fixture__candidate__v2" / "metrics.json").exists()
+
+
 def test_replay_retrieval_expands_raw_hits(tmp_path):
     fixture = ReplayFixture(
         name="raw_hit",
@@ -107,7 +128,7 @@ def test_replay_retrieval_expands_raw_hits(tmp_path):
     )
 
     metrics = run_replay(fixture, _small_policy(), output_dir=tmp_path)
-    raw_metrics = json.loads((tmp_path / "raw_hit" / "metrics.json").read_text())
+    raw_metrics = json.loads((tmp_path / "raw_hit__small_policy__v1" / "metrics.json").read_text())
 
     assert metrics.retrieval_canaries_found == 1
     assert raw_metrics["retrieval_canaries_found"] == 1
@@ -123,7 +144,7 @@ def test_replay_reports_headroom_fresh_tail_and_chatter_risk_metrics(tmp_path):
     )
 
     metrics = run_replay(fixture, _small_policy(), output_dir=tmp_path)
-    raw_metrics = json.loads((tmp_path / "pressure_metrics" / "metrics.json").read_text())
+    raw_metrics = json.loads((tmp_path / "pressure_metrics__small_policy__v1" / "metrics.json").read_text())
 
     assert metrics.fresh_tail_message_count == 1
     assert metrics.fresh_tail_tokens > 0

--- a/tests/test_benchmarking_report.py
+++ b/tests/test_benchmarking_report.py
@@ -1,0 +1,90 @@
+"""Tests for benchmark summary provenance and policy comparison."""
+
+from benchmarking.report import compare_policies, summarize_metrics
+from benchmarking.types import ReplayMetrics
+
+
+def _metrics(
+    *,
+    policy_name: str,
+    policy_version: str = "1",
+    active_canaries_found: int = 1,
+    retrieval_canaries_found: int = 1,
+    total_canaries: int = 1,
+    repeated_compaction_risk: bool = False,
+    fresh_tail_pressure_ratio: float = 0.10,
+    failures: list[str] | None = None,
+) -> ReplayMetrics:
+    return ReplayMetrics(
+        policy_name=policy_name,
+        policy_version=policy_version,
+        fixture_name="repeated_compaction_chatter",
+        fixture_tags=["compaction_chatter", "synthetic"],
+        prompt_tokens_before=1_000,
+        prompt_tokens_after=500,
+        threshold_tokens=800,
+        compression_count=1,
+        compaction_attempts=1,
+        post_compaction_headroom_tokens=300,
+        post_compaction_headroom_ratio=0.375,
+        fresh_tail_message_count=2,
+        fresh_tail_tokens=80,
+        fresh_tail_pressure_ratio=fresh_tail_pressure_ratio,
+        estimated_next_turn_tokens=120,
+        repeated_compaction_risk=repeated_compaction_risk,
+        active_canaries_found=active_canaries_found,
+        retrieval_canaries_found=retrieval_canaries_found,
+        total_canaries=total_canaries,
+        active_canary_recall=active_canaries_found / total_canaries,
+        retrieval_canary_recall=retrieval_canaries_found / total_canaries,
+        failures=failures or [],
+    )
+
+
+def test_compare_policies_ranks_stable_recall_above_chattery_policy():
+    rows = [
+        _metrics(policy_name="baseline", repeated_compaction_risk=True, fresh_tail_pressure_ratio=0.80),
+        _metrics(policy_name="candidate", policy_version="2"),
+    ]
+
+    comparison = compare_policies(rows)
+
+    assert [row["policy_name"] for row in comparison] == ["candidate", "baseline"]
+    assert comparison[0]["policy_version"] == "2"
+    assert comparison[0]["repeated_compaction_risk_count"] == 0
+    assert comparison[1]["repeated_compaction_risk_count"] == 1
+    assert comparison[1]["fresh_tail_pressure_events"] == 1
+    assert comparison[0]["score"] > comparison[1]["score"]
+
+
+def test_compare_policies_keeps_policy_versions_separate():
+    rows = [
+        _metrics(policy_name="candidate", policy_version="1", repeated_compaction_risk=True),
+        _metrics(policy_name="candidate", policy_version="2"),
+    ]
+
+    comparison = compare_policies(rows)
+
+    assert [(row["policy_name"], row["policy_version"]) for row in comparison] == [
+        ("candidate", "2"),
+        ("candidate", "1"),
+    ]
+    assert [row["runs"] for row in comparison] == [1, 1]
+
+
+def test_summarize_metrics_includes_versioned_provenance_and_comparison():
+    rows = [
+        _metrics(policy_name="baseline", repeated_compaction_risk=True, fresh_tail_pressure_ratio=0.80),
+        _metrics(policy_name="candidate", policy_version="2"),
+    ]
+
+    summary = summarize_metrics(rows)
+
+    assert summary["benchmark_version"] == "2"
+    assert summary["generated_at_utc"].endswith("Z")
+    assert summary["policy_versions"] == {"baseline": "1", "candidate": "2"}
+    assert summary["fixture_suite"] == [
+        {"name": "repeated_compaction_chatter", "runs": 2, "tags": ["compaction_chatter", "synthetic"]}
+    ]
+    assert summary["metric_summary"]["repeated_compaction_risk_count"] == 1
+    assert [row["policy_name"] for row in summary["policy_comparison"]] == ["candidate", "baseline"]

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -57,13 +57,16 @@ def test_metrics_round_trips_with_failure_list():
     assert restored == metrics
 
 
-def test_builtin_policies_include_baseline_and_codex_candidate():
+def test_builtin_policies_include_baseline_codex_candidate_and_pressure_smoke():
     policies = {policy.name: policy for policy in builtin_policies()}
 
     assert policies["baseline_272k"].context_length == 272_000
     assert policies["baseline_272k"].fresh_tail_count == 64
     assert policies["codex_gpt_long_context_candidate"].leaf_chunk_tokens == 8_000
     assert policies["codex_gpt_long_context_candidate"].target_after_compaction == 0.55
+    assert policies["codex_gpt_long_context_candidate"].policy_version == "1"
+    assert policies["pressure_smoke"].context_length < 1_000
+    assert policies["pressure_smoke"].policy_version == "1"
 
 
 def test_load_policy_accepts_json_and_minimal_yaml(tmp_path):


### PR DESCRIPTION
## Summary
- Add benchmark provenance metadata and ranked policy comparison output to `summary.json`.
- Add replay metrics for post-compaction headroom, fresh-tail pressure, repeated-compaction risk, and active/retrieval canary recall.
- Add a benchmark-only `pressure_smoke` policy plus docs so the default replay suite proves pressure/chatter metrics can trigger compaction.
- Isolate replay state and per-run metrics by fixture, policy name, and policy version so same-name policy revisions cannot share benchmark artifacts.

## Why
- #190 landed the deterministic replay harness, but the default output did not yet compare policies or expose enough pressure/headroom signals to evaluate preset candidates.
- #189 needs benchmark-quality evidence before any `preset: auto`, `/lcm preset suggest`, `/lcm preset apply`, live-provider tuning, or config mutation work.

## Validation
- [x] Focused validation on current head `9b1b457`: `python -m pytest tests/test_benchmarking_fixtures.py tests/test_benchmarking_replay.py tests/test_benchmarking_report.py tests/test_benchmarking_types.py -q` -> `21 passed`
- [x] Benchmark smoke on current head `9b1b457`: baseline `long_history_canaries` replay -> passed, `runs=1`, `total_failures=0`, `policy_comparison_keys=[baseline_272k@1]`
- [x] Benchmark smoke on current head `9b1b457`: external-CWD CLI with repo-relative fixture/policy paths -> passed, `runs=1`, `total_failures=0`, `policy_comparison_keys=[baseline_272k@1]`
- [x] Benchmark smoke on current head `9b1b457`: pressure `repeated_compaction_chatter` replay -> passed, `runs=1`, `total_failures=0`, `compression_count=1`, `compaction_attempts=1`, `policy_comparison_keys=[pressure_smoke@1]`
- [x] Default validation on current head `9b1b457` after merging current `origin/main` `8d631d1`: `python -m pytest -q` -> `735 passed`
- [x] Default validation on current head `9b1b457`: `python -m compileall -q .`
- [x] Default validation on current head `9b1b457`: `python -m py_compile scripts/import_lossless_claw.py`
- [x] Default validation on current head `9b1b457`: `bash -n scripts/install.sh scripts/update.sh`
- [x] Default validation on current head `9b1b457`: `git diff --check`
- [x] Workflow validation: unchanged workflows, no workflow files changed

## Notes
- This PR is updated to current `main` with a merge-forward commit so the existing PR branch was normal-pushed, no force push.
- This PR stays benchmark-only. It does not add runtime preset selection, live provider calls, Hermes config mutation, or `/lcm preset` commands.
- `pressure_smoke` is a deterministic benchmark control policy, not a runtime preset recommendation.
- A read-only review pass found two warnings before opening, both fixed: the README now uses ignored `benchmarks/runs/`, and policy comparison separates same-name policy versions instead of blending them.
- Codex later flagged same-name policy versions sharing replay state/output paths. Fixed in `15f6979` with regression coverage.
- Current head is `9b1b457` on current `main` `8d631d1`.

Refs #189
