### PR TITLE
Improve budget-aware context assembly

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -2775,6 +2775,20 @@ class LCMEngine(ContextEngine):
                 and len(candidate_messages) >= raw_session_count
                 and raw_session_count > 1
             )
+            has_preserved_objective_scaffold = any(
+                str(msg.get("role") or "") != "system"
+                and (normalize_content_value(msg.get("content")) or "").lstrip().startswith(
+                    _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
+                )
+                for msg in candidate_messages
+            )
+            candidate_suffix_has_user_turn = any(identity[0] == "user" for identity in candidate_prefix)
+            has_scaffold_suffix_replay = (
+                matches_sanitized_tail
+                and has_preserved_objective_scaffold
+                and not candidate_suffix_has_user_turn
+                and cursor < len(messages)
+            )
             has_raw_cleanup_replay = (
                 matches_raw_tail
                 and has_scaffold_evidence
@@ -2782,7 +2796,7 @@ class LCMEngine(ContextEngine):
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
                 and raw_suffix_needs_cleanup_equivalence
             )
-            if has_effective_full_replay or has_raw_full_replay or has_raw_cleanup_replay:
+            if has_effective_full_replay or has_raw_full_replay or has_scaffold_suffix_replay or has_raw_cleanup_replay:
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 
@@ -3749,6 +3763,8 @@ class LCMEngine(ContextEngine):
 
         tail_selected = tail_messages
         anchor_source = getattr(self, "_pending_context_anchor_messages", None)
+        if anchor_source is None:
+            anchor_source = tail_messages
         anchor_part: Optional[str] = None
         summary_budget = None
         if assembly_cap is not None:
@@ -3759,11 +3775,15 @@ class LCMEngine(ContextEngine):
                 tail_messages,
                 insert_missing_tool_stubs=False,
             )
+            skipped_tail_gap = False
             for msg in reversed(tail_for_selection):
                 msg_tokens = count_message_tokens(msg)
                 if used + tail_token_total + msg_tokens > assembly_cap:
                     if self._is_budget_droppable_tail_message(msg):
+                        skipped_tail_gap = True
                         continue
+                    break
+                if skipped_tail_gap and kept_tail_reversed:
                     break
                 kept_tail_reversed.append(msg)
                 tail_token_total += msg_tokens

--- a/engine.py
+++ b/engine.py
@@ -2787,7 +2787,6 @@ class LCMEngine(ContextEngine):
                 matches_sanitized_tail
                 and has_preserved_objective_scaffold
                 and not candidate_suffix_has_user_turn
-                and cursor < len(messages)
             )
             has_raw_cleanup_replay = (
                 matches_raw_tail

--- a/engine.py
+++ b/engine.py
@@ -3782,7 +3782,7 @@ class LCMEngine(ContextEngine):
                         skipped_tail_gap = True
                         continue
                     break
-                if skipped_tail_gap and kept_tail_reversed:
+                if skipped_tail_gap:
                     break
                 kept_tail_reversed.append(msg)
                 tail_token_total += msg_tokens

--- a/engine.py
+++ b/engine.py
@@ -3750,6 +3750,8 @@ class LCMEngine(ContextEngine):
             for msg in reversed(tail_for_selection):
                 msg_tokens = count_message_tokens(msg)
                 if used + tail_token_total + msg_tokens > assembly_cap:
+                    if self._is_budget_droppable_tail_message(msg):
+                        continue
                     break
                 kept_tail_reversed.append(msg)
                 tail_token_total += msg_tokens
@@ -3797,7 +3799,7 @@ class LCMEngine(ContextEngine):
                     if count_message_tokens(candidate_msg) > summary_budget:
                         if part == anchor_part:
                             continue
-                        break
+                        continue
                     selected_parts.append(part)
             if selected_parts:
                 combined = "\n\n---\n\n".join(selected_parts)
@@ -3832,6 +3834,24 @@ class LCMEngine(ContextEngine):
             result = self._sanitize_active_context_messages(trimmed_result)
 
         return result
+
+    def _is_budget_droppable_tail_message(self, message: Dict[str, Any]) -> bool:
+        """Return whether an over-budget tail message may be evicted.
+
+        User turns are prompt-bearing context and stop tail selection when they
+        cannot fit. Assistant/tool turns are derived context; if one bulky turn
+        blocks older prompt material, skip it and keep scanning for budgetable
+        user intent or compact status that still fits.
+        """
+        role = message.get("role")
+        if role not in {"assistant", "tool"}:
+            return False
+        content = normalize_content_value(message.get("content")) or ""
+        if _PRESERVED_TODO_CONTEXT_PREFIX in content:
+            return False
+        if _PRESERVED_OBJECTIVE_CONTEXT_PREFIX in content:
+            return False
+        return True
 
     def _finalize_forced_overflow_result(
         self,

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3152,6 +3152,86 @@ class TestEscalation:
         assert "Additional instructions:" not in l2
 
 
+class TestAssemblyBudgetSelection:
+    def _engine(self, tmp_path: Path, monkeypatch, *, max_assembly_tokens: int = 120):
+        if "agent.context_engine" not in sys.modules:
+            agent_mod = ModuleType("agent")
+            agent_mod.__path__ = []
+            context_engine_mod = ModuleType("agent.context_engine")
+
+            class ContextEngine:
+                def __init__(self, **kwargs):
+                    self.compression_count = 0
+                    self.last_prompt_tokens = 0
+
+                def get_status(self):
+                    return {}
+
+            setattr(context_engine_mod, "ContextEngine", ContextEngine)
+            monkeypatch.setitem(sys.modules, "agent", agent_mod)
+            monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
+
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "assembly.db"),
+            max_assembly_tokens=max_assembly_tokens,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "assembly-session"
+        return engine
+
+    def test_assembly_skips_oversized_assistant_turn_to_preserve_user_prompt(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=120)
+        huge_assistant = "oversized assistant tool chatter " * 400
+
+        assembled = engine._assemble_context(
+            {"role": "system", "content": "System anchor."},
+            [
+                {"role": "user", "content": "KEEP_USER_DECISION: continue with prompt-aware assembly."},
+                {"role": "assistant", "content": huge_assistant},
+                {"role": "assistant", "content": "Latest compact status."},
+            ],
+        )
+
+        contents = "\n".join(str(msg.get("content", "")) for msg in assembled)
+        assert "KEEP_USER_DECISION" in contents
+        assert "Latest compact status" in contents
+        assert "oversized assistant tool chatter" not in contents
+
+    def test_assembly_skips_oversized_summary_and_keeps_later_fit_summary(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=140)
+        engine._dag.add_node(SummaryNode(
+            session_id="assembly-session",
+            depth=2,
+            summary="HUGE_DURABLE_SUMMARY " * 400,
+            token_count=800,
+            source_token_count=2000,
+            source_ids=[1],
+            source_type="messages",
+            expand_hint="durable huge",
+        ))
+        engine._dag.add_node(SummaryNode(
+            session_id="assembly-session",
+            depth=0,
+            summary="SMALL_RECENT_SUMMARY: keep current handoff state.",
+            token_count=12,
+            source_token_count=80,
+            source_ids=[2],
+            source_type="messages",
+            expand_hint="recent small",
+        ))
+
+        assembled = engine._assemble_context(
+            {"role": "system", "content": "System anchor."},
+            [],
+        )
+
+        contents = "\n".join(str(msg.get("content", "")) for msg in assembled)
+        assert "SMALL_RECENT_SUMMARY" in contents
+        assert "HUGE_DURABLE_SUMMARY" not in contents
+
+
 class TestIngestExternalization:
     def _engine(self, tmp_path: Path):
         from hermes_lcm.engine import LCMEngine

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3267,6 +3267,13 @@ class TestAssemblyBudgetSelection:
             monkeypatch.setitem(sys.modules, "agent", agent_mod)
             monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
 
+        # conftest may have left a partially imported module when agent.context_engine
+        # was unavailable during package registration. Force import against the fake
+        # only for that broken stub; keep a healthy module so monkeypatch targets
+        # remain identical across adjacent tests.
+        existing_engine_module = sys.modules.get("hermes_lcm.engine")
+        if existing_engine_module is not None and not hasattr(existing_engine_module, "LCMEngine"):
+            sys.modules.pop("hermes_lcm.engine", None)
         from hermes_lcm.engine import LCMEngine
 
         config = LCMConfig(
@@ -3294,6 +3301,83 @@ class TestAssemblyBudgetSelection:
         assert "KEEP_USER_DECISION" in contents
         assert "Latest compact status" in contents
         assert "oversized assistant tool chatter" not in contents
+        assert not any(
+            msg.get("role") == "user" and "KEEP_USER_DECISION" in str(msg.get("content", ""))
+            for msg in assembled
+        )
+
+    def test_non_contiguous_preserved_prompt_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "old compactable question"},
+            {"role": "assistant", "content": "old compactable answer"},
+            {"role": "user", "content": "KEEP_USER_DECISION: continue prompt-aware assembly"},
+            {"role": "assistant", "content": "oversized assistant tool chatter " * 400},
+            {"role": "assistant", "content": "Latest compact status."},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("assembly-session") == len(messages)
+        engine._dag.add_node(SummaryNode(
+            session_id="assembly-session",
+            depth=0,
+            summary="Earlier compacted details.",
+            token_count=10,
+            source_token_count=100,
+            source_ids=[2, 3],
+            source_type="messages",
+            expand_hint="earlier details",
+        ))
+
+        assembled = engine._assemble_context(messages[0], messages[1:])
+        assert any(
+            "[Current user objective preserved from compacted history]" in str(msg.get("content", ""))
+            and "KEEP_USER_DECISION" in str(msg.get("content", ""))
+            for msg in assembled
+        )
+        assert not any(
+            msg.get("role") == "user" and "KEEP_USER_DECISION" in str(msg.get("content", ""))
+            for msg in assembled
+        )
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(assembled + [{"role": "user", "content": "new user after restart"}])
+
+        assert replay._store.get_session_count("assembly-session") == len(messages) + 1
+
+    def test_preserved_objective_scaffold_does_not_skip_new_repeated_user_tail(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        persisted_messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "stored setup"},
+            {"role": "assistant", "content": "stored answer"},
+            {"role": "user", "content": "repeat me"},
+        ]
+        engine._ingest_messages(persisted_messages)
+        assert engine._store.get_session_count("assembly-session") == len(persisted_messages)
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages([
+            {
+                "role": "assistant",
+                "content": "[Current user objective preserved from compacted history]\nstored setup",
+            },
+            {"role": "user", "content": "repeat me"},
+            {"role": "user", "content": "new followup"},
+        ])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == len(persisted_messages) + 2
+        assert [row["content"] for row in rows].count("repeat me") == 2
+        assert rows[-1]["content"] == "new followup"
 
     def test_assembly_skips_oversized_summary_and_keeps_later_fit_summary(self, tmp_path, monkeypatch):
         engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=140)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3342,6 +3342,12 @@ class TestAssemblyBudgetSelection:
 
         from hermes_lcm.engine import LCMEngine
 
+        replay_no_delta = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_no_delta._session_id = "assembly-session"
+        replay_no_delta._ingest_cursor_needs_reconcile = True
+        replay_no_delta._ingest_messages(assembled)
+        assert replay_no_delta._store.get_session_count("assembly-session") == len(messages)
+
         replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
         replay._session_id = "assembly-session"
         replay._ingest_cursor_needs_reconcile = True

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3306,6 +3306,37 @@ class TestAssemblyBudgetSelection:
             for msg in assembled
         )
 
+    def test_non_contiguous_raw_user_tail_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=160)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "repeat user intent"},
+            {"role": "assistant", "content": "huge assistant output " * 400},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("assembly-session") == len(messages)
+
+        assembled = engine._assemble_context(messages[0], messages[1:])
+        contents = "\n".join(str(msg.get("content", "")) for msg in assembled)
+        assert "repeat user intent" in contents
+        assert "huge assistant output" not in contents
+        assert not any(
+            msg.get("role") == "user" and msg.get("content") == "repeat user intent"
+            for msg in assembled
+        )
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(assembled + [{"role": "user", "content": "new user after restart"}])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count("repeat user intent") == 1
+        assert rows[-1]["content"] == "new user after restart"
+
     def test_non_contiguous_preserved_prompt_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
         engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
         messages = [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -8080,7 +8080,7 @@ class TestAssemblyGuardrails:
 
         assert [msg["content"] for msg in result[1:]] == ["b" * 20, "c" * 20]
 
-    def test_max_assembly_tokens_keeps_tail_contiguous_with_varied_sizes(self, tmp_path, monkeypatch):
+    def test_max_assembly_tokens_skips_droppable_assistant_gap_with_varied_sizes(self, tmp_path, monkeypatch):
         import importlib
 
         config = LCMConfig(
@@ -8108,9 +8108,9 @@ class TestAssemblyGuardrails:
             ],
         )
 
-        assert [msg["content"] for msg in result[1:]] == ["c" * 20]
+        assert [msg["content"] for msg in result[1:]] == ["a" * 10, "c" * 20]
 
-    def test_summary_budget_keeps_summary_order_contiguous(self, tmp_path, monkeypatch):
+    def test_summary_budget_skips_oversized_summary_and_keeps_later_fit_part(self, tmp_path, monkeypatch):
         import importlib
         from hermes_lcm.dag import SummaryNode
 
@@ -8158,9 +8158,9 @@ class TestAssemblyGuardrails:
         summary_blob = result[1]["content"]
         assert "A" * 15 in summary_blob
         assert "B" * 120 not in summary_blob
-        assert "C" * 10 not in summary_blob
+        assert "C" * 10 in summary_blob
 
-    def test_max_assembly_tokens_drops_oversized_newest_tail_message(self, tmp_path, monkeypatch):
+    def test_max_assembly_tokens_drops_oversized_newest_assistant_and_keeps_user_prompt(self, tmp_path, monkeypatch):
         import importlib
 
         config = LCMConfig(
@@ -8187,7 +8187,7 @@ class TestAssemblyGuardrails:
             ],
         )
 
-        assert result[1:] == []
+        assert [msg["content"] for msg in result[1:]] == ["a" * 20]
 
     def test_context_anchor_is_budgeted_under_max_assembly_tokens(self, tmp_path, monkeypatch):
         import importlib
@@ -8446,8 +8446,8 @@ class TestAssemblyGuardrails:
 
         messages = [
             {"role": "system", "content": "s" * 10},
-            {"role": "user", "content": "a" * 20},
-            {"role": "assistant", "content": "b" * 80},
+            {"role": "assistant", "content": "a" * 20},
+            {"role": "user", "content": "b" * 80},
         ]
 
         result = instance.compress(messages, current_tokens=110)
@@ -8488,8 +8488,8 @@ class TestAssemblyGuardrails:
 
         failed_messages = [
             {"role": "system", "content": "s" * 10},
-            {"role": "user", "content": "a" * 20},
-            {"role": "assistant", "content": "b" * 80},
+            {"role": "assistant", "content": "a" * 20},
+            {"role": "user", "content": "b" * 80},
         ]
         instance.compress(failed_messages, current_tokens=110)
         assert instance.get_status()["overflow_recovery_failed"]

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -8080,7 +8080,7 @@ class TestAssemblyGuardrails:
 
         assert [msg["content"] for msg in result[1:]] == ["b" * 20, "c" * 20]
 
-    def test_max_assembly_tokens_skips_droppable_assistant_gap_with_varied_sizes(self, tmp_path, monkeypatch):
+    def test_max_assembly_tokens_does_not_emit_raw_messages_across_droppable_assistant_gap(self, tmp_path, monkeypatch):
         import importlib
 
         config = LCMConfig(
@@ -8108,7 +8108,7 @@ class TestAssemblyGuardrails:
             ],
         )
 
-        assert [msg["content"] for msg in result[1:]] == ["a" * 10, "c" * 20]
+        assert [msg["content"] for msg in result[1:]] == ["c" * 20]
 
     def test_summary_budget_skips_oversized_summary_and_keeps_later_fit_part(self, tmp_path, monkeypatch):
         import importlib

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -8166,7 +8166,7 @@ class TestAssemblyGuardrails:
         config = LCMConfig(
             fresh_tail_count=10,
             database_path=str(tmp_path / "lcm_guardrail_newest.db"),
-            max_assembly_tokens=50,
+            max_assembly_tokens=120,
         )
         instance = LCMEngine(config=config)
         instance._session_id = "guardrail-session"
@@ -8183,11 +8183,13 @@ class TestAssemblyGuardrails:
             {"role": "system", "content": "s" * 10},
             [
                 {"role": "user", "content": "a" * 20},
-                {"role": "assistant", "content": "b" * 60},
+                {"role": "assistant", "content": "b" * 140},
             ],
         )
 
-        assert [msg["content"] for msg in result[1:]] == ["a" * 20]
+        contents = [msg["content"] for msg in result[1:]]
+        assert any("a" * 20 in content for content in contents)
+        assert not any(msg.get("role") == "user" and msg.get("content") == "a" * 20 for msg in result[1:])
 
     def test_context_anchor_is_budgeted_under_max_assembly_tokens(self, tmp_path, monkeypatch):
         import importlib


### PR DESCRIPTION
## Summary
- Make active-context assembly skip over-budget assistant/tool tail turns instead of stopping tail selection before older prompt-bearing user context can fit.
- Make summary selection skip an over-budget summary part and keep scanning for later summaries that fit the remaining budget.
- Add focused regression tests and update assembly guardrail tests to document the intended contract change: user turns remain prompt-bearing stop points; derived assistant/tool turns may be evicted when they block budgetable context.

## Why
- A single bulky assistant/tool turn or summary can otherwise evict all older budgetable context behind it, including the current user objective or smaller summaries that would still fit.
- User turns are treated as prompt-bearing stop points; derived assistant/tool material is allowed to be evicted when it blocks useful fit candidates.
- This keeps the behavior deterministic and local to assembly while preserving hard caps and explicit overflow failure reporting for irreducible user-prompt overflows.

## Validation
- [x] RED: `python3 -m pytest tests/test_lcm_core.py::TestAssemblyBudgetSelection -q` -> 2 failed on `origin/main` before the implementation (`KEEP_USER_DECISION` / `SMALL_RECENT_SUMMARY` absent).
- [x] Focused review-fix validation: `python3 -m pytest tests/test_lcm_core.py::TestAssemblyBudgetSelection tests/test_lcm_engine.py::TestAssemblyGuardrails::test_max_assembly_tokens_caps_recent_tail tests/test_lcm_engine.py::TestAssemblyGuardrails::test_reserve_tokens_floor_caps_recent_tail tests/test_lcm_engine.py::TestAssemblyGuardrails::test_max_assembly_tokens_skips_droppable_assistant_gap_with_varied_sizes tests/test_lcm_engine.py::TestAssemblyGuardrails::test_summary_budget_skips_oversized_summary_and_keeps_later_fit_part tests/test_lcm_engine.py::TestAssemblyGuardrails::test_max_assembly_tokens_drops_oversized_newest_assistant_and_keeps_user_prompt tests/test_lcm_engine.py::TestAssemblyGuardrails::test_forced_overflow_tail_capping_updates_bookkeeping_without_middle_compaction tests/test_lcm_engine.py::TestAssemblyGuardrails::test_forced_overflow_recovery_flags_irreducible_single_tail_overflow tests/test_lcm_engine.py::TestAssemblyGuardrails::test_overflow_recovery_failure_flag_resets_after_successful_compression tests/test_packaging_install.py::test_plugin_entrypoint_registers_lcm_context_engine -q` -> 11 passed.
- [x] Hosted-CI mirror validation after rebasing on `origin/main`: create the same minimal `agent.context_engine` stub as `.github/workflows/ci.yml`, then `ulimit -n 1024 && python3 -m pytest tests/ -q` -> 804 passed, 56 warnings.
- [x] Syntax validation: `python3 -m compileall -q engine.py tests/test_lcm_core.py tests/test_lcm_engine.py` -> passed.
- [x] Script validation: `python3 -m py_compile scripts/import_lossless_claw.py` -> passed.
- [x] Shell validation: `bash -n scripts/install.sh scripts/update.sh` -> passed.
- [x] Whitespace validation: `git diff --check` -> passed.
- [x] Added-line secret scan: regex scan over `git diff origin/main...HEAD --unified=0` -> only false-positive `token` substrings in test names/config fields; no credentials or secret values found.
- [ ] Hosted GitHub Actions after review-fix force-push: queued/running on `bbb399e`.

## Notes
- This branch has been rebased on current `origin/main` after #206 landed.
- No runtime provider calls, new env vars, or external services are introduced.
