### PR TITLE
Add structured focus briefs

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -78,6 +78,39 @@ def _invoke_summary_llm(prompt: str, max_tokens: int, model: str = "", timeout: 
     return _call_llm_for_summary(prompt, max_tokens, **kwargs)
 
 
+def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
+    """Return a single-line, bounded focus topic for prompt injection."""
+    normalized = " ".join(str(focus_topic or "").split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max(0, max_chars - 1)].rstrip() + "…"
+
+
+def _build_l1_focus_brief(focus_topic: str) -> str:
+    topic = _normalized_focus_topic(focus_topic)
+    if not topic:
+        return ""
+    return (
+        "Focus brief:\n"
+        f"Primary focus: {topic}\n"
+        "Preserve concrete decisions, constraints, files, commands, identifiers, and current state for this focus.\n"
+        "Spend roughly 60-70% of the summary budget on the focus when relevant.\n"
+        "Do not discard unrelated blockers or active tasks just because they are off-focus.\n"
+    )
+
+
+def _build_l2_focus_brief(focus_topic: str) -> str:
+    topic = _normalized_focus_topic(focus_topic)
+    if not topic:
+        return ""
+    return (
+        "Focus brief:\n"
+        f"Primary focus: {topic}\n"
+        "Prefer bullets that preserve decisions, blockers, files, commands, identifiers, and current state for this focus.\n"
+        "Keep other active tasks only when they are current blockers or handoff state.\n"
+    )
+
+
 def _build_l1_prompt(text: str, token_budget: int, depth: int,
                      focus_topic: str = "", custom_instructions: str = "") -> str:
     """Level 1: preserve details."""
@@ -88,12 +121,7 @@ def _build_l1_prompt(text: str, token_budget: int, depth: int,
     }
     guidance = depth_guidance.get(depth, depth_guidance[2])
 
-    focus_guidance = ""
-    if focus_topic:
-        focus_guidance = (
-            f'Prioritize preserving information related to: "{focus_topic}".\n'
-            "Spend roughly 60-70% of the summary budget on that topic when relevant.\n"
-        )
+    focus_guidance = _build_l1_focus_brief(focus_topic)
 
     custom_block = ""
     if custom_instructions:
@@ -114,11 +142,7 @@ CONTENT:
 def _build_l2_prompt(text: str, token_budget: int,
                      focus_topic: str = "", custom_instructions: str = "") -> str:
     """Level 2: aggressive bullet points."""
-    focus_guidance = ""
-    if focus_topic:
-        focus_guidance = (
-            f'Prioritize bullets related to: "{focus_topic}" when present.\n'
-        )
+    focus_guidance = _build_l2_focus_brief(focus_topic)
 
     custom_block = ""
     if custom_instructions:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3094,6 +3094,38 @@ class TestEscalation:
     def test_truncate_short(self):
         assert _deterministic_truncate("hello", 1000) == "hello"
 
+    def test_focus_topic_builds_structured_l1_brief(self):
+        from hermes_lcm.escalation import _build_l1_prompt
+        prompt = _build_l1_prompt(
+            "test content", 500, depth=0,
+            focus_topic="database migrations",
+        )
+        assert "Focus brief:" in prompt
+        assert "Primary focus: database migrations" in prompt
+        assert "Preserve concrete decisions, constraints, files, commands, identifiers, and current state for this focus." in prompt
+        assert "Do not discard unrelated blockers or active tasks just because they are off-focus." in prompt
+
+    def test_focus_topic_builds_structured_l2_brief(self):
+        from hermes_lcm.escalation import _build_l2_prompt
+        prompt = _build_l2_prompt(
+            "test content", 500,
+            focus_topic="release blockers",
+        )
+        assert "Focus brief:" in prompt
+        assert "Primary focus: release blockers" in prompt
+        assert "Prefer bullets that preserve decisions, blockers, files, commands, identifiers, and current state for this focus." in prompt
+        assert "Keep other active tasks only when they are current blockers or handoff state." in prompt
+
+    def test_focus_topic_is_normalized_and_bounded_in_prompts(self):
+        from hermes_lcm.escalation import _build_l1_prompt
+        noisy_focus = "  migration\n\n" + ("very-long-topic " * 40)
+        prompt = _build_l1_prompt("test content", 500, depth=0, focus_topic=noisy_focus)
+        primary_focus_line = next(line for line in prompt.splitlines() if line.startswith("Primary focus:"))
+        assert "\n" not in primary_focus_line
+        assert "migration very-long-topic" in primary_focus_line
+        assert len(primary_focus_line) <= 180
+        assert primary_focus_line.endswith("…")
+
     def test_custom_instructions_injected_into_l1_prompt(self):
         from hermes_lcm.escalation import _build_l1_prompt
         prompt = _build_l1_prompt(


### PR DESCRIPTION
## Summary

Adds a small structured Focus brief for summary prompts when `focus_topic` is supplied:

- normalizes and bounds focus-topic text before injecting it into prompts
- gives L1 summarization a concrete preservation contract for focus-related decisions, constraints, files, commands, identifiers, and current state
- gives L2 summarization an aggressive bullet-preservation contract while keeping unrelated blockers/handoff state
- preserves existing empty-focus and custom-instructions behavior

This is intentionally prompt-only and provider-free: it does not change runtime storage, DAG shape, model routing, or benchmark policy files.

## Why

The current focus guidance is a single ad-hoc line. A structured, bounded Focus brief gives the summarizer clearer retention priorities for focus-related context while reducing prompt-injection and noise risk from long or multi-line topics.

## Validation

- [x] RED verified: the new Focus-brief tests failed against the existing ad-hoc focus guidance.
- [x] `python3 -m pytest tests/test_lcm_core.py::TestEscalation -q`
- [x] `python3 -m compileall -q escalation.py tests/test_lcm_core.py`
- [x] `git diff --check`
- [x] Added-line scans for secret-like strings, private/local markers, shell/eval/pickle/SQL patterns: 0 hits

## Notes

`tests/test_lcm_engine.py` still does not collect in this standalone checkout because the host `agent.context_engine` module is absent. This PR is scoped to `escalation.py`, so the local gate uses the escalation prompt tests directly.
