### PR TITLE
fix: register LCM diagnostic tools safely

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,27 @@ def _make_wrapped_handler(tool_name: str, engine):
     return _wrapped
 
 
+def _host_forwards_registered_tool_messages(ctx) -> bool:
+    """Return whether ctx.register_tool handlers receive active messages.
+
+    Hermes Agent's current registry dispatch passes task_id/user_task to
+    plugin tools, but not the active conversation messages list. Registering
+    duplicate lcm_* tool names on that host makes the model call the registry
+    handler instead of the native context-engine dispatch branch, so LCM loses
+    current-turn ingest before lcm_grep/lcm_expand style recovery.
+
+    Keep plugin-side tool registration opt-in until a host explicitly
+    advertises that registered context-engine handlers receive messages.
+    """
+    capability = getattr(ctx, "context_engine_tool_handlers_receive_messages", False)
+    if callable(capability):
+        try:
+            capability = capability()
+        except Exception:
+            return False
+    return bool(capability)
+
+
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
@@ -56,11 +77,11 @@ def register(ctx):
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
 
-    # Register tools via the plugin registry so they are discoverable by
-    # hosts that support plugin-provided tool registration. Keep the
-    # context-engine toolset and dispatch path so platform_toolsets gating,
-    # schema deduplication, and live messages=... ingestion remain equivalent
-    # to Hermes Agent's native context-engine handling.
+    # Register tools via the plugin registry only on hosts that preserve the
+    # active messages=... contract for registered context-engine tools. Current
+    # Hermes Agent handles lcm_* correctly through the native context-engine
+    # schema/dispatch path; registering duplicate names there would shadow that
+    # path and lose current-turn ingest.
     _TOOLS = {
         "lcm_grep": LCM_GREP,
         "lcm_load_session": LCM_LOAD_SESSION,
@@ -71,7 +92,7 @@ def register(ctx):
         "lcm_doctor": LCM_DOCTOR,
     }
     register_tool = getattr(ctx, "register_tool", None)
-    if callable(register_tool):
+    if callable(register_tool) and _host_forwards_registered_tool_messages(ctx):
         for name, schema in _TOOLS.items():
             try:
                 register_tool(
@@ -88,6 +109,12 @@ def register(ctx):
                     name,
                     exc,
                 )
+    elif callable(register_tool):
+        logger.info(
+            "LCM plugin tool registration skipped because this Hermes host "
+            "does not advertise messages forwarding for registered "
+            "context-engine tools; continuing with context-engine schemas"
+        )
     else:
         logger.info(
             "LCM tool registration unavailable on this Hermes host; "

--- a/__init__.py
+++ b/__init__.py
@@ -73,13 +73,21 @@ def register(ctx):
     register_tool = getattr(ctx, "register_tool", None)
     if callable(register_tool):
         for name, schema in _TOOLS.items():
-            register_tool(
-                name=name,
-                toolset="context_engine",
-                schema=schema,
-                handler=_make_wrapped_handler(name, engine),
-                description=schema.get("description", ""),
-            )
+            try:
+                register_tool(
+                    name=name,
+                    toolset="context_engine",
+                    schema=schema,
+                    handler=_make_wrapped_handler(name, engine),
+                    description=schema.get("description", ""),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "LCM tool registration failed for %s; "
+                    "continuing with context-engine schemas: %s",
+                    name,
+                    exc,
+                )
     else:
         logger.info(
             "LCM tool registration unavailable on this Hermes host; "

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+
 """Hermes LCM Plugin — Lossless Context Management.
 
 Replaces the built-in ContextCompressor with a DAG-based context engine
@@ -19,10 +20,27 @@ def _env_flag_enabled(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _make_wrapped_handler(handler, engine):
+    """Wrap a raw lcm_* handler so kwargs['engine'] is always bound."""
+    def _wrapped(args, **kwargs):
+        return handler(args, engine=engine, **kwargs)
+    return _wrapped
+
+
 def register(ctx):
-    """Plugin entry point — register the LCM context engine."""
+    """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
     from .engine import LCMEngine
+    from . import tools as lcm_tools
+    from .schemas import (
+        LCM_GREP,
+        LCM_LOAD_SESSION,
+        LCM_DESCRIBE,
+        LCM_EXPAND,
+        LCM_EXPAND_QUERY,
+        LCM_STATUS,
+        LCM_DOCTOR,
+    )
 
     config = LCMConfig.from_env()
 
@@ -39,6 +57,27 @@ def register(ctx):
 
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
+
+    # Register tools via the plugin registry so they are discoverable
+    # by the global tool system (not just the context-engine fallback).
+    _TOOLS = {
+        "lcm_grep": LCM_GREP,
+        "lcm_load_session": LCM_LOAD_SESSION,
+        "lcm_describe": LCM_DESCRIBE,
+        "lcm_expand": LCM_EXPAND,
+        "lcm_expand_query": LCM_EXPAND_QUERY,
+        "lcm_status": LCM_STATUS,
+        "lcm_doctor": LCM_DOCTOR,
+    }
+    for name, schema in _TOOLS.items():
+        handler = getattr(lcm_tools, name)
+        ctx.register_tool(
+            name=name,
+            toolset="lcm",
+            schema=schema,
+            handler=_make_wrapped_handler(handler, engine),
+            description=schema.get("description", f"LCM tool: {name}"),
+        )
 
     register_command = getattr(ctx, "register_command", None)
     slash_enabled = _env_flag_enabled("LCM_ENABLE_SLASH_COMMAND", default=False)

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-
 """Hermes LCM Plugin — Lossless Context Management.
 
 Replaces the built-in ContextCompressor with a DAG-based context engine
@@ -20,10 +19,10 @@ def _env_flag_enabled(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _make_wrapped_handler(handler, engine):
-    """Wrap a raw lcm_* handler so kwargs['engine'] is always bound."""
-    def _wrapped(args, **kwargs):
-        return handler(args, engine=engine, **kwargs)
+def _make_wrapped_handler(tool_name: str, engine):
+    """Route a registered lcm_* tool through the engine dispatch path."""
+    def _wrapped(args: dict, **kwargs) -> str:
+        return engine.handle_tool_call(tool_name, args, **kwargs)
     return _wrapped
 
 
@@ -31,7 +30,6 @@ def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
     from .engine import LCMEngine
-    from . import tools as lcm_tools
     from .schemas import (
         LCM_GREP,
         LCM_LOAD_SESSION,
@@ -58,8 +56,11 @@ def register(ctx):
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
 
-    # Register tools via the plugin registry so they are discoverable
-    # by the global tool system (not just the context-engine fallback).
+    # Register tools via the plugin registry so they are discoverable by
+    # hosts that support plugin-provided tool registration. Keep the
+    # context-engine toolset and dispatch path so platform_toolsets gating,
+    # schema deduplication, and live messages=... ingestion remain equivalent
+    # to Hermes Agent's native context-engine handling.
     _TOOLS = {
         "lcm_grep": LCM_GREP,
         "lcm_load_session": LCM_LOAD_SESSION,
@@ -69,14 +70,20 @@ def register(ctx):
         "lcm_status": LCM_STATUS,
         "lcm_doctor": LCM_DOCTOR,
     }
-    for name, schema in _TOOLS.items():
-        handler = getattr(lcm_tools, name)
-        ctx.register_tool(
-            name=name,
-            toolset="lcm",
-            schema=schema,
-            handler=_make_wrapped_handler(handler, engine),
-            description=schema.get("description", f"LCM tool: {name}"),
+    register_tool = getattr(ctx, "register_tool", None)
+    if callable(register_tool):
+        for name, schema in _TOOLS.items():
+            register_tool(
+                name=name,
+                toolset="context_engine",
+                schema=schema,
+                handler=_make_wrapped_handler(name, engine),
+                description=schema.get("description", ""),
+            )
+    else:
+        logger.info(
+            "LCM tool registration unavailable on this Hermes host; "
+            "continuing with context-engine schemas"
         )
 
     register_command = getattr(ctx, "register_command", None)

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -205,6 +205,29 @@ def test_register_gracefully_degrades_when_host_lacks_register_tool():
     assert ctx.engine.name == "lcm"
 
 
+def test_register_gracefully_degrades_when_register_tool_hook_raises():
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_register_tool_raises")
+
+    class _CtxRaisesTool:
+        def __init__(self):
+            self.engine = None
+            self.register_tool_calls = []
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            self.register_tool_calls.append(name)
+            raise TypeError("host register_tool signature mismatch")
+
+    ctx = _CtxRaisesTool()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert ctx.engine.name == "lcm"
+    assert ctx.register_tool_calls
+
+
 def test_registered_tool_handlers_route_through_engine_handle_tool_call(monkeypatch):
     module = _load_plugin_entrypoint_module("hermes_lcm_packaging_tool_handler_route")
     registered = {}

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -158,6 +158,8 @@ def test_plugin_entrypoint_registers_declared_lcm_tools():
     registered = []
 
     class _Ctx:
+        context_engine_tool_handlers_receive_messages = True
+
         def __init__(self):
             self.engine = None
 
@@ -188,6 +190,38 @@ def test_plugin_entrypoint_registers_declared_lcm_tools():
         assert callable(entry["handler"])
 
 
+def test_plugin_entrypoint_skips_registered_lcm_tools_without_message_forwarding():
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_tool_registration_unsafe_host")
+    registered = {}
+
+    class _HermesAgentLikeCtx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            registered[name] = {
+                "handler": handler,
+                "toolset": toolset,
+            }
+
+        def registry_dispatch(self, name, args):
+            return registered[name]["handler"](
+                args,
+                task_id="task-1",
+                user_task="find current turn",
+            )
+
+    ctx = _HermesAgentLikeCtx()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert registered == {}
+    assert EXPECTED_LCM_TOOLS.issubset({schema["name"] for schema in ctx.engine.get_tool_schemas()})
+
+
 def test_register_gracefully_degrades_when_host_lacks_register_tool():
     module = _load_plugin_entrypoint_module("hermes_lcm_packaging_no_register_tool")
 
@@ -209,6 +243,8 @@ def test_register_gracefully_degrades_when_register_tool_hook_raises():
     module = _load_plugin_entrypoint_module("hermes_lcm_packaging_register_tool_raises")
 
     class _CtxRaisesTool:
+        context_engine_tool_handlers_receive_messages = True
+
         def __init__(self):
             self.engine = None
             self.register_tool_calls = []
@@ -233,6 +269,8 @@ def test_registered_tool_handlers_route_through_engine_handle_tool_call(monkeypa
     registered = {}
 
     class _Ctx:
+        context_engine_tool_handlers_receive_messages = True
+
         def __init__(self):
             self.engine = None
 
@@ -241,6 +279,14 @@ def test_registered_tool_handlers_route_through_engine_handle_tool_call(monkeypa
 
         def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
             registered[name] = handler
+
+        def registry_dispatch(self, name, args, messages):
+            return registered[name](
+                args,
+                task_id="task-1",
+                user_task="find current turn",
+                messages=messages,
+            )
 
     ctx = _Ctx()
     module.register(ctx)
@@ -256,9 +302,9 @@ def test_registered_tool_handlers_route_through_engine_handle_tool_call(monkeypa
     monkeypatch.setattr(ctx.engine, "handle_tool_call", spy_handle_tool_call)
     messages = [{"role": "user", "content": "find current turn"}]
 
-    for tool_name, handler in registered.items():
+    for tool_name in registered:
         args = {"query": "current turn"}
-        assert handler(args, messages=messages) == f"handled:{tool_name}"
+        assert ctx.registry_dispatch(tool_name, args, messages) == f"handled:{tool_name}"
 
     assert {name for name, _, _ in calls} == EXPECTED_LCM_TOOLS
     for name, args, kwargs in calls:

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -4,6 +4,17 @@ import subprocess
 import sys
 
 
+EXPECTED_LCM_TOOLS = {
+    "lcm_grep",
+    "lcm_load_session",
+    "lcm_describe",
+    "lcm_expand",
+    "lcm_expand_query",
+    "lcm_status",
+    "lcm_doctor",
+}
+
+
 def _load_plugin_entrypoint_module(module_name: str):
     repo_root = Path(__file__).resolve().parent.parent
     spec = importlib.util.spec_from_file_location(
@@ -28,6 +39,9 @@ def _register_plugin_engine(module_name: str):
         def register_context_engine(self, engine):
             self.engine = engine
 
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            pass
+
     ctx = _Ctx()
     module.register(ctx)
     return ctx.engine
@@ -49,16 +63,7 @@ def test_plugin_manifest_lists_all_registered_tools():
     repo_root = Path(__file__).resolve().parent.parent
     manifest = (repo_root / "plugin.yaml").read_text(encoding="utf-8")
 
-    expected_tools = {
-        "lcm_grep",
-        "lcm_load_session",
-        "lcm_describe",
-        "lcm_expand",
-        "lcm_expand_query",
-        "lcm_status",
-        "lcm_doctor",
-    }
-    for tool_name in expected_tools:
+    for tool_name in EXPECTED_LCM_TOOLS:
         assert f"  - {tool_name}\n" in manifest
 
 
@@ -145,15 +150,97 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     assert "plugin_git_dirty" in identity
 
     tool_names = {schema["name"] for schema in engine.get_tool_schemas()}
-    assert {
-        "lcm_grep",
-        "lcm_load_session",
-        "lcm_describe",
-        "lcm_expand",
-        "lcm_expand_query",
-        "lcm_status",
-        "lcm_doctor",
-    }.issubset(tool_names)
+    assert EXPECTED_LCM_TOOLS.issubset(tool_names)
+
+
+def test_plugin_entrypoint_registers_declared_lcm_tools():
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_tool_registration")
+    registered = []
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            registered.append(
+                {
+                    "name": name,
+                    "toolset": toolset,
+                    "schema": schema,
+                    "handler": handler,
+                    "description": description,
+                    "emoji": emoji,
+                }
+            )
+
+    ctx = _Ctx()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert {entry["name"] for entry in registered} == EXPECTED_LCM_TOOLS
+    assert {entry["toolset"] for entry in registered} == {"context_engine"}
+    for entry in registered:
+        assert entry["schema"]["name"] == entry["name"]
+        assert entry["description"] == entry["schema"].get("description", "")
+        assert callable(entry["handler"])
+
+
+def test_register_gracefully_degrades_when_host_lacks_register_tool():
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_no_register_tool")
+
+    class _CtxNoTool:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _CtxNoTool()
+    module.register(ctx)
+
+    assert ctx.engine is not None
+    assert ctx.engine.name == "lcm"
+
+
+def test_registered_tool_handlers_route_through_engine_handle_tool_call(monkeypatch):
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_tool_handler_route")
+    registered = {}
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            registered[name] = handler
+
+    ctx = _Ctx()
+    module.register(ctx)
+    assert ctx.engine is not None
+    assert set(registered) == EXPECTED_LCM_TOOLS
+
+    calls = []
+
+    def spy_handle_tool_call(name, args, **kwargs):
+        calls.append((name, args, kwargs))
+        return f"handled:{name}"
+
+    monkeypatch.setattr(ctx.engine, "handle_tool_call", spy_handle_tool_call)
+    messages = [{"role": "user", "content": "find current turn"}]
+
+    for tool_name, handler in registered.items():
+        args = {"query": "current turn"}
+        assert handler(args, messages=messages) == f"handled:{tool_name}"
+
+    assert {name for name, _, _ in calls} == EXPECTED_LCM_TOOLS
+    for name, args, kwargs in calls:
+        assert args == {"query": "current turn"}
+        assert kwargs["messages"] == messages
 
 
 def test_git_runtime_identity_preserves_unknown_dirty_state_when_git_probe_fails(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Continues the closed #201 implementation with original authorship preserved for Stephen Bowman on the picked-up commit.
- Keeps LCM's native context-engine schema/dispatch path as the canonical path on current Hermes Agent hosts.
- Gates duplicate `ctx.register_tool` registration behind an explicit host capability, `context_engine_tool_handlers_receive_messages`, so current Hermes Agent-shaped registries do not shadow the native context-engine branch and lose current-turn `messages=...` ingest.
- Adds packaging regressions for declared tool registration on message-forwarding hosts, Hermes Agent-like registry dispatch without messages, hosts without `register_tool`, host hooks that raise during registration, and handler kwargs forwarding through a host dispatch shim.

## Why
- #201 was closed by the contributor because they could not finish the requested changes in the near term and invited others to pick it up.
- Tosko4 caught that the prior plugin-side registration path was unsafe on current Hermes Agent: `model_tools.handle_function_call` forwards `task_id` and `user_task` to registry tools, but not `messages`. Registering duplicate `lcm_*` names also prevents the native context-engine schema path from adding those names to `_context_engine_tool_names`, so `context_compressor.handle_tool_call(..., messages=messages)` is bypassed.
- The plugin-side fix now fails closed: LCM registers duplicate tool names only when a host explicitly promises that registered context-engine handlers receive active messages. Otherwise it logs and continues with context-engine schemas.
- This still does not claim to be the canonical host-side fix for #200. It keeps the plugin-side compatibility work safe while #200 remains a Hermes Agent host/tool-surface issue.

## Validation
- [x] Focused validation: `python -m pytest tests/test_packaging_install.py -q` -> `14 passed`
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `591 passed`
  - [x] `python -m pytest -q` -> `822 passed`
  - [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> `822 passed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD && git diff --check`
- [ ] Workflow validation, if workflows changed: not applicable, no workflow changes

## Notes
- Attribution: first commit preserves Stephen Bowman's authorship from #201 and includes the cherry-pick source commit.
- The branch is rebased on `origin/main` at `2527979fbb726b393ccbb2897615bb75a8ac45ae`.
- The branch intentionally uses `Refs #200`, not a closing keyword, because the confirmed primary failure remains the Hermes Agent host-side context-engine toolset gating/dispatch path.
- PR #209 is still red on CI and has unresolved maintainer changes requested; this branch is a clean maintainer-owned continuation of #201 with the requested guard and dispatch-path safety fixes.

Refs #200
Refs #201
