### PR TITLE
Add summary failure benchmark profiles

### DIFF
--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,10 +1,11 @@
 """Deterministic benchmark harness for model-aware LCM preset tuning."""
 
-from .types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics
+from .types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode
 
 __all__ = [
     "Canary",
     "LCMPolicy",
     "ReplayFixture",
     "ReplayMetrics",
+    "SummaryFailureMode",
 ]

--- a/benchmarking/fixtures.py
+++ b/benchmarking/fixtures.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import Iterable, Mapping
 
-from .types import ReplayFixture, SummaryFailureMode
+from .types import ReplayFixture, SummaryFailureMode, _summary_failure_mode
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -140,7 +140,7 @@ def make_summary_failure_fixture(
         filler_words=filler_words,
     )
     tags = list(dict.fromkeys([*fixture.tags, "summary_failure"]))
-    mode = SummaryFailureMode(str(summary_failure_mode))
+    mode = _summary_failure_mode(summary_failure_mode)
     return ReplayFixture(
         name=fixture.name,
         messages=fixture.messages,

--- a/benchmarking/fixtures.py
+++ b/benchmarking/fixtures.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import Iterable, Mapping
 
-from .types import ReplayFixture
+from .types import ReplayFixture, SummaryFailureMode
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -121,3 +121,33 @@ def make_synthetic_fixture(
         "canaries": canaries,
         "tags": ["synthetic", "deterministic"],
     })
+
+
+def make_summary_failure_fixture(
+    *,
+    name: str,
+    summary_level: int,
+    summary_failure_mode: str | SummaryFailureMode,
+    message_pairs: int = 12,
+    canary_count: int = 3,
+    filler_words: int = 40,
+) -> ReplayFixture:
+    """Build a synthetic fixture annotated for summary failure-mode benchmarking."""
+    fixture = make_synthetic_fixture(
+        name=name,
+        message_pairs=message_pairs,
+        canary_count=canary_count,
+        filler_words=filler_words,
+    )
+    tags = list(dict.fromkeys([*fixture.tags, "summary_failure"]))
+    mode = SummaryFailureMode(str(summary_failure_mode))
+    return ReplayFixture(
+        name=fixture.name,
+        messages=fixture.messages,
+        canaries=fixture.canaries,
+        tags=tags,
+        benchmark_profile={
+            "summary_level": int(summary_level),
+            "summary_failure_mode": mode.value,
+        },
+    )

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from .metrics import canary_present, count_active_canaries, normalize_message_content
-from .types import LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode
+from .types import LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode, _summary_failure_mode
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -181,7 +181,7 @@ def _ratio(numerator: int | float, denominator: int | float) -> float:
 def _summary_profile(fixture: ReplayFixture) -> tuple[int, SummaryFailureMode]:
     profile = fixture.benchmark_profile
     level = int(profile.get("summary_level", 1)) if profile else 1
-    mode = SummaryFailureMode(str(profile.get("summary_failure_mode", SummaryFailureMode.NONE))) if profile else SummaryFailureMode.NONE
+    mode = _summary_failure_mode(profile.get("summary_failure_mode")) if profile else SummaryFailureMode.NONE
     return level, mode
 
 

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from .metrics import canary_present, count_active_canaries, normalize_message_content
-from .types import LCMPolicy, ReplayFixture, ReplayMetrics
+from .types import LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -178,6 +178,13 @@ def _ratio(numerator: int | float, denominator: int | float) -> float:
     return numerator / denominator
 
 
+def _summary_profile(fixture: ReplayFixture) -> tuple[int, SummaryFailureMode]:
+    profile = fixture.benchmark_profile
+    level = int(profile.get("summary_level", 1)) if profile else 1
+    mode = SummaryFailureMode(str(profile.get("summary_failure_mode", SummaryFailureMode.NONE))) if profile else SummaryFailureMode.NONE
+    return level, mode
+
+
 def run_replay(
     fixture: ReplayFixture,
     policy: LCMPolicy,
@@ -200,6 +207,7 @@ def run_replay(
     start = time.perf_counter()
     failures: list[str] = []
     messages = [dict(message) for message in fixture.messages]
+    summary_level, summary_failure_mode = _summary_profile(fixture)
     compressed_messages = messages
     compaction_attempts = 0
     before = count_messages_tokens(messages)
@@ -223,6 +231,8 @@ def run_replay(
             policy_version=policy.policy_version,
             fixture_name=fixture.name,
             fixture_tags=list(fixture.tags),
+            summary_level=summary_level,
+            summary_failure_mode=summary_failure_mode,
             prompt_tokens_before=before,
             prompt_tokens_after=after,
             threshold_tokens=engine.threshold_tokens,
@@ -261,6 +271,8 @@ def run_replay(
             policy_version=policy.policy_version,
             fixture_name=fixture.name,
             fixture_tags=list(fixture.tags),
+            summary_level=summary_level,
+            summary_failure_mode=summary_failure_mode,
             prompt_tokens_before=before,
             prompt_tokens_after=after,
             threshold_tokens=engine.threshold_tokens,

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -56,6 +56,21 @@ def _policy_versions(rows: list[ReplayMetrics]) -> dict[str, str | list[str]]:
     }
 
 
+def _summary_failure_modes(rows: list[ReplayMetrics]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        mode = row.summary_failure_mode.value if hasattr(row.summary_failure_mode, "value") else str(row.summary_failure_mode)
+        counts[mode] += 1
+    return dict(sorted(counts.items()))
+
+
+def _summary_level_runs(rows: list[ReplayMetrics]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[str(row.summary_level)] += 1
+    return dict(sorted(counts.items()))
+
+
 def _metric_summary(rows: list[ReplayMetrics]) -> dict[str, object]:
     total_canaries = sum(row.total_canaries for row in rows)
     return {
@@ -63,6 +78,8 @@ def _metric_summary(rows: list[ReplayMetrics]) -> dict[str, object]:
         "compression_count": sum(row.compression_count for row in rows),
         "compaction_attempts": sum(row.compaction_attempts for row in rows),
         "repeated_compaction_risk_count": sum(1 for row in rows if row.repeated_compaction_risk),
+        "summary_failure_modes": _summary_failure_modes(rows),
+        "summary_level_runs": _summary_level_runs(rows),
         "fresh_tail_pressure_events": sum(
             1 for row in rows if row.fresh_tail_pressure_ratio >= FRESH_TAIL_PRESSURE_THRESHOLD
         ),

--- a/benchmarking/types.py
+++ b/benchmarking/types.py
@@ -3,7 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from enum import Enum
 from typing import Any, Mapping
+
+
+class SummaryFailureMode(str, Enum):
+    NONE = "none"
+    LLM_TIMEOUT_THEN_TRUNCATE = "llm_timeout_then_truncate"
+    LLM_REFUSAL_THEN_TRUNCATE = "llm_refusal_then_truncate"
+    EMPTY_SUMMARY_THEN_TRUNCATE = "empty_summary_then_truncate"
+
+
+def _summary_failure_mode(value: Any) -> SummaryFailureMode:
+    if isinstance(value, SummaryFailureMode):
+        return value
+    return SummaryFailureMode(str(value or SummaryFailureMode.NONE.value))
 
 
 def _as_bool(value: Any) -> bool:
@@ -79,14 +93,18 @@ class ReplayFixture:
     messages: list[dict[str, Any]]
     canaries: list[Canary] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
+    benchmark_profile: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "name": self.name,
             "messages": list(self.messages),
             "canaries": [canary.to_dict() for canary in self.canaries],
             "tags": list(self.tags),
         }
+        if self.benchmark_profile:
+            data["benchmark_profile"] = dict(self.benchmark_profile)
+        return data
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ReplayFixture":
@@ -95,6 +113,7 @@ class ReplayFixture:
             messages=[dict(message) for message in data["messages"]],
             canaries=[Canary.from_dict(item) for item in data.get("canaries", [])],
             tags=[str(tag) for tag in data.get("tags", [])],
+            benchmark_profile=dict(data.get("benchmark_profile", {})),
         )
 
 
@@ -114,6 +133,8 @@ class ReplayMetrics:
     failures: list[str] = field(default_factory=list)
     policy_version: str = "1"
     fixture_tags: list[str] = field(default_factory=list)
+    summary_level: int = 1
+    summary_failure_mode: SummaryFailureMode = SummaryFailureMode.NONE
     post_compaction_headroom_ratio: float = 0.0
     fresh_tail_message_count: int = 0
     fresh_tail_tokens: int = 0
@@ -130,7 +151,9 @@ class ReplayMetrics:
     elapsed_ms: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        data["summary_failure_mode"] = _summary_failure_mode(self.summary_failure_mode).value
+        return data
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ReplayMetrics":
@@ -149,6 +172,8 @@ class ReplayMetrics:
             failures=[str(item) for item in data.get("failures", [])],
             policy_version=str(data.get("policy_version", "1")),
             fixture_tags=[str(item) for item in data.get("fixture_tags", [])],
+            summary_level=int(data.get("summary_level", 1)),
+            summary_failure_mode=_summary_failure_mode(data.get("summary_failure_mode", SummaryFailureMode.NONE)),
             post_compaction_headroom_ratio=float(data.get("post_compaction_headroom_ratio", 0.0)),
             fresh_tail_message_count=int(data.get("fresh_tail_message_count", 0)),
             fresh_tail_tokens=int(data.get("fresh_tail_tokens", 0)),

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,6 +15,8 @@ The benchmark harness is offline by default:
 python scripts/lcm_benchmark.py \
   --fixture benchmarks/fixtures/long_history_canaries.json \
   --fixture benchmarks/fixtures/repeated_compaction_chatter.json \
+  --fixture benchmarks/fixtures/summary_timeout_probe.json \
+  --fixture benchmarks/fixtures/summary_refusal_probe.json \
   --output benchmarks/runs/local-smoke \
   --json
 ```
@@ -60,6 +62,8 @@ python scripts/lcm_benchmark.py \
 
 Synthetic fixture specs use `name:pairs:canaries:filler_words` and are deterministic. They are bounded to 250 message pairs and 2,000 filler words so typos do not create huge benchmark outputs. Benchmark output directories should be fresh or cleaned between runs because the harness refuses to reuse non-empty per-run directories.
 
+The committed `summary_timeout_probe` and `summary_refusal_probe` fixtures are small pilot fixtures for summary-provider failure-mode accounting. Their `benchmark_profile` records `summary_level` and `summary_failure_mode` metadata so reports can group timeout/refusal fallback scenarios without embedding provider calls or secrets in fixture content.
+
 `codex_gpt_long_context` is a benchmark candidate and now has an inspectable dry-run preset surface. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
 
 ## Output files
@@ -76,7 +80,7 @@ Summary metadata includes:
 - `generated_at_utc`
 - `fixture_suite`
 - `policy_versions`
-- `metric_summary`
+- `metric_summary` (including `summary_failure_modes` and `summary_level_runs` when summary-failure profiles are present)
 - `policy_comparison`
 
 The comparison score is intentionally conservative. It rewards canary recall and stability, then penalizes failures, repeated-compaction risk, and excessive fresh-tail pressure. Treat it as a harness signal, not as proof that a policy is ready to become `preset: auto`.

--- a/benchmarks/fixtures/summary_refusal_probe.json
+++ b/benchmarks/fixtures/summary_refusal_probe.json
@@ -1,0 +1,20 @@
+{
+  "name": "summary_refusal_probe",
+  "tags": ["synthetic", "summary_failure", "refusal"],
+  "benchmark_profile": {
+    "summary_level": 3,
+    "summary_failure_mode": "llm_refusal_then_truncate"
+  },
+  "messages": [
+    {"role": "system", "content": "You are a deterministic LCM benchmark agent."},
+    {"role": "user", "content": "CANARY_REFUSAL = VALUE_REFUSAL. This replay marks an LLM refusal before deterministic truncation fallback."},
+    {"role": "assistant", "content": "Acknowledged refusal anchor."},
+    {"role": "user", "content": "Refusal probe backlog segment. refusal_probe_filler_0 refusal_probe_filler_1 refusal_probe_filler_2 refusal_probe_filler_3 refusal_probe_filler_4 refusal_probe_filler_5."},
+    {"role": "assistant", "content": "Acknowledged refusal probe backlog."},
+    {"role": "user", "content": "Recent user turn should remain available after fallback handling."},
+    {"role": "assistant", "content": "Recent assistant turn should remain available after fallback handling."}
+  ],
+  "canaries": [
+    {"id": "CANARY_REFUSAL", "value": "VALUE_REFUSAL", "expected_query": "CANARY_REFUSAL"}
+  ]
+}

--- a/benchmarks/fixtures/summary_timeout_probe.json
+++ b/benchmarks/fixtures/summary_timeout_probe.json
@@ -1,0 +1,20 @@
+{
+  "name": "summary_timeout_probe",
+  "tags": ["synthetic", "summary_failure", "timeout"],
+  "benchmark_profile": {
+    "summary_level": 3,
+    "summary_failure_mode": "llm_timeout_then_truncate"
+  },
+  "messages": [
+    {"role": "system", "content": "You are a deterministic LCM benchmark agent."},
+    {"role": "user", "content": "CANARY_TIMEOUT = VALUE_TIMEOUT. This replay marks an LLM timeout before deterministic truncation fallback."},
+    {"role": "assistant", "content": "Acknowledged timeout anchor."},
+    {"role": "user", "content": "Timeout probe backlog segment. timeout_probe_filler_0 timeout_probe_filler_1 timeout_probe_filler_2 timeout_probe_filler_3 timeout_probe_filler_4 timeout_probe_filler_5."},
+    {"role": "assistant", "content": "Acknowledged timeout probe backlog."},
+    {"role": "user", "content": "Recent user turn should remain available after fallback handling."},
+    {"role": "assistant", "content": "Recent assistant turn should remain available after fallback handling."}
+  ],
+  "canaries": [
+    {"id": "CANARY_TIMEOUT", "value": "VALUE_TIMEOUT", "expected_query": "CANARY_TIMEOUT"}
+  ]
+}

--- a/tests/test_benchmarking_fixtures.py
+++ b/tests/test_benchmarking_fixtures.py
@@ -4,7 +4,13 @@ import json
 
 import pytest
 
-from benchmarking.fixtures import load_fixture, make_synthetic_fixture, parse_synthetic_fixture_spec
+from benchmarking.fixtures import (
+    fixture_from_dict,
+    load_fixture,
+    make_summary_failure_fixture,
+    make_synthetic_fixture,
+    parse_synthetic_fixture_spec,
+)
 from benchmarking.policies import load_policy
 from benchmarking.replay import run_replay
 
@@ -36,6 +42,48 @@ def test_load_fixture_rejects_missing_required_keys(tmp_path):
 
     with pytest.raises(ValueError, match="messages"):
         load_fixture(path)
+
+
+def test_fixture_preserves_benchmark_profile_metadata():
+    fixture = fixture_from_dict({
+        "name": "summary_timeout_probe",
+        "tags": ["synthetic", "summary_failure"],
+        "messages": [
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "CANARY_TIMEOUT = VALUE_TIMEOUT"},
+        ],
+        "canaries": [
+            {"id": "CANARY_TIMEOUT", "value": "VALUE_TIMEOUT", "expected_query": "CANARY_TIMEOUT"},
+        ],
+        "benchmark_profile": {
+            "summary_level": 3,
+            "summary_failure_mode": "llm_timeout_then_truncate",
+        },
+    })
+
+    assert fixture.benchmark_profile == {
+        "summary_level": 3,
+        "summary_failure_mode": "llm_timeout_then_truncate",
+    }
+    assert fixture.to_dict()["benchmark_profile"] == fixture.benchmark_profile
+
+
+def test_make_summary_failure_fixture_marks_profile_and_tags():
+    fixture = make_summary_failure_fixture(
+        name="timeout_probe",
+        summary_level=3,
+        summary_failure_mode="llm_timeout_then_truncate",
+        message_pairs=4,
+        canary_count=1,
+        filler_words=6,
+    )
+
+    assert fixture.benchmark_profile == {
+        "summary_level": 3,
+        "summary_failure_mode": "llm_timeout_then_truncate",
+    }
+    assert "summary_failure" in fixture.tags
+    assert "timeout_probe_filler_5" in fixture.messages[1]["content"]
 
 
 def test_make_synthetic_fixture_is_deterministic():
@@ -84,6 +132,22 @@ def test_parse_synthetic_fixture_spec_rejects_invalid_specs():
         parse_synthetic_fixture_spec("bad:251:1:5")
     with pytest.raises(ValueError, match="filler_words exceeds maximum"):
         parse_synthetic_fixture_spec("bad:1:1:2001")
+
+
+def test_committed_summary_failure_fixtures_load_profiles():
+    timeout_fixture = load_fixture("benchmarks/fixtures/summary_timeout_probe.json")
+    refusal_fixture = load_fixture("benchmarks/fixtures/summary_refusal_probe.json")
+
+    assert timeout_fixture.benchmark_profile == {
+        "summary_level": 3,
+        "summary_failure_mode": "llm_timeout_then_truncate",
+    }
+    assert refusal_fixture.benchmark_profile == {
+        "summary_level": 3,
+        "summary_failure_mode": "llm_refusal_then_truncate",
+    }
+    assert "summary_failure" in timeout_fixture.tags
+    assert timeout_fixture.canaries[0].expected_query == "CANARY_TIMEOUT"
 
 
 def test_committed_long_history_fixture_loads():

--- a/tests/test_benchmarking_fixtures.py
+++ b/tests/test_benchmarking_fixtures.py
@@ -13,6 +13,7 @@ from benchmarking.fixtures import (
 )
 from benchmarking.policies import load_policy
 from benchmarking.replay import run_replay
+from benchmarking.types import SummaryFailureMode
 
 
 def test_load_fixture_parses_canaries(tmp_path):
@@ -84,6 +85,22 @@ def test_make_summary_failure_fixture_marks_profile_and_tags():
     }
     assert "summary_failure" in fixture.tags
     assert "timeout_probe_filler_5" in fixture.messages[1]["content"]
+
+
+def test_make_summary_failure_fixture_accepts_enum_failure_mode():
+    fixture = make_summary_failure_fixture(
+        name="timeout_probe",
+        summary_level=3,
+        summary_failure_mode=SummaryFailureMode.LLM_TIMEOUT_THEN_TRUNCATE,
+        message_pairs=4,
+        canary_count=1,
+        filler_words=6,
+    )
+
+    assert fixture.benchmark_profile == {
+        "summary_level": 3,
+        "summary_failure_mode": "llm_timeout_then_truncate",
+    }
 
 
 def test_make_synthetic_fixture_is_deterministic():

--- a/tests/test_benchmarking_replay.py
+++ b/tests/test_benchmarking_replay.py
@@ -9,7 +9,7 @@ import hermes_lcm.engine as lcm_engine
 
 from benchmarking.fixtures import make_synthetic_fixture
 from benchmarking.replay import run_replay, run_replays
-from benchmarking.types import Canary, LCMPolicy, ReplayFixture
+from benchmarking.types import Canary, LCMPolicy, ReplayFixture, SummaryFailureMode
 
 
 def _small_policy(**overrides):
@@ -43,6 +43,23 @@ def test_replay_below_threshold_does_not_compress(tmp_path):
     assert metrics.compression_count == 0
     assert metrics.prompt_tokens_before == metrics.prompt_tokens_after
     assert Path(metrics.database_path).is_relative_to(tmp_path)
+
+
+def test_replay_defaults_partial_summary_profile_failure_mode_to_none(tmp_path):
+    fixture = ReplayFixture(
+        name="partial_summary_profile",
+        messages=[
+            {"role": "system", "content": "You are a test agent."},
+            {"role": "user", "content": "small hello"},
+        ],
+        benchmark_profile={"summary_level": 2},
+    )
+    policy = _small_policy(context_length=10_000, context_threshold=0.90)
+
+    metrics = run_replay(fixture, policy, output_dir=tmp_path)
+
+    assert metrics.summary_level == 2
+    assert metrics.summary_failure_mode is SummaryFailureMode.NONE
 
 
 def test_replay_above_threshold_compresses_and_reports_canary_recall(tmp_path):

--- a/tests/test_benchmarking_report.py
+++ b/tests/test_benchmarking_report.py
@@ -14,6 +14,8 @@ def _metrics(
     active_canaries_found: int = 1,
     retrieval_canaries_found: int = 1,
     total_canaries: int = 1,
+    summary_level: int = 1,
+    summary_failure_mode: str = "none",
     repeated_compaction_risk: bool = False,
     fresh_tail_pressure_ratio: float = 0.10,
     failures: list[str] | None = None,
@@ -38,6 +40,8 @@ def _metrics(
         active_canaries_found=active_canaries_found,
         retrieval_canaries_found=retrieval_canaries_found,
         total_canaries=total_canaries,
+        summary_level=summary_level,
+        summary_failure_mode=summary_failure_mode,
         active_canary_recall=active_canaries_found / total_canaries,
         retrieval_canary_recall=retrieval_canaries_found / total_canaries,
         failures=failures or [],
@@ -91,6 +95,39 @@ def test_summarize_metrics_includes_versioned_provenance_and_comparison():
     ]
     assert summary["metric_summary"]["repeated_compaction_risk_count"] == 1
     assert [row["policy_name"] for row in summary["policy_comparison"]] == ["candidate", "baseline"]
+
+
+
+def test_summarize_metrics_groups_summary_failure_modes():
+    rows = [
+        _metrics(
+            policy_name="candidate",
+            summary_level=1,
+            summary_failure_mode="none",
+        ),
+        _metrics(
+            policy_name="candidate",
+            summary_level=3,
+            summary_failure_mode="llm_timeout_then_truncate",
+            failures=["TimeoutError: summary provider timed out"],
+        ),
+        _metrics(
+            policy_name="baseline",
+            summary_level=3,
+            summary_failure_mode="llm_refusal_then_truncate",
+        ),
+    ]
+
+    summary = summarize_metrics(rows)
+
+    assert summary["metric_summary"]["summary_failure_modes"] == {
+        "none": 1,
+        "llm_refusal_then_truncate": 1,
+        "llm_timeout_then_truncate": 1,
+    }
+    assert summary["metric_summary"]["summary_level_runs"] == {"1": 1, "3": 2}
+    candidate_row = next(row for row in summary["policy_comparison"] if row["policy_name"] == "candidate")
+    assert candidate_row["summary_failure_modes"]["llm_timeout_then_truncate"] == 1
 
 
 def test_build_community_export_is_scrubbed_and_includes_policy_settings():

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -3,7 +3,7 @@
 import json
 
 from benchmarking.policies import builtin_policies, load_policy
-from benchmarking.types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics
+from benchmarking.types import Canary, LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode
 
 
 def test_policy_round_trips_through_json_mapping():
@@ -34,6 +34,48 @@ def test_fixture_round_trips_nested_canaries():
 
     assert restored == fixture
     assert restored.canaries[0].expected_query == "CANARY_ALPHA"
+
+
+def test_fixture_round_trips_benchmark_profile_metadata():
+    fixture = ReplayFixture(
+        name="summary_timeout_probe",
+        messages=[{"role": "user", "content": "CANARY_TIMEOUT = VALUE_TIMEOUT"}],
+        canaries=[Canary(id="CANARY_TIMEOUT", value="VALUE_TIMEOUT", expected_query="CANARY_TIMEOUT")],
+        tags=["summary_failure"],
+        benchmark_profile={
+            "summary_level": 3,
+            "summary_failure_mode": "llm_timeout_then_truncate",
+        },
+    )
+
+    restored = ReplayFixture.from_dict(json.loads(json.dumps(fixture.to_dict())))
+
+    assert restored == fixture
+    assert restored.benchmark_profile["summary_level"] == 3
+
+
+def test_metrics_round_trips_summary_failure_profile():
+    metrics = ReplayMetrics(
+        policy_name="baseline_272k",
+        fixture_name="summary_timeout_probe",
+        prompt_tokens_before=100,
+        prompt_tokens_after=80,
+        threshold_tokens=75,
+        compression_count=1,
+        compaction_attempts=1,
+        post_compaction_headroom_tokens=-5,
+        active_canaries_found=1,
+        retrieval_canaries_found=2,
+        total_canaries=2,
+        summary_level=3,
+        summary_failure_mode=SummaryFailureMode.LLM_TIMEOUT_THEN_TRUNCATE,
+        failures=["TimeoutError: summary provider timed out"],
+    )
+
+    restored = ReplayMetrics.from_dict(json.loads(json.dumps(metrics.to_dict())))
+
+    assert restored == metrics
+    assert restored.summary_failure_mode == SummaryFailureMode.LLM_TIMEOUT_THEN_TRUNCATE
 
 
 def test_metrics_round_trips_with_failure_list():


### PR DESCRIPTION
## Summary

Adds small, offline benchmark metadata for summary-provider failure modes:

- add `benchmark_profile` metadata to replay fixtures
- add `summary_level` and `summary_failure_mode` fields to replay metrics
- aggregate `summary_failure_modes` and `summary_level_runs` in benchmark summaries / policy comparisons
- add two committed pilot fixtures for timeout/refusal fallback scenarios
- document the new pilot fixtures and report fields

This stays provider-free and deterministic; the fixtures describe failure-mode scenarios without making live LLM calls or embedding private transcript content.

## Why

This gives the benchmarking harness a stable way to describe and report summary-failure scenarios before any live provider integration is attempted. It makes timeout/refusal fallback behavior visible in fixtures and reports while keeping the PR fully offline and backwards-compatible.

## Validation

- [x] Rebased onto current `origin/main` (`9802c97`).
- [x] Focused benchmark validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest tests/test_benchmarking_fixtures.py tests/test_benchmarking_report.py tests/test_benchmarking_types.py -q` -> `25 passed, 32 warnings`
- [x] Default validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest -q` -> `808 passed, 250 warnings`
- [x] `python3 -m compileall -q benchmarking tests/test_benchmarking_fixtures.py tests/test_benchmarking_report.py tests/test_benchmarking_types.py`
- [x] `python3 -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] Added-line hygiene scan for secret/private markers -> one benign docs hit on the word `secrets`; no secret literals or private markers added

## Notes

- The standalone full-suite run used a minimal synthetic `agent.context_engine` test stub, matching the plugin checkout's host-module boundary.
- The new fixtures are synthetic and intentionally small; they describe timeout/refusal failure modes without invoking providers.

Refs #12
