### PR TITLE
feat: add opt-in sensitive pattern redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,12 +216,27 @@ Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
 
 Sensitive-pattern handling is disabled by default so ordinary LCM storage and
 `lcm_expand` remain lossless. When `LCM_SENSITIVE_PATTERNS_ENABLED=true`, matched
-secret values are replaced with deterministic metadata-only placeholders before
-SQLite, FTS, summaries, active replay, and externalized payload JSON receive the
-content. This is intentionally not lossless for matching values: the raw matched
-secret is unrecoverable after redaction. `lcm_status` and `lcm_doctor` expose the
-enabled state, configured pattern names, unknown names, source, and placeholder
-format without exposing raw secret values.
+secret values are replaced with metadata-only placeholders before SQLite, FTS,
+summaries, active replay, and externalized payload JSON receive the content. This
+is intentionally not lossless for matching values: the raw matched secret is
+unrecoverable after redaction.
+
+Supported named catalog entries are:
+
+- `api_key`: `api_key`, `api_token`, `access_token`, `secret_key`, and
+  `client_secret` assignments or JSON keys.
+- `bearer_token`: `Bearer ...` strings and token-like JSON keys.
+- `password_assignment`: `password`, `passwd`, `pwd`, and `passphrase`
+  assignments or JSON keys, including quoted values with spaces.
+- `private_key`: PEM private-key blocks.
+
+Redaction is forward-only. Enabling it does not rewrite existing SQLite rows,
+FTS shadow tables, DAG summaries, or externalized payload JSON that were written
+before the setting was enabled. Non-password placeholders include a short
+truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
+the digest to avoid making password-like values easier to dictionary-check.
+`lcm_status` and `lcm_doctor` expose the enabled state, configured pattern names,
+unknown names, source, and placeholder format without exposing raw secret values.
 
 ### Cache policy boundary
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ compacted.
 - **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
 - **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
 - **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
+- **Sensitive-pattern controls** - optional named redaction of API keys, bearer tokens, passwords, and private keys before LCM stores or summarizes them
 - **Storage-boundary payload guard** - media-ish `data:*;base64` and long base64-looking strings are externalized before LCM writes them to SQLite
 - **Diagnostics** - `lcm_status`, `lcm_doctor`, and optional `/lcm` slash commands
 
@@ -196,6 +197,8 @@ environment variables:
 | `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
 | `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
 | `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
+| `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
+| `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
@@ -210,6 +213,15 @@ environment variables:
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
 
 Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
+
+Sensitive-pattern handling is disabled by default so ordinary LCM storage and
+`lcm_expand` remain lossless. When `LCM_SENSITIVE_PATTERNS_ENABLED=true`, matched
+secret values are replaced with deterministic metadata-only placeholders before
+SQLite, FTS, summaries, active replay, and externalized payload JSON receive the
+content. This is intentionally not lossless for matching values: the raw matched
+secret is unrecoverable after redaction. `lcm_status` and `lcm_doctor` expose the
+enabled state, configured pattern names, unknown names, source, and placeholder
+format without exposing raw secret values.
 
 ### Cache policy boundary
 

--- a/command.py
+++ b/command.py
@@ -1077,7 +1077,7 @@ def _doctor_text(engine) -> str:
     protection = sensitive_pattern_status(engine._config)
     if protection["enabled"] and protection["active_patterns"]:
         observations.append(
-            "sensitive_pattern_handling: enabled; matching raw secret values are replaced before SQLite, FTS, summaries, and externalized payloads"
+            "sensitive_pattern_handling: enabled; matching raw secret values are replaced before SQLite, FTS, summaries, active replay, and externalized payloads"
         )
     elif protection["enabled"]:
         observations.append("sensitive_pattern_handling: enabled but no active known patterns are configured")

--- a/command.py
+++ b/command.py
@@ -9,7 +9,7 @@ import sqlite3
 from typing import Any
 
 from .db_bootstrap import external_content_fts_needs_repair, repair_external_content_fts
-from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks
+from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks, sensitive_pattern_status
 from .dag import build_nodes_fts_spec
 from .presets import (
     explicit_operator_overrides,
@@ -127,7 +127,7 @@ def _status_text(engine) -> str:
         "effective_unknown_messages": int(source_stats.get("effective_unknown_messages", 0) or 0),
         **({"error": source_stats.get("error")} if source_stats.get("error") else {}),
     }
-
+    protection = status.get("ingest_protection") or sensitive_pattern_status(engine._config)
 
     lines = [
         "LCM status",
@@ -157,6 +157,9 @@ def _status_text(engine) -> str:
         f"last_cache_write_tokens: {status.get('last_cache_write_tokens', 0)}",
         f"last_reasoning_tokens: {status.get('last_reasoning_tokens', 0)}",
         f"cache_read_ratio: {float(status.get('cache_read_ratio', 0.0) or 0.0) * 100:.1f}%",
+        f"sensitive_patterns_enabled: {_fmt_bool(protection.get('enabled'))}",
+        f"sensitive_patterns: {', '.join(protection.get('patterns') or []) or '(none)'}",
+        f"sensitive_patterns_source: {protection.get('source', 'default')}",
         # Filter classification for current_session_id (the foreground view).
         # When a side channel is in flight, get_status() reports the bound
         # session's flags; we read the engine properties instead so this row
@@ -1071,6 +1074,22 @@ def _doctor_text(engine) -> str:
             f"protected_sessions: skipped {clean_scan['protected_count']} currently bound session(s) from cleanup candidates"
         )
 
+    protection = sensitive_pattern_status(engine._config)
+    if protection["enabled"] and protection["active_patterns"]:
+        observations.append(
+            "sensitive_pattern_handling: enabled; matching raw secret values are replaced before SQLite, FTS, summaries, and externalized payloads"
+        )
+    elif protection["enabled"]:
+        observations.append("sensitive_pattern_handling: enabled but no active known patterns are configured")
+        recommended_actions.append("set LCM_SENSITIVE_PATTERNS to one or more known names, or disable sensitive handling")
+    else:
+        observations.append("sensitive_pattern_handling: disabled")
+    if protection["unknown_patterns"]:
+        issues.append("sensitive_pattern_config")
+        recommended_actions.append(
+            "remove unknown LCM_SENSITIVE_PATTERNS entries or replace them with supported names"
+        )
+
     doctor_status = "issues-found" if integrity != "ok" or issues else (
         "action-recommended" if recommended_actions else "ok"
     )
@@ -1106,6 +1125,10 @@ def _doctor_text(engine) -> str:
         f"suspicious_base64_like_rows: {payload_risks['suspicious_base64_like_rows']}",
         f"quarantined_assistant_rows: {payload_risks['quarantined_assistant_rows']}",
         f"suspicious_repetitive_assistant_rows: {payload_risks['suspicious_repetitive_assistant_rows']}",
+        f"sensitive_patterns_enabled: {_fmt_bool(protection.get('enabled'))}",
+        f"sensitive_patterns: {', '.join(protection.get('patterns') or []) or '(none)'}",
+        f"sensitive_patterns_source: {protection.get('source', 'default')}",
+        f"sensitive_patterns_unknown: {', '.join(protection.get('unknown_patterns') or []) or '(none)'}",
         f"externalized_payload_dir: {externalized_stats['externalized_payload_dir']}",
         f"externalized_payload_count: {externalized_stats['externalized_payload_count']}",
         f"externalized_payload_bytes: {externalized_stats['externalized_payload_bytes']}",

--- a/config.py
+++ b/config.py
@@ -189,6 +189,17 @@ class LCMConfig:
     # Directory for daily extraction files (empty = auto: ~/.hermes/lcm-extractions/)
     extraction_output_path: str = ""
 
+    # -- Sensitive-pattern handling ---
+    # Disabled by default. When enabled, named patterns redact matching secrets
+    # before LCM storage, FTS indexing, summarization, or externalization.
+    sensitive_patterns_enabled: bool = False
+    # Named pattern catalog entries to apply when sensitive handling is enabled.
+    sensitive_patterns: list[str] = field(
+        default_factory=lambda: ["api_key", "bearer_token", "password_assignment", "private_key"]
+    )
+    # Diagnostics: where the sensitive pattern list came from.
+    sensitive_patterns_source: str = "default"
+
     # -- Large tool-output externalization ---
     # When enabled, oversized tool results are written to plugin-managed storage
     # and replaced with compact references in pre-compaction serializer input.
@@ -268,6 +279,14 @@ class LCMConfig:
         c.extraction_enabled = _parse_bool_env("LCM_EXTRACTION_ENABLED", c.extraction_enabled)
         c.extraction_model = _str("LCM_EXTRACTION_MODEL", c.extraction_model)
         c.extraction_output_path = _str("LCM_EXTRACTION_OUTPUT_PATH", c.extraction_output_path)
+        c.sensitive_patterns_enabled = _parse_bool_env(
+            "LCM_SENSITIVE_PATTERNS_ENABLED",
+            c.sensitive_patterns_enabled,
+        )
+        raw_sensitive_patterns = os.environ.get("LCM_SENSITIVE_PATTERNS")
+        if raw_sensitive_patterns is not None:
+            c.sensitive_patterns = _parse_pattern_list(raw_sensitive_patterns)
+            c.sensitive_patterns_source = "env"
         c.large_output_externalization_enabled = _parse_bool_env(
             "LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED",
             c.large_output_externalization_enabled,

--- a/engine.py
+++ b/engine.py
@@ -42,7 +42,9 @@ from .ingest_protection import (
     protect_inline_payloads_in_text,
     protect_messages_for_ingest,
     quarantine_suspicious_assistant_messages,
+    redact_sensitive_value,
     restore_ingest_payload_placeholders,
+    sensitive_pattern_status,
 )
 from .schemas import (
     LCM_DESCRIBE,
@@ -2165,6 +2167,7 @@ class LCMEngine(ContextEngine):
         lifecycle_state = self._lifecycle.get_by_conversation(conversation_id) if conversation_id else None
         status["engine"] = "lcm"
         status["runtime_identity"] = self.get_runtime_identity()
+        status["ingest_protection"] = sensitive_pattern_status(self._config)
         try:
             status["source_lineage"] = self._store.get_source_stats(session_id or None)
         except Exception as exc:  # pragma: no cover - defensive
@@ -2978,6 +2981,23 @@ class LCMEngine(ContextEngine):
             externalize=externalize_messages,
             prefer_existing_externalized=prefer_existing_externalized,
         )
+        redacted_replay_messages: list[Dict[str, Any]] = []
+        for message in replay_messages:
+            redacted_message = dict(message)
+            if "content" in redacted_message:
+                redacted_message["content"] = redact_sensitive_value(
+                    redacted_message.get("content"),
+                    self._config,
+                    parse_json_strings=False,
+                )
+            if "tool_calls" in redacted_message:
+                redacted_message["tool_calls"] = redact_sensitive_value(
+                    redacted_message.get("tool_calls"),
+                    self._config,
+                    parse_json_strings=True,
+                )
+            redacted_replay_messages.append(redacted_message)
+        replay_messages = redacted_replay_messages
         if self._ingest_cursor_needs_reconcile:
             reconcile_messages = replay_messages
             if self._compiled_ignore_message_patterns:
@@ -3160,7 +3180,11 @@ class LCMEngine(ContextEngine):
         matched_tool_ids = _matched_tool_call_ids(messages)
         for msg in messages:
             role = msg.get("role", "unknown")
-            content = msg.get("content") or ""
+            content = redact_sensitive_value(
+                msg.get("content") or "",
+                self._config,
+                parse_json_strings=False,
+            )
             content = sanitize_pre_compaction_content(content)
 
             if role == "tool":
@@ -3198,6 +3222,11 @@ class LCMEngine(ContextEngine):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
                             args = fn.get("arguments", "")
+                            args = redact_sensitive_value(
+                                args,
+                                self._config,
+                                parse_json_strings=True,
+                            )
                             args = sanitize_pre_compaction_tool_arguments(args)
                             if len(args) > 500:
                                 args = args[:400] + "..."

--- a/engine.py
+++ b/engine.py
@@ -821,7 +821,7 @@ class LCMEngine(ContextEngine):
             )
             self._last_compression_status = "noop"
             self._last_compression_noop_reason = f"bypassed: {reason}"
-            return messages
+            return self._redact_active_replay_messages(messages)
 
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
         force_overflow = self._should_force_overflow_recovery(
@@ -2935,6 +2935,25 @@ class LCMEngine(ContextEngine):
         )
         return 0
 
+    def _redact_active_replay_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        redacted_replay_messages: list[Dict[str, Any]] = []
+        for message in messages:
+            redacted_message = dict(message)
+            if "content" in redacted_message:
+                redacted_message["content"] = redact_sensitive_value(
+                    redacted_message.get("content"),
+                    self._config,
+                    parse_json_strings=False,
+                )
+            if "tool_calls" in redacted_message:
+                redacted_message["tool_calls"] = redact_sensitive_value(
+                    redacted_message.get("tool_calls"),
+                    self._config,
+                    parse_json_strings=True,
+                )
+            redacted_replay_messages.append(redacted_message)
+        return redacted_replay_messages
+
     def _ingest_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Persist new messages to the store.
 
@@ -2950,7 +2969,7 @@ class LCMEngine(ContextEngine):
         """
         if not self._session_id:
             logger.debug("Ingest skipped: no session_id")
-            return list(messages)
+            return self._redact_active_replay_messages(messages)
 
         if self._session_ignored or self._session_stateless:
             logger.debug(
@@ -2958,7 +2977,7 @@ class LCMEngine(ContextEngine):
                 "ignored" if self._session_ignored else "stateless",
                 self._session_id,
             )
-            return list(messages)
+            return self._redact_active_replay_messages(messages)
 
         n = len(messages)
         cursor = min(max(self._ingest_cursor, 0), n)
@@ -2981,23 +3000,7 @@ class LCMEngine(ContextEngine):
             externalize=externalize_messages,
             prefer_existing_externalized=prefer_existing_externalized,
         )
-        redacted_replay_messages: list[Dict[str, Any]] = []
-        for message in replay_messages:
-            redacted_message = dict(message)
-            if "content" in redacted_message:
-                redacted_message["content"] = redact_sensitive_value(
-                    redacted_message.get("content"),
-                    self._config,
-                    parse_json_strings=False,
-                )
-            if "tool_calls" in redacted_message:
-                redacted_message["tool_calls"] = redact_sensitive_value(
-                    redacted_message.get("tool_calls"),
-                    self._config,
-                    parse_json_strings=True,
-                )
-            redacted_replay_messages.append(redacted_message)
-        replay_messages = redacted_replay_messages
+        replay_messages = self._redact_active_replay_messages(replay_messages)
         if self._ingest_cursor_needs_reconcile:
             reconcile_messages = replay_messages
             if self._compiled_ignore_message_patterns:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -97,7 +97,7 @@ _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*r
 _SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
 _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     "api_key": re.compile(
-        r"(?P<prefix>\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key)\b\s*[\"']?\s*[:=]\s*[\"']?)"
+        r"(?P<prefix>\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key|client[_-]?secret)\b\s*[\"']?\s*[:=]\s*[\"']?)"
         r"(?P<secret>[A-Za-z0-9._~+/=-]{12,})"
         r"(?P<suffix>[\"']?)",
         re.IGNORECASE,
@@ -108,9 +108,9 @@ _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
         re.IGNORECASE,
     ),
     "password_assignment": re.compile(
-        r"(?P<prefix>\b(?:password|passwd|pwd)\b\s*[\"']?\s*[:=]\s*[\"']?)"
-        r"(?P<secret>[^\s,\"'\]}]{6,})"
-        r"(?P<suffix>[\"']?)",
+        r"(?P<prefix>\b(?:password|passwd|pwd|passphrase)\b\s*[\"']?\s*[:=]\s*)"
+        r"(?:(?P<quote>[\"'])(?P<secret_quoted>[^\r\n\]\}]{6,}?)(?P=quote)|"
+        r"(?P<secret_unquoted>[^\s,\"'\]}]{6,}))",
         re.IGNORECASE,
     ),
     "private_key": re.compile(
@@ -157,7 +157,7 @@ def sensitive_pattern_status(config) -> dict[str, Any]:
         "active_patterns": active if enabled else [],
         "unknown_patterns": unknown,
         "source": getattr(config, "sensitive_patterns_source", "default"),
-        "placeholder_format": "[LCM sensitive redaction: name=<pattern>; chars=<n>; bytes=<n>; sha256=<16>]",
+        "placeholder_format": "[LCM sensitive redaction: name=<pattern>; chars=<n>; bytes=<n>; sha256=<16 for non-password>]",
         "lossless_recovery": False if enabled and active else None,
     }
 
@@ -199,22 +199,29 @@ def _active_sensitive_pattern_names(config) -> list[str]:
 
 
 def _sensitive_placeholder(pattern_name: str, secret: str) -> str:
-    digest = hashlib.sha256(secret.encode("utf-8", errors="surrogatepass")).hexdigest()[:16]
-    return (
+    parts = [
         f"{_SENSITIVE_PLACEHOLDER_PREFIX} "
         f"name={_safe_placeholder_metadata(pattern_name)}; "
-        f"chars={len(secret)}; bytes={len(secret.encode('utf-8', errors='surrogatepass'))}; "
-        f"sha256={digest}]"
-    )
+        f"chars={len(secret)}; bytes={len(secret.encode('utf-8', errors='surrogatepass'))}"
+    ]
+    if pattern_name != "password_assignment":
+        digest = hashlib.sha256(secret.encode("utf-8", errors="surrogatepass")).hexdigest()[:16]
+        parts.append(f"sha256={digest}")
+    return "; ".join(parts) + "]"
 
 
 def _redact_match(pattern_name: str, match: re.Match[str]) -> str:
     group_names = match.re.groupindex
-    if "secret" not in group_names or match.groupdict().get("secret") is None:
+    secret_group = None
+    for candidate in ("secret", "secret_quoted", "secret_unquoted"):
+        if candidate in group_names and match.groupdict().get(candidate) is not None:
+            secret_group = candidate
+            break
+    if secret_group is None:
         return _sensitive_placeholder(pattern_name, match.group(0))
-    secret = match.group("secret")
-    relative_start = match.start("secret") - match.start(0)
-    relative_end = match.end("secret") - match.start(0)
+    secret = match.group(secret_group)
+    relative_start = match.start(secret_group) - match.start(0)
+    relative_end = match.end(secret_group) - match.start(0)
     full = match.group(0)
     return full[:relative_start] + _sensitive_placeholder(pattern_name, secret) + full[relative_end:]
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -94,6 +94,30 @@ _WORD_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 _REPETITION_SEGMENT_SPLIT_RE = re.compile(r"(?:\n+|(?<=[.!?])\s+)")
 _GENERIC_BASE64_MIN_CHARS = 4096
 _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
+_SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
+_SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
+    "api_key": re.compile(
+        r"(?P<prefix>\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key)\b\s*[\"']?\s*[:=]\s*[\"']?)"
+        r"(?P<secret>[A-Za-z0-9._~+/=-]{12,})"
+        r"(?P<suffix>[\"']?)",
+        re.IGNORECASE,
+    ),
+    "bearer_token": re.compile(
+        r"(?P<prefix>\bBearer\s+)"
+        r"(?P<secret>[A-Za-z0-9._~+/=-]{12,})",
+        re.IGNORECASE,
+    ),
+    "password_assignment": re.compile(
+        r"(?P<prefix>\b(?:password|passwd|pwd)\b\s*[\"']?\s*[:=]\s*[\"']?)"
+        r"(?P<secret>[^\s,\"'\]}]{6,})"
+        r"(?P<suffix>[\"']?)",
+        re.IGNORECASE,
+    ),
+    "private_key": re.compile(
+        r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+        re.IGNORECASE | re.DOTALL,
+    ),
+}
 
 
 def is_externalized_ingest_placeholder(text: str) -> bool:
@@ -119,6 +143,154 @@ def extract_ingest_externalized_refs(text: str) -> list[str]:
         if ref and ref not in refs:
             refs.append(ref)
     return refs
+
+
+def sensitive_pattern_status(config) -> dict[str, Any]:
+    """Return metadata-only status for opt-in sensitive redaction."""
+    configured, active, unknown = _configured_sensitive_pattern_names(config)
+    enabled = bool(getattr(config, "sensitive_patterns_enabled", False))
+    return {
+        "sensitive_patterns_enabled": enabled,
+        "enabled": enabled,
+        "sensitive_patterns": configured,
+        "patterns": configured,
+        "active_patterns": active if enabled else [],
+        "unknown_patterns": unknown,
+        "source": getattr(config, "sensitive_patterns_source", "default"),
+        "placeholder_format": "[LCM sensitive redaction: name=<pattern>; chars=<n>; bytes=<n>; sha256=<16>]",
+        "lossless_recovery": False if enabled and active else None,
+    }
+
+
+def _configured_sensitive_pattern_names(config) -> tuple[list[str], list[str], list[str]]:
+    raw = getattr(config, "sensitive_patterns", []) or []
+    if isinstance(raw, str):
+        names = [part.strip() for part in raw.split(",") if part.strip()]
+    else:
+        names = [str(part).strip() for part in raw if str(part).strip()]
+    if not names:
+        return [], [], []
+    configured: list[str] = []
+    active: list[str] = []
+    unknown: list[str] = []
+    for name in names:
+        normalized = name.lower().strip()
+        if normalized in {"all", "default"}:
+            for catalog_name in _SENSITIVE_PATTERN_CATALOG:
+                if catalog_name not in configured:
+                    configured.append(catalog_name)
+                if catalog_name not in active:
+                    active.append(catalog_name)
+            continue
+        configured.append(normalized)
+        if normalized in _SENSITIVE_PATTERN_CATALOG:
+            if normalized not in active:
+                active.append(normalized)
+        elif normalized not in unknown:
+            unknown.append(normalized)
+    return configured, active, unknown
+
+
+def _active_sensitive_pattern_names(config) -> list[str]:
+    if not bool(getattr(config, "sensitive_patterns_enabled", False)):
+        return []
+    _configured, active, _unknown = _configured_sensitive_pattern_names(config)
+    return active
+
+
+def _sensitive_placeholder(pattern_name: str, secret: str) -> str:
+    digest = hashlib.sha256(secret.encode("utf-8", errors="surrogatepass")).hexdigest()[:16]
+    return (
+        f"{_SENSITIVE_PLACEHOLDER_PREFIX} "
+        f"name={_safe_placeholder_metadata(pattern_name)}; "
+        f"chars={len(secret)}; bytes={len(secret.encode('utf-8', errors='surrogatepass'))}; "
+        f"sha256={digest}]"
+    )
+
+
+def _redact_match(pattern_name: str, match: re.Match[str]) -> str:
+    group_names = match.re.groupindex
+    if "secret" not in group_names or match.groupdict().get("secret") is None:
+        return _sensitive_placeholder(pattern_name, match.group(0))
+    secret = match.group("secret")
+    relative_start = match.start("secret") - match.start(0)
+    relative_end = match.end("secret") - match.start(0)
+    full = match.group(0)
+    return full[:relative_start] + _sensitive_placeholder(pattern_name, secret) + full[relative_end:]
+
+
+def _sensitive_pattern_for_key(key: Any, active_names: list[str]) -> str | None:
+    if not isinstance(key, str):
+        return None
+    normalized = re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+    compact = normalized.replace("_", "")
+    if "api_key" in active_names and (
+        compact in {"apikey", "apitoken", "accesstoken", "secretkey", "clientsecret"}
+        or ("api" in normalized and "key" in normalized)
+        or ("access" in normalized and "token" in normalized)
+        or ("secret" in normalized and "key" in normalized)
+    ):
+        return "api_key"
+    if "bearer_token" in active_names and compact in {"authorization", "authtoken", "bearertoken", "token"}:
+        return "bearer_token"
+    if "password_assignment" in active_names and compact in {"password", "passwd", "pwd", "passphrase"}:
+        return "password_assignment"
+    return None
+
+
+def redact_sensitive_text(text: str, config) -> str:
+    """Replace configured sensitive spans with deterministic placeholders."""
+    if not isinstance(text, str) or not text:
+        return text
+    active_names = _active_sensitive_pattern_names(config)
+    if not active_names:
+        return text
+    protected = text
+    for name in active_names:
+        pattern = _SENSITIVE_PATTERN_CATALOG[name]
+        protected = pattern.sub(lambda match, pattern_name=name: _redact_match(pattern_name, match), protected)
+    return protected
+
+
+def _redact_entire_sensitive_string(text: str, pattern_name: str) -> str:
+    if not text or _SENSITIVE_PLACEHOLDER_PREFIX in text:
+        return text
+    return _sensitive_placeholder(pattern_name, text)
+
+
+def redact_sensitive_value(value: Any, config, *, parse_json_strings: bool = False) -> Any:
+    """Recursively redact configured sensitive values without externalizing data."""
+    active_names = _active_sensitive_pattern_names(config)
+    if not active_names:
+        return value
+    if isinstance(value, dict):
+        protected: dict[Any, Any] = {}
+        for key, val in value.items():
+            protected_key = redact_sensitive_text(key, config) if isinstance(key, str) else key
+            key_pattern = _sensitive_pattern_for_key(key, active_names)
+            if key_pattern and isinstance(val, str):
+                text_redacted = redact_sensitive_text(val, config)
+                if text_redacted == val:
+                    text_redacted = _redact_entire_sensitive_string(val, key_pattern)
+                protected[protected_key] = text_redacted
+            else:
+                protected[protected_key] = redact_sensitive_value(
+                    val,
+                    config,
+                    parse_json_strings=parse_json_strings,
+                )
+        return protected
+    if isinstance(value, list):
+        return [redact_sensitive_value(item, config, parse_json_strings=parse_json_strings) for item in value]
+    if not isinstance(value, str):
+        return value
+    if parse_json_strings:
+        parsed = _maybe_parse_json_string(value)
+        if parsed is not None and not _json_has_duplicate_object_keys(value):
+            protected = redact_sensitive_value(parsed, config, parse_json_strings=True)
+            if protected != parsed:
+                return json.dumps(protected, ensure_ascii=False, separators=(",", ":"))
+    return redact_sensitive_text(value, config)
 
 
 def _safe_placeholder_metadata(value: Any) -> str:
@@ -449,6 +621,11 @@ def _protect_value(
     hermes_home: str,
     parse_json_strings: bool = False,
 ) -> Any:
+    value = redact_sensitive_value(
+        value,
+        config,
+        parse_json_strings=parse_json_strings,
+    )
     if isinstance(value, dict):
         protected: dict[Any, Any] = {}
         for key, val in value.items():
@@ -554,6 +731,7 @@ def protect_inline_payloads_in_text(
     """
     if not isinstance(text, str):
         return text
+    text = redact_sensitive_text(text, config)
     return _protect_payload_substrings(
         text,
         role=role,
@@ -591,7 +769,11 @@ def protect_message_for_ingest(
     """
     msg = dict(message or {})
     role = str(msg.get("role") or "unknown")
-    original_content = msg.get("content")
+    original_content = redact_sensitive_value(
+        msg.get("content"),
+        config,
+        parse_json_strings=False,
+    )
     normalized_content = normalize_content_value(original_content)
 
     # Preserve the pre-existing opt-in large-output behavior on message content.

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -218,6 +218,116 @@ def test_sensitive_patterns_visible_in_status_and_doctor(tmp_path):
     assert "api_key" in protection["detail"]["patterns"]
 
 
+def test_sensitive_patterns_redact_bypassed_active_replay_without_storage(tmp_path):
+    secret = "sk-bypasssecret1234567890abcdef"
+    tool_secret = "sk-bypasstoolsecret1234567890abcdef"
+    messages = [
+        {"role": "user", "content": f"api_key={secret}"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": json.dumps({"api_key": tool_secret}),
+                    },
+                }
+            ],
+        },
+    ]
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "no-session.db"),
+        large_output_externalization_path=str(tmp_path / "no-session-externalized"),
+        sensitive_patterns_enabled=True,
+    )
+    no_session_engine = LCMEngine(config=config, hermes_home=str(tmp_path / "no-session-home"))
+    no_session_active = no_session_engine._ingest_messages(deepcopy(messages))
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "ignored.db"),
+        large_output_externalization_path=str(tmp_path / "ignored-externalized"),
+        sensitive_patterns_enabled=True,
+        ignore_session_patterns=["cron:*"],
+    )
+    ignored_engine = LCMEngine(config=config, hermes_home=str(tmp_path / "ignored-home"))
+    ignored_engine.on_session_start(
+        "nightly",
+        platform="cron",
+        conversation_id="ignored-conversation",
+        context_length=200_000,
+    )
+    ignored_active = ignored_engine.compress(deepcopy(messages), current_tokens=0)
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "stateless.db"),
+        large_output_externalization_path=str(tmp_path / "stateless-externalized"),
+        sensitive_patterns_enabled=True,
+        stateless_session_patterns=["debug:*"],
+    )
+    stateless_engine = LCMEngine(config=config, hermes_home=str(tmp_path / "stateless-home"))
+    stateless_engine.on_session_start(
+        "scratch",
+        platform="debug",
+        conversation_id="stateless-conversation",
+        context_length=200_000,
+    )
+    stateless_active = stateless_engine.compress(deepcopy(messages), current_tokens=0)
+
+    for active in (no_session_active, ignored_active, stateless_active):
+        active_text = json.dumps(active, sort_keys=True)
+        assert secret not in active_text
+        assert tool_secret not in active_text
+        assert active_text.count("[LCM sensitive redaction:") == 2
+        assert "content" not in active[1]
+
+    assert ignored_engine._store.get_session_messages(ignored_engine.current_session_id) == []
+    assert stateless_engine._store.get_session_messages(stateless_engine.current_session_id) == []
+
+
+def test_sensitive_patterns_cover_client_secret_duplicate_json_and_quoted_passwords(tmp_path):
+    engine = _sensitive_engine(tmp_path)
+    client_secret = "oauthsupersecret1234567890"
+    first_json_secret = "oldoauthclientsecret1234567890"
+    second_json_secret = "newoauthclientsecret1234567890"
+    password_phrase = "correct horse battery staple"
+    duplicate_key_json = (
+        f'{{"client_secret":"{first_json_secret}",'
+        f'"client_secret":"{second_json_secret}"}}'
+    )
+
+    engine._ingest_messages([
+        {
+            "role": "user",
+            "content": f"client_secret={client_secret} password=\"{password_phrase}\"",
+        },
+        {
+            "role": "assistant",
+            "content": "prepared oauth call",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "oauth", "arguments": duplicate_key_json},
+                }
+            ],
+        },
+    ])
+
+    rows = engine._store._conn.execute(
+        "SELECT content, COALESCE(tool_calls, '') FROM messages ORDER BY store_id"
+    ).fetchall()
+    stored_text = "\n".join("\n".join(row) for row in rows)
+    for raw in (client_secret, first_json_secret, second_json_secret, password_phrase, "horse battery staple"):
+        assert raw not in stored_text
+        assert engine._store.search(raw, session_id=engine.current_session_id) == []
+    assert "client_secret=" in stored_text
+    assert 'password="[LCM sensitive redaction:' in stored_text
+    assert "sha256=" not in stored_text.split('password="', 1)[1].split('"', 1)[0]
+
+
 def test_extract_externalized_ref_recovers_tool_and_non_tool_placeholders():
     placeholders = [
         "[Externalized tool output: tool_call_id=call_1; chars=1200; bytes=1200; ref=tool.json]",

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -19,7 +19,7 @@ from hermes_lcm.engine import LCMEngine
 import hermes_lcm.engine as lcm_engine_module
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
 from hermes_lcm.externalize import build_transcript_gc_placeholder, externalize_ingest_payload, extract_externalized_ref
-from hermes_lcm.ingest_protection import extract_ingest_externalized_refs
+from hermes_lcm.ingest_protection import extract_ingest_externalized_refs, redact_sensitive_text
 from hermes_lcm.tokens import count_messages_tokens
 
 
@@ -34,6 +34,25 @@ def _engine(tmp_path: Path) -> LCMEngine:
         database_path=str(tmp_path / "lcm.db"),
         large_output_externalization_path=str(tmp_path / "externalized"),
     )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "payload-session",
+        platform="telegram",
+        conversation_id="payload-conversation",
+        context_length=200_000,
+    )
+    return engine
+
+
+def _sensitive_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    setattr(config, "sensitive_patterns_enabled", True)
+    setattr(config, "sensitive_patterns", ["api_key", "bearer_token", "password_assignment", "private_key"])
+    for key, value in overrides.items():
+        setattr(config, key, value)
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
     engine.on_session_start(
         "payload-session",
@@ -74,6 +93,129 @@ def _expand_ref(engine: LCMEngine, ref: str) -> dict:
 
 def _externalized_files(tmp_path: Path) -> list[Path]:
     return sorted((tmp_path / "externalized").glob("*.json"))
+
+
+def test_sensitive_patterns_disabled_by_default_preserves_lossless_raw_text(tmp_path):
+    engine = _engine(tmp_path)
+    secret = "sk-defaultpreserved1234567890abcdef"
+
+    engine._ingest_messages([{"role": "user", "content": f"api_key={secret}"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert secret in content
+
+
+def test_sensitive_redaction_continues_after_existing_placeholder(tmp_path):
+    engine = _sensitive_engine(tmp_path)
+    first_secret = "sk-firstsecret1234567890abcdef"
+    second_secret = "sk-secondsecret1234567890abcdef"
+    partially_redacted = redact_sensitive_text(f"api_key={first_secret}", engine._config)
+    assert first_secret not in partially_redacted
+
+    redacted = redact_sensitive_text(
+        f"prefix {partially_redacted} and api_key={second_secret}",
+        engine._config,
+    )
+
+    assert first_secret not in redacted
+    assert second_secret not in redacted
+    assert redacted.count("[LCM sensitive redaction:") == 2
+
+
+def test_sensitive_patterns_redact_user_assistant_tool_and_tool_calls_before_sqlite_write(tmp_path):
+    engine = _sensitive_engine(tmp_path)
+    user_secret = "sk-usersecret1234567890abcdef"
+    assistant_secret = "Bearer assistantTOKEN1234567890abcdef"
+    tool_secret = "password=tool-secret-value"
+    tool_call_secret = "sk-toolcall1234567890abcdef"
+
+    engine._ingest_messages([
+        {"role": "user", "content": f"please use api_key={user_secret} for the request"},
+        {
+            "role": "assistant",
+            "content": f"I would call it with {assistant_secret}",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "deploy",
+                        "arguments": json.dumps({"api_key": tool_call_secret}),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": tool_secret},
+    ])
+
+    rows = engine._store._conn.execute(
+        "SELECT content, COALESCE(tool_calls, '') FROM messages ORDER BY store_id"
+    ).fetchall()
+    stored_text = "\n".join("\n".join(row) for row in rows)
+    for raw in (user_secret, assistant_secret, "tool-secret-value", tool_call_secret):
+        assert raw not in stored_text
+        assert engine._store.search(raw, session_id=engine.current_session_id) == []
+    assert stored_text.count("[LCM sensitive redaction:") >= 4
+    assert "please use api_key=" in stored_text
+
+
+def test_sensitive_patterns_redact_before_large_payload_externalization(tmp_path):
+    engine = _sensitive_engine(
+        tmp_path,
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=40,
+    )
+    secret = "sk-externalized1234567890abcdef"
+    content = f"api_key={secret}\n" + ("large payload line\n" * 20)
+
+    engine._ingest_messages([{"role": "user", "content": content}])
+
+    _store_id, stored_content, _tool_calls = _single_message_row(engine, role="user")
+    assert secret not in stored_content
+    ref = _extract_ref(stored_content)
+    expanded = _expand_ref(engine, ref)
+    assert secret not in expanded["content"]
+    assert "[LCM sensitive redaction:" in expanded["content"]
+
+
+def test_sensitive_patterns_redact_before_summary_serialization(tmp_path, monkeypatch):
+    engine = _sensitive_engine(tmp_path, fresh_tail_count=1, leaf_chunk_tokens=1)
+    secret = "sk-summary1234567890abcdef"
+    captured = {}
+
+    def fake_summarize(**kwargs):
+        captured["text"] = kwargs["text"]
+        assert secret not in kwargs["text"]
+        return "summary without raw credential", 1
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", fake_summarize)
+
+    engine.compress(
+        [
+            {"role": "user", "content": f"api_key={secret} should be hidden"},
+            {"role": "user", "content": "fresh tail"},
+        ],
+        current_tokens=10_000,
+    )
+
+    assert captured["text"]
+    assert "[LCM sensitive redaction:" in captured["text"]
+    node = engine._dag.get_session_nodes(engine.current_session_id)[0]
+    assert secret not in node.summary
+
+
+def test_sensitive_patterns_visible_in_status_and_doctor(tmp_path):
+    engine = _sensitive_engine(tmp_path)
+
+    status = json.loads(lcm_tools.lcm_status({}, engine=engine))
+    assert status["ingest_protection"]["sensitive_patterns_enabled"] is True
+    assert "api_key" in status["ingest_protection"]["sensitive_patterns"]
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    protection = next(check for check in doctor["checks"] if check["check"] == "sensitive_pattern_handling")
+    assert protection["status"] == "pass"
+    assert protection["detail"]["enabled"] is True
+    assert "api_key" in protection["detail"]["patterns"]
 
 
 def test_extract_externalized_ref_recovers_tool_and_non_tool_placeholders():

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -347,6 +347,9 @@ class TestConfig:
         assert c.extraction_enabled is False
         assert c.extraction_model == ""
         assert c.extraction_output_path == ""
+        assert c.sensitive_patterns_enabled is False
+        assert c.sensitive_patterns == ["api_key", "bearer_token", "password_assignment", "private_key"]
+        assert c.sensitive_patterns_source == "default"
         assert c.large_output_externalization_enabled is False
         assert c.large_output_externalization_threshold_chars == 12_000
         assert c.large_output_externalization_path == ""
@@ -388,6 +391,8 @@ class TestConfig:
         monkeypatch.setenv("LCM_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("LCM_EXTRACTION_MODEL", "openai/gpt-5.4-mini")
         monkeypatch.setenv("LCM_EXTRACTION_OUTPUT_PATH", "/tmp/extractions")
+        monkeypatch.setenv("LCM_SENSITIVE_PATTERNS_ENABLED", "true")
+        monkeypatch.setenv("LCM_SENSITIVE_PATTERNS", "api_key,bearer_token")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", "true")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", "4096")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", "/tmp/lcm-large-outputs")
@@ -417,6 +422,9 @@ class TestConfig:
         assert c.extraction_enabled is True
         assert c.extraction_model == "openai/gpt-5.4-mini"
         assert c.extraction_output_path == "/tmp/extractions"
+        assert c.sensitive_patterns_enabled is True
+        assert c.sensitive_patterns == ["api_key", "bearer_token"]
+        assert c.sensitive_patterns_source == "env"
         assert c.large_output_externalization_enabled is True
         assert c.large_output_externalization_threshold_chars == 4096
         assert c.large_output_externalization_path == "/tmp/lcm-large-outputs"

--- a/tools.py
+++ b/tools.py
@@ -22,6 +22,7 @@ from .ingest_protection import (
     extract_ingest_externalized_refs,
     restore_ingest_payload_placeholders,
     scan_sqlite_payload_risks,
+    sensitive_pattern_status,
 )
 from .model_routing import apply_lcm_model_route
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
@@ -1583,6 +1584,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             ),
         },
         "source_lineage": source_lineage,
+        "ingest_protection": full_status.get("ingest_protection", sensitive_pattern_status(engine._config)),
         "ingest_reconciliation": ingest_reconciliation,
         "runtime_identity": runtime_identity,
         "lifecycle": lifecycle,
@@ -1674,6 +1676,25 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     except Exception as e:
         checks.append({
             "check": "payload_storage",
+            "status": "fail",
+            "detail": str(e),
+        })
+
+    try:
+        protection = sensitive_pattern_status(engine._config)
+        protection_status = "pass"
+        if protection["enabled"] and not protection["active_patterns"]:
+            protection_status = "warn"
+        elif protection["unknown_patterns"]:
+            protection_status = "warn"
+        checks.append({
+            "check": "sensitive_pattern_handling",
+            "status": protection_status,
+            "detail": protection,
+        })
+    except Exception as e:
+        checks.append({
+            "check": "sensitive_pattern_handling",
             "status": "fail",
             "detail": str(e),
         })


### PR DESCRIPTION
## Summary
- Add opt-in sensitive-pattern redaction for API keys, client secrets, bearer tokens, password assignments, and private key blocks.
- Redact configured matches before SQLite/FTS storage, active replay, summarizer serialization, and externalized ingest payload JSON, including no-session, ignored-session, and stateless-session active replay returns.
- Surface metadata-only status in `lcm_status`, `lcm_doctor`, and `/lcm status`/`/lcm doctor`, and document the non-lossless/forward-only tradeoff.

## Why
- LCM's existing ingest protection guarded payload size/media risks, but ordinary credential-like text could still be stored or summarized.
- Operators need a conservative, named-pattern option that protects common secrets without changing default lossless behavior.

## Validation
- [x] Focused validation: `python -m pytest tests/test_ingest_protection.py::test_sensitive_patterns_disabled_by_default_preserves_lossless_raw_text tests/test_ingest_protection.py::test_sensitive_redaction_continues_after_existing_placeholder tests/test_ingest_protection.py::test_sensitive_patterns_redact_user_assistant_tool_and_tool_calls_before_sqlite_write tests/test_ingest_protection.py::test_sensitive_patterns_redact_before_large_payload_externalization tests/test_ingest_protection.py::test_sensitive_patterns_redact_before_summary_serialization tests/test_ingest_protection.py::test_sensitive_patterns_visible_in_status_and_doctor tests/test_ingest_protection.py::test_sensitive_patterns_redact_bypassed_active_replay_without_storage tests/test_ingest_protection.py::test_sensitive_patterns_cover_client_secret_duplicate_json_and_quoted_passwords tests/test_lcm_core.py::TestConfig::test_defaults tests/test_lcm_core.py::TestConfig::test_from_env -q` -> `10 passed, 20 warnings`
- [x] Storage-boundary validation: `python -m pytest tests/test_ingest_protection.py -q` -> `90 passed, 20 warnings`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `580 passed, 45 warnings`
  - [x] `python -m pytest -q` -> `799 passed, 56 warnings`
  - [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> `799 passed, 56 warnings`
  - [x] `python -m compileall -q .` -> pass
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> pass
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> pass
  - [x] `git diff --check` -> pass
- [x] Workflow validation, if workflows changed: not applicable, no workflow files changed.

## Notes
- Sensitive-pattern handling is disabled by default.
- When enabled, matched values are intentionally unrecoverable from LCM storage and are replaced with metadata-only placeholders.
- `password_assignment` placeholders omit the short digest to avoid offline dictionary checks against password-like values. Other placeholders keep the short digest for correlation.
- Redaction is forward-only. Existing SQLite rows, FTS shadow tables, DAG summaries, and externalized payload JSON written before enabling the setting are not rewritten.
- Unknown `LCM_SENSITIVE_PATTERNS` entries are surfaced as warnings in diagnostics instead of silently becoming active.

Closes #186
