### PR TITLE
Add summary fallback circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ environment variables:
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
 | `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | `0.0` | Disabled at `0.0`; when set, permits critical-pressure bypasses for bounded deferred catch-up and cache-friendly follow-on condensation only |
 | `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
+| `LCM_SUMMARY_FALLBACK_MODELS` | empty | Comma-separated summarization models tried after `LCM_SUMMARY_MODEL` or the auxiliary task default fails |
+| `LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `2` | Consecutive failed summarization calls before a route is skipped temporarily |
+| `LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS` | `300` | Seconds to skip an open summary route before retrying it |
 | `LCM_EXPANSION_MODEL` | summary model / auxiliary | Override `lcm_expand_query` synthesis model |
 | `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Context budget used by the auxiliary LLM for `lcm_expand_query` |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for one summarization call |

--- a/config.py
+++ b/config.py
@@ -214,6 +214,12 @@ class LCMConfig:
 
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model
+    # Optional fallback summary models tried after summary_model/task default.
+    summary_fallback_models: list[str] = field(default_factory=list)
+    # Consecutive failed summary calls before a route is skipped temporarily.
+    summary_circuit_breaker_failure_threshold: int = 2
+    # Seconds to skip an open summary route before allowing a retry.
+    summary_circuit_breaker_cooldown_seconds: int = 300
     expansion_model: str = ""     # empty = fall back to summary_model / Hermes auxiliary model
     # Serialized summary/raw/child-source/externalized context budget fed to lcm_expand_query's auxiliary LLM before it returns a bounded answer.
     expansion_context_tokens: int = 32_000
@@ -304,6 +310,17 @@ class LCMConfig:
             c.large_output_transcript_gc_enabled,
         )
         c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
+        raw_summary_fallback_models = os.environ.get("LCM_SUMMARY_FALLBACK_MODELS")
+        if raw_summary_fallback_models is not None:
+            c.summary_fallback_models = _parse_pattern_list(raw_summary_fallback_models)
+        c.summary_circuit_breaker_failure_threshold = _int(
+            "LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+            c.summary_circuit_breaker_failure_threshold,
+        )
+        c.summary_circuit_breaker_cooldown_seconds = _int(
+            "LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS",
+            c.summary_circuit_breaker_cooldown_seconds,
+        )
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
         c.expansion_context_tokens = _int("LCM_EXPANSION_CONTEXT_TOKENS", c.expansion_context_tokens)
         c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)

--- a/engine.py
+++ b/engine.py
@@ -21,7 +21,11 @@ from agent.context_engine import ContextEngine
 
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
-from .escalation import _strip_reasoning_blocks, summarize_with_escalation
+from .escalation import (
+    SummaryCircuitBreaker,
+    _strip_reasoning_blocks,
+    summarize_with_escalation,
+)
 from .externalize import (
     build_transcript_gc_placeholder,
     extract_externalized_ref,
@@ -359,6 +363,10 @@ class LCMEngine(ContextEngine):
         self.emit_automatic_compaction_status = False
         self.quiet_mode = True
         self.summary_model = self._config.summary_model
+        self._summary_circuit_breaker = SummaryCircuitBreaker(
+            failure_threshold=self._config.summary_circuit_breaker_failure_threshold,
+            cooldown_seconds=self._config.summary_circuit_breaker_cooldown_seconds,
+        )
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
         self._last_compression_status = "idle"
@@ -762,6 +770,8 @@ class LCMEngine(ContextEngine):
                     token_budget=token_budget,
                     depth=0,
                     model=self._config.summary_model,
+                    fallback_models=self._config.summary_fallback_models,
+                    circuit_breaker=self._summary_circuit_breaker,
                     timeout=self._config.summary_timeout_ms / 1000,
                     l2_budget_ratio=self._config.l2_budget_ratio,
                     l3_truncate_tokens=self._config.l3_truncate_tokens,
@@ -3581,6 +3591,8 @@ class LCMEngine(ContextEngine):
                 token_budget=token_budget,
                 depth=depth + 1,
                 model=self._config.summary_model,
+                fallback_models=self._config.summary_fallback_models,
+                circuit_breaker=self._summary_circuit_breaker,
                 timeout=self._config.summary_timeout_ms / 1000,
                 l2_budget_ratio=self._config.l2_budget_ratio,
                 l3_truncate_tokens=self._config.l3_truncate_tokens,

--- a/escalation.py
+++ b/escalation.py
@@ -14,7 +14,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Callable, Optional
 
 from .model_routing import apply_lcm_model_route
 from .tokens import count_tokens
@@ -185,6 +185,7 @@ def _invoke_summary_llm_chain(
     fallback_models: list[str] | tuple[str, ...] | None = None,
     timeout: float | None = None,
     circuit_breaker: SummaryCircuitBreaker | None = None,
+    accepts_result: Callable[[str], bool] | None = None,
 ) -> Optional[str]:
     chain = _summary_model_chain(model, fallback_models)
     skipped = 0
@@ -206,7 +207,7 @@ def _invoke_summary_llm_chain(
         except Exception as exc:
             logger.warning("LLM summarization failed: %s", exc)
             result = None
-        if result:
+        if result and (accepts_result is None or accepts_result(result)):
             if circuit_breaker is not None:
                 circuit_breaker.record_success(candidate_model)
             return result
@@ -314,9 +315,10 @@ def summarize_with_escalation(
         fallback_models=fallback_models,
         timeout=timeout,
         circuit_breaker=circuit_breaker,
+        accepts_result=lambda result: count_tokens(result) < source_tokens,
     )
 
-    if l1_result and count_tokens(l1_result) < source_tokens:
+    if l1_result:
         logger.debug("L1 summarization succeeded (%d tokens)", count_tokens(l1_result))
         return l1_result, 1
 
@@ -332,9 +334,10 @@ def summarize_with_escalation(
         fallback_models=fallback_models,
         timeout=timeout,
         circuit_breaker=circuit_breaker,
+        accepts_result=lambda result: count_tokens(result) < source_tokens,
     )
 
-    if l2_result and count_tokens(l2_result) < source_tokens:
+    if l2_result:
         logger.debug("L2 summarization succeeded (%d tokens)", count_tokens(l2_result))
         return l2_result, 2
 

--- a/escalation.py
+++ b/escalation.py
@@ -7,10 +7,14 @@ Level 3 (Fallback):   Deterministic truncation — no LLM, guaranteed convergenc
 Each level checks if Tokens(summary) < Tokens(source). If not, escalates.
 """
 
+from __future__ import annotations
+
 import inspect
 import logging
 import re
-from typing import List, Optional
+import time
+from dataclasses import dataclass, field
+from typing import Optional
 
 from .model_routing import apply_lcm_model_route
 from .tokens import count_tokens
@@ -30,6 +34,57 @@ _THINK_BLOCK_RE = re.compile(
     r"</(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
+
+_DEFAULT_ROUTE_KEY = "<task-default>"
+
+
+@dataclass
+class SummaryCircuitBreaker:
+    """In-process circuit breaker for summary model routes.
+
+    The breaker is intentionally small and process-local. It prevents a hot
+    compression loop from repeatedly hitting a failing auxiliary route while
+    preserving deterministic L3 truncation as the final convergence fallback.
+    """
+
+    failure_threshold: int = 2
+    cooldown_seconds: int = 300
+    _failures: dict[str, int] = field(default_factory=dict)
+    _open_until: dict[str, float] = field(default_factory=dict)
+
+    def _key(self, model: str | None) -> str:
+        return (model or "").strip() or _DEFAULT_ROUTE_KEY
+
+    def allows(self, model: str | None, *, now: float | None = None) -> bool:
+        key = self._key(model)
+        current_time = time.monotonic() if now is None else now
+        opened_until = self._open_until.get(key, 0.0)
+        if opened_until <= current_time:
+            if key in self._open_until:
+                self._open_until.pop(key, None)
+            return True
+        return False
+
+    def record_success(self, model: str | None) -> None:
+        key = self._key(model)
+        self._failures.pop(key, None)
+        self._open_until.pop(key, None)
+
+    def record_failure(self, model: str | None, *, now: float | None = None) -> None:
+        key = self._key(model)
+        failures = self._failures.get(key, 0) + 1
+        self._failures[key] = failures
+        threshold = max(1, int(self.failure_threshold or 1))
+        if failures >= threshold:
+            current_time = time.monotonic() if now is None else now
+            cooldown = max(0, int(self.cooldown_seconds or 0))
+            self._open_until[key] = current_time + cooldown
+            logger.warning(
+                "LCM summary route circuit opened for %s after %d failure(s); cooldown=%ss",
+                key,
+                failures,
+                cooldown,
+            )
 
 
 def _strip_reasoning_blocks(text: str) -> str:
@@ -111,6 +166,57 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
     )
 
 
+def _summary_model_chain(primary_model: str = "", fallback_models: list[str] | tuple[str, ...] | None = None) -> list[str]:
+    chain: list[str] = []
+    for model in [primary_model, *(fallback_models or [])]:
+        normalized = (model or "").strip()
+        if normalized not in chain:
+            chain.append(normalized)
+    if not chain:
+        chain.append("")
+    return chain
+
+
+def _invoke_summary_llm_chain(
+    prompt: str,
+    max_tokens: int,
+    *,
+    model: str = "",
+    fallback_models: list[str] | tuple[str, ...] | None = None,
+    timeout: float | None = None,
+    circuit_breaker: SummaryCircuitBreaker | None = None,
+) -> Optional[str]:
+    chain = _summary_model_chain(model, fallback_models)
+    skipped = 0
+    for candidate_model in chain:
+        if circuit_breaker is not None and not circuit_breaker.allows(candidate_model):
+            skipped += 1
+            logger.warning(
+                "LCM summary route skipped by open circuit: %s",
+                candidate_model or _DEFAULT_ROUTE_KEY,
+            )
+            continue
+        try:
+            result = _invoke_summary_llm(
+                prompt,
+                max_tokens,
+                model=candidate_model,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            logger.warning("LLM summarization failed: %s", exc)
+            result = None
+        if result:
+            if circuit_breaker is not None:
+                circuit_breaker.record_success(candidate_model)
+            return result
+        if circuit_breaker is not None:
+            circuit_breaker.record_failure(candidate_model)
+    if skipped == len(chain):
+        logger.warning("LCM summary fallback chain exhausted: all routes are temporarily open")
+    return None
+
+
 def _build_l1_prompt(text: str, token_budget: int, depth: int,
                      focus_topic: str = "", custom_instructions: str = "") -> str:
     """Level 1: preserve details."""
@@ -189,6 +295,8 @@ def summarize_with_escalation(
     l3_truncate_tokens: int = 512,
     focus_topic: str = "",
     custom_instructions: str = "",
+    fallback_models: list[str] | tuple[str, ...] | None = None,
+    circuit_breaker: SummaryCircuitBreaker | None = None,
 ) -> tuple[str, int]:
     """Run 3-level escalation. Returns (summary, level_used).
 
@@ -199,7 +307,14 @@ def summarize_with_escalation(
     l1_prompt = _build_l1_prompt(text, token_budget, depth,
                                  focus_topic=focus_topic,
                                  custom_instructions=custom_instructions)
-    l1_result = _invoke_summary_llm(l1_prompt, token_budget * 2, model=model, timeout=timeout)
+    l1_result = _invoke_summary_llm_chain(
+        l1_prompt,
+        token_budget * 2,
+        model=model,
+        fallback_models=fallback_models,
+        timeout=timeout,
+        circuit_breaker=circuit_breaker,
+    )
 
     if l1_result and count_tokens(l1_result) < source_tokens:
         logger.debug("L1 summarization succeeded (%d tokens)", count_tokens(l1_result))
@@ -210,7 +325,14 @@ def summarize_with_escalation(
     l2_prompt = _build_l2_prompt(text, l2_budget,
                                  focus_topic=focus_topic,
                                  custom_instructions=custom_instructions)
-    l2_result = _invoke_summary_llm(l2_prompt, l2_budget * 2, model=model, timeout=timeout)
+    l2_result = _invoke_summary_llm_chain(
+        l2_prompt,
+        l2_budget * 2,
+        model=model,
+        fallback_models=fallback_models,
+        timeout=timeout,
+        circuit_breaker=circuit_breaker,
+    )
 
     if l2_result and count_tokens(l2_result) < source_tokens:
         logger.debug("L2 summarization succeeded (%d tokens)", count_tokens(l2_result))

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -289,6 +289,67 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert seen["provider"] == "lcpp"
         assert seen["model"] == "4B-Qwen3-2507-compressor"
 
+    def test_summary_fallback_chain_uses_next_model_after_primary_failure(self, monkeypatch):
+        from hermes_lcm import escalation
+
+        calls = []
+
+        def fake_summary_call(prompt, max_tokens, model="", timeout=None):
+            calls.append(model)
+            if model == "primary-model":
+                return None
+            return "fallback summary"
+
+        monkeypatch.setattr(escalation, "_call_llm_for_summary", fake_summary_call)
+
+        summary, level = escalation.summarize_with_escalation(
+            "source text " * 80,
+            source_tokens=200,
+            token_budget=50,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+        )
+
+        assert summary == "fallback summary"
+        assert level == 1
+        assert calls == ["primary-model", "fallback-model"]
+
+    def test_summary_circuit_breaker_skips_temporarily_open_route(self, monkeypatch):
+        from hermes_lcm import escalation
+        from hermes_lcm.escalation import SummaryCircuitBreaker
+
+        calls = []
+        breaker = SummaryCircuitBreaker(failure_threshold=1, cooldown_seconds=60)
+
+        def fake_summary_call(prompt, max_tokens, model="", timeout=None):
+            calls.append(model)
+            if model == "primary-model":
+                return None
+            return "fallback summary"
+
+        monkeypatch.setattr(escalation, "_call_llm_for_summary", fake_summary_call)
+
+        first_summary, first_level = escalation.summarize_with_escalation(
+            "source text " * 80,
+            source_tokens=200,
+            token_budget=50,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+            circuit_breaker=breaker,
+        )
+        second_summary, second_level = escalation.summarize_with_escalation(
+            "source text " * 80,
+            source_tokens=200,
+            token_budget=50,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+            circuit_breaker=breaker,
+        )
+
+        assert (first_summary, first_level) == ("fallback summary", 1)
+        assert (second_summary, second_level) == ("fallback summary", 1)
+        assert calls == ["primary-model", "fallback-model", "fallback-model"]
+
     def test_extraction_call_passes_provider_and_stripped_model(self, monkeypatch):
         from hermes_lcm.extraction import _call_extraction_llm
 
@@ -364,6 +425,9 @@ class TestConfig:
         assert c.stateless_session_patterns_source == "default"
         assert c.ignore_message_patterns_source == "default"
         assert c.summary_model == ""
+        assert c.summary_fallback_models == []
+        assert c.summary_circuit_breaker_failure_threshold == 2
+        assert c.summary_circuit_breaker_cooldown_seconds == 300
         assert c.expansion_model == ""
         assert c.expansion_context_tokens == 32_000
         assert c.summary_timeout_ms == 60_000
@@ -379,6 +443,9 @@ class TestConfig:
             "^Cronjob Response:,^>>>Cronjob Response<<<:",
         )
         monkeypatch.setenv("LCM_EXPANSION_MODEL", "openai/gpt-5.4-mini")
+        monkeypatch.setenv("LCM_SUMMARY_FALLBACK_MODELS", "fast-model, reliable-model")
+        monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "3")
+        monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS", "120")
         monkeypatch.setenv("LCM_EXPANSION_CONTEXT_TOKENS", "64000")
         monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
         monkeypatch.setenv("LCM_EXPANSION_TIMEOUT_MS", "90000")
@@ -409,6 +476,9 @@ class TestConfig:
         assert c.ignore_session_patterns_source == "env"
         assert c.stateless_session_patterns_source == "env"
         assert c.ignore_message_patterns_source == "env"
+        assert c.summary_fallback_models == ["fast-model", "reliable-model"]
+        assert c.summary_circuit_breaker_failure_threshold == 3
+        assert c.summary_circuit_breaker_cooldown_seconds == 120
         assert c.expansion_model == "openai/gpt-5.4-mini"
         assert c.expansion_context_tokens == 64_000
         assert c.summary_timeout_ms == 45_000

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -314,6 +314,32 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert level == 1
         assert calls == ["primary-model", "fallback-model"]
 
+    def test_summary_fallback_chain_uses_next_model_after_non_compressing_primary(self, monkeypatch):
+        from hermes_lcm import escalation
+
+        calls = []
+
+        def fake_summary_call(prompt, max_tokens, model="", timeout=None):
+            calls.append(model)
+            if model == "primary-model":
+                return "primary verbose text " * 300
+            return "short fallback"
+
+        monkeypatch.setattr(escalation, "_call_llm_for_summary", fake_summary_call)
+
+        summary, level = escalation.summarize_with_escalation(
+            "source text " * 80,
+            source_tokens=200,
+            token_budget=50,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+        )
+
+        assert summary == "short fallback"
+        assert level == 1
+        assert calls == ["primary-model", "fallback-model"]
+
+
     def test_summary_circuit_breaker_skips_temporarily_open_route(self, monkeypatch):
         from hermes_lcm import escalation
         from hermes_lcm.escalation import SummaryCircuitBreaker


### PR DESCRIPTION
## Summary

- Adds an optional summary-model fallback chain plus a small in-process circuit breaker for LCM summarization calls.
- Treats non-compressing LLM output as a route failure so fallback routes and the circuit breaker can engage before deterministic L3 truncation.
- Keeps default behavior unchanged: with no new env vars set, LCM still uses `LCM_SUMMARY_MODEL` or the Hermes auxiliary compression task default and still falls back to deterministic L3 truncation if LLM summarization cannot produce a smaller summary.
- Rebased onto current `main` after the structured focus-brief changes and kept both focus-brief prompt guidance and fallback/circuit-breaker routing.
- Adds focused tests for fallback routing, non-compressing primary output, breaker skip behavior, default config compatibility, and env parsing.

## Why

- Summary-provider failures should degrade to backup routes before forcing deterministic truncation.
- A provider returning verbose/non-compressing text is a summarization failure for LCM even when the call technically returned text.
- Repeated failing routes should be temporarily skipped inside one engine instance so one bad route does not slow every leaf/condensation attempt.
- The fallback/breaker knobs are opt-in and preserve existing installations unless explicitly configured.

## Validation

- [x] Rebased onto current `origin/main` (`9802c97`).
- [x] Focused regression validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest tests/test_lcm_core.py::TestProviderPrefixedAuxiliaryCalls::test_summary_fallback_chain_uses_next_model_after_non_compressing_primary tests/test_lcm_core.py::TestProviderPrefixedAuxiliaryCalls::test_summary_fallback_chain_uses_next_model_after_primary_failure tests/test_lcm_core.py::TestProviderPrefixedAuxiliaryCalls::test_summary_circuit_breaker_skips_temporarily_open_route -q` -> `3 passed, 22 warnings`
- [x] Focused validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest tests/test_lcm_core.py -q` -> `188 passed, 22 warnings`
- [x] Default validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest -q` -> `805 passed, 58 warnings`
- [x] `python3 -m compileall -q config.py engine.py escalation.py tests/test_lcm_core.py`
- [x] `python3 -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check`
- [x] Added-line hygiene scan for secrets/private markers -> `added_marker_hits 0`

## Notes

- The standalone validation uses the same minimal synthetic `agent.context_engine` test stub as the other current PR validation runs, matching this plugin checkout's host-module boundary.
- The rebase conflict was limited to `escalation.py`; resolution keeps the already-merged focus-brief helpers and adds the fallback/circuit-breaker helpers below them.
