### PR TITLE
Fix quarantined assistant replay safety

### DIFF
--- a/command.py
+++ b/command.py
@@ -941,6 +941,8 @@ def _doctor_text(engine) -> str:
             "suspicious_data_uri_content_rows": [],
             "suspicious_data_uri_tool_calls_rows": [],
             "suspicious_base64_like_rows": [],
+            "quarantined_assistant_rows": [],
+            "suspicious_repetitive_assistant_rows": [],
         }
         externalized_stats = {
             "externalized_payload_count": 0,
@@ -1090,6 +1092,8 @@ def _doctor_text(engine) -> str:
         f"suspicious_data_uri_content_rows: {payload_risks['suspicious_data_uri_content_rows']}",
         f"suspicious_data_uri_tool_calls_rows: {payload_risks['suspicious_data_uri_tool_calls_rows']}",
         f"suspicious_base64_like_rows: {payload_risks['suspicious_base64_like_rows']}",
+        f"quarantined_assistant_rows: {payload_risks['quarantined_assistant_rows']}",
+        f"suspicious_repetitive_assistant_rows: {payload_risks['suspicious_repetitive_assistant_rows']}",
         f"externalized_payload_dir: {externalized_stats['externalized_payload_dir']}",
         f"externalized_payload_count: {externalized_stats['externalized_payload_count']}",
         f"externalized_payload_bytes: {externalized_stats['externalized_payload_bytes']}",

--- a/engine.py
+++ b/engine.py
@@ -2953,14 +2953,18 @@ class LCMEngine(ContextEngine):
             for idx in range(scan_start, n):
                 ignored_original_messages[idx] = self._matches_ignore_message_patterns(messages[idx])
         externalize_messages = [False] * n
+        prefer_existing_externalized = [False] * n
         for idx in range(scan_start, n):
             externalize_messages[idx] = not ignored_original_messages[idx]
+        for idx in range(0, scan_start):
+            prefer_existing_externalized[idx] = not ignored_original_messages[idx]
         replay_messages = quarantine_suspicious_assistant_messages(
             messages,
             session_id=self._session_id,
             config=self._config,
             hermes_home=self._hermes_home,
             externalize=externalize_messages,
+            prefer_existing_externalized=prefer_existing_externalized,
         )
         if self._ingest_cursor_needs_reconcile:
             reconcile_messages = replay_messages

--- a/engine.py
+++ b/engine.py
@@ -2355,7 +2355,8 @@ class LCMEngine(ContextEngine):
                 r"kind=quarantined_assistant_output; "
                 r"reason=[A-Za-z0-9_.:/-]+; "
                 r"scope=ignored_message_pattern; field=content; "
-                r"chars=\d+; bytes=\d+\]",
+                r"chars=\d+; bytes=\d+; "
+                r"sha256=[0-9a-f]{16}\]",
                 text.strip(),
             )
         )
@@ -2371,9 +2372,10 @@ class LCMEngine(ContextEngine):
         ) or ""
         if matches_message_pattern(text, self._compiled_ignore_message_patterns):
             return True
-        externalized_text = self._stored_row_externalized_text_for_pattern_matching(msg)
-        if externalized_text and externalized_text != text:
-            return matches_message_pattern(externalized_text, self._compiled_ignore_message_patterns)
+        if stored_row:
+            externalized_text = self._stored_row_externalized_text_for_pattern_matching(msg)
+            if externalized_text and externalized_text != text:
+                return matches_message_pattern(externalized_text, self._compiled_ignore_message_patterns)
         return False
 
     def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
@@ -2585,10 +2587,28 @@ class LCMEngine(ContextEngine):
     @staticmethod
     def _is_quarantined_assistant_replay_identity(identity: tuple[str, str, str, str]) -> bool:
         role, content, _tool_call_id, _tool_calls = identity
-        return (
-            role == "assistant"
-            and "assistant output quarantined" in content
-            and "quarantined_assistant_output" in content
+        if role != "assistant":
+            return False
+        text = str(content or "").strip()
+        return bool(
+            re.fullmatch(
+                r"\[Externalized LCM ingest payload: assistant output quarantined; "
+                r"kind=quarantined_assistant_output; "
+                r"reason=[A-Za-z0-9_.:/-]+; "
+                r"field=[A-Za-z0-9_.:/<>\[\]-]+; "
+                r"chars=\d+; bytes=\d+; "
+                r"ref=[^\]\s]+\]",
+                text,
+            )
+            or re.fullmatch(
+                r"\[LCM active replay placeholder: assistant output quarantined; "
+                r"kind=quarantined_assistant_output; "
+                r"reason=[A-Za-z0-9_.:/-]+; "
+                r"scope=ignored_message_pattern; field=content; "
+                r"chars=\d+; bytes=\d+; "
+                r"sha256=[0-9a-f]{16}\]",
+                text,
+            )
         )
 
     def _ignored_message_is_quarantinable_assistant(self, msg: Dict[str, Any]) -> bool:
@@ -2597,11 +2617,11 @@ class LCMEngine(ContextEngine):
             text_content_for_pattern_matching(msg.get("content")) or "",
         ):
             return True
-        if not self._matches_ignore_message_patterns(msg):
-            return False
         identity = self._message_replay_identity(msg)
         if self._is_quarantined_assistant_replay_identity(identity):
             return True
+        if not self._matches_ignore_message_patterns(msg):
+            return False
         if identity[0] != "assistant":
             return False
         content = normalize_content_value(msg.get("content")) or ""
@@ -2651,6 +2671,12 @@ class LCMEngine(ContextEngine):
                 if not self._is_volatile_ignored_quarantine_placeholder(
                     msg,
                     text_content_for_pattern_matching(msg.get("content")) or "",
+                )
+                and not (
+                    self._compiled_ignore_message_patterns
+                    and self._is_quarantined_assistant_replay_identity(
+                        self._message_replay_identity(msg)
+                    )
                 )
             ]
             candidate_identity_messages = (
@@ -2920,17 +2946,21 @@ class LCMEngine(ContextEngine):
             return list(messages)
 
         n = len(messages)
-        ignored_original_messages = (
-            [self._matches_ignore_message_patterns(message) for message in messages]
-            if self._compiled_ignore_message_patterns
-            else [False] * n
-        )
+        cursor = min(max(self._ingest_cursor, 0), n)
+        scan_start = 0 if self._ingest_cursor_needs_reconcile else cursor
+        ignored_original_messages = [False] * n
+        if self._compiled_ignore_message_patterns:
+            for idx in range(scan_start, n):
+                ignored_original_messages[idx] = self._matches_ignore_message_patterns(messages[idx])
+        externalize_messages = [False] * n
+        for idx in range(scan_start, n):
+            externalize_messages[idx] = not ignored_original_messages[idx]
         replay_messages = quarantine_suspicious_assistant_messages(
             messages,
             session_id=self._session_id,
             config=self._config,
             hermes_home=self._hermes_home,
-            externalize=[not ignored for ignored in ignored_original_messages],
+            externalize=externalize_messages,
         )
         if self._ingest_cursor_needs_reconcile:
             reconcile_messages = replay_messages
@@ -2941,7 +2971,7 @@ class LCMEngine(ContextEngine):
                 ]
             self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
             self._ingest_cursor_needs_reconcile = False
-        cursor = self._ingest_cursor
+        cursor = min(max(self._ingest_cursor, 0), n)
         logger.debug(
             "Ingest: session=%s cursor=%d incoming=%d",
             self._session_id, cursor, n,
@@ -2957,7 +2987,10 @@ class LCMEngine(ContextEngine):
         if self._compiled_ignore_message_patterns:
             kept: List[Dict[str, Any]] = []
             for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
-                if ignored_original_messages[cursor + offset]:
+                if ignored_original_messages[cursor + offset] or self._is_volatile_ignored_quarantine_placeholder(
+                    replay_msg,
+                    text_content_for_pattern_matching(replay_msg.get("content")) or "",
+                ):
                     self._ignored_message_count += 1
                     text = text_content_for_pattern_matching(original_msg.get("content")) or ""
                     excerpt = text[:80].replace("\n", " ")

--- a/engine.py
+++ b/engine.py
@@ -2677,11 +2677,13 @@ class LCMEngine(ContextEngine):
                     and self._is_quarantined_assistant_replay_identity(
                         self._message_replay_identity(msg)
                     )
+                    and self._matches_ignore_message_patterns(msg, stored_row=True)
                 )
             ]
+            filtered_candidate_placeholders = len(candidate_non_placeholder_messages) < len(candidate_visible_messages)
             candidate_identity_messages = (
                 candidate_non_placeholder_messages
-                if candidate_non_placeholder_messages
+                if candidate_non_placeholder_messages or filtered_candidate_placeholders
                 else candidate_visible_messages
             )
             candidate_prefix = [

--- a/engine.py
+++ b/engine.py
@@ -2720,8 +2720,18 @@ class LCMEngine(ContextEngine):
             # tail; otherwise a fresh delta can repeat the remaining visible
             # suffix and must be preserved.
             candidate_has_system = any(identity[0] == "system" for identity in candidate_prefix)
-            candidate_dropped_quarantined_assistant = any(
-                self._ignored_message_is_quarantinable_assistant(msg)
+            candidate_dropped_quarantine_replay_placeholder = any(
+                self._is_volatile_ignored_quarantine_placeholder(
+                    msg,
+                    text_content_for_pattern_matching(msg.get("content")) or "",
+                )
+                or (
+                    self._compiled_ignore_message_patterns
+                    and self._is_quarantined_assistant_replay_identity(
+                        self._message_replay_identity(msg)
+                    )
+                    and self._matches_ignore_message_patterns(msg, stored_row=True)
+                )
                 for msg in candidate_messages
             )
             has_quarantined_singleton_replay = (
@@ -2733,7 +2743,7 @@ class LCMEngine(ContextEngine):
             )
             has_filtered_full_replay = (
                 matches_sanitized_tail
-                and candidate_dropped_quarantined_assistant
+                and candidate_dropped_quarantine_replay_placeholder
                 and len(candidate_prefix) >= effective_session_count
                 and effective_session_count > 0
             )

--- a/engine.py
+++ b/engine.py
@@ -37,9 +37,11 @@ from .extraction import (
 )
 from .ingest_protection import (
     _json_has_duplicate_object_keys,
+    assistant_output_quarantine_reason,
     extract_ingest_externalized_refs,
     protect_inline_payloads_in_text,
     protect_messages_for_ingest,
+    quarantine_suspicious_assistant_messages,
     restore_ingest_payload_placeholders,
 )
 from .schemas import (
@@ -605,11 +607,14 @@ class LCMEngine(ContextEngine):
         """Pre-flight check — also ingests messages into the store."""
         if self._session_ignored or self._session_stateless or self._thread_context_stateless():
             return False
+        replay_messages = None
         if self._session_id and messages:
             try:
-                self._ingest_messages(messages)
+                replay_messages = self._ingest_messages(messages)
             except Exception as e:
                 logger.warning("Ingest during preflight: %s", e)
+        if replay_messages is not None and replay_messages != messages:
+            return True
         from .tokens import count_messages_tokens
         rough = count_messages_tokens(messages)
         if self._should_force_overflow_recovery(observed_tokens=rough):
@@ -830,10 +835,12 @@ class LCMEngine(ContextEngine):
             else None
         )
 
-        # Step 1: Ingest new messages into the immutable store
-        self._ingest_messages(messages)
-
-        working_messages = list(messages)
+        # Step 1: Ingest new messages into the immutable store. Work from a
+        # replay-safe view so quarantined assistant loops do not enter summaries
+        # or provider context after the durable row has been written.
+        working_messages = self._ingest_messages(messages)
+        anchor_source_messages = list(working_messages)
+        pressure_messages = messages if len(messages) == len(working_messages) else working_messages
         leaf_compacted_this_turn = False
         leaf_passes = 0
         critical_budget_pressure = self._critical_budget_pressure_reached(
@@ -878,7 +885,8 @@ class LCMEngine(ContextEngine):
                 noop_reason = "no eligible raw backlog outside fresh tail"
                 break
 
-            raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
+            pressure_candidate_raw = pressure_messages[leading_anchor_count:fresh_tail_start]
+            raw_tokens_outside_tail = count_messages_tokens(pressure_candidate_raw)
             if self._config.dynamic_leaf_chunk_enabled:
                 working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
                 if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
@@ -936,7 +944,9 @@ class LCMEngine(ContextEngine):
             self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
             self._persist_frontier_marker()
 
+            pressure_remaining_messages = pressure_messages[leading_anchor_count + len(compacted_chunk):]
             working_messages = working_messages[:leading_anchor_count] + remaining_messages
+            pressure_messages = pressure_messages[:leading_anchor_count] + pressure_remaining_messages
             leaf_compacted_this_turn = True
             leaf_passes += 1
             estimated_active_tokens = max(0, estimated_active_tokens - source_tokens + summary_tokens)
@@ -953,7 +963,10 @@ class LCMEngine(ContextEngine):
                 ]
                 if not remaining_raw:
                     break
-                remaining_raw_tokens = count_messages_tokens(remaining_raw)
+                pressure_remaining_raw = pressure_messages[
+                    leading_anchor_count:max(0, len(pressure_messages) - self._config.fresh_tail_count)
+                ]
+                remaining_raw_tokens = count_messages_tokens(pressure_remaining_raw)
                 remaining_threshold = self._working_leaf_chunk_tokens(remaining_raw_tokens)
                 if remaining_raw_tokens < remaining_threshold:
                     if not (deferred_maintenance_active and critical_budget_pressure):
@@ -965,22 +978,22 @@ class LCMEngine(ContextEngine):
                 observed_tokens=observed_prompt_tokens,
             )
             if force_overflow and len(messages) >= 1:
-                leading_anchor_count = self._leading_anchor_count(messages)
+                leading_anchor_count = self._leading_anchor_count(working_messages)
                 compressed = self._assemble_overflow_recovery_context(
-                    messages[0] if leading_anchor_count else None,
-                    messages[leading_anchor_count:],
+                    working_messages[0] if leading_anchor_count else None,
+                    working_messages[leading_anchor_count:],
                     assembly_cap_override=recovery_assembly_cap,
                 )
                 return self._finalize_forced_overflow_result(
-                    messages,
+                    working_messages,
                     compressed,
                     assembly_cap_override=recovery_assembly_cap,
                 )
             sanitized_messages = self._sanitize_active_context_messages(
-                messages,
+                working_messages,
                 insert_missing_tool_stubs=False,
             )
-            if sanitized_messages != messages:
+            if sanitized_messages != working_messages:
                 # _ingest_messages() already advanced the cursor to the original
                 # active-context length. If the host continues from a sanitized
                 # context, keeping the old cursor could make the next appended
@@ -1009,7 +1022,8 @@ class LCMEngine(ContextEngine):
             observed_tokens=observed_prompt_tokens,
         )
         leading_anchor_count = self._leading_anchor_count(working_messages)
-        self._pending_context_anchor_messages = messages[leading_anchor_count:]
+        anchor_leading_count = self._leading_anchor_count(anchor_source_messages)
+        self._pending_context_anchor_messages = anchor_source_messages[anchor_leading_count:]
         try:
             compressed = self._assemble_context(
                 working_messages[0] if leading_anchor_count else None,
@@ -2305,6 +2319,47 @@ class LCMEngine(ContextEngine):
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
 
+    def _stored_row_externalized_text_for_pattern_matching(self, msg: Dict[str, Any]) -> str:
+        content = msg.get("content")
+        if not isinstance(content, str):
+            return ""
+        refs = extract_ingest_externalized_refs(content)
+        legacy_ref = extract_externalized_ref(content)
+        if legacy_ref and legacy_ref not in refs:
+            refs.append(legacy_ref)
+        parts: list[str] = []
+        session_id = str(msg.get("session_id") or self._session_id or "")
+        for ref in refs:
+            payload = load_externalized_payload(
+                ref,
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            if not payload:
+                continue
+            payload_session_id = str(payload.get("session_id") or "")
+            if session_id and payload_session_id and payload_session_id != session_id:
+                continue
+            payload_content = payload.get("content")
+            if isinstance(payload_content, str):
+                parts.append(payload_content)
+        return "\n".join(parts)
+
+    @staticmethod
+    def _is_volatile_ignored_quarantine_placeholder(msg: Dict[str, Any], text: str) -> bool:
+        if str(msg.get("role") or "") != "assistant":
+            return False
+        return bool(
+            re.fullmatch(
+                r"\[LCM active replay placeholder: assistant output quarantined; "
+                r"kind=quarantined_assistant_output; "
+                r"reason=[A-Za-z0-9_.:/-]+; "
+                r"scope=ignored_message_pattern; field=content; "
+                r"chars=\d+; bytes=\d+\]",
+                text.strip(),
+            )
+        )
+
     def _matches_ignore_message_patterns(self, msg: Dict[str, Any], *, stored_row: bool = False) -> bool:
         if not self._compiled_ignore_message_patterns:
             return False
@@ -2314,7 +2369,12 @@ class LCMEngine(ContextEngine):
             if stored_row
             else text_content_for_pattern_matching(content)
         ) or ""
-        return matches_message_pattern(text, self._compiled_ignore_message_patterns)
+        if matches_message_pattern(text, self._compiled_ignore_message_patterns):
+            return True
+        externalized_text = self._stored_row_externalized_text_for_pattern_matching(msg)
+        if externalized_text and externalized_text != text:
+            return matches_message_pattern(externalized_text, self._compiled_ignore_message_patterns)
+        return False
 
     def _is_replayed_context_scaffold_message(self, msg: Dict[str, Any]) -> bool:
         """Return true for active-context scaffolding that should not be re-ingested."""
@@ -2437,7 +2497,7 @@ class LCMEngine(ContextEngine):
             )
             tool_calls = self._restore_ingest_payload_placeholders_in_value(tool_calls, session_id=session_id)
             ref = extract_externalized_ref(content)
-            if ref:
+            if ref and "quarantined_assistant_output" not in content:
                 payload = load_externalized_payload(
                     ref,
                     config=self._config,
@@ -2522,6 +2582,31 @@ class LCMEngine(ContextEngine):
             tool_calls,
         )
 
+    @staticmethod
+    def _is_quarantined_assistant_replay_identity(identity: tuple[str, str, str, str]) -> bool:
+        role, content, _tool_call_id, _tool_calls = identity
+        return (
+            role == "assistant"
+            and "assistant output quarantined" in content
+            and "quarantined_assistant_output" in content
+        )
+
+    def _ignored_message_is_quarantinable_assistant(self, msg: Dict[str, Any]) -> bool:
+        if self._is_volatile_ignored_quarantine_placeholder(
+            msg,
+            text_content_for_pattern_matching(msg.get("content")) or "",
+        ):
+            return True
+        if not self._matches_ignore_message_patterns(msg):
+            return False
+        identity = self._message_replay_identity(msg)
+        if self._is_quarantined_assistant_replay_identity(identity):
+            return True
+        if identity[0] != "assistant":
+            return False
+        content = normalize_content_value(msg.get("content")) or ""
+        return assistant_output_quarantine_reason(content) is not None
+
     def _stored_tail_for_sanitized_active_replay(
         self,
         stored_tail: list[tuple[str, str, str, str]],
@@ -2554,11 +2639,28 @@ class LCMEngine(ContextEngine):
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
-            candidate_prefix = [
-                self._message_replay_identity(msg)
+            candidate_visible_messages = [
+                msg
                 for msg in candidate_messages
                 if not self._is_replayed_context_scaffold_message(msg)
                 and not self._matches_ignore_message_patterns(msg)
+            ]
+            candidate_non_placeholder_messages = [
+                msg
+                for msg in candidate_visible_messages
+                if not self._is_volatile_ignored_quarantine_placeholder(
+                    msg,
+                    text_content_for_pattern_matching(msg.get("content")) or "",
+                )
+            ]
+            candidate_identity_messages = (
+                candidate_non_placeholder_messages
+                if candidate_non_placeholder_messages
+                else candidate_visible_messages
+            )
+            candidate_prefix = [
+                self._message_replay_identity(msg)
+                for msg in candidate_identity_messages
             ]
             if not candidate_prefix:
                 empty_prefix_cursor = cursor
@@ -2590,8 +2692,28 @@ class LCMEngine(ContextEngine):
             # tail; otherwise a fresh delta can repeat the remaining visible
             # suffix and must be preserved.
             candidate_has_system = any(identity[0] == "system" for identity in candidate_prefix)
+            candidate_dropped_quarantined_assistant = any(
+                self._ignored_message_is_quarantinable_assistant(msg)
+                for msg in candidate_messages
+            )
+            has_quarantined_singleton_replay = (
+                matches_sanitized_tail
+                and len(candidate_prefix) == 1
+                and effective_session_count == 1
+                and self._is_quarantined_assistant_replay_identity(candidate_prefix[0])
+                and self._is_quarantined_assistant_replay_identity(sanitized_replay_tail[0])
+            )
+            has_filtered_full_replay = (
+                matches_sanitized_tail
+                and candidate_dropped_quarantined_assistant
+                and len(candidate_prefix) >= effective_session_count
+                and effective_session_count > 0
+            )
             has_effective_full_replay = matches_sanitized_tail and len(candidate_prefix) >= effective_session_count and (
-                candidate_has_system or (effective_session_count > 1 and not sanitized_tail_collapsed)
+                candidate_has_system
+                or (effective_session_count > 1 and not sanitized_tail_collapsed)
+                or has_quarantined_singleton_replay
+                or has_filtered_full_replay
             )
             has_scaffold_evidence = any(
                 self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages
@@ -2772,7 +2894,7 @@ class LCMEngine(ContextEngine):
         )
         return 0
 
-    def _ingest_messages(self, messages: List[Dict[str, Any]]) -> None:
+    def _ingest_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Persist new messages to the store.
 
         Uses a cursor to track which portion of the current messages list
@@ -2780,10 +2902,14 @@ class LCMEngine(ContextEngine):
         the cursor is reset to len(compressed), so only messages appended
         after compaction are ingested — regardless of how the store count
         compares to the current list length.
+
+        Returns a replay-safe copy of ``messages`` with obviously broken
+        assistant loops replaced by quarantine placeholders. Existing callers may
+        ignore the return value when they only need durable persistence.
         """
         if not self._session_id:
             logger.debug("Ingest skipped: no session_id")
-            return
+            return list(messages)
 
         if self._session_ignored or self._session_stateless:
             logger.debug(
@@ -2791,11 +2917,29 @@ class LCMEngine(ContextEngine):
                 "ignored" if self._session_ignored else "stateless",
                 self._session_id,
             )
-            return
+            return list(messages)
 
         n = len(messages)
+        ignored_original_messages = (
+            [self._matches_ignore_message_patterns(message) for message in messages]
+            if self._compiled_ignore_message_patterns
+            else [False] * n
+        )
+        replay_messages = quarantine_suspicious_assistant_messages(
+            messages,
+            session_id=self._session_id,
+            config=self._config,
+            hermes_home=self._hermes_home,
+            externalize=[not ignored for ignored in ignored_original_messages],
+        )
         if self._ingest_cursor_needs_reconcile:
-            self._ingest_cursor = self._reconcile_ingest_cursor_from_store(messages)
+            reconcile_messages = replay_messages
+            if self._compiled_ignore_message_patterns:
+                reconcile_messages = [
+                    original_msg if ignored_original_messages[idx] else replay_msg
+                    for idx, (original_msg, replay_msg) in enumerate(zip(messages, replay_messages))
+                ]
+            self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
             self._ingest_cursor_needs_reconcile = False
         cursor = self._ingest_cursor
         logger.debug(
@@ -2803,33 +2947,35 @@ class LCMEngine(ContextEngine):
             self._session_id, cursor, n,
         )
 
-        new_messages = messages[cursor:] if cursor < n else []
+        new_messages = replay_messages[cursor:] if cursor < n else []
+        original_new_messages = messages[cursor:] if cursor < n else []
 
         if not new_messages:
-            return
+            return replay_messages
 
+        messages_to_store = new_messages
         if self._compiled_ignore_message_patterns:
             kept: List[Dict[str, Any]] = []
-            for msg in new_messages:
-                if self._matches_ignore_message_patterns(msg):
+            for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
+                if ignored_original_messages[cursor + offset]:
                     self._ignored_message_count += 1
-                    text = text_content_for_pattern_matching(msg.get("content")) or ""
+                    text = text_content_for_pattern_matching(original_msg.get("content")) or ""
                     excerpt = text[:80].replace("\n", " ")
                     logger.debug(
                         "LCM ignore_message_patterns dropped %s message: %r",
-                        msg.get("role", "unknown"),
+                        original_msg.get("role", "unknown"),
                         excerpt,
                     )
                     continue
-                kept.append(msg)
-            new_messages = kept
+                kept.append(replay_msg)
+            messages_to_store = kept
 
-        if not new_messages:
+        if not messages_to_store:
             self._ingest_cursor = n
-            return
+            return replay_messages
 
         protected_messages = protect_messages_for_ingest(
-            new_messages,
+            messages_to_store,
             session_id=self._session_id,
             config=self._config,
             hermes_home=self._hermes_home,
@@ -2842,7 +2988,8 @@ class LCMEngine(ContextEngine):
             source=self._session_platform,
         )
         self._ingest_cursor = n
-        logger.debug("Ingested %d messages into LCM store", len(new_messages))
+        logger.debug("Ingested %d messages into LCM store", len(messages_to_store))
+        return replay_messages
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
         """Map current raw messages back to store_ids in stable store order.

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -250,6 +250,28 @@ def _externalize_quarantined_assistant_output(
     return _quarantined_assistant_placeholder(summary, reason=reason)
 
 
+def _existing_quarantined_assistant_placeholder(
+    content: str,
+    *,
+    role: str,
+    session_id: str,
+    config,
+    hermes_home: str,
+    reason: str,
+) -> str | None:
+    existing = find_externalized_payload_for_message(
+        content,
+        session_id=session_id,
+        kind=_QUARANTINED_ASSISTANT_KIND,
+        role=role,
+        config=config,
+        hermes_home=hermes_home,
+    )
+    if existing is None:
+        return None
+    return _quarantined_assistant_placeholder(existing, reason=reason)
+
+
 def restore_ingest_payload_placeholders(
     text: str,
     *,
@@ -642,6 +664,7 @@ def quarantine_suspicious_assistant_message(
     session_id: str = "",
     *,
     externalize: bool = True,
+    prefer_existing_externalized: bool = False,
 ) -> Dict[str, Any]:
     """Return ``message`` with obviously broken assistant output quarantined.
 
@@ -667,10 +690,21 @@ def quarantine_suspicious_assistant_message(
             reason=reason,
         )
     else:
-        placeholder = _volatile_quarantined_assistant_placeholder(
-            normalized_content,
-            reason=reason,
-        )
+        placeholder = None
+        if prefer_existing_externalized:
+            placeholder = _existing_quarantined_assistant_placeholder(
+                normalized_content,
+                role=role,
+                session_id=session_id,
+                config=config,
+                hermes_home=hermes_home,
+                reason=reason,
+            )
+        if placeholder is None:
+            placeholder = _volatile_quarantined_assistant_placeholder(
+                normalized_content,
+                reason=reason,
+            )
     if not placeholder:
         return msg
     msg["content"] = placeholder
@@ -683,6 +717,7 @@ def quarantine_suspicious_assistant_messages(
     hermes_home: str = "",
     session_id: str = "",
     externalize: List[bool] | None = None,
+    prefer_existing_externalized: List[bool] | None = None,
 ) -> List[Dict[str, Any]]:
     return [
         quarantine_suspicious_assistant_message(
@@ -691,6 +726,9 @@ def quarantine_suspicious_assistant_messages(
             hermes_home=hermes_home,
             session_id=session_id,
             externalize=True if externalize is None else externalize[idx],
+            prefer_existing_externalized=False
+            if prefer_existing_externalized is None
+            else prefer_existing_externalized[idx],
         )
         for idx, message in enumerate(messages)
     ]

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -10,6 +10,7 @@ externalized-payload tools.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -190,12 +191,14 @@ def _quarantined_assistant_placeholder(summary: Dict[str, Any], *, reason: str) 
 
 
 def _volatile_quarantined_assistant_placeholder(content: str, *, reason: str) -> str:
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
     return (
         "[LCM active replay placeholder: assistant output quarantined; "
         f"kind={_QUARANTINED_ASSISTANT_KIND}; "
         f"reason={_safe_placeholder_metadata(reason)}; "
         "scope=ignored_message_pattern; field=content; "
-        f"chars={len(content)}; bytes={len(content.encode('utf-8'))}]"
+        f"chars={len(content)}; bytes={len(content.encode('utf-8'))}; "
+        f"sha256={digest}]"
     )
 
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections import Counter
 from typing import Any, Dict, List
 
 from .externalize import (
     externalize_ingest_payload,
     extract_externalized_ref,
+    find_externalized_payload_for_message,
     is_externalized_placeholder,
     load_externalized_payload,
     maybe_externalize_payload,
@@ -83,6 +85,12 @@ _DATA_URI_BASE64_RE = re.compile(
 _BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{4096,})(?![A-Za-z0-9+/=_-])")
 _BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_\s-]+$")
 _EXTERNALIZED_PLACEHOLDER_PREFIX = "[Externalized LCM ingest payload:"
+_QUARANTINED_ASSISTANT_KIND = "quarantined_assistant_output"
+_QUARANTINED_ASSISTANT_REASON = "high_repetition"
+_QUARANTINED_ASSISTANT_MIN_CHARS = 65_536
+_QUARANTINED_ASSISTANT_MIN_TOKENS = 1_000
+_WORD_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+_REPETITION_SEGMENT_SPLIT_RE = re.compile(r"(?:\n+|(?<=[.!?])\s+)")
 _GENERIC_BASE64_MIN_CHARS = 4096
 _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
 
@@ -110,6 +118,133 @@ def extract_ingest_externalized_refs(text: str) -> list[str]:
         if ref and ref not in refs:
             refs.append(ref)
     return refs
+
+
+def _safe_placeholder_metadata(value: Any) -> str:
+    text = str(value or "?")
+    safe = re.sub(r"[^A-Za-z0-9_.:/-]+", "-", text).strip("-")
+    return (safe or "?")[:120]
+
+
+def _normalized_repetition_segments(text: str) -> list[str]:
+    segments = []
+    for segment in _REPETITION_SEGMENT_SPLIT_RE.split(text):
+        normalized = re.sub(r"\s+", " ", segment.strip().lower())
+        if len(normalized) >= 32:
+            segments.append(normalized)
+    return segments
+
+
+def assistant_output_quarantine_reason(text: str) -> str | None:
+    """Return a quarantine reason for obviously broken assistant output.
+
+    The gate is intentionally conservative: content must be very large and show
+    both low token novelty and repeated sentence/line segments. Long diverse
+    reports and code with varied identifiers should stay inline.
+    """
+    if not isinstance(text, str) or len(text) < _QUARANTINED_ASSISTANT_MIN_CHARS:
+        return None
+
+    normalized = re.sub(r"\s+", " ", text.strip().lower())
+    tokens = _WORD_TOKEN_RE.findall(normalized)
+    if len(tokens) < _QUARANTINED_ASSISTANT_MIN_TOKENS:
+        if len(normalized) >= _QUARANTINED_ASSISTANT_MIN_CHARS and len(set(normalized)) <= 12:
+            return _QUARANTINED_ASSISTANT_REASON
+        return None
+
+    token_counts = Counter(tokens)
+    unique_token_ratio = len(token_counts) / max(1, len(tokens))
+    top_token_ratio = token_counts.most_common(1)[0][1] / max(1, len(tokens))
+
+    segments = _normalized_repetition_segments(text)
+    top_segment_ratio = 0.0
+    duplicate_segment_ratio = 0.0
+    if len(segments) >= 20:
+        segment_counts = Counter(segments)
+        top_segment_ratio = segment_counts.most_common(1)[0][1] / len(segments)
+        duplicate_segment_ratio = 1.0 - (len(segment_counts) / len(segments))
+
+    if unique_token_ratio <= 0.03 and (
+        top_segment_ratio >= 0.10
+        or duplicate_segment_ratio >= 0.50
+        or top_token_ratio >= 0.08
+    ):
+        return _QUARANTINED_ASSISTANT_REASON
+
+    # Covers degenerate long loops with little punctuation/newline structure.
+    if unique_token_ratio <= 0.015 and len(set(normalized)) <= 64:
+        return _QUARANTINED_ASSISTANT_REASON
+
+    return None
+
+
+def _quarantined_assistant_placeholder(summary: Dict[str, Any], *, reason: str) -> str:
+    return (
+        "[Externalized LCM ingest payload: assistant output quarantined; "
+        f"kind={_safe_placeholder_metadata(summary.get('kind') or _QUARANTINED_ASSISTANT_KIND)}; "
+        f"reason={_safe_placeholder_metadata(reason)}; "
+        f"field={_safe_placeholder_metadata(summary.get('field_path') or 'content')}; "
+        f"chars={summary.get('content_chars', 0)}; bytes={summary.get('content_bytes', 0)}; "
+        f"ref={summary.get('ref', '')}]"
+    )
+
+
+def _volatile_quarantined_assistant_placeholder(content: str, *, reason: str) -> str:
+    return (
+        "[LCM active replay placeholder: assistant output quarantined; "
+        f"kind={_QUARANTINED_ASSISTANT_KIND}; "
+        f"reason={_safe_placeholder_metadata(reason)}; "
+        "scope=ignored_message_pattern; field=content; "
+        f"chars={len(content)}; bytes={len(content.encode('utf-8'))}]"
+    )
+
+
+def _externalize_quarantined_assistant_output(
+    content: str,
+    *,
+    role: str,
+    session_id: str,
+    config,
+    hermes_home: str,
+    reason: str,
+) -> str | None:
+    existing = find_externalized_payload_for_message(
+        content,
+        session_id=session_id,
+        kind=_QUARANTINED_ASSISTANT_KIND,
+        role=role,
+        config=config,
+        hermes_home=hermes_home,
+    )
+    if existing is not None:
+        return _quarantined_assistant_placeholder(existing, reason=reason)
+
+    result = externalize_ingest_payload(
+        content,
+        role=role,
+        session_id=session_id,
+        field_path="content",
+        config=config,
+        hermes_home=hermes_home,
+        kind=_QUARANTINED_ASSISTANT_KIND,
+    )
+    if result is None:
+        logger.warning(
+            "LCM ingest protection could not quarantine repetitive assistant output; preserving inline content for lossless recovery"
+        )
+        return None
+
+    payload = result.get("payload") or {}
+    path = result.get("path")
+    summary = {
+        "ref": getattr(path, "name", ""),
+        "kind": payload.get("kind", _QUARANTINED_ASSISTANT_KIND),
+        "role": payload.get("role", role),
+        "field_path": payload.get("field_path", "content"),
+        "content_chars": payload.get("content_chars", len(content)),
+        "content_bytes": payload.get("content_bytes", len(content.encode("utf-8"))),
+    }
+    return _quarantined_assistant_placeholder(summary, reason=reason)
 
 
 def restore_ingest_payload_placeholders(
@@ -442,16 +577,34 @@ def protect_message_for_ingest(
         if is_externalized_ingest_placeholder(normalized_content) or is_externalized_placeholder(normalized_content):
             msg["content"] = original_content
         else:
-            kind = _externalization_kind_for_message(msg)
-            externalized = maybe_externalize_payload(
-                normalized_content,
-                kind=kind,
-                tool_call_id=str(msg.get("tool_call_id") or ""),
-                session_id=session_id,
-                role=role,
-                config=config,
-                hermes_home=hermes_home,
+            reason = (
+                assistant_output_quarantine_reason(normalized_content)
+                if role == "assistant"
+                else None
             )
+            externalized = None
+            if reason:
+                placeholder = _externalize_quarantined_assistant_output(
+                    normalized_content,
+                    role=role,
+                    session_id=session_id,
+                    config=config,
+                    hermes_home=hermes_home,
+                    reason=reason,
+                )
+                if placeholder:
+                    externalized = {"placeholder": placeholder}
+            if externalized is None:
+                kind = _externalization_kind_for_message(msg)
+                externalized = maybe_externalize_payload(
+                    normalized_content,
+                    kind=kind,
+                    tool_call_id=str(msg.get("tool_call_id") or ""),
+                    session_id=session_id,
+                    role=role,
+                    config=config,
+                    hermes_home=hermes_home,
+                )
             if externalized:
                 msg["content"] = externalized["placeholder"]
             else:
@@ -477,6 +630,67 @@ def protect_message_for_ingest(
         )
 
     return msg
+
+
+def quarantine_suspicious_assistant_message(
+    message: Dict[str, Any],
+    config,
+    hermes_home: str = "",
+    session_id: str = "",
+    *,
+    externalize: bool = True,
+) -> Dict[str, Any]:
+    """Return ``message`` with obviously broken assistant output quarantined.
+
+    Unlike full ingest protection, this only touches suspicious assistant text.
+    It is safe for active-context replay because it does not externalize user
+    media, tool results, or ordinary long content.
+    """
+    msg = dict(message or {})
+    role = str(msg.get("role") or "unknown")
+    if role != "assistant":
+        return msg
+    normalized_content = normalize_content_value(msg.get("content"))
+    reason = assistant_output_quarantine_reason(normalized_content)
+    if not reason:
+        return msg
+    if externalize:
+        placeholder = _externalize_quarantined_assistant_output(
+            normalized_content,
+            role=role,
+            session_id=session_id,
+            config=config,
+            hermes_home=hermes_home,
+            reason=reason,
+        )
+    else:
+        placeholder = _volatile_quarantined_assistant_placeholder(
+            normalized_content,
+            reason=reason,
+        )
+    if not placeholder:
+        return msg
+    msg["content"] = placeholder
+    return msg
+
+
+def quarantine_suspicious_assistant_messages(
+    messages: List[Dict[str, Any]],
+    config,
+    hermes_home: str = "",
+    session_id: str = "",
+    externalize: List[bool] | None = None,
+) -> List[Dict[str, Any]]:
+    return [
+        quarantine_suspicious_assistant_message(
+            message,
+            config=config,
+            hermes_home=hermes_home,
+            session_id=session_id,
+            externalize=True if externalize is None else externalize[idx],
+        )
+        for idx, message in enumerate(messages)
+    ]
 
 
 def protect_messages_for_ingest(
@@ -604,6 +818,44 @@ def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
         if len(generic_rows) >= limit:
             break
 
+    quarantined_assistant_rows = [
+        make_row(row, field="content", length_key="content_len", category=_QUARANTINED_ASSISTANT_KIND)
+        for row in conn.execute(
+            """
+            SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
+            FROM messages
+            WHERE role = 'assistant'
+              AND content LIKE '%Externalized LCM ingest payload:%quarantined_assistant_output%'
+            ORDER BY store_id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    ]
+
+    suspicious_repetitive_assistant_rows = []
+    for row in conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
+        FROM messages
+        WHERE role = 'assistant'
+          AND COALESCE(length(content), 0) >= ?
+          AND content NOT LIKE '%Externalized LCM ingest payload:%quarantined_assistant_output%'
+        ORDER BY content_len DESC
+        LIMIT ?
+        """,
+        (_QUARANTINED_ASSISTANT_MIN_CHARS, candidate_cap),
+    ).fetchall():
+        value = row[-1]
+        if isinstance(value, str):
+            reason = assistant_output_quarantine_reason(value)
+            if reason:
+                suspicious_repetitive_assistant_rows.append(
+                    make_row(row, field="content", length_key="content_len", category=reason)
+                )
+        if len(suspicious_repetitive_assistant_rows) >= limit:
+            break
+
     return {
         "largest_content_rows": [
             make_row(row, field="content", length_key="content_len", category="largest_content")
@@ -622,6 +874,8 @@ def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
             for row in data_uri_tool_calls
         ],
         "suspicious_base64_like_rows": generic_rows,
+        "quarantined_assistant_rows": quarantined_assistant_rows,
+        "suspicious_repetitive_assistant_rows": suspicious_repetitive_assistant_rows,
     }
 
 def externalized_payload_stats(config, hermes_home: str = "") -> dict[str, Any]:

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1632,6 +1632,56 @@ class _PrefixPattern:
         return object() if str(text).startswith("Cronjob Response:") else None
 
 
+class _CountingIgnorePattern:
+    pattern = "^DROP:"
+
+    def __init__(self):
+        self.seen: list[str] = []
+
+    def search(self, text, timeout=None):
+        self.seen.append(str(text))
+        return object() if str(text).startswith("DROP:") else None
+
+
+def test_ignore_message_patterns_scan_only_new_tail_after_cursor(tmp_path):
+    engine = _engine(tmp_path)
+    pattern = _CountingIgnorePattern()
+    engine._compiled_ignore_message_patterns = [pattern]
+    messages = [
+        {"role": "user", "content": f"old message {idx}"}
+        for idx in range(50)
+    ]
+
+    engine._ingest_messages(messages)
+    pattern.seen.clear()
+    engine._ingest_messages(messages + [{"role": "user", "content": "new message"}])
+
+    assert pattern.seen == ["new message"]
+    rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["content"] for row in rows][-2:] == ["old message 49", "new message"]
+
+
+def test_live_placeholder_text_does_not_match_ignore_pattern_via_payload(tmp_path):
+    engine = _engine(tmp_path)
+    pattern = _CountingIgnorePattern()
+    engine._compiled_ignore_message_patterns = [pattern]
+    result = externalize_ingest_payload(
+        "DROP: hidden payload should not filter copied placeholder text",
+        role="user",
+        session_id=engine.current_session_id,
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path / "home"),
+    )
+    assert result is not None
+    placeholder = result["placeholder"]
+
+    engine.compress([{"role": "user", "content": placeholder}])
+
+    rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["content"] for row in rows] == [placeholder]
+
+
 def test_ignore_message_patterns_remain_storage_only_for_compress_replay(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm.db"),
@@ -1851,6 +1901,40 @@ def test_singleton_quarantined_assistant_rebind_reconciliation_does_not_duplicat
     assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
 
 
+def test_fresh_singleton_quarantined_assistant_delta_after_rebind_is_stored(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "fresh-singleton-quarantine-delta-session",
+        platform="telegram",
+        conversation_id="fresh-singleton-quarantine-delta-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "assistant", "content": _broken_assistant_output()}])
+    assert len(first._store.get_session_messages(first.current_session_id)) == 1
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second.on_session_start(
+        "fresh-singleton-quarantine-delta-session",
+        platform="telegram",
+        conversation_id="fresh-singleton-quarantine-delta-conversation",
+        context_length=10_000,
+    )
+    second.compress([{"role": "assistant", "content": _broken_assistant_output() + " distinct fresh delta"}])
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert len(second_rows) == 2
+    assert second._last_ingest_reconciliation["action"] == "persisted batch"
+
+
 def test_no_system_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm.db"),
@@ -1888,8 +1972,85 @@ def test_no_system_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(
 
     second_rows = second._store.get_session_messages(second.current_session_id)
     assert [row["role"] for row in second_rows] == ["user"]
+    assert [row["content"] for row in second_rows] == ["fresh request"]
     assert "assistant output quarantined" in str(second_active[0].get("content", ""))
+    assert "sha256=" in str(second_active[0].get("content", ""))
     assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
+
+
+def test_no_system_trailing_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "user", "content": "fresh request"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    first.on_session_start(
+        "no-system-trailing-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-trailing-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert [row["content"] for row in first._store.get_session_messages(first.current_session_id)] == ["fresh request"]
+    assert "sha256=" in str(first_active[-1].get("content", ""))
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "no-system-trailing-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-trailing-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in second_rows] == ["fresh request"]
+
+
+def test_only_ignored_quarantined_assistant_rebind_does_not_store_placeholder(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    first.on_session_start(
+        "only-ignored-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="only-ignored-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress([{"role": "assistant", "content": _broken_assistant_output()}])
+    assert first._store.get_session_messages(first.current_session_id) == []
+    assert "sha256=" in str(first_active[0].get("content", ""))
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "only-ignored-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="only-ignored-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second.compress(first_active)
+
+    assert second._store.get_session_messages(second.current_session_id) == []
 
 
 def test_ignore_message_patterns_do_not_drop_plain_text_that_mentions_quarantine_markers(tmp_path):
@@ -1910,6 +2071,142 @@ def test_ignore_message_patterns_do_not_drop_plain_text_that_mentions_quarantine
 
     rows = engine._store.get_session_messages(engine.current_session_id)
     assert [row["content"] for row in rows] == [text]
+
+
+def test_rebind_with_ignore_patterns_preserves_assistant_text_that_mentions_quarantine_markers(tmp_path):
+    class _DropOnlyPattern:
+        pattern = "drop me only"
+
+        def search(self, text, timeout=None):
+            return object() if "drop me only" in str(text) else None
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    text = (
+        "This assistant message literally mentions assistant output quarantined "
+        "and quarantined_assistant_output, but it is not an LCM placeholder."
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "literal-quarantine-marker-session",
+        platform="telegram",
+        conversation_id="literal-quarantine-marker-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "user", "content": "seed"}])
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_DropOnlyPattern()]
+    second.on_session_start(
+        "literal-quarantine-marker-session",
+        platform="telegram",
+        conversation_id="literal-quarantine-marker-conversation",
+        context_length=10_000,
+    )
+    second.compress([{"role": "assistant", "content": text}])
+
+    rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in rows] == ["seed", text]
+    assert second._last_ingest_reconciliation["action"] == "persisted batch"
+
+
+def test_rebind_with_ignore_patterns_preserves_trailing_literal_quarantine_placeholder_text(tmp_path):
+    class _DropOnlyPattern:
+        pattern = "drop me only"
+
+        def search(self, text, timeout=None):
+            return object() if "drop me only" in str(text) else None
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    literal = (
+        "[LCM active replay placeholder: assistant output quarantined; "
+        "kind=quarantined_assistant_output; reason=high_repetition; "
+        "scope=ignored_message_pattern; field=content; chars=65536; bytes=65536]"
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "trailing-literal-quarantine-placeholder-session",
+        platform="telegram",
+        conversation_id="trailing-literal-quarantine-placeholder-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "user", "content": "seed"}])
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_DropOnlyPattern()]
+    second.on_session_start(
+        "trailing-literal-quarantine-placeholder-session",
+        platform="telegram",
+        conversation_id="trailing-literal-quarantine-placeholder-conversation",
+        context_length=10_000,
+    )
+    second.compress([{"role": "assistant", "content": literal}])
+
+    rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in rows] == ["seed", literal]
+
+
+def test_rebind_with_ignore_patterns_preserves_literal_quarantine_placeholder_before_repeated_tail(tmp_path):
+    class _DropOnlyPattern:
+        pattern = "drop me only"
+
+        def search(self, text, timeout=None):
+            return object() if "drop me only" in str(text) else None
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    literal = (
+        "[LCM active replay placeholder: assistant output quarantined; "
+        "kind=quarantined_assistant_output; reason=high_repetition; "
+        "scope=ignored_message_pattern; field=content; chars=65536; bytes=65536]"
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "literal-quarantine-placeholder-before-tail-session",
+        platform="telegram",
+        conversation_id="literal-quarantine-placeholder-before-tail-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "user", "content": "fresh request"}])
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_DropOnlyPattern()]
+    second.on_session_start(
+        "literal-quarantine-placeholder-before-tail-session",
+        platform="telegram",
+        conversation_id="literal-quarantine-placeholder-before-tail-conversation",
+        context_length=10_000,
+    )
+    second.compress([
+        {"role": "assistant", "content": literal},
+        {"role": "user", "content": "fresh request"},
+    ])
+
+    rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in rows] == ["fresh request", literal, "fresh request"]
+    assert second._last_ingest_reconciliation["action"] == "persisted batch"
 
 
 def test_ignore_message_patterns_do_not_drop_literal_quarantine_placeholder_text(tmp_path):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -16,9 +16,11 @@ from hermes_lcm import tools as lcm_tools
 from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
+import hermes_lcm.engine as lcm_engine_module
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
 from hermes_lcm.externalize import build_transcript_gc_placeholder, externalize_ingest_payload, extract_externalized_ref
 from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
+from hermes_lcm.tokens import count_messages_tokens
 
 
 DATA_PAYLOAD = base64.b64encode(("LCM payload boundary repro ".encode("ascii")) * 900).decode("ascii")
@@ -1335,6 +1337,733 @@ def test_lcm_doctor_reports_externalized_payload_stats(tmp_path):
     externalized_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
     assert externalized_check["detail"]["externalized_payload_count"] == 1
     assert externalized_check["detail"]["externalized_payload_bytes"] > 0
+
+
+BROKEN_ASSISTANT_MARKER = "BROKEN_ASSISTANT_LOOP_MARKER_196"
+
+
+def _broken_assistant_output() -> str:
+    paragraph = (
+        f"{BROKEN_ASSISTANT_MARKER}: I am drafting the same response again. "
+        "I will repeat the plan, restate the same tool loop, and continue without adding new information. "
+        "This paragraph is intentionally repetitive model-loop output.\n"
+    )
+    return paragraph * 520
+
+
+def _legitimate_long_report() -> str:
+    return "\n".join(
+        f"Section {idx:04d}: finding={idx * 17}; evidence=case-{idx:04d}; "
+        f"next_step=review-module-{idx % 97}; note=unique-context-{idx * idx}."
+        for idx in range(1800)
+    )
+
+
+def test_repetitive_assistant_output_is_quarantined_before_sqlite_and_fts(tmp_path):
+    engine = _engine(tmp_path)
+    broken = _broken_assistant_output()
+    assert len(broken) > 70_000
+
+    engine._ingest_messages([{"role": "assistant", "content": broken}])
+
+    store_id, content, _tool_calls = _single_message_row(engine, role="assistant")
+    assert "assistant output quarantined" in content
+    assert "high_repetition" in content
+    assert BROKEN_ASSISTANT_MARKER not in content
+    assert engine._store.search(BROKEN_ASSISTANT_MARKER, session_id=engine.current_session_id) == []
+
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["kind"] == "quarantined_assistant_output"
+    assert expanded["content"] == broken
+
+    raw_message = json.loads(lcm_tools.lcm_expand({"store_id": store_id, "max_tokens": 100_000}, engine=engine))
+    assert raw_message["externalized_ref"] == ref
+    assert raw_message["externalized"]["kind"] == "quarantined_assistant_output"
+
+    doctor = handle_lcm_command("doctor", engine)
+    assert "quarantined_assistant_rows:" in doctor
+    assert "suspicious_repetitive_assistant_rows: []" in doctor
+
+
+def test_quarantined_assistant_output_does_not_enter_summaries_or_active_context(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=100,
+        context_threshold=0.10,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "quarantine-summary-session",
+        platform="telegram",
+        conversation_id="quarantine-summary-conversation",
+        context_length=10_000,
+    )
+    broken = _broken_assistant_output()
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "please help"},
+        {"role": "assistant", "content": broken},
+        {"role": "user", "content": "fresh tail"},
+    ]
+
+    def summarize_without_marker(**kwargs):
+        text = kwargs["text"]
+        assert BROKEN_ASSISTANT_MARKER not in text
+        return text, 1
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", summarize_without_marker)
+
+    active_context = engine.compress(messages)
+
+    nodes = engine._dag.get_session_nodes(engine.current_session_id)
+    assert nodes
+    assert all(BROKEN_ASSISTANT_MARKER not in node.summary for node in nodes)
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+    assert any("assistant output quarantined" in str(message.get("content", "")) for message in active_context)
+
+
+def test_quarantined_assistant_output_does_not_enter_summaries_or_active_context_after_preflight(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=100,
+        context_threshold=0.10,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "quarantine-preflight-session",
+        platform="telegram",
+        conversation_id="quarantine-preflight-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "please help"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh tail"},
+    ]
+
+    assert engine.should_compress_preflight(messages)
+
+    def summarize_without_marker(**kwargs):
+        text = kwargs["text"]
+        assert BROKEN_ASSISTANT_MARKER not in text
+        return text, 1
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", summarize_without_marker)
+
+    active_context = engine.compress(messages)
+
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+    assert any("assistant output quarantined" in str(message.get("content", "")) for message in active_context)
+    nodes = engine._dag.get_session_nodes(engine.current_session_id)
+    assert nodes
+    assert all(BROKEN_ASSISTANT_MARKER not in node.summary for node in nodes)
+
+
+def test_dynamic_quarantined_assistant_pressure_continues_after_first_leaf_pass(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=100,
+        dynamic_leaf_chunk_enabled=True,
+        dynamic_leaf_chunk_max=100,
+        context_threshold=0.10,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "dynamic-quarantine-pressure-session",
+        platform="telegram",
+        conversation_id="dynamic-quarantine-pressure-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": " ".join(["large-user"] * 130)},
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh tail"},
+    ]
+    summarized_texts: list[str] = []
+
+    def summarize_without_marker(**kwargs):
+        text = kwargs["text"]
+        assert BROKEN_ASSISTANT_MARKER not in text
+        summarized_texts.append(text)
+        return "summary", 1
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", summarize_without_marker)
+
+    active_context = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    nodes = engine._dag.get_session_nodes(engine.current_session_id)
+    assert len(nodes) >= 2
+    assert len(summarized_texts) >= 2
+    assert any("assistant output quarantined" in text for text in summarized_texts)
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+
+
+def test_quarantined_assistant_tool_call_content_does_not_enter_summarization(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=100,
+        context_threshold=0.10,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "quarantine-tool-call-summary-session",
+        platform="telegram",
+        conversation_id="quarantine-tool-call-summary-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "please call the tool"},
+        {
+            "role": "assistant",
+            "content": _broken_assistant_output(),
+            "tool_calls": [{"id": "call_loop", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_loop", "content": "tool result"},
+        {"role": "user", "content": "fresh tail"},
+    ]
+
+    def summarize_without_marker(**kwargs):
+        text = kwargs["text"]
+        assert BROKEN_ASSISTANT_MARKER not in text
+        assert "assistant output quarantined" in text
+        return text, 1
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", summarize_without_marker)
+
+    active_context = engine.compress(messages)
+
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+    _store_id, content, _tool_calls = _single_message_row(engine, role="assistant")
+    assert "assistant output quarantined" in content
+    assert BROKEN_ASSISTANT_MARKER not in content
+
+
+def test_quarantined_assistant_tool_call_content_is_removed_from_noop_active_replay(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "quarantine-tool-call-noop-session",
+        platform="telegram",
+        conversation_id="quarantine-tool-call-noop-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "please call the tool"},
+        {
+            "role": "assistant",
+            "content": _broken_assistant_output(),
+            "tool_calls": [{"id": "call_loop", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_loop", "content": "tool result"},
+    ]
+
+    active_context = engine.compress(messages)
+
+    assistant = next(message for message in active_context if message.get("role") == "assistant")
+    assert assistant["tool_calls"] == messages[2]["tool_calls"]
+    assert "assistant output quarantined" in assistant["content"]
+    assert BROKEN_ASSISTANT_MARKER not in assistant["content"]
+
+
+def test_quarantined_assistant_rebind_reconciliation_does_not_duplicate_rows(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "user", "content": "please help"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first.compress(messages)
+    first_count = len(first._store.get_session_messages(first.current_session_id))
+    assert first_count == 2
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second.on_session_start(
+        "quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second.compress(messages)
+
+    rows = second._store.get_session_messages(second.current_session_id)
+    assert len(rows) == first_count
+    assert [row["role"] for row in rows] == ["user", "assistant"]
+    assert "assistant output quarantined" in rows[-1]["content"]
+    assert BROKEN_ASSISTANT_MARKER not in rows[-1]["content"]
+
+
+class _PrefixPattern:
+    pattern = "^Cronjob Response:"
+
+    def search(self, text, timeout=None):
+        return object() if str(text).startswith("Cronjob Response:") else None
+
+
+def test_ignore_message_patterns_remain_storage_only_for_compress_replay(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine._compiled_ignore_message_patterns = [_PrefixPattern()]
+    engine.on_session_start(
+        "ignore-storage-only-session",
+        platform="telegram",
+        conversation_id="ignore-storage-only-conversation",
+        context_length=10_000,
+    )
+    ignored = "Cronjob Response: noisy heartbeat"
+    kept = "real user request"
+    messages = [
+        {"role": "user", "content": ignored},
+        {"role": "user", "content": kept},
+    ]
+
+    active_context = engine.compress(messages)
+
+    assert [message.get("content") for message in active_context] == [ignored, kept]
+    stored_contents = [row["content"] for row in engine._store.get_session_messages(engine.current_session_id)]
+    assert stored_contents == [kept]
+    assert engine._store.search("noisy heartbeat", session_id=engine.current_session_id) == []
+
+
+def test_quarantined_assistant_preflight_requests_cleanup_when_no_compaction_needed(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "quarantine-preflight-noop-session",
+        platform="telegram",
+        conversation_id="quarantine-preflight-noop-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "user", "content": "please help"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+    ]
+
+    assert engine.should_compress_preflight(messages)
+
+    active_context = engine.compress(messages)
+    assert any("assistant output quarantined" in str(message.get("content", "")) for message in active_context)
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+
+
+class _ContainsBrokenAssistantPattern:
+    pattern = BROKEN_ASSISTANT_MARKER
+
+    def search(self, text, timeout=None):
+        return object() if BROKEN_ASSISTANT_MARKER in str(text) else None
+
+
+def test_ignore_message_patterns_match_original_suspicious_assistant_before_storage(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    engine.on_session_start(
+        "ignore-quarantine-storage-session",
+        platform="telegram",
+        conversation_id="ignore-quarantine-storage-conversation",
+        context_length=10_000,
+    )
+    messages = [
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    active_context = engine.compress(messages)
+
+    assert "assistant output quarantined" in str(active_context[0].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(active_context[0].get("content", ""))
+    stored_rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["role"] for row in stored_rows] == ["user"]
+    assert engine._store.search(BROKEN_ASSISTANT_MARKER, session_id=engine.current_session_id) == []
+    assert _externalized_files(tmp_path) == []
+
+
+def test_ignored_quarantined_assistant_rebind_reconciliation_does_not_duplicate_rows(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    first.on_session_start(
+        "ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert "assistant output quarantined" in str(first_active[1].get("content", ""))
+    first_rows = first._store.get_session_messages(first.current_session_id)
+    assert [row["role"] for row in first_rows] == ["system", "user"]
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second_active = second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["role"] for row in second_rows] == ["system", "user"]
+    assert "assistant output quarantined" in str(second_active[1].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(second_active[1].get("content", ""))
+
+
+def test_existing_quarantined_assistant_row_rebinds_after_ignore_pattern_added(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "ignore-added-after-quarantine-session",
+        platform="telegram",
+        conversation_id="ignore-added-after-quarantine-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert "assistant output quarantined" in str(first_active[1].get("content", ""))
+    first_rows = first._store.get_session_messages(first.current_session_id)
+    assert [row["role"] for row in first_rows] == ["system", "assistant", "user"]
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "ignore-added-after-quarantine-session",
+        platform="telegram",
+        conversation_id="ignore-added-after-quarantine-conversation",
+        context_length=10_000,
+    )
+    second_active = second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["role"] for row in second_rows] == ["system", "assistant", "user"]
+    assert "assistant output quarantined" in str(second_active[1].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(second_active[1].get("content", ""))
+
+
+def test_singleton_quarantined_assistant_rebind_reconciliation_does_not_duplicate_row(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [{"role": "assistant", "content": _broken_assistant_output()}]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "singleton-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="singleton-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert "assistant output quarantined" in str(first_active[0].get("content", ""))
+    assert len(first._store.get_session_messages(first.current_session_id)) == 1
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second.on_session_start(
+        "singleton-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="singleton-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second_active = second.compress(messages)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert len(second_rows) == 1
+    assert "assistant output quarantined" in str(second_active[0].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
+
+
+def test_no_system_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    first.on_session_start(
+        "no-system-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert [row["role"] for row in first._store.get_session_messages(first.current_session_id)] == ["user"]
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "no-system-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second_active = second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["role"] for row in second_rows] == ["user"]
+    assert "assistant output quarantined" in str(second_active[0].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
+
+
+def test_ignore_message_patterns_do_not_drop_plain_text_that_mentions_quarantine_markers(tmp_path):
+    class _DropOnlyPattern:
+        pattern = "drop me only"
+
+        def search(self, text, timeout=None):
+            return object() if "drop me only" in str(text) else None
+
+    engine = _engine(tmp_path)
+    engine._compiled_ignore_message_patterns = [_DropOnlyPattern()]
+    text = (
+        "This is a normal note mentioning scope=ignored_message_pattern, "
+        "assistant output quarantined, and quarantined_assistant_output."
+    )
+
+    engine.compress([{"role": "user", "content": text}])
+
+    rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["content"] for row in rows] == [text]
+
+
+def test_ignore_message_patterns_do_not_drop_literal_quarantine_placeholder_text(tmp_path):
+    class _DropOnlyPattern:
+        pattern = "drop me only"
+
+        def search(self, text, timeout=None):
+            return object() if "drop me only" in str(text) else None
+
+    engine = _engine(tmp_path)
+    engine._compiled_ignore_message_patterns = [_DropOnlyPattern()]
+    text = (
+        "[LCM active replay placeholder: assistant output quarantined; "
+        "kind=quarantined_assistant_output; reason=high_repetition; "
+        "scope=ignored_message_pattern; field=content; chars=65536; bytes=65536]"
+    )
+
+    engine.compress([{"role": "assistant", "content": text}])
+
+    rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["content"] for row in rows] == [text]
+
+
+def test_rebind_does_not_skip_literal_quarantine_placeholder_without_ignore_patterns(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    literal = (
+        "[LCM active replay placeholder: assistant output quarantined; "
+        "kind=quarantined_assistant_output; reason=high_repetition; "
+        "scope=ignored_message_pattern; field=content; chars=65536; bytes=65536]"
+    )
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "literal-placeholder-rebind-session",
+        platform="telegram",
+        conversation_id="literal-placeholder-rebind-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "user", "content": "seed"}])
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second.on_session_start(
+        "literal-placeholder-rebind-session",
+        platform="telegram",
+        conversation_id="literal-placeholder-rebind-conversation",
+        context_length=10_000,
+    )
+    second.compress([{"role": "assistant", "content": literal}])
+
+    rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in rows] == ["seed", literal]
+
+
+def test_no_system_raw_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    first.on_session_start(
+        "no-system-raw-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-raw-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    first.compress(messages)
+    assert [row["content"] for row in first._store.get_session_messages(first.current_session_id)] == ["fresh request"]
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "no-system-raw-ignore-quarantine-rebind-session",
+        platform="telegram",
+        conversation_id="no-system-raw-ignore-quarantine-rebind-conversation",
+        context_length=10_000,
+    )
+    second_active = second.compress(messages)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in second_rows] == ["fresh request"]
+    assert "assistant output quarantined" in str(second_active[0].get("content", ""))
+    assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
+
+
+def test_no_system_filtered_non_quarantine_rebind_preserves_repeated_tail_delta(tmp_path):
+    class _CronPattern:
+        pattern = "^Cronjob Response:"
+
+        def search(self, text, timeout=None):
+            return object() if str(text).startswith("Cronjob Response:") else None
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first._compiled_ignore_message_patterns = [_CronPattern()]
+    first.on_session_start(
+        "no-system-filtered-delta-session",
+        platform="telegram",
+        conversation_id="no-system-filtered-delta-conversation",
+        context_length=10_000,
+    )
+    first.compress([{"role": "user", "content": "fresh request"}])
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_CronPattern()]
+    second.on_session_start(
+        "no-system-filtered-delta-session",
+        platform="telegram",
+        conversation_id="no-system-filtered-delta-conversation",
+        context_length=10_000,
+    )
+    second.compress([
+        {"role": "user", "content": "Cronjob Response: noisy heartbeat"},
+        {"role": "user", "content": "fresh request"},
+    ])
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["content"] for row in second_rows] == ["fresh request", "fresh request"]
+
+
+def test_legitimate_long_assistant_report_is_not_quarantined(tmp_path):
+    engine = _engine(tmp_path)
+    report = _legitimate_long_report()
+    assert len(report) > 70_000
+
+    engine._ingest_messages([{"role": "assistant", "content": report}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="assistant")
+    assert "assistant output quarantined" not in content
+    assert "Section 0001" in content
+    assert "Section 1799" in content
 
 
 def test_readme_documents_storage_boundary_payload_guard():

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2406,7 +2406,7 @@ def test_rebind_does_not_skip_literal_quarantine_placeholder_without_ignore_patt
     assert [row["content"] for row in rows] == ["seed", literal]
 
 
-def test_no_system_raw_ignored_quarantined_assistant_rebind_does_not_duplicate_tail(tmp_path):
+def test_no_system_raw_ignored_quarantined_assistant_rebind_preserves_repeated_tail_delta(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm.db"),
         fresh_tail_count=10,
@@ -2442,7 +2442,7 @@ def test_no_system_raw_ignored_quarantined_assistant_rebind_does_not_duplicate_t
     second_active = second.compress(messages)
 
     second_rows = second._store.get_session_messages(second.current_session_id)
-    assert [row["content"] for row in second_rows] == ["fresh request"]
+    assert [row["content"] for row in second_rows] == ["fresh request", "fresh request"]
     assert "assistant output quarantined" in str(second_active[0].get("content", ""))
     assert BROKEN_ASSISTANT_MARKER not in str(second_active[0].get("content", ""))
 

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1465,6 +1465,56 @@ def test_quarantined_assistant_output_does_not_enter_summaries_or_active_context
     assert all(BROKEN_ASSISTANT_MARKER not in node.summary for node in nodes)
 
 
+def test_preflight_quarantined_assistant_rebind_keeps_durable_placeholder(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "user", "content": "please help"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "quarantine-preflight-rebind-session",
+        platform="telegram",
+        conversation_id="quarantine-preflight-rebind-conversation",
+        context_length=1_000_000,
+    )
+    assert first.should_compress_preflight(messages)
+
+    preflight_rows = first._store.get_session_messages(first.current_session_id)
+    assert len(preflight_rows) == 2
+    assert "Externalized LCM ingest payload" in str(preflight_rows[1].get("content", ""))
+    assert "LCM active replay placeholder" not in str(preflight_rows[1].get("content", ""))
+
+    active_context = first.compress(messages)
+    assert len(active_context) == 2
+    assert all(BROKEN_ASSISTANT_MARKER not in str(message.get("content", "")) for message in active_context)
+    assert "Externalized LCM ingest payload" in str(active_context[1].get("content", ""))
+    assert "LCM active replay placeholder" not in str(active_context[1].get("content", ""))
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second.on_session_start(
+        "quarantine-preflight-rebind-session",
+        platform="telegram",
+        conversation_id="quarantine-preflight-rebind-conversation",
+        context_length=1_000_000,
+    )
+    second.compress(active_context)
+
+    rebound_rows = second._store.get_session_messages(second.current_session_id)
+    assert len(rebound_rows) == 2
+    assert [row["role"] for row in rebound_rows] == ["user", "assistant"]
+    assert "Externalized LCM ingest payload" in str(rebound_rows[1].get("content", ""))
+    assert all("LCM active replay placeholder" not in str(row.get("content", "")) for row in rebound_rows)
+
+
 def test_dynamic_quarantined_assistant_pressure_continues_after_first_leaf_pass(tmp_path, monkeypatch):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm.db"),

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1796,6 +1796,13 @@ class _ContainsBrokenAssistantPattern:
         return object() if BROKEN_ASSISTANT_MARKER in str(text) else None
 
 
+class _NeverMatchesPattern:
+    pattern = "NEVER_MATCHES_BROKEN_ASSISTANT"
+
+    def search(self, text, timeout=None):
+        return None
+
+
 def test_ignore_message_patterns_match_original_suspicious_assistant_before_storage(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm.db"),
@@ -1912,6 +1919,88 @@ def test_existing_quarantined_assistant_row_rebinds_after_ignore_pattern_added(t
     assert [row["role"] for row in second_rows] == ["system", "assistant", "user"]
     assert "assistant output quarantined" in str(second_active[1].get("content", ""))
     assert BROKEN_ASSISTANT_MARKER not in str(second_active[1].get("content", ""))
+
+
+def test_nonmatching_ignore_pattern_preserves_existing_quarantine_rebind_prefix(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": _broken_assistant_output()},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "nonmatching-ignore-quarantine-session",
+        platform="telegram",
+        conversation_id="nonmatching-ignore-quarantine-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert "assistant output quarantined" in str(first_active[1].get("content", ""))
+    assert [row["role"] for row in first._store.get_session_messages(first.current_session_id)] == [
+        "system",
+        "assistant",
+        "user",
+    ]
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_NeverMatchesPattern()]
+    second.on_session_start(
+        "nonmatching-ignore-quarantine-session",
+        platform="telegram",
+        conversation_id="nonmatching-ignore-quarantine-conversation",
+        context_length=10_000,
+    )
+    second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert [row["role"] for row in second_rows] == ["system", "assistant", "user"]
+    assert len(second_rows) == 3
+
+
+def test_singleton_quarantined_assistant_row_rebinds_after_ignore_pattern_added(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        fresh_tail_count=10,
+        leaf_chunk_tokens=10_000,
+        context_threshold=0.95,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    messages = [{"role": "assistant", "content": _broken_assistant_output()}]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    first.on_session_start(
+        "singleton-ignore-added-session",
+        platform="telegram",
+        conversation_id="singleton-ignore-added-conversation",
+        context_length=10_000,
+    )
+    first_active = first.compress(messages)
+    assert "assistant output quarantined" in str(first_active[0].get("content", ""))
+    assert len(first._store.get_session_messages(first.current_session_id)) == 1
+    first.shutdown()
+
+    second = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    second._compiled_ignore_message_patterns = [_ContainsBrokenAssistantPattern()]
+    second.on_session_start(
+        "singleton-ignore-added-session",
+        platform="telegram",
+        conversation_id="singleton-ignore-added-conversation",
+        context_length=10_000,
+    )
+    second.compress(first_active)
+
+    second_rows = second._store.get_session_messages(second.current_session_id)
+    assert len(second_rows) == 1
+    assert [row["role"] for row in second_rows] == ["assistant"]
 
 
 def test_singleton_quarantined_assistant_rebind_reconciliation_does_not_duplicate_row(tmp_path):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3997,6 +3997,51 @@ class TestEngineCompress:
         compressed_contents = [msg.get("content") for msg in compressed]
         assert messages[-1]["content"] in compressed_contents
 
+    def test_dynamic_leaf_chunk_pressure_uses_current_working_window_after_each_pass(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=200,
+            database_path=str(tmp_path / "lcm_dynamic_leaf_current_window.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "test-session"
+        engine.context_length = 200000
+        engine.threshold_tokens = 0
+
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(8):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({
+                "role": role,
+                "content": f"Message {i}: " + ((f"token{i} ") * (20 + i * 7)),
+            })
+
+        token_pairs: list[tuple[int | None, int]] = []
+        last_pressure_tokens: int | None = None
+
+        def record_working_leaf_chunk_tokens(raw_tokens: int) -> int:
+            nonlocal last_pressure_tokens
+            last_pressure_tokens = raw_tokens
+            return 1
+
+        def select_one(candidate_raw, _token_limit):
+            token_pairs.append((last_pressure_tokens, count_messages_tokens(candidate_raw)))
+            return candidate_raw[:1]
+
+        def fake_summary(chunk, focus_topic=None):
+            return chunk, count_messages_tokens(chunk), "Window summary.\nExpand for details about: current window", 1, 0
+
+        monkeypatch.setattr(engine, "_working_leaf_chunk_tokens", record_working_leaf_chunk_tokens)
+        monkeypatch.setattr(engine, "_select_oldest_leaf_chunk", select_one)
+        monkeypatch.setattr(engine, "_summarize_leaf_chunk_with_rescue", fake_summary)
+
+        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+        assert len(token_pairs) >= 2
+        assert all(pressure == candidate for pressure, candidate in token_pairs)
+
     def test_adaptive_leaf_rescue_stops_after_bounded_retry_worthy_failures(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,

--- a/tools.py
+++ b/tools.py
@@ -1661,6 +1661,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             len(payload_risks["suspicious_data_uri_content_rows"])
             + len(payload_risks["suspicious_data_uri_tool_calls_rows"])
             + len(payload_risks["suspicious_base64_like_rows"])
+            + len(payload_risks["suspicious_repetitive_assistant_rows"])
         )
         checks.append({
             "check": "payload_storage",


### PR DESCRIPTION
Fixes #196.

This adds an ingest-time quarantine for obviously broken, huge repetitive assistant output. The original body is externalized for lossless recovery, while durable message content, FTS, summaries, and active replay use a compact placeholder.

What changed:

• Quarantine high-repetition assistant content before SQLite and FTS storage
• Keep lcm_expand recovery lossless through the externalized payload ref
• Use the quarantined replay view for compression and active context
• Preserve assistant tool_calls while replacing only suspicious content
• Keep ignore_message_patterns storage-only and compatible with quarantine placeholders
• Harden restart/rebind reconciliation for original transcripts, replay-safe active context, singleton quarantined rows, and no-system ignore plus quarantine tails
• Report quarantined and legacy suspicious repetitive assistant rows in doctor output

Validation:

• python -m pytest tests/test_ingest_protection.py::test_singleton_quarantined_assistant_rebind_reconciliation_does_not_duplicate_row tests/test_ingest_protection.py::test_no_system_ignored_quarantined_assistant_rebind_does_not_duplicate_tail -q
• python -m pytest tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_persists_single_delta_message_matching_store_tail tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_persists_single_delta_message_matching_store_tail_with_followup tests/test_lcm_engine.py::TestEngineABC::test_existing_session_restart_persists_delta_message_matching_store_tail -q
• python -m pytest tests/test_ingest_protection.py tests/test_lcm_engine.py -q
• python -m pytest -q
• git diff --check
• Codex read-only blocker audit: clean