### PR TITLE
feat: add Codex GPT benchmark policy

### DIFF
--- a/benchmarking/fixtures.py
+++ b/benchmarking/fixtures.py
@@ -11,6 +11,8 @@ from .types import ReplayFixture
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+_MAX_SYNTHETIC_MESSAGE_PAIRS = 250
+_MAX_SYNTHETIC_FILLER_WORDS = 2_000
 
 
 def _resolve_path(path: str | Path) -> Path:
@@ -38,8 +40,42 @@ def load_fixture(path: str | Path) -> ReplayFixture:
     return fixture_from_dict(data)
 
 
-def load_fixtures(paths: Iterable[str | Path]) -> list[ReplayFixture]:
-    return [load_fixture(path) for path in paths]
+def load_fixtures(paths: Iterable[str | Path], synthetic_specs: Iterable[str] | None = None) -> list[ReplayFixture]:
+    fixtures = [load_fixture(path) for path in paths]
+    fixtures.extend(parse_synthetic_fixture_spec(spec) for spec in (synthetic_specs or []))
+    return fixtures
+
+
+def parse_synthetic_fixture_spec(spec: str) -> ReplayFixture:
+    """Parse `name:pairs:canaries:filler_words` into a deterministic fixture."""
+    parts = spec.split(":")
+    if len(parts) != 4 or not parts[0].strip():
+        raise ValueError("synthetic fixture spec must be name:pairs:canaries:filler_words")
+    name = parts[0].strip()
+    try:
+        message_pairs = int(parts[1])
+        canary_count = int(parts[2])
+        filler_words = int(parts[3])
+    except ValueError as exc:
+        raise ValueError("synthetic fixture counts must be integers") from exc
+    if message_pairs <= 0:
+        raise ValueError("message_pairs must be positive")
+    if canary_count < 0:
+        raise ValueError("canary_count cannot be negative")
+    if canary_count > message_pairs:
+        raise ValueError("canary_count cannot exceed message_pairs")
+    if message_pairs > _MAX_SYNTHETIC_MESSAGE_PAIRS:
+        raise ValueError(f"message_pairs exceeds maximum {_MAX_SYNTHETIC_MESSAGE_PAIRS}")
+    if filler_words < 0:
+        raise ValueError("filler_words cannot be negative")
+    if filler_words > _MAX_SYNTHETIC_FILLER_WORDS:
+        raise ValueError(f"filler_words exceeds maximum {_MAX_SYNTHETIC_FILLER_WORDS}")
+    return make_synthetic_fixture(
+        name=name,
+        message_pairs=message_pairs,
+        canary_count=canary_count,
+        filler_words=filler_words,
+    )
 
 
 def iter_fixture_files(directory: str | Path = "benchmarks/fixtures") -> list[Path]:

--- a/benchmarking/policies.py
+++ b/benchmarking/policies.py
@@ -36,14 +36,14 @@ def builtin_policies() -> list[LCMPolicy]:
             notes="Current long-context baseline: 64-message fresh tail, 20k leaf chunks.",
         ),
         LCMPolicy(
-            name="codex_gpt_long_context_candidate",
+            name="codex_gpt_long_context",
             context_length=272_000,
             context_threshold=0.75,
             fresh_tail_count=24,
             leaf_chunk_tokens=8_000,
             target_after_compaction=0.55,
             policy_version="1",
-            notes="Initial deterministic GPT/Codex long-context candidate.",
+            notes="Initial benchmark candidate for GPT/Codex long-context routes.",
         ),
         LCMPolicy(
             name="pressure_smoke",

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -191,6 +191,10 @@ def run_replay(
 
     root_dir = Path(output_dir)
     run_dir = root_dir / f"{_safe_name(fixture.name)}__{_policy_run_key(policy)}"
+    if run_dir.exists() and not run_dir.is_dir():
+        raise ValueError(f"Refusing to reuse benchmark run path that is not a directory: {run_dir}")
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise ValueError(f"Refusing to reuse non-empty benchmark run directory: {run_dir}")
     run_dir.mkdir(parents=True, exist_ok=True)
     engine = _new_engine(policy, run_dir)
     start = time.perf_counter()

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -32,10 +32,35 @@ python scripts/lcm_benchmark.py \
 When no `--policy` is supplied, the harness loads built-in policies:
 
 - `baseline_272k`, current long-context baseline
-- `codex_gpt_long_context_candidate`, initial Codex/GPT long-context candidate
+- `codex_gpt_long_context`, initial GPT/Codex long-context benchmark candidate
 - `pressure_smoke`, a deliberately small benchmark-only policy that proves pressure/chatter metrics trigger compaction
 
-`pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
+The committed policy files in `benchmarks/policies/` are the canonical benchmark inputs. Compare the GPT/Codex candidate against baseline with committed fixtures:
+
+```bash
+python scripts/lcm_benchmark.py \
+  --fixture benchmarks/fixtures/long_history_canaries.json \
+  --fixture benchmarks/fixtures/repeated_compaction_chatter.json \
+  --policy benchmarks/policies/baseline.yaml \
+  --policy benchmarks/policies/codex_gpt_long_context.yaml \
+  --output benchmarks/runs/codex-gpt-long-context \
+  --json
+```
+
+For a large deterministic pressure probe without committing a huge transcript fixture, generate a synthetic fixture inline:
+
+```bash
+python scripts/lcm_benchmark.py \
+  --synthetic-fixture codex_pressure_probe:42:4:1000 \
+  --policy benchmarks/policies/baseline.yaml \
+  --policy benchmarks/policies/codex_gpt_long_context.yaml \
+  --output benchmarks/runs/codex-gpt-pressure \
+  --json
+```
+
+Synthetic fixture specs use `name:pairs:canaries:filler_words` and are deterministic. They are bounded to 250 message pairs and 2,000 filler words so typos do not create huge benchmark outputs. Benchmark output directories should be fresh or cleaned between runs because the harness refuses to reuse non-empty per-run directories.
+
+`codex_gpt_long_context` is a benchmark candidate, not an automatically selected runtime preset yet. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
 
 ## Output files
 

--- a/benchmarks/policies/codex_gpt_long_context.yaml
+++ b/benchmarks/policies/codex_gpt_long_context.yaml
@@ -1,0 +1,12 @@
+name: codex_gpt_long_context
+context_length: 272000
+context_threshold: 0.75
+fresh_tail_count: 24
+leaf_chunk_tokens: 8000
+condensation_fanin: 4
+incremental_max_depth: 1
+dynamic_leaf_chunk_enabled: false
+target_after_compaction: 0.55
+min_turns_between_compactions: 0
+policy_version: "1"
+notes: "Initial benchmark candidate for GPT/Codex long-context routes."

--- a/scripts/lcm_benchmark.py
+++ b/scripts/lcm_benchmark.py
@@ -21,6 +21,12 @@ from benchmarking.report import write_metrics_jsonl, write_summary
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", action="append", default=[], help="Fixture JSON path. Repeatable.")
+    parser.add_argument(
+        "--synthetic-fixture",
+        action="append",
+        default=[],
+        help="Deterministic synthetic fixture spec: name:pairs:canaries:filler_words. Repeatable.",
+    )
     parser.add_argument("--policy", action="append", default=[], help="Policy JSON/YAML path. Repeatable.")
     parser.add_argument("--output", required=True, help="Benchmark output directory.")
     parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
@@ -40,17 +46,17 @@ def _validate_output_path(path: Path, *, allow_external: bool) -> Path:
             f"Refusing output outside repo: {resolved}. "
             "Pass --allow-external-output to override."
         )
-    resolved.mkdir(parents=True, exist_ok=True)
     return resolved
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _parse_args(argv or sys.argv[1:])
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if not args.fixture and not args.synthetic_fixture:
+        raise SystemExit("At least one --fixture or --synthetic-fixture is required")
     output_dir = _validate_output_path(Path(args.output), allow_external=args.allow_external_output)
-    if not args.fixture:
-        raise SystemExit("At least one --fixture path is required")
-    fixtures = load_fixtures(args.fixture)
+    fixtures = load_fixtures(args.fixture, synthetic_specs=args.synthetic_fixture)
     policies = load_policies(args.policy)
+    output_dir.mkdir(parents=True, exist_ok=True)
     metrics = run_replays(fixtures, policies, output_dir=output_dir)
     write_metrics_jsonl(output_dir / "metrics.jsonl", metrics)
     summary = write_summary(output_dir / "summary.json", metrics)

--- a/tests/test_benchmarking_cli.py
+++ b/tests/test_benchmarking_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the deterministic benchmark CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_benchmark_cli():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "lcm_benchmark.py"
+    spec = importlib.util.spec_from_file_location("lcm_benchmark_cli", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_accepts_synthetic_fixture_specs(tmp_path):
+    cli = _load_benchmark_cli()
+
+    result = cli.main([
+        "--synthetic-fixture",
+        "cli_probe:2:1:3",
+        "--policy",
+        "benchmarks/policies/pressure_smoke.yaml",
+        "--output",
+        str(tmp_path),
+        "--allow-external-output",
+        "--json",
+    ])
+
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    metrics = json.loads((tmp_path / "metrics.jsonl").read_text())
+
+    assert result == 0
+    assert summary["fixtures"] == ["cli_probe"]
+    assert summary["policies"] == ["pressure_smoke"]
+    assert metrics["fixture_name"] == "cli_probe"
+    assert metrics["policy_name"] == "pressure_smoke"
+
+
+def test_cli_missing_fixture_does_not_create_output_directory(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "missing-input-output"
+
+    with pytest.raises(SystemExit, match="At least one --fixture or --synthetic-fixture is required"):
+        cli.main([
+            "--output",
+            str(output_dir),
+            "--allow-external-output",
+        ])
+
+    assert not output_dir.exists()
+
+
+def test_cli_empty_argv_does_not_fall_back_to_process_argv(tmp_path, monkeypatch):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "process-argv-output"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pytest",
+            "--synthetic-fixture",
+            "argv_leak:1:1:1",
+            "--policy",
+            "benchmarks/policies/pressure_smoke.yaml",
+            "--output",
+            str(output_dir),
+            "--allow-external-output",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main([])
+
+    assert excinfo.value.code == 2
+    assert not output_dir.exists()
+
+
+def test_cli_invalid_synthetic_spec_does_not_create_output_directory(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "invalid-synthetic-output"
+
+    with pytest.raises(ValueError, match="message_pairs must be positive"):
+        cli.main([
+            "--synthetic-fixture",
+            "bad:0:1:5",
+            "--output",
+            str(output_dir),
+            "--allow-external-output",
+        ])
+
+    assert not output_dir.exists()
+
+
+def test_cli_missing_fixture_path_does_not_create_output_directory(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "missing-fixture-output"
+
+    with pytest.raises(FileNotFoundError):
+        cli.main([
+            "--fixture",
+            "benchmarks/fixtures/does-not-exist.json",
+            "--output",
+            str(output_dir),
+            "--allow-external-output",
+        ])
+
+    assert not output_dir.exists()
+
+
+def test_cli_missing_policy_path_does_not_create_output_directory(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "missing-policy-output"
+
+    with pytest.raises(FileNotFoundError):
+        cli.main([
+            "--synthetic-fixture",
+            "policy_probe:1:1:1",
+            "--policy",
+            "benchmarks/policies/does-not-exist.yaml",
+            "--output",
+            str(output_dir),
+            "--allow-external-output",
+        ])
+
+    assert not output_dir.exists()

--- a/tests/test_benchmarking_fixtures.py
+++ b/tests/test_benchmarking_fixtures.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from benchmarking.fixtures import load_fixture, make_synthetic_fixture
+from benchmarking.fixtures import load_fixture, make_synthetic_fixture, parse_synthetic_fixture_spec
 from benchmarking.policies import load_policy
 from benchmarking.replay import run_replay
 
@@ -59,6 +59,31 @@ def test_make_synthetic_fixture_is_deterministic():
         "CANARY_DETERMINISTIC_0001",
     ]
     assert "CANARY_DETERMINISTIC_0000 = VALUE_DETERMINISTIC_0000" in first.messages[1]["content"]
+
+
+def test_parse_synthetic_fixture_spec_builds_named_fixture():
+    fixture = parse_synthetic_fixture_spec("codex_pressure_probe:5:2:7")
+
+    assert fixture.name == "codex_pressure_probe"
+    assert len(fixture.messages) == 11
+    assert len(fixture.canaries) == 2
+    assert fixture.tags == ["synthetic", "deterministic"]
+    assert "codex_pressure_probe_filler_6" in fixture.messages[1]["content"]
+
+
+def test_parse_synthetic_fixture_spec_rejects_invalid_specs():
+    with pytest.raises(ValueError, match="name:pairs:canaries:filler_words"):
+        parse_synthetic_fixture_spec("bad")
+    with pytest.raises(ValueError, match="message_pairs must be positive"):
+        parse_synthetic_fixture_spec("bad:0:1:5")
+    with pytest.raises(ValueError, match="canary_count cannot be negative"):
+        parse_synthetic_fixture_spec("bad:1:-1:5")
+    with pytest.raises(ValueError, match="canary_count cannot exceed message_pairs"):
+        parse_synthetic_fixture_spec("bad:1:2:5")
+    with pytest.raises(ValueError, match="message_pairs exceeds maximum"):
+        parse_synthetic_fixture_spec("bad:251:1:5")
+    with pytest.raises(ValueError, match="filler_words exceeds maximum"):
+        parse_synthetic_fixture_spec("bad:1:1:2001")
 
 
 def test_committed_long_history_fixture_loads():

--- a/tests/test_benchmarking_replay.py
+++ b/tests/test_benchmarking_replay.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 import hermes_lcm.engine as lcm_engine
 
 from benchmarking.fixtures import make_synthetic_fixture
@@ -93,6 +95,33 @@ def test_replay_uses_output_directory_for_state_and_not_home(tmp_path, monkeypat
     assert Path(metrics.database_path).is_relative_to(output_dir)
     assert Path(metrics.hermes_home).is_relative_to(output_dir)
     assert not (fake_home / ".hermes" / "lcm.db").exists()
+
+
+def test_replay_refuses_to_reuse_existing_non_empty_run_directory(tmp_path):
+    fixture = ReplayFixture(
+        name="stale_fixture",
+        messages=[{"role": "user", "content": "small hello"}],
+    )
+    policy = _small_policy(context_length=10_000, context_threshold=0.90)
+    run_dir = tmp_path / "stale_fixture__small_policy__v1"
+    run_dir.mkdir()
+    (run_dir / "stale.txt").write_text("old benchmark output")
+
+    with pytest.raises(ValueError, match="Refusing to reuse non-empty benchmark run directory"):
+        run_replay(fixture, policy, output_dir=tmp_path)
+
+
+def test_replay_refuses_run_directory_path_that_is_file(tmp_path):
+    fixture = ReplayFixture(
+        name="file_fixture",
+        messages=[{"role": "user", "content": "small hello"}],
+    )
+    policy = _small_policy(context_length=10_000, context_threshold=0.90)
+    run_dir = tmp_path / "file_fixture__small_policy__v1"
+    run_dir.write_text("not a directory")
+
+    with pytest.raises(ValueError, match="Refusing to reuse benchmark run path"):
+        run_replay(fixture, policy, output_dir=tmp_path)
 
 
 def test_run_replays_isolates_same_name_policy_versions(tmp_path):

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -57,16 +57,40 @@ def test_metrics_round_trips_with_failure_list():
     assert restored == metrics
 
 
-def test_builtin_policies_include_baseline_codex_candidate_and_pressure_smoke():
+def test_builtin_policies_include_baseline_codex_policy_and_pressure_smoke():
     policies = {policy.name: policy for policy in builtin_policies()}
 
     assert policies["baseline_272k"].context_length == 272_000
     assert policies["baseline_272k"].fresh_tail_count == 64
-    assert policies["codex_gpt_long_context_candidate"].leaf_chunk_tokens == 8_000
-    assert policies["codex_gpt_long_context_candidate"].target_after_compaction == 0.55
-    assert policies["codex_gpt_long_context_candidate"].policy_version == "1"
+    assert policies["codex_gpt_long_context"].context_length == 272_000
+    assert policies["codex_gpt_long_context"].fresh_tail_count == 24
+    assert policies["codex_gpt_long_context"].leaf_chunk_tokens == 8_000
+    assert policies["codex_gpt_long_context"].target_after_compaction == 0.55
+    assert policies["codex_gpt_long_context"].policy_version == "1"
     assert policies["pressure_smoke"].context_length < 1_000
     assert policies["pressure_smoke"].policy_version == "1"
+
+
+def test_committed_codex_gpt_long_context_policy_matches_builtin_policy():
+    policy = load_policy("benchmarks/policies/codex_gpt_long_context.yaml")
+    builtin = {item.name: item for item in builtin_policies()}["codex_gpt_long_context"]
+
+    assert policy == builtin
+    assert "benchmark candidate" in policy.notes
+
+
+def test_committed_policy_files_match_builtin_policies():
+    builtins = {item.name: item for item in builtin_policies()}
+    policy_paths = [
+        "benchmarks/policies/baseline.yaml",
+        "benchmarks/policies/codex_gpt_long_context.yaml",
+        "benchmarks/policies/pressure_smoke.yaml",
+    ]
+
+    loaded = [load_policy(path) for path in policy_paths]
+
+    assert {policy.name for policy in loaded} == set(builtins)
+    assert loaded == [builtins[policy.name] for policy in loaded]
 
 
 def test_load_policy_accepts_json_and_minimal_yaml(tmp_path):


### PR DESCRIPTION
## Summary
- Add the `codex_gpt_long_context` benchmark candidate as a built-in policy and committed policy file.
- Add deterministic `--synthetic-fixture name:pairs:canaries:filler_words` support for large pressure probes without committing huge transcripts.
- Harden benchmark CLI and replay safety: bounded synthetic specs, input loading before output directory creation, explicit refusal to reuse non-empty per-run directories, and CLI argv regression coverage.
- Add benchmark tests for policy parity, synthetic fixture parsing, CLI behavior, replay isolation, and output safety.

## Why
- Moves #189 from “the harness can compare policies” toward “a candidate policy can beat baseline under pressure” while keeping this benchmark-only.
- Provides repeatable pressure evidence for GPT/Codex long-context tuning without runtime preset selection or live config mutation.

## Validation
- [x] Focused validation: `python -m pytest tests/test_benchmarking_cli.py tests/test_benchmarking_fixtures.py tests/test_benchmarking_replay.py tests/test_benchmarking_report.py tests/test_benchmarking_types.py -q` -> `33 passed`
- [x] Pressure smoke: `python scripts/lcm_benchmark.py --synthetic-fixture codex_pressure_probe:42:4:1000 --policy benchmarks/policies/baseline.yaml --policy benchmarks/policies/codex_gpt_long_context.yaml --output /tmp/hermes-lcm-codex-gpt-pressure-cli-* --allow-external-output --json` -> `runs 2`, `failures 0`, `codex_gpt_long_context@1 score 92.5`, `baseline_272k@1 score 72.5`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `579 passed`
  - [x] `python -m pytest -q` -> `747 passed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'` -> local execution policy blocked lowering the file descriptor limit, not retried
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Workflow validation, if workflows changed: not applicable, no workflow files changed

## Notes
- Benchmark-only: no `preset: auto`, no `/lcm preset suggest`, no `/lcm preset apply`, no live-provider tuning, and no automatic live config mutation.
- Final read-only review of the staged diff returned `APPROVED`.
- The umbrella issue should stay open until benchmark evidence is used to decide whether and how to promote a runtime preset.

Refs #189
