### PR TITLE
fix: register LCM tools via ctx.register_tool() so lcm_* appear in agent toolset

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+
 """Hermes LCM Plugin — Lossless Context Management.
 
 Replaces the built-in ContextCompressor with a DAG-based context engine
@@ -19,10 +20,27 @@ def _env_flag_enabled(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _make_wrapped_handler(handler, engine):
+    """Wrap a raw lcm_* handler so kwargs['engine'] is always bound."""
+    def _wrapped(args, **kwargs):
+        return handler(args, engine=engine, **kwargs)
+    return _wrapped
+
+
 def register(ctx):
-    """Plugin entry point — register the LCM context engine."""
+    """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
     from .engine import LCMEngine
+    from . import tools as lcm_tools
+    from .schemas import (
+        LCM_GREP,
+        LCM_LOAD_SESSION,
+        LCM_DESCRIBE,
+        LCM_EXPAND,
+        LCM_EXPAND_QUERY,
+        LCM_STATUS,
+        LCM_DOCTOR,
+    )
 
     config = LCMConfig.from_env()
 
@@ -39,6 +57,27 @@ def register(ctx):
 
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
+
+    # Register tools via the plugin registry so they are discoverable
+    # by the global tool system (not just the context-engine fallback).
+    _TOOLS = {
+        "lcm_grep": LCM_GREP,
+        "lcm_load_session": LCM_LOAD_SESSION,
+        "lcm_describe": LCM_DESCRIBE,
+        "lcm_expand": LCM_EXPAND,
+        "lcm_expand_query": LCM_EXPAND_QUERY,
+        "lcm_status": LCM_STATUS,
+        "lcm_doctor": LCM_DOCTOR,
+    }
+    for name, schema in _TOOLS.items():
+        handler = getattr(lcm_tools, name)
+        ctx.register_tool(
+            name=name,
+            toolset="lcm",
+            schema=schema,
+            handler=_make_wrapped_handler(handler, engine),
+            description=schema.get("description", f"LCM tool: {name}"),
+        )
 
     register_command = getattr(ctx, "register_command", None)
     slash_enabled = _env_flag_enabled("LCM_ENABLE_SLASH_COMMAND", default=False)


### PR DESCRIPTION
## Summary

Fixes #200 — the plugin's `plugin.yaml` declared 7 `lcm_*` tools, but `register()` never called `ctx.register_tool()`. As a result, the tools were invisible to the global tool registry and only accessible through the ContextCompressor fallback path, which does not run for all agent configurations.

## Changes

- Added `_make_wrapped_handler()` to bind the `LCMEngine` instance into each `lcm_*` handler.
- Extended `__init__.py:register()` to import all 7 schemas and handlers, then call `ctx.register_tool(name, toolset="lcm", schema=..., handler=...)` for each.
- The context engine registration (`ctx.register_context_engine()`) and slash command registration are unchanged.

## Tool Registration Table

| Tool | Schema | Handler |
|------|--------|---------|
| `lcm_grep` | `LCM_GREP` | `lcm_tools.lcm_grep` |
| `lcm_load_session` | `LCM_LOAD_SESSION` | `lcm_tools.lcm_load_session` |
| `lcm_describe` | `LCM_DESCRIBE` | `lcm_tools.lcm_describe` |
| `lcm_expand` | `LCM_EXPAND` | `lcm_tools.lcm_expand` |
| `lcm_expand_query` | `LCM_EXPAND_QUERY` | `lcm_tools.lcm_expand_query` |
| `lcm_status` | `LCM_STATUS` | `lcm_tools.lcm_status` |
| `lcm_doctor` | `LCM_DOCTOR` | `lcm_tools.lcm_doctor` |

## Verification

- `python3 -c "import ast; ast.parse(open('__init__.py').read())"` passes (syntax OK).
- Manual review confirms all 7 names in `plugin.yaml` `provides_tools` are now wired.

## Follow-up (deferred)

- Item 2 from the #200 debt list: `engine.handle_tool_call()` is still called by `tool_executor.py` via `agent.context_compressor.handle_tool_call()`. This path is still the primary dispatch for context-engine tools. Removing it is a larger refactor that needs the test suite passing and maintainer sign-off — deferred.
- Item 3: full `pytest tests/` run needs a local hermes-agent environment with correct PYTHONPATH.
- Item 6: removing `get_tool_schemas()`/`handle_tool_call()` from engine should only happen after registry routing is proven stable across all configs.
