### PR TITLE
Add structured preset status surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ LCM_LEAF_CHUNK_TOKENS=8000
 `target_after_compaction=0.55` is still benchmark provenance, not a runtime
 setting, because the engine does not expose that live knob yet.
 
+For dashboards and agents, `lcm_status` also exposes the same information under
+`preset_suggestion` as read-only JSON: suggested preset name/family, selection
+reason, match confidence, provenance, explicit override diagnostics, invalid
+override diagnostics, unsupported benchmark-only fields, and the dry-run delta.
+This surface is safe to consume without scraping slash-command text; it does not
+write files, mutate process state, expose local benchmark run paths, or apply
+`LCM_*` environment changes.
+
 ### FAQ: tuning LCM for large context windows
 
 Long-context models change the tuning problem. A 1M-token model does not mean

--- a/presets.py
+++ b/presets.py
@@ -168,6 +168,112 @@ def preset_env_diff(
     return lines
 
 
+def _preset_dry_run_delta(
+    preset: LCMPreset,
+    config: Any,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return structured preset dry-run actions without mutating runtime state."""
+
+    env = environ if environ is not None else os.environ
+    explicit = explicit_operator_overrides(env)
+    invalid = invalid_operator_overrides(env)
+    delta: list[dict[str, Any]] = []
+    for field, preset_value in preset.runtime_env.items():
+        env_var = _FIELD_ENV[field]
+        current = _current_config_value(config, field)
+        if field in explicit:
+            delta.append({
+                "field": field,
+                "env": env_var,
+                "action": "keep_explicit",
+                "current_value": _parse_override_value(field, env[env_var]),
+                "preset_value": preset_value,
+            })
+        elif field in invalid:
+            delta.append({
+                "field": field,
+                "env": env_var,
+                "action": "replace_invalid",
+                "invalid_value": env.get(env_var, ""),
+                "current_value": current,
+                "preset_value": preset_value,
+            })
+        else:
+            delta.append({
+                "field": field,
+                "env": env_var,
+                "action": "set",
+                "current_value": current,
+                "preset_value": preset_value,
+            })
+    return delta
+
+
+def preset_status_payload(
+    engine: Any,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return read-only, machine-readable preset suggestion metadata."""
+
+    env = environ if environ is not None else os.environ
+    preset, reason = suggest_preset_for_engine(engine)
+    explicit = explicit_operator_overrides(env)
+    invalid = invalid_operator_overrides(env)
+    config = getattr(engine, "_config", None)
+
+    explicit_payload = {
+        field: {
+            "env": env_var,
+            "value": _parse_override_value(field, env[env_var]),
+        }
+        for field, env_var in explicit.items()
+    }
+    invalid_payload = {
+        field: {
+            "env": env_var,
+            "value": env.get(env_var, ""),
+            "runtime_value": _current_config_value(config, field),
+            **(
+                {"preset_value": preset.runtime_env[field]}
+                if preset is not None and field in preset.runtime_env
+                else {}
+            ),
+        }
+        for field, env_var in invalid.items()
+    }
+
+    payload: dict[str, Any] = {
+        "read_only": True,
+        "runtime_mutation": False,
+        "reason": reason,
+        "match_confidence": "context-only" if preset is not None else "none",
+        "suggested_preset": None,
+        "provenance": {},
+        "explicit_overrides": explicit_payload,
+        "invalid_overrides": invalid_payload,
+        "dry_run_delta": [],
+    }
+    if preset is None:
+        return payload
+
+    payload["suggested_preset"] = {
+        "name": preset.name,
+        "family": preset.family,
+        "description": preset.description,
+        "policy_version": preset.policy_version,
+        "policy_path": preset.policy_path,
+        "applies_to": list(preset.applies_to),
+        "unsupported_runtime_fields": dict(preset.unsupported_runtime_fields),
+        "notes": preset.notes,
+    }
+    payload["provenance"] = dict(preset.provenance)
+    payload["dry_run_delta"] = _preset_dry_run_delta(preset, config, environ=env)
+    return payload
+
+
 def suggest_preset_for_engine(engine: Any) -> tuple[LCMPreset | None, str]:
     """Return the safest shipped preset suggestion for the current engine state."""
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12465,6 +12465,34 @@ class TestEngineTools:
         assert result["source_lineage"]["normalized_unknown_messages"] == 1
         assert result["source_lineage"]["legacy_blank_source_messages"] == 0
 
+    def test_handle_status_exposes_structured_preset_suggestion(self, engine, monkeypatch):
+        monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "abc")
+        engine.context_length = 272000
+
+        result = json.loads(engine.handle_tool_call("lcm_status", {}))
+        preset = result["preset_suggestion"]
+
+        assert preset["read_only"] is True
+        assert preset["runtime_mutation"] is False
+        assert preset["suggested_preset"]["name"] == "codex_gpt_long_context"
+        assert preset["suggested_preset"]["family"] == "GPT/Codex long-context"
+        assert preset["match_confidence"] == "context-only"
+        assert preset["provenance"]["benchmark_version"] == "2"
+        assert preset["invalid_overrides"]["fresh_tail_count"] == {
+            "env": "LCM_FRESH_TAIL_COUNT",
+            "value": "abc",
+            "runtime_value": engine._config.fresh_tail_count,
+            "preset_value": 24,
+        }
+        assert {
+            "field": "fresh_tail_count",
+            "env": "LCM_FRESH_TAIL_COUNT",
+            "action": "replace_invalid",
+            "invalid_value": "abc",
+            "current_value": engine._config.fresh_tail_count,
+            "preset_value": 24,
+        } in preset["dry_run_delta"]
+
     def test_handle_status_shows_compression_ratio(self, engine):
         engine._dag.add_node(
             SummaryNode(

--- a/tools.py
+++ b/tools.py
@@ -25,6 +25,7 @@ from .ingest_protection import (
     sensitive_pattern_status,
 )
 from .model_routing import apply_lcm_model_route
+from .presets import preset_status_payload
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 from .store import build_message_fts_spec
 
@@ -1585,6 +1586,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         },
         "source_lineage": source_lineage,
         "ingest_protection": full_status.get("ingest_protection", sensitive_pattern_status(engine._config)),
+        "preset_suggestion": preset_status_payload(engine),
         "ingest_reconciliation": ingest_reconciliation,
         "runtime_identity": runtime_identity,
         "lifecycle": lifecycle,


### PR DESCRIPTION
## Summary
- Adds a structured `preset_suggestion` payload to `lcm_status`.
- Reuses the existing preset suggestion and dry-run helpers so dashboards and agents can read preset provenance without scraping `/lcm preset suggest` text.
- Documents the new read-only status field in the README and covers invalid override plus dry-run delta behavior in tests.

## Why
- Issue #199 asks for a machine-readable preset recommendation/provenance surface in `lcm_status`.
- This keeps preset introspection read-only and automation-friendly while preserving the existing CLI command behavior.

## Validation
- [x] Focused validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest tests/test_lcm_preset_command.py tests/test_lcm_engine.py::TestEngineTools::test_handle_status_returns_session_overview tests/test_lcm_engine.py::TestEngineTools::test_handle_status_exposes_structured_preset_suggestion -q` -> `9 passed, 32 warnings`
- [x] Default validation: `PYTHONPATH=/tmp/tars-investigations/hermes-lcm-quickwins/test-stubs:$PYTHONPATH python3 -m pytest -q` -> `803 passed, 251 warnings`
- [x] `python3 -m compileall -q presets.py tools.py tests/test_lcm_engine.py`
- [x] `python3 -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] Added-line hygiene scan for secrets/private markers -> `added_risky_marker_hits 0`

## Notes
- The payload is explicitly read-only (`read_only: true`, `runtime_mutation: false`) and does not mutate process state, files, or environment variables.
- The standalone full-suite run used a minimal synthetic `agent.context_engine` test stub, matching the existing standalone checkout limitation.

Refs #199
