### PR TITLE
feat: add inspectable preset surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ safe shipped suggestion for the current context window when one exists, and
 labels the current selector as `context-only` when the provider/model family is
 not available to the plugin. `/lcm preset apply ... --dry-run` previews env-var
 settings only; it does not
-write files, change process state, or override explicit preset-managed `LCM_*`
-environment variables.
+write files, change process state, or override explicit parseable
+preset-managed `LCM_*` environment variables. Invalid preset-managed env values
+are reported as invalid instead of being treated as active runtime overrides.
 
 The current `codex_gpt_long_context` dry-run preview is:
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,37 @@ If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the
 session.
 
+### Preset inspection and dry-run suggestions
+
+Model-aware presets are inspectable, but they are not automatic live config
+mutations. With `LCM_ENABLE_SLASH_COMMAND=true`, use:
+
+```text
+/lcm preset show codex_gpt_long_context
+/lcm preset suggest
+/lcm preset apply codex_gpt_long_context --dry-run
+```
+
+`/lcm preset show` reports the shipped preset metadata, benchmark provenance,
+policy file, policy version, and metric summary. `/lcm preset suggest` chooses a
+safe shipped suggestion for the current context window when one exists, and
+labels the current selector as `context-only` when the provider/model family is
+not available to the plugin. `/lcm preset apply ... --dry-run` previews env-var
+settings only; it does not
+write files, change process state, or override explicit preset-managed `LCM_*`
+environment variables.
+
+The current `codex_gpt_long_context` dry-run preview is:
+
+```text
+LCM_CONTEXT_THRESHOLD=0.75
+LCM_FRESH_TAIL_COUNT=24
+LCM_LEAF_CHUNK_TOKENS=8000
+```
+
+`target_after_compaction=0.55` is still benchmark provenance, not a runtime
+setting, because the engine does not expose that live knob yet.
+
 ### FAQ: tuning LCM for large context windows
 
 Long-context models change the tuning problem. A 1M-token model does not mean

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -7,9 +7,9 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from statistics import mean
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
-from .types import ReplayMetrics
+from .types import LCMPolicy, ReplayMetrics
 
 BENCHMARK_VERSION = "2"
 FRESH_TAIL_PRESSURE_THRESHOLD = 0.30
@@ -177,3 +177,59 @@ def write_summary(path: str | Path, metrics: Iterable[ReplayMetrics]) -> dict[st
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return summary
+
+
+def _policy_settings(policies: Iterable[LCMPolicy]) -> dict[str, dict[str, object]]:
+    settings: dict[str, dict[str, object]] = {}
+    for policy in policies:
+        data = policy.to_dict()
+        data.pop("notes", None)
+        settings[f"{policy.name}@{policy.policy_version}"] = data
+    return settings
+
+
+def build_community_export(
+    summary: Mapping[str, Any],
+    *,
+    policies: Iterable[LCMPolicy],
+    provider: str = "",
+    model: str = "",
+) -> dict[str, object]:
+    """Build a scrubbed benchmark result export for community sharing.
+
+    The export intentionally omits per-run metrics because those contain local
+    paths such as ``database_path`` and ``hermes_home``. It includes only the
+    aggregate comparison/provenance fields needed to reproduce and discuss a
+    preset result.
+    """
+
+    return {
+        "schema_version": "1",
+        "benchmark_version": summary.get("benchmark_version", BENCHMARK_VERSION),
+        "generated_at_utc": summary.get("generated_at_utc", _utc_timestamp()),
+        "provider": provider,
+        "model": model,
+        "transcript_contents_included": False,
+        "fixtures": list(summary.get("fixtures", [])),
+        "fixture_suite": list(summary.get("fixture_suite", [])),
+        "policies": list(summary.get("policies", [])),
+        "policy_versions": dict(summary.get("policy_versions", {})),
+        "policy_settings": _policy_settings(policies),
+        "metric_summary": dict(summary.get("metric_summary", {})),
+        "policy_comparison": list(summary.get("policy_comparison", [])),
+    }
+
+
+def write_community_export(
+    path: str | Path,
+    summary: Mapping[str, Any],
+    *,
+    policies: Iterable[LCMPolicy],
+    provider: str = "",
+    model: str = "",
+) -> dict[str, object]:
+    export = build_community_export(summary, policies=policies, provider=provider, model=model)
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(export, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return export

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -143,7 +143,7 @@ LCM_FRESH_TAIL_COUNT=24
 LCM_LEAF_CHUNK_TOKENS=8000
 ```
 
-Explicit preset-managed operator config wins. If `LCM_FRESH_TAIL_COUNT` or another supported preset-managed `LCM_*` knob is already set, `/lcm preset suggest` and `/lcm preset apply ... --dry-run` report that value as kept rather than overwritten. Runtime `target_after_compaction` is still benchmark-only metadata because the engine does not yet expose that as a live config field.
+Explicit parseable preset-managed operator config wins. If `LCM_FRESH_TAIL_COUNT` or another supported preset-managed `LCM_*` knob is already set to a value the runtime can parse, `/lcm preset suggest` and `/lcm preset apply ... --dry-run` report that value as kept rather than overwritten. Invalid env values are reported separately, and the preview shows the preset value that would replace them. Runtime `target_after_compaction` is still benchmark-only metadata because the engine does not yet expose that as a live config field.
 
 ## Metrics added for preset research
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,7 +60,7 @@ python scripts/lcm_benchmark.py \
 
 Synthetic fixture specs use `name:pairs:canaries:filler_words` and are deterministic. They are bounded to 250 message pairs and 2,000 filler words so typos do not create huge benchmark outputs. Benchmark output directories should be fresh or cleaned between runs because the harness refuses to reuse non-empty per-run directories.
 
-`codex_gpt_long_context` is a benchmark candidate, not an automatically selected runtime preset yet. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
+`codex_gpt_long_context` is a benchmark candidate and now has an inspectable dry-run preset surface. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
 
 ## Output files
 
@@ -81,6 +81,70 @@ Summary metadata includes:
 
 The comparison score is intentionally conservative. It rewards canary recall and stability, then penalizes failures, repeated-compaction risk, and excessive fresh-tail pressure. Treat it as a harness signal, not as proof that a policy is ready to become `preset: auto`.
 
+## Scrubbed community exports
+
+Use `--export` to write a shareable benchmark result JSON without raw transcript contents or local state paths. The export path follows the same repo-containment policy as `--output`; pass `--allow-external-output` when writing either path outside the repository.
+
+```bash
+python scripts/lcm_benchmark.py \
+  --synthetic-fixture codex_pressure_probe:42:4:1000 \
+  --policy benchmarks/policies/baseline.yaml \
+  --policy benchmarks/policies/codex_gpt_long_context.yaml \
+  --output benchmarks/runs/codex-gpt-pressure \
+  --export benchmarks/runs/codex-gpt-pressure-export.json \
+  --provider openai-codex \
+  --model gpt-5.5
+```
+
+Only the file written by `--export` is the scrubbed community artifact. If you also pass `--json`, stdout prints the full local benchmark summary, including per-run diagnostic paths, and should not be shared as the community export.
+
+The export contract is intentionally aggregate-only:
+
+- `schema_version`
+- `benchmark_version`
+- `generated_at_utc`
+- `provider` and `model` labels supplied by the operator
+- `transcript_contents_included: false`
+- `fixture_suite`
+- `fixtures`
+- `policies`
+- `policy_versions`
+- `policy_settings`
+- `metric_summary`
+- `policy_comparison`
+
+The export omits per-run `metrics` rows because they can include local `database_path` and `hermes_home` values. Raw transcript content is never included by default.
+
+## Preset provenance and dry-run surface
+
+The shipped preset catalog is inspectable from the `/lcm` command surface when slash commands are enabled:
+
+```text
+/lcm preset show codex_gpt_long_context
+/lcm preset suggest
+/lcm preset apply codex_gpt_long_context --dry-run
+```
+
+Current `codex_gpt_long_context` provenance:
+
+- policy file: `benchmarks/policies/codex_gpt_long_context.yaml`
+- policy version: `1`
+- benchmark version: `2`
+- fixture suite: `codex_pressure_probe:42:4:1000`
+- pressure score: `92.5` vs `72.5` for `baseline_272k`
+- retrieval canary recall: `1.0`
+- repeated-compaction risk: candidate `0`, baseline `1`
+
+The dry-run apply surface previews env-var changes only:
+
+```text
+LCM_CONTEXT_THRESHOLD=0.75
+LCM_FRESH_TAIL_COUNT=24
+LCM_LEAF_CHUNK_TOKENS=8000
+```
+
+Explicit preset-managed operator config wins. If `LCM_FRESH_TAIL_COUNT` or another supported preset-managed `LCM_*` knob is already set, `/lcm preset suggest` and `/lcm preset apply ... --dry-run` report that value as kept rather than overwritten. Runtime `target_after_compaction` is still benchmark-only metadata because the engine does not yet expose that as a live config field.
+
 ## Metrics added for preset research
 
 Each replay records:
@@ -94,4 +158,19 @@ Each replay records:
 - `active_canary_recall`
 - `retrieval_canary_recall`
 
-These are the first benchmark-quality signals for issue #189. Runtime preset selection, `/lcm preset suggest`, `/lcm preset apply`, live-provider tuning, and automatic config edits remain out of scope.
+These are the first benchmark-quality signals for issue #189. Runtime `preset: auto`, live-provider tuning, and automatic config edits remain out of scope.
+
+## Symptom-to-knob tuning guide
+
+Use benchmark output and `lcm_status`, not guesswork:
+
+| Symptom | First knob to inspect | Direction |
+|---------|-----------------------|-----------|
+| Compaction happens nearly every turn | `post_compaction_headroom_tokens`, `repeated_compaction_risk`, `LCM_CONTEXT_THRESHOLD` | Lower the trigger or target more headroom before considering runtime auto-preset behavior |
+| Fresh tail dominates the active prompt | `fresh_tail_pressure_ratio`, `fresh_tail_tokens`, `LCM_FRESH_TAIL_COUNT` | Lower the protected tail for long-context GPT/Codex-style routes; keep it high only when recent tool turns must stay verbatim |
+| Leaf passes are huge and slow | `LCM_LEAF_CHUNK_TOKENS`, `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | Reduce chunk size or enable dynamic chunking after confirming raw backlog is the pressure source |
+| Old facts are not in the active prompt but are retrievable | `active_canary_recall`, `retrieval_canary_recall` | Do not overfit for active recall; train usage toward `lcm_grep`, `lcm_expand`, and `lcm_expand_query` |
+| Old facts are not retrievable | `retrieval_canary_recall`, failures, fixture coverage | Treat as a correctness bug or fixture gap before changing preset thresholds |
+| Large tool outputs dominate token pressure | externalization status, payload sizes | Enable large-output externalization before tuning compaction thresholds |
+
+Hard gates for promoting a preset: no replay failures, no raw transcript leakage in exports, stable retrieval recall, explainable fixture/provenance metadata, and no conflict with explicit operator config.

--- a/command.py
+++ b/command.py
@@ -14,6 +14,7 @@ from .dag import build_nodes_fts_spec
 from .presets import (
     explicit_operator_overrides,
     get_preset,
+    invalid_operator_overrides,
     preset_env_diff,
     shipped_presets,
     suggest_preset_for_engine,
@@ -1430,6 +1431,10 @@ def _preset_suggest_text(engine) -> str:
         return "\n".join(lines)
 
     explicit = explicit_operator_overrides()
+    invalid = invalid_operator_overrides()
+    invalid_text = ", ".join(
+        f"{env_var}={os.environ.get(env_var, '')}" for env_var in sorted(invalid.values())
+    ) if invalid else "(none)"
     lines.extend([
         f"suggested_preset: {preset.name}",
         f"reason: {reason}",
@@ -1437,6 +1442,7 @@ def _preset_suggest_text(engine) -> str:
         f"policy_version: {preset.policy_version}",
         f"benchmark_version: {preset.provenance.get('benchmark_version', '(unknown)')}",
         "explicit_overrides: " + (", ".join(sorted(explicit.values())) if explicit else "(none)"),
+        f"invalid_overrides: {invalid_text}",
         "preview:",
     ])
     for item in preset_env_diff(preset, engine._config):

--- a/command.py
+++ b/command.py
@@ -11,6 +11,14 @@ from typing import Any
 from .db_bootstrap import external_content_fts_needs_repair, repair_external_content_fts
 from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks
 from .dag import build_nodes_fts_spec
+from .presets import (
+    explicit_operator_overrides,
+    get_preset,
+    preset_env_diff,
+    shipped_presets,
+    suggest_preset_for_engine,
+    unsupported_runtime_fields_text,
+)
 from .session_patterns import build_session_match_keys, matches_session_pattern
 from .store import build_message_fts_spec
 
@@ -94,6 +102,9 @@ def _help_text(error: str | None = None) -> str:
         "- /lcm backup: create a timestamped SQLite backup before any future cleanup workflow",
         "- /lcm rotate: preview a tail-preserving in-place compact of the active session (read-only)",
         "- /lcm rotate apply: backup-first rotate that advances the lifecycle frontier past pre-tail raw messages",
+        "- /lcm preset show [name]: inspect shipped preset metadata and benchmark provenance",
+        "- /lcm preset suggest: preview the best shipped preset for the current engine state",
+        "- /lcm preset apply <name> --dry-run: preview env-var changes without mutating live config",
         "- /lcm help: show this help",
     ])
     return "\n".join(lines)
@@ -1360,6 +1371,134 @@ def _backup_text(engine) -> str:
     ])
 
 
+def _unknown_preset_text(name: str) -> str:
+    available = ", ".join(preset.name for preset in shipped_presets()) or "(none)"
+    return "\n".join([
+        "LCM preset",
+        "status: error",
+        f"error: unknown preset {name}",
+        f"available_presets: {available}",
+    ])
+
+
+def _preset_show_text(tokens: list[str], engine) -> str:
+    if len(tokens) > 1:
+        return _help_text("`/lcm preset show` accepts at most one preset name.")
+    preset = get_preset(tokens[0] if tokens else None)
+    if preset is None:
+        return _unknown_preset_text(tokens[0])
+    provenance = dict(preset.provenance)
+    metric_summary = dict(provenance.get("metric_summary") or {})
+    fixture_suite = ", ".join(str(item) for item in provenance.get("fixture_suite") or []) or "(unknown)"
+    applies_to = ", ".join(preset.applies_to) if preset.applies_to else "(unspecified)"
+    lines = [
+        "LCM preset show",
+        f"preset: {preset.name}",
+        f"family: {preset.family}",
+        f"description: {preset.description}",
+        f"policy_version: {preset.policy_version}",
+        f"policy_path: {preset.policy_path}",
+        f"benchmark_version: {provenance.get('benchmark_version', '(unknown)')}",
+        f"fixture_suite: {fixture_suite}",
+        f"score: {metric_summary.get('score', '(unknown)')}",
+        f"baseline_score: {metric_summary.get('baseline_score', '(unknown)')}",
+        f"retrieval_canary_recall: {metric_summary.get('retrieval_canary_recall', '(unknown)')}",
+        f"applies_to: {applies_to}",
+        "runtime_env:",
+    ]
+    for item in preset_env_diff(preset, engine._config):
+        lines.append(f"- {item}")
+    lines.extend([
+        f"unsupported_runtime_fields: {unsupported_runtime_fields_text(preset)}",
+        "operator_config_precedence: explicit preset-managed LCM_* overrides win",
+        "runtime_mutation: no",
+        f"notes: {preset.notes}",
+    ])
+    return "\n".join(lines)
+
+
+def _preset_suggest_text(engine) -> str:
+    preset, reason = suggest_preset_for_engine(engine)
+    lines = ["LCM preset suggest"]
+    if preset is None:
+        lines.extend([
+            "suggested_preset: (none)",
+            f"reason: {reason}",
+            "note: run deterministic benchmarks before promoting a runtime preset",
+            "note: suggestion only; no live config was changed",
+        ])
+        return "\n".join(lines)
+
+    explicit = explicit_operator_overrides()
+    lines.extend([
+        f"suggested_preset: {preset.name}",
+        f"reason: {reason}",
+        "match_confidence: context-only",
+        f"policy_version: {preset.policy_version}",
+        f"benchmark_version: {preset.provenance.get('benchmark_version', '(unknown)')}",
+        "explicit_overrides: " + (", ".join(sorted(explicit.values())) if explicit else "(none)"),
+        "preview:",
+    ])
+    for item in preset_env_diff(preset, engine._config):
+        lines.append(f"- {item}")
+    lines.extend([
+        f"unsupported_runtime_fields: {unsupported_runtime_fields_text(preset)}",
+        "note: suggestion only; no live config was changed",
+    ])
+    return "\n".join(lines)
+
+
+def _preset_apply_text(tokens: list[str], engine) -> str:
+    if not tokens:
+        return _help_text("`/lcm preset apply` requires a preset name and `--dry-run`.")
+    dry_run = "--dry-run" in tokens
+    selected = [token for token in tokens if token != "--dry-run"]
+    if len(selected) != 1:
+        return _help_text("`/lcm preset apply` accepts exactly one preset name and optional `--dry-run`.")
+    preset_name = selected[0]
+    preset = get_preset(preset_name)
+    if preset is None:
+        return _unknown_preset_text(preset_name)
+    if not dry_run:
+        return "\n".join([
+            "LCM preset apply",
+            "status: denied",
+            "error: preset apply is preview-only for now; pass --dry-run",
+            "note: no live config was changed",
+        ])
+
+    lines = [
+        "LCM preset apply",
+        "status: dry-run",
+        f"preset: {preset.name}",
+        "would_set:",
+    ]
+    for item in preset_env_diff(preset, engine._config):
+        lines.append(f"- {item}")
+    lines.extend([
+        f"unsupported_runtime_fields: {unsupported_runtime_fields_text(preset)}",
+        "operator_config_precedence: explicit preset-managed LCM_* overrides win",
+        "note: no live config was changed",
+    ])
+    return "\n".join(lines)
+
+
+def _preset_text(tokens: list[str], engine) -> str:
+    if not tokens:
+        return _help_text("`/lcm preset` requires `show`, `suggest`, or `apply`.")
+    subcommand = tokens[0].lower()
+    rest = tokens[1:]
+    if subcommand == "show":
+        return _preset_show_text(rest, engine)
+    if subcommand == "suggest":
+        if rest:
+            return _help_text("`/lcm preset suggest` does not accept extra arguments.")
+        return _preset_suggest_text(engine)
+    if subcommand == "apply":
+        return _preset_apply_text(rest, engine)
+    return _help_text("`/lcm preset` supports `show`, `suggest`, and `apply`.")
+
+
 def handle_lcm_command(raw_args: str | None, engine) -> str:
     tokens = [part.strip() for part in (raw_args or "").strip().split() if part.strip()]
     if not tokens:
@@ -1403,6 +1542,9 @@ def handle_lcm_command(raw_args: str | None, engine) -> str:
         if len(rest) == 1 and rest[0].lower() == "apply":
             return _rotate_apply_text(engine)
         return _help_text("`/lcm rotate` accepts an optional `apply` subcommand.")
+
+    if head == "preset":
+        return _preset_text(rest, engine)
 
     if head == "help":
         return _help_text()

--- a/presets.py
+++ b/presets.py
@@ -1,0 +1,149 @@
+"""Shipped model-family preset metadata and dry-run helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class LCMPreset:
+    """Inspectable preset metadata.
+
+    Presets are deliberately metadata and dry-run suggestions for now. They do
+    not mutate live config and do not override explicit operator settings.
+    """
+
+    name: str
+    family: str
+    description: str
+    policy_path: str
+    policy_version: str
+    runtime_env: Mapping[str, Any]
+    unsupported_runtime_fields: Mapping[str, Any] = field(default_factory=dict)
+    applies_to: tuple[str, ...] = ()
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    notes: str = ""
+
+    @property
+    def policy_key(self) -> str:
+        return f"{self.name}@{self.policy_version}"
+
+
+_FIELD_ENV = {
+    "context_threshold": "LCM_CONTEXT_THRESHOLD",
+    "fresh_tail_count": "LCM_FRESH_TAIL_COUNT",
+    "leaf_chunk_tokens": "LCM_LEAF_CHUNK_TOKENS",
+    "condensation_fanin": "LCM_CONDENSATION_FANIN",
+    "incremental_max_depth": "LCM_INCREMENTAL_MAX_DEPTH",
+}
+
+_CODEX_GPT_LONG_CONTEXT = LCMPreset(
+    name="codex_gpt_long_context",
+    family="GPT/Codex long-context",
+    description="Benchmark-backed candidate for GPT/Codex-style long-context routes.",
+    policy_path="benchmarks/policies/codex_gpt_long_context.yaml",
+    policy_version="1",
+    runtime_env={
+        "context_threshold": 0.75,
+        "fresh_tail_count": 24,
+        "leaf_chunk_tokens": 8_000,
+    },
+    unsupported_runtime_fields={
+        "target_after_compaction": 0.55,
+    },
+    applies_to=(
+        "Codex/OpenAI-style long-context routes",
+        "large context windows near 272k tokens",
+        "workloads where repeated compaction risk matters more than keeping a 64-message fresh tail",
+    ),
+    provenance={
+        "benchmark_version": "2",
+        "fixture_suite": ["codex_pressure_probe:42:4:1000"],
+        "metric_summary": {
+            "score": 92.5,
+            "baseline_score": 72.5,
+            "retrieval_canary_recall": 1.0,
+            "baseline_repeated_compaction_risk_count": 1,
+            "candidate_repeated_compaction_risk_count": 0,
+        },
+        "evidence": "Merged #194 pressure smoke, benchmark-only candidate policy.",
+    },
+    notes=(
+        "Benchmark-only candidate until the preset surface matures. "
+        "No live provider tuning or automatic config mutation is performed."
+    ),
+)
+
+
+def shipped_presets() -> list[LCMPreset]:
+    """Return the shipped, inspectable preset catalog."""
+
+    return [_CODEX_GPT_LONG_CONTEXT]
+
+
+def get_preset(name: str | None = None) -> LCMPreset | None:
+    """Return a preset by name, or the default shipped preset when omitted."""
+
+    selected = (name or _CODEX_GPT_LONG_CONTEXT.name).strip()
+    for preset in shipped_presets():
+        if preset.name == selected:
+            return preset
+    return None
+
+
+def explicit_operator_overrides(environ: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return runtime preset fields explicitly set by LCM_* env vars."""
+
+    env = environ if environ is not None else os.environ
+    return {
+        field: env_var
+        for field, env_var in _FIELD_ENV.items()
+        if env_var in env
+    }
+
+
+def _current_config_value(config: Any, field: str) -> Any:
+    return getattr(config, field, "(unknown)")
+
+
+def preset_env_diff(
+    preset: LCMPreset,
+    config: Any,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Render env-var changes a preset would suggest without applying them."""
+
+    env = environ if environ is not None else os.environ
+    explicit = explicit_operator_overrides(env)
+    lines: list[str] = []
+    for field, value in preset.runtime_env.items():
+        env_var = _FIELD_ENV[field]
+        if field in explicit:
+            current = env.get(env_var, _current_config_value(config, field))
+            lines.append(f"{env_var}: keep explicit value {current} (preset {value})")
+        else:
+            lines.append(f"{env_var}={value}")
+    return lines
+
+
+def suggest_preset_for_engine(engine: Any) -> tuple[LCMPreset | None, str]:
+    """Return the safest shipped preset suggestion for the current engine state."""
+
+    context_length = int(getattr(engine, "context_length", 0) or 0)
+    if context_length >= 200_000:
+        return (
+            _CODEX_GPT_LONG_CONTEXT,
+            "context-window match for GPT/Codex candidate; verify provider/model family before applying",
+        )
+    return None, f"no shipped benchmarked preset matches context_length {context_length}"
+
+
+def unsupported_runtime_fields_text(preset: LCMPreset) -> str:
+    if not preset.unsupported_runtime_fields:
+        return "(none)"
+    return ", ".join(
+        f"{key}={value}" for key, value in sorted(preset.unsupported_runtime_fields.items())
+    )

--- a/presets.py
+++ b/presets.py
@@ -39,6 +39,14 @@ _FIELD_ENV = {
     "incremental_max_depth": "LCM_INCREMENTAL_MAX_DEPTH",
 }
 
+_FIELD_PARSERS = {
+    "context_threshold": float,
+    "fresh_tail_count": int,
+    "leaf_chunk_tokens": int,
+    "condensation_fanin": int,
+    "incremental_max_depth": int,
+}
+
 _CODEX_GPT_LONG_CONTEXT = LCMPreset(
     name="codex_gpt_long_context",
     family="GPT/Codex long-context",
@@ -93,14 +101,37 @@ def get_preset(name: str | None = None) -> LCMPreset | None:
     return None
 
 
+def _parse_override_value(field: str, raw: str) -> Any:
+    return _FIELD_PARSERS[field](raw)
+
+
+def _valid_override_value(field: str, raw: str) -> bool:
+    try:
+        _parse_override_value(field, raw)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def explicit_operator_overrides(environ: Mapping[str, str] | None = None) -> dict[str, str]:
-    """Return runtime preset fields explicitly set by LCM_* env vars."""
+    """Return parseable runtime preset fields explicitly set by LCM_* env vars."""
 
     env = environ if environ is not None else os.environ
     return {
         field: env_var
         for field, env_var in _FIELD_ENV.items()
-        if env_var in env
+        if env_var in env and _valid_override_value(field, env[env_var])
+    }
+
+
+def invalid_operator_overrides(environ: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return present but unparsable runtime preset env vars."""
+
+    env = environ if environ is not None else os.environ
+    return {
+        field: env_var
+        for field, env_var in _FIELD_ENV.items()
+        if env_var in env and not _valid_override_value(field, env[env_var])
     }
 
 
@@ -118,12 +149,20 @@ def preset_env_diff(
 
     env = environ if environ is not None else os.environ
     explicit = explicit_operator_overrides(env)
+    invalid = invalid_operator_overrides(env)
     lines: list[str] = []
     for field, value in preset.runtime_env.items():
         env_var = _FIELD_ENV[field]
         if field in explicit:
-            current = env.get(env_var, _current_config_value(config, field))
+            current = _parse_override_value(field, env[env_var])
             lines.append(f"{env_var}: keep explicit value {current} (preset {value})")
+        elif field in invalid:
+            raw = env.get(env_var, "")
+            current = _current_config_value(config, field)
+            lines.append(
+                f"{env_var}={value} "
+                f"(invalid current value {raw} ignored by runtime; runtime value {current})"
+            )
         else:
             lines.append(f"{env_var}={value}")
     return lines

--- a/scripts/lcm_benchmark.py
+++ b/scripts/lcm_benchmark.py
@@ -15,7 +15,7 @@ if str(REPO_ROOT) not in sys.path:
 from benchmarking.fixtures import load_fixtures
 from benchmarking.policies import load_policies
 from benchmarking.replay import run_replays
-from benchmarking.report import write_metrics_jsonl, write_summary
+from benchmarking.report import write_community_export, write_metrics_jsonl, write_summary
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -30,6 +30,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--policy", action="append", default=[], help="Policy JSON/YAML path. Repeatable.")
     parser.add_argument("--output", required=True, help="Benchmark output directory.")
     parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
+    parser.add_argument("--export", help="Write a scrubbed community benchmark export JSON file.")
+    parser.add_argument("--provider", default="", help="Provider label for --export metadata.")
+    parser.add_argument("--model", default="", help="Model label for --export metadata.")
     parser.add_argument(
         "--allow-external-output",
         action="store_true",
@@ -54,12 +57,25 @@ def main(argv: list[str] | None = None) -> int:
     if not args.fixture and not args.synthetic_fixture:
         raise SystemExit("At least one --fixture or --synthetic-fixture is required")
     output_dir = _validate_output_path(Path(args.output), allow_external=args.allow_external_output)
+    export_path = (
+        _validate_output_path(Path(args.export), allow_external=args.allow_external_output)
+        if args.export
+        else None
+    )
     fixtures = load_fixtures(args.fixture, synthetic_specs=args.synthetic_fixture)
     policies = load_policies(args.policy)
     output_dir.mkdir(parents=True, exist_ok=True)
     metrics = run_replays(fixtures, policies, output_dir=output_dir)
     write_metrics_jsonl(output_dir / "metrics.jsonl", metrics)
     summary = write_summary(output_dir / "summary.json", metrics)
+    if export_path:
+        write_community_export(
+            export_path,
+            summary,
+            policies=policies,
+            provider=args.provider,
+            model=args.model,
+        )
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     return 0

--- a/scripts/lcm_benchmark.py
+++ b/scripts/lcm_benchmark.py
@@ -30,13 +30,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--policy", action="append", default=[], help="Policy JSON/YAML path. Repeatable.")
     parser.add_argument("--output", required=True, help="Benchmark output directory.")
     parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
-    parser.add_argument("--export", help="Write a scrubbed community benchmark export JSON file.")
+    parser.add_argument(
+        "--export",
+        help="Write a scrubbed community benchmark export JSON file under --output.",
+    )
     parser.add_argument("--provider", default="", help="Provider label for --export metadata.")
     parser.add_argument("--model", default="", help="Model label for --export metadata.")
     parser.add_argument(
         "--allow-external-output",
         action="store_true",
-        help="Allow --output outside this repository.",
+        help="Allow --output outside this repository. --export must still be under --output.",
     )
     return parser.parse_args(argv)
 
@@ -52,16 +55,44 @@ def _validate_output_path(path: Path, *, allow_external: bool) -> Path:
     return resolved
 
 
+def _validate_export_path(path: Path, *, output_dir: Path) -> Path:
+    output_root = output_dir.resolve()
+    if path.is_absolute():
+        resolved = path.resolve()
+    else:
+        cwd_relative = path.resolve()
+        resolved = (
+            cwd_relative
+            if cwd_relative.is_relative_to(output_root)
+            else (output_root / path).resolve()
+        )
+
+    if not resolved.is_relative_to(output_root):
+        raise SystemExit(
+            f"Refusing --export outside output directory: {resolved}. "
+            "Place the export under --output."
+        )
+
+    repo_root = REPO_ROOT.resolve()
+    if resolved.is_relative_to(repo_root):
+        repo_relative_parts = resolved.relative_to(repo_root).parts
+        if repo_relative_parts and repo_relative_parts[0] == ".git":
+            raise SystemExit(f"Refusing --export inside .git: {resolved}")
+
+    if resolved.exists():
+        raise SystemExit(f"Refusing to overwrite existing export file: {resolved}")
+
+    return resolved
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv if argv is not None else sys.argv[1:])
     if not args.fixture and not args.synthetic_fixture:
         raise SystemExit("At least one --fixture or --synthetic-fixture is required")
     output_dir = _validate_output_path(Path(args.output), allow_external=args.allow_external_output)
-    export_path = (
-        _validate_output_path(Path(args.export), allow_external=args.allow_external_output)
-        if args.export
-        else None
-    )
+    export_path = None
+    if args.export:
+        export_path = _validate_export_path(Path(args.export), output_dir=output_dir)
     fixtures = load_fixtures(args.fixture, synthetic_specs=args.synthetic_fixture)
     policies = load_policies(args.policy)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_benchmarking_cli.py
+++ b/tests/test_benchmarking_cli.py
@@ -131,3 +131,60 @@ def test_cli_missing_policy_path_does_not_create_output_directory(tmp_path):
         ])
 
     assert not output_dir.exists()
+
+
+def test_cli_writes_scrubbed_community_export(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = tmp_path / "benchmark-output"
+    export_path = tmp_path / "community-export.json"
+
+    result = cli.main([
+        "--synthetic-fixture",
+        "export_probe:2:1:3",
+        "--policy",
+        "benchmarks/policies/codex_gpt_long_context.yaml",
+        "--output",
+        str(output_dir),
+        "--allow-external-output",
+        "--export",
+        str(export_path),
+        "--provider",
+        "openai-codex",
+        "--model",
+        "gpt-5.5",
+    ])
+
+    export = json.loads(export_path.read_text())
+    serialized = json.dumps(export, sort_keys=True)
+
+    assert result == 0
+    assert export["schema_version"] == "1"
+    assert export["provider"] == "openai-codex"
+    assert export["model"] == "gpt-5.5"
+    assert export["transcript_contents_included"] is False
+    assert export["policy_settings"]["codex_gpt_long_context@1"]["context_length"] == 272000
+    assert "notes" not in export["policy_settings"]["codex_gpt_long_context@1"]
+    assert "database_path" not in serialized
+    assert "hermes_home" not in serialized
+    assert "messages" not in serialized
+
+
+def test_cli_export_outside_repo_requires_allow_external_output(tmp_path):
+    cli = _load_benchmark_cli()
+    output_dir = Path("benchmarks/runs") / f"export-policy-test-{tmp_path.name}"
+    export_path = tmp_path / "community-export.json"
+
+    with pytest.raises(SystemExit, match="Refusing output outside repo"):
+        cli.main([
+            "--synthetic-fixture",
+            "export_probe:2:1:3",
+            "--policy",
+            "benchmarks/policies/codex_gpt_long_context.yaml",
+            "--output",
+            str(output_dir),
+            "--export",
+            str(export_path),
+        ])
+
+    assert not export_path.exists()
+    assert not output_dir.exists()

--- a/tests/test_benchmarking_cli.py
+++ b/tests/test_benchmarking_cli.py
@@ -136,7 +136,7 @@ def test_cli_missing_policy_path_does_not_create_output_directory(tmp_path):
 def test_cli_writes_scrubbed_community_export(tmp_path):
     cli = _load_benchmark_cli()
     output_dir = tmp_path / "benchmark-output"
-    export_path = tmp_path / "community-export.json"
+    export_path = output_dir / "community-export.json"
 
     result = cli.main([
         "--synthetic-fixture",
@@ -169,12 +169,12 @@ def test_cli_writes_scrubbed_community_export(tmp_path):
     assert "messages" not in serialized
 
 
-def test_cli_export_outside_repo_requires_allow_external_output(tmp_path):
+def test_cli_export_outside_output_directory_is_rejected(tmp_path):
     cli = _load_benchmark_cli()
     output_dir = Path("benchmarks/runs") / f"export-policy-test-{tmp_path.name}"
     export_path = tmp_path / "community-export.json"
 
-    with pytest.raises(SystemExit, match="Refusing output outside repo"):
+    with pytest.raises(SystemExit, match="Refusing --export outside output directory"):
         cli.main([
             "--synthetic-fixture",
             "export_probe:2:1:3",
@@ -188,3 +188,39 @@ def test_cli_export_outside_repo_requires_allow_external_output(tmp_path):
 
     assert not export_path.exists()
     assert not output_dir.exists()
+
+
+def test_cli_export_refuses_existing_repo_file():
+    cli = _load_benchmark_cli()
+    readme_path = Path("README.md")
+    original_readme = readme_path.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="Refusing to overwrite existing export file"):
+        cli.main([
+            "--synthetic-fixture",
+            "export_probe:2:1:3",
+            "--policy",
+            "benchmarks/policies/codex_gpt_long_context.yaml",
+            "--output",
+            ".",
+            "--export",
+            "README.md",
+        ])
+
+    assert readme_path.read_text(encoding="utf-8") == original_readme
+
+
+def test_cli_export_refuses_git_directory():
+    cli = _load_benchmark_cli()
+
+    with pytest.raises(SystemExit, match="Refusing --export inside .git"):
+        cli.main([
+            "--synthetic-fixture",
+            "export_probe:2:1:3",
+            "--policy",
+            "benchmarks/policies/codex_gpt_long_context.yaml",
+            "--output",
+            ".",
+            "--export",
+            ".git/config",
+        ])

--- a/tests/test_benchmarking_report.py
+++ b/tests/test_benchmarking_report.py
@@ -1,6 +1,9 @@
 """Tests for benchmark summary provenance and policy comparison."""
 
-from benchmarking.report import compare_policies, summarize_metrics
+import json
+
+from benchmarking.policies import builtin_policies
+from benchmarking.report import build_community_export, compare_policies, summarize_metrics
 from benchmarking.types import ReplayMetrics
 
 
@@ -88,3 +91,37 @@ def test_summarize_metrics_includes_versioned_provenance_and_comparison():
     ]
     assert summary["metric_summary"]["repeated_compaction_risk_count"] == 1
     assert [row["policy_name"] for row in summary["policy_comparison"]] == ["candidate", "baseline"]
+
+
+def test_build_community_export_is_scrubbed_and_includes_policy_settings():
+    rows = [
+        _metrics(policy_name="baseline_272k", repeated_compaction_risk=True, fresh_tail_pressure_ratio=0.80),
+        _metrics(policy_name="codex_gpt_long_context"),
+    ]
+    rows[0].database_path = "/tmp/private/lcm.db"
+    rows[0].hermes_home = "/home/w0lf/.hermes/profiles/turing"
+    summary = summarize_metrics(rows)
+    policies = builtin_policies()
+
+    export = build_community_export(
+        summary,
+        policies=policies,
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+    serialized = json.dumps(export, sort_keys=True)
+
+    assert export["schema_version"] == "1"
+    assert export["benchmark_version"] == "2"
+    assert export["provider"] == "openai-codex"
+    assert export["model"] == "gpt-5.5"
+    assert export["transcript_contents_included"] is False
+    assert export["policy_settings"]["codex_gpt_long_context@1"]["fresh_tail_count"] == 24
+    assert export["policy_settings"]["codex_gpt_long_context@1"]["leaf_chunk_tokens"] == 8000
+    assert "notes" not in export["policy_settings"]["codex_gpt_long_context@1"]
+    assert export["fixture_suite"] == summary["fixture_suite"]
+    assert export["policy_comparison"] == summary["policy_comparison"]
+    assert "database_path" not in serialized
+    assert "hermes_home" not in serialized
+    assert "/home/w0lf" not in serialized
+    assert "messages" not in serialized

--- a/tests/test_lcm_preset_command.py
+++ b/tests/test_lcm_preset_command.py
@@ -122,3 +122,18 @@ def test_lcm_preset_apply_dry_run_keeps_explicit_managed_env_values(tmp_path, mo
     assert "LCM_LEAF_CHUNK_TOKENS: keep explicit value 12000 (preset 8000)" in result
     assert "LCM_FRESH_TAIL_COUNT=24" in result
     assert engine._config.leaf_chunk_tokens == 12_000
+
+
+def test_lcm_preset_dry_run_does_not_honor_invalid_env_overrides(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "abc")
+    engine = _engine(tmp_path)
+
+    suggest = handle_lcm_command("preset suggest", engine)
+    apply = handle_lcm_command("preset apply codex_gpt_long_context --dry-run", engine)
+
+    assert "explicit_overrides: (none)" in suggest
+    assert "invalid_overrides: LCM_FRESH_TAIL_COUNT=abc" in suggest
+    for result in (suggest, apply):
+        assert "LCM_FRESH_TAIL_COUNT=24 (invalid current value abc ignored by runtime; runtime value 64)" in result
+        assert "keep explicit value abc" not in result

--- a/tests/test_lcm_preset_command.py
+++ b/tests/test_lcm_preset_command.py
@@ -1,0 +1,124 @@
+"""Tests for /lcm preset inspection and dry-run application."""
+
+from hermes_lcm.command import handle_lcm_command
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+_PRESET_ENV_VARS = (
+    "LCM_CONTEXT_THRESHOLD",
+    "LCM_FRESH_TAIL_COUNT",
+    "LCM_LEAF_CHUNK_TOKENS",
+    "LCM_CONDENSATION_FANIN",
+    "LCM_INCREMENTAL_MAX_DEPTH",
+)
+
+
+def _clear_preset_env(monkeypatch):
+    for key in _PRESET_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _engine(tmp_path, *, context_length: int = 272_000) -> LCMEngine:
+    config = LCMConfig(database_path=str(tmp_path / "lcm_preset.db"))
+    hermes_home = tmp_path / "hermes_home"
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine._session_id = "preset-session"
+    engine._session_platform = "cli"
+    engine.context_length = context_length
+    engine.threshold_tokens = int(context_length * config.context_threshold)
+    return engine
+
+
+def test_lcm_preset_help_lists_inspection_commands(tmp_path):
+    engine = _engine(tmp_path)
+
+    result = handle_lcm_command("help", engine)
+
+    assert "- /lcm preset show" in result
+    assert "- /lcm preset suggest" in result
+    assert "- /lcm preset apply <name> --dry-run" in result
+
+
+def test_lcm_preset_show_exposes_codex_provenance_without_mutating_config(tmp_path):
+    engine = _engine(tmp_path)
+    before = (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+    result = handle_lcm_command("preset show codex_gpt_long_context", engine)
+
+    assert "LCM preset show" in result
+    assert "preset: codex_gpt_long_context" in result
+    assert "policy_version: 1" in result
+    assert "benchmark_version: 2" in result
+    assert "fixture_suite: codex_pressure_probe:42:4:1000" in result
+    assert "score: 92.5" in result
+    assert "baseline_score: 72.5" in result
+    assert "policy_path: benchmarks/policies/codex_gpt_long_context.yaml" in result
+    assert "operator_config_precedence: explicit preset-managed LCM_* overrides win" in result
+    assert "runtime_mutation: no" in result
+    assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+
+def test_lcm_preset_suggest_reports_explicit_operator_config_precedence(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "99")
+    engine = _engine(tmp_path)
+    engine._config.fresh_tail_count = 99
+
+    result = handle_lcm_command("preset suggest", engine)
+
+    assert "LCM preset suggest" in result
+    assert "suggested_preset: codex_gpt_long_context" in result
+    assert "reason: context-window match for GPT/Codex candidate; verify provider/model family before applying" in result
+    assert "match_confidence: context-only" in result
+    assert "explicit_overrides: LCM_FRESH_TAIL_COUNT" in result
+    assert "LCM_FRESH_TAIL_COUNT: keep explicit value 99 (preset 24)" in result
+    assert "note: suggestion only; no live config was changed" in result
+
+
+def test_lcm_preset_suggest_declines_unbenchmarked_context_window(tmp_path):
+    engine = _engine(tmp_path, context_length=32_000)
+
+    result = handle_lcm_command("preset suggest", engine)
+
+    assert "LCM preset suggest" in result
+    assert "suggested_preset: (none)" in result
+    assert "reason: no shipped benchmarked preset matches context_length 32000" in result
+    assert "note: run deterministic benchmarks before promoting a runtime preset" in result
+
+
+def test_lcm_preset_apply_requires_dry_run_and_does_not_mutate_config(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    engine = _engine(tmp_path)
+    before = (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+    denied = handle_lcm_command("preset apply codex_gpt_long_context", engine)
+    dry_run = handle_lcm_command("preset apply codex_gpt_long_context --dry-run", engine)
+
+    assert "LCM preset apply" in denied
+    assert "status: denied" in denied
+    assert "error: preset apply is preview-only for now; pass --dry-run" in denied
+    assert "LCM preset apply" in dry_run
+    assert "status: dry-run" in dry_run
+    assert "preset: codex_gpt_long_context" in dry_run
+    assert "would_set:" in dry_run
+    assert "LCM_CONTEXT_THRESHOLD=0.75" in dry_run
+    assert "LCM_FRESH_TAIL_COUNT=24" in dry_run
+    assert "LCM_LEAF_CHUNK_TOKENS=8000" in dry_run
+    assert "unsupported_runtime_fields: target_after_compaction=0.55" in dry_run
+    assert "note: no live config was changed" in dry_run
+    assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+
+def test_lcm_preset_apply_dry_run_keeps_explicit_managed_env_values(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    monkeypatch.setenv("LCM_LEAF_CHUNK_TOKENS", "12000")
+    engine = _engine(tmp_path)
+    engine._config.leaf_chunk_tokens = 12_000
+
+    result = handle_lcm_command("preset apply codex_gpt_long_context --dry-run", engine)
+
+    assert "status: dry-run" in result
+    assert "LCM_LEAF_CHUNK_TOKENS: keep explicit value 12000 (preset 8000)" in result
+    assert "LCM_FRESH_TAIL_COUNT=24" in result
+    assert engine._config.leaf_chunk_tokens == 12_000


### PR DESCRIPTION
## Summary
- Add an inspect-only preset catalog for `codex_gpt_long_context` with benchmark provenance and dry-run application helpers.
- Add `/lcm preset show`, `/lcm preset suggest`, and `/lcm preset apply <name> --dry-run` without mutating live config.
- Add scrubbed community benchmark export JSON, plus docs for preset provenance, export workflow, and symptom-to-knob tuning.
- Validate preset-managed env overrides before honoring them, so invalid `LCM_*` values are reported instead of treated as active runtime overrides.
- Constrain `--export` to the benchmark output directory and refuse existing export targets or `.git/**` paths.

## Why
- Finishes the remaining #189 slices after the candidate policy landed in #194.
- Gives operators inspectable evidence before copying benchmarked settings.
- Keeps `preset: auto`, live-provider tuning, and automatic live config edits explicitly deferred.
- Keeps dry-run guidance aligned with `LCMConfig.from_env` fallback behavior when env values are invalid.
- Preserves the benchmark safety contract that generated artifacts stay isolated to the requested output directory.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_preset_command.py tests/test_benchmarking_cli.py tests/test_benchmarking_report.py tests/test_benchmarking_types.py -q` -> `29 passed`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `580 passed`
  - [x] `python -m pytest -q` -> `791 passed`
  - [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> `791 passed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- No workflow files changed, so `actionlint` was not run. Refreshed onto `origin/main` after #197 and re-ran validation on head `92f6f79`.
- The preset surface is inspect-only. `apply` requires `--dry-run` and only prints env-var suggestions.
- Explicit parseable preset-managed `LCM_*` environment variables win over preset defaults.
- Invalid preset-managed `LCM_*` values are reported as invalid and are not treated as active explicit overrides.
- Community exports are aggregate-only. The local `--json` benchmark summary remains diagnostic output and can include local paths.
- `--export` paths are now output-contained. Relative export names outside `--output` are resolved under `--output`; existing files and `.git/**` are refused.
- `target_after_compaction=0.55` remains benchmark provenance only because it is not a live runtime config field.
- Deferred by design: `preset: auto`, live-provider tuning, automatic live config edits, and silent runtime mutation.

Closes #189

