### PR TITLE
fix: surface LCM schema health in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,9 +477,9 @@ the original text inline rather than dropping data.
 `lcm_doctor` reports the effective SQLite database path, core schema-table
 presence, SQLite `journal_mode`, `quick_check`, database/WAL sizes, the largest
 content/tool-call rows, suspicious inline `data:*;base64` rows, suspicious long
-base64-looking rows, and aggregate externalized-payload stats. Doctor output is
-metadata-only for these scans; it intentionally does not print raw payload
-previews.
+base64-looking rows, and aggregate externalized-payload stats.
+Doctor output is metadata-only for these scans; it intentionally does not print
+raw payload previews.
 
 This guard is scoped to LCM's own `lcm.db` write boundary. It does not prevent
 Hermes core, or any other host layer, from writing inline payloads to Hermes

--- a/README.md
+++ b/README.md
@@ -474,11 +474,12 @@ duplicate those payload bytes into `lcm.db`, FTS shadow tables, WAL files, or
 ordinary SQLite backups. If externalization fails, LCM logs a warning and leaves
 the original text inline rather than dropping data.
 
-`lcm_doctor` reports SQLite `journal_mode`, `quick_check`, database/WAL sizes,
-the largest content/tool-call rows, suspicious inline `data:*;base64` rows,
-suspicious long base64-looking rows, and aggregate externalized-payload stats.
-Doctor output is metadata-only for these scans; it intentionally does not print
-raw payload previews.
+`lcm_doctor` reports the effective SQLite database path, core schema-table
+presence, SQLite `journal_mode`, `quick_check`, database/WAL sizes, the largest
+content/tool-call rows, suspicious inline `data:*;base64` rows, suspicious long
+base64-looking rows, and aggregate externalized-payload stats. Doctor output is
+metadata-only for these scans; it intentionally does not print raw payload
+previews.
 
 This guard is scoped to LCM's own `lcm.db` write boundary. It does not prevent
 Hermes core, or any other host layer, from writing inline payloads to Hermes

--- a/command.py
+++ b/command.py
@@ -895,6 +895,7 @@ def _doctor_text(engine) -> str:
     schema_missing_tables = [str(name) for name in schema_missing_raw] if isinstance(schema_missing_raw, list) else []
     schema_existing_raw = schema_health.get("existing_tables")
     schema_existing_tables = [str(name) for name in schema_existing_raw] if isinstance(schema_existing_raw, list) else []
+    schema_core_status = "error" if schema_health.get("error") else "missing" if schema_missing_tables else "ok"
     if schema_missing_tables or schema_health.get("error"):
         issues.append("schema_core_tables")
 
@@ -1000,17 +1001,17 @@ def _doctor_text(engine) -> str:
     observations: list[str] = []
     recommended_actions: list[str] = []
 
-    if schema_missing_tables:
+    if schema_health.get("error"):
+        observations.append(f"schema_core_tables: error: {schema_health['error']}")
+        recommended_actions.append(
+            "verify SQLite can read sqlite_master for the database inspected by Hermes"
+        )
+    elif schema_missing_tables:
         observations.append(
             "schema_core_tables: missing " + ", ".join(schema_missing_tables)
         )
         recommended_actions.append(
             "verify HERMES_HOME/LCM_DATABASE_PATH point at the database inspected by Hermes"
-        )
-    elif schema_health.get("error"):
-        observations.append(f"schema_core_tables: error: {schema_health['error']}")
-        recommended_actions.append(
-            "verify SQLite can read sqlite_master for the database inspected by Hermes"
         )
     else:
         observations.append("schema_core_tables: ok")
@@ -1133,7 +1134,7 @@ def _doctor_text(engine) -> str:
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"wal_size: {_fmt_size(wal_size)}",
-        f"schema_core_tables: {'missing' if schema_missing_tables else 'ok'}",
+        f"schema_core_tables: {schema_core_status}",
         f"schema_missing_tables: {', '.join(schema_missing_tables) or '(none)'}",
         f"schema_existing_tables: {', '.join(schema_existing_tables) or '(none)'}",
         f"journal_mode: {journal_mode}",

--- a/command.py
+++ b/command.py
@@ -8,7 +8,11 @@ import os
 import sqlite3
 from typing import Any
 
-from .db_bootstrap import external_content_fts_needs_repair, repair_external_content_fts
+from .db_bootstrap import (
+    external_content_fts_needs_repair,
+    inspect_lcm_schema_health,
+    repair_external_content_fts,
+)
 from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks, sensitive_pattern_status
 from .dag import build_nodes_fts_spec
 from .presets import (
@@ -886,6 +890,13 @@ def _doctor_text(engine) -> str:
     dag_conn = engine._dag._conn
 
     issues: list[str] = []
+    schema_health = inspect_lcm_schema_health(store_conn, database_path=str(db_path))
+    schema_missing_raw = schema_health.get("missing_tables")
+    schema_missing_tables = [str(name) for name in schema_missing_raw] if isinstance(schema_missing_raw, list) else []
+    schema_existing_raw = schema_health.get("existing_tables")
+    schema_existing_tables = [str(name) for name in schema_existing_raw] if isinstance(schema_existing_raw, list) else []
+    if schema_missing_tables or schema_health.get("error"):
+        issues.append("schema_core_tables")
 
     def _safe_count(conn, query: str, issue_key: str) -> int | str:
         try:
@@ -988,6 +999,21 @@ def _doctor_text(engine) -> str:
 
     observations: list[str] = []
     recommended_actions: list[str] = []
+
+    if schema_missing_tables:
+        observations.append(
+            "schema_core_tables: missing " + ", ".join(schema_missing_tables)
+        )
+        recommended_actions.append(
+            "verify HERMES_HOME/LCM_DATABASE_PATH point at the database inspected by Hermes"
+        )
+    elif schema_health.get("error"):
+        observations.append(f"schema_core_tables: error: {schema_health['error']}")
+        recommended_actions.append(
+            "verify SQLite can read sqlite_master for the database inspected by Hermes"
+        )
+    else:
+        observations.append("schema_core_tables: ok")
 
     if debt_rows:
         first = debt_rows[0]
@@ -1107,6 +1133,9 @@ def _doctor_text(engine) -> str:
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"wal_size: {_fmt_size(wal_size)}",
+        f"schema_core_tables: {'missing' if schema_missing_tables else 'ok'}",
+        f"schema_missing_tables: {', '.join(schema_missing_tables) or '(none)'}",
+        f"schema_existing_tables: {', '.join(schema_existing_tables) or '(none)'}",
         f"journal_mode: {journal_mode}",
         f"quick_check: {quick_check}",
         f"sqlite_integrity: {integrity}",

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 SCHEMA_VERSION = 4
 SQLITE_BUSY_TIMEOUT_MS = 30_000
 _MIN_DISK_SPACE_BYTES = 50 * 1024 * 1024
+REQUIRED_CORE_TABLES = (
+    "messages",
+    "metadata",
+    "summary_nodes",
+    "lcm_lifecycle_state",
+    "lcm_migration_state",
+    "messages_fts",
+    "nodes_fts",
+)
 
 
 class ExternalContentFtsSpec:
@@ -162,6 +171,53 @@ def get_existing_table_names(conn: sqlite3.Connection, names: Iterable[str]) -> 
         if row and row[0]:
             existing.add(row[0])
     return existing
+
+
+def _database_path_for_connection(conn: sqlite3.Connection, fallback: str = "") -> str:
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except sqlite3.DatabaseError:
+        return fallback
+    for row in rows:
+        if len(row) >= 3 and row[1] == "main" and row[2]:
+            return str(row[2])
+    return fallback
+
+
+def inspect_lcm_schema_health(
+    conn: sqlite3.Connection,
+    *,
+    database_path: str = "",
+    required_tables: Iterable[str] = REQUIRED_CORE_TABLES,
+) -> dict[str, object]:
+    """Return read-only health metadata for the core hermes-lcm SQLite schema."""
+    required = tuple(required_tables)
+    resolved_path = _database_path_for_connection(conn, database_path)
+    detail: dict[str, object] = {
+        "database_path": resolved_path,
+        "required_tables": list(required),
+        "existing_tables": [],
+        "missing_tables": list(required),
+    }
+    try:
+        rows = conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type='table'
+            ORDER BY name
+            """
+        ).fetchall()
+    except sqlite3.DatabaseError as exc:
+        detail["error"] = str(exc)
+        return detail
+
+    existing = sorted(str(row[0]) for row in rows if row and row[0])
+    existing_set = set(existing)
+    missing = [name for name in required if name not in existing_set]
+    detail["existing_tables"] = existing
+    detail["missing_tables"] = missing
+    return detail
 
 
 def get_fts_shadow_table_names(table_name: str) -> list[str]:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -173,7 +173,9 @@ def get_existing_table_names(conn: sqlite3.Connection, names: Iterable[str]) -> 
     return existing
 
 
-def _database_path_for_connection(conn: sqlite3.Connection, fallback: str = "") -> str:
+def _database_path_for_connection(conn: sqlite3.Connection | None, fallback: str = "") -> str:
+    if conn is None:
+        return fallback
     try:
         rows = conn.execute("PRAGMA database_list").fetchall()
     except sqlite3.DatabaseError:
@@ -185,7 +187,7 @@ def _database_path_for_connection(conn: sqlite3.Connection, fallback: str = "") 
 
 
 def inspect_lcm_schema_health(
-    conn: sqlite3.Connection,
+    conn: sqlite3.Connection | None,
     *,
     database_path: str = "",
     required_tables: Iterable[str] = REQUIRED_CORE_TABLES,
@@ -197,8 +199,12 @@ def inspect_lcm_schema_health(
         "database_path": resolved_path,
         "required_tables": list(required),
         "existing_tables": [],
-        "missing_tables": list(required),
+        "missing_tables": [],
     }
+    if conn is None:
+        detail["error"] = "LCM store connection is not initialized"
+        return detail
+
     try:
         rows = conn.execute(
             """

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -238,6 +238,38 @@ def test_lcm_doctor_tool_flags_header_only_database_schema(engine):
     assert "lcm_lifecycle_state" in schema_check["detail"]["missing_tables"]
 
 
+def test_lcm_doctor_handles_closed_store_connection(engine):
+    db_path = Path(engine._store.db_path)
+    engine.shutdown()
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "LCM doctor" in result
+    assert "status: issues-found" in result
+    assert f"database_path: {db_path}" in result
+    assert "schema_core_tables: error:" in result
+    assert "LCM store connection is not initialized" in result
+
+
+def test_lcm_doctor_prioritizes_schema_inspection_error(engine, monkeypatch):
+    def _schema_error(_conn, *, database_path="", required_tables=()):
+        return {
+            "database_path": database_path,
+            "required_tables": ["messages"],
+            "existing_tables": [],
+            "missing_tables": ["messages"],
+            "error": "database disk image is malformed",
+        }
+
+    monkeypatch.setattr(command_mod, "inspect_lcm_schema_health", _schema_error)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "schema_core_tables: error: database disk image is malformed" in result
+    assert "schema_core_tables: missing" not in result
+    assert "verify SQLite can read sqlite_master for the database inspected by Hermes" in result
+
+
 def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_doctor_actions.db"),

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1,5 +1,6 @@
 """Tests for /lcm command surface and diagnostics."""
 
+import json
 from pathlib import Path
 import importlib.util
 import sqlite3
@@ -7,6 +8,7 @@ import sys
 
 import pytest
 
+from hermes_lcm import tools as lcm_tools
 import hermes_lcm.command as command_mod
 from hermes_lcm.command import _fmt_size, handle_lcm_command
 from hermes_lcm.config import LCMConfig
@@ -25,6 +27,27 @@ def engine(tmp_path):
     e.context_length = 200000
     e.threshold_tokens = int(200000 * config.context_threshold)
     return e
+
+
+def _replace_with_header_only_sqlite_db(e: LCMEngine) -> Path:
+    """Replace the active DB file with a valid SQLite header and no tables."""
+    db_path = Path(e._store.db_path)
+    e.shutdown()
+    for path in (db_path, Path(str(db_path) + "-wal"), Path(str(db_path) + "-shm")):
+        path.unlink(missing_ok=True)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+    e._store._conn = sqlite3.connect(str(db_path), timeout=5.0, check_same_thread=False)
+    e._dag._conn = sqlite3.connect(str(db_path), timeout=5.0, check_same_thread=False)
+    e._lifecycle._conn = sqlite3.connect(
+        str(db_path),
+        timeout=30.0,
+        check_same_thread=False,
+        isolation_level=None,
+    )
+    e._lifecycle._conn.row_factory = sqlite3.Row
+    return db_path
 
 
 def test_lcm_engine_declares_automatic_compaction_silent(engine):
@@ -182,6 +205,37 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "plugin_version: 0.12.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
+
+
+def test_lcm_doctor_flags_header_only_database_schema(engine):
+    db_path = _replace_with_header_only_sqlite_db(engine)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "LCM doctor" in result
+    assert "status: issues-found" in result
+    assert f"database_path: {db_path}" in result
+    assert "schema_core_tables: missing" in result
+    assert "schema_missing_tables:" in result
+    assert "messages" in result
+    assert "summary_nodes" in result
+    assert "lcm_lifecycle_state" in result
+    assert "verify HERMES_HOME/LCM_DATABASE_PATH point at the database inspected by Hermes" in result
+
+
+def test_lcm_doctor_tool_flags_header_only_database_schema(engine):
+    db_path = _replace_with_header_only_sqlite_db(engine)
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    schema_check = next(check for check in doctor["checks"] if check["check"] == "schema_core_tables")
+
+    assert doctor["overall"] == "unhealthy"
+    assert schema_check["status"] == "fail"
+    assert schema_check["detail"]["database_path"] == str(db_path)
+    assert schema_check["detail"]["existing_tables"] == []
+    assert "messages" in schema_check["detail"]["missing_tables"]
+    assert "summary_nodes" in schema_check["detail"]["missing_tables"]
+    assert "lcm_lifecycle_state" in schema_check["detail"]["missing_tables"]
 
 
 def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path):

--- a/tools.py
+++ b/tools.py
@@ -15,7 +15,7 @@ from .externalize import (
     load_externalized_payload,
 )
 from .dag import build_nodes_fts_spec
-from .db_bootstrap import check_external_content_fts_integrity
+from .db_bootstrap import check_external_content_fts_integrity, inspect_lcm_schema_health
 from .extraction import sanitize_pre_compaction_content
 from .ingest_protection import (
     externalized_payload_stats,
@@ -1620,6 +1620,28 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "detail": str(e),
         })
 
+    try:
+        conn = engine._store._conn
+        if conn is None:
+            raise RuntimeError("LCM store connection is not initialized")
+        schema_health = inspect_lcm_schema_health(
+            conn,
+            database_path=str(engine._store.db_path),
+        )
+        missing_tables = schema_health.get("missing_tables")
+        has_missing = isinstance(missing_tables, list) and bool(missing_tables)
+        checks.append({
+            "check": "schema_core_tables",
+            "status": "fail" if has_missing or schema_health.get("error") else "pass",
+            "detail": schema_health,
+        })
+    except Exception as e:
+        checks.append({
+            "check": "schema_core_tables",
+            "status": "fail",
+            "detail": str(e),
+        })
+
     # 1b. FTS5 integrity, separated from generic SQLite integrity so malformed
     # inverted indexes point at the exact table and repair path.
     for check_name, conn, spec in (
@@ -1651,6 +1673,8 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "check": "sqlite_storage",
             "status": "pass" if quick_check_row and quick_check_row[0] == "ok" else "fail",
             "detail": {
+                "database_path": str(db_path),
+                "database_exists": db_path.exists(),
                 "journal_mode": journal_mode_row[0] if journal_mode_row else "unknown",
                 "quick_check": quick_check_row[0] if quick_check_row else "unknown",
                 "database_size_bytes": db_path.stat().st_size if db_path.exists() else 0,


### PR DESCRIPTION
## Summary
- Add a read-only core-schema health check shared by `/lcm doctor` and `lcm_doctor`.
- Report the effective database path plus existing/missing core tables alongside SQLite/WAL storage metadata.
- Add regressions for a valid SQLite-header-only `lcm.db`, closed store connections, and schema-inspection read errors, plus README coverage for the diagnostic surface.

## Why
- #202 reports a valid SQLite header with an empty schema, where generic `quick_check` / `integrity_check` can still look clean.
- Operators need an explicit schema-table signal and the exact inspected database path before assuming data corruption versus a profile/path mismatch.
- Schema inspection failures should degrade into doctor output, not crash the slash command or get misreported as simple missing tables.

## Validation
- [x] Focused schema-health validation:
  - RED: `python -m pytest tests/test_lcm_command.py::test_lcm_doctor_flags_header_only_database_schema tests/test_lcm_command.py::test_lcm_doctor_tool_flags_header_only_database_schema -q` -> failed on missing `schema_core_tables`
  - GREEN: `python -m pytest tests/test_lcm_command.py::test_lcm_doctor_flags_header_only_database_schema tests/test_lcm_command.py::test_lcm_doctor_tool_flags_header_only_database_schema -q` -> `2 passed`
  - Codex follow-up RED: `python -m pytest tests/test_lcm_command.py::test_lcm_doctor_handles_closed_store_connection tests/test_lcm_command.py::test_lcm_doctor_prioritizes_schema_inspection_error -q` -> failed on closed connection crash and missing/error priority
  - Codex follow-up GREEN: `python -m pytest tests/test_lcm_command.py::test_lcm_doctor_handles_closed_store_connection tests/test_lcm_command.py::test_lcm_doctor_prioritizes_schema_inspection_error tests/test_lcm_command.py::test_lcm_doctor_flags_header_only_database_schema tests/test_lcm_command.py::test_lcm_doctor_tool_flags_header_only_database_schema -q` -> `4 passed`
  - `python -m pytest tests/test_lcm_command.py tests/test_ingest_protection.py::test_readme_documents_storage_boundary_payload_guard tests/test_ingest_protection.py::test_sensitive_patterns_visible_in_status_and_doctor -q` -> `45 passed`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `580 passed`
  - [x] `python -m pytest -q` -> `803 passed`
  - [x] `bash -lc 'ulimit -n 1024; python -m pytest -q'` -> `803 passed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint` -> not run; no workflow files changed

## Notes
- Defensive diagnostic hardening only. This does not claim to reproduce or fix a suspected abrupt-kill/WAL durability path.
- Follow-up commit addresses Codex review feedback: closed store connections now degrade to schema error output, and schema inspection errors take precedence over missing-table reporting.
- The issue should stay open if follow-up work is needed for startup checkpointing or a proven init-commit failure mode.

Refs #202
