### PR TITLE
fix: return active stubs for externalized payloads

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -2511,15 +2511,15 @@ class LCMEngine(ContextEngine):
                 session_id=session_id,
             )
             tool_calls = self._restore_ingest_payload_placeholders_in_value(tool_calls, session_id=session_id)
-            ref = extract_externalized_ref(content)
-            if ref and "quarantined_assistant_output" not in content:
-                payload = load_externalized_payload(
-                    ref,
-                    config=self._config,
-                    hermes_home=self._hermes_home,
-                )
-                if payload is not None and isinstance(payload.get("content"), str):
-                    content = payload["content"]
+        ref = extract_externalized_ref(content)
+        if ref and "quarantined_assistant_output" not in content:
+            payload = load_externalized_payload(
+                ref,
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            if payload is not None and isinstance(payload.get("content"), str):
+                content = payload["content"]
         tool_calls_identity = self._stable_tool_calls_identity(tool_calls)
         return (
             str(msg.get("role") or "unknown"),
@@ -2754,6 +2754,13 @@ class LCMEngine(ContextEngine):
                 and self._is_quarantined_assistant_replay_identity(candidate_prefix[0])
                 and self._is_quarantined_assistant_replay_identity(sanitized_replay_tail[0])
             )
+            has_externalized_singleton_replay = (
+                matches_raw_tail
+                and len(candidate_prefix) == 1
+                and raw_session_count == 1
+                and bool(extract_externalized_ref(normalize_content_value(candidate_identity_messages[0].get("content")) or ""))
+                and candidate_prefix == stored_tail
+            )
             has_filtered_full_replay = (
                 matches_sanitized_tail
                 and candidate_dropped_quarantine_replay_placeholder
@@ -2795,7 +2802,13 @@ class LCMEngine(ContextEngine):
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
                 and raw_suffix_needs_cleanup_equivalence
             )
-            if has_effective_full_replay or has_raw_full_replay or has_scaffold_suffix_replay or has_raw_cleanup_replay:
+            if (
+                has_effective_full_replay
+                or has_externalized_singleton_replay
+                or has_raw_full_replay
+                or has_scaffold_suffix_replay
+                or has_raw_cleanup_replay
+            ):
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None
 
@@ -3045,11 +3058,15 @@ class LCMEngine(ContextEngine):
         if not new_messages:
             return replay_messages
 
-        messages_to_store = new_messages
+        messages_to_store_with_index: list[tuple[int, Dict[str, Any]]] = [
+            (cursor + offset, replay_msg)
+            for offset, replay_msg in enumerate(new_messages)
+        ]
         if self._compiled_ignore_message_patterns:
-            kept: List[Dict[str, Any]] = []
+            kept: list[tuple[int, Dict[str, Any]]] = []
             for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
-                if ignored_original_messages[cursor + offset] or self._is_volatile_ignored_quarantine_placeholder(
+                absolute_idx = cursor + offset
+                if ignored_original_messages[absolute_idx] or self._is_volatile_ignored_quarantine_placeholder(
                     replay_msg,
                     text_content_for_pattern_matching(replay_msg.get("content")) or "",
                 ):
@@ -3062,15 +3079,15 @@ class LCMEngine(ContextEngine):
                         excerpt,
                     )
                     continue
-                kept.append(replay_msg)
-            messages_to_store = kept
+                kept.append((absolute_idx, replay_msg))
+            messages_to_store_with_index = kept
 
-        if not messages_to_store:
+        if not messages_to_store_with_index:
             self._ingest_cursor = n
             return replay_messages
 
         protected_messages = protect_messages_for_ingest(
-            messages_to_store,
+            [msg for _idx, msg in messages_to_store_with_index],
             session_id=self._session_id,
             config=self._config,
             hermes_home=self._hermes_home,
@@ -3082,9 +3099,15 @@ class LCMEngine(ContextEngine):
             estimates,
             source=self._session_platform,
         )
+        active_replay_messages = list(replay_messages)
+        for (absolute_idx, replay_msg), protected_msg in zip(messages_to_store_with_index, protected_messages):
+            active_msg = dict(protected_msg)
+            if "content" not in replay_msg and active_msg.get("content") in (None, ""):
+                active_msg.pop("content", None)
+            active_replay_messages[absolute_idx] = active_msg
         self._ingest_cursor = n
-        logger.debug("Ingested %d messages into LCM store", len(messages_to_store))
-        return replay_messages
+        logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
+        return active_replay_messages
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
         """Map current raw messages back to store_ids in stable store order.

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3709,6 +3709,51 @@ class TestIngestExternalization:
         assert payload["role"] == "user"
         assert payload["content"] == content
 
+    def test_compress_returns_externalized_stub_for_oversized_active_tail(self, tmp_path):
+        import hermes_lcm.tools as lcm_tools
+        from hermes_lcm.engine import LCMEngine
+
+        engine, output_dir = self._engine(tmp_path)
+        content = "ACTIVE_RAW_NEEDLE:" + ("r" * 5000)
+        messages = [{"role": "user", "content": content}]
+
+        active_context = engine.compress(messages)
+
+        assert len(active_context) == 1
+        active_content = active_context[0]["content"]
+        assert active_content.startswith("[Externalized payload: kind=raw_payload;")
+        assert "ACTIVE_RAW_NEEDLE" not in active_content
+        assert len(active_content) < 512
+        assert messages[0]["content"] == content
+
+        stored = engine._store.get_session_messages("ingest-session")
+        assert stored[0]["content"] == active_content
+        assert engine._get_store_ids_for_messages(active_context) == [stored[0]["store_id"]]
+        assert engine._store.search("ACTIVE_RAW_NEEDLE", session_id="ingest-session") == []
+        payload_path = next(output_dir.glob("*.json"))
+        expanded = json.loads(
+            lcm_tools.lcm_expand(
+                {"externalized_ref": payload_path.name, "max_tokens": 20_000},
+                engine=engine,
+            )
+        )
+        assert expanded["kind"] == "raw_payload"
+        assert expanded["content"] == content
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(active_context)
+        assert replay._store.get_session_count("ingest-session") == 1
+
+        replay_with_delta = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_with_delta._session_id = "ingest-session"
+        replay_with_delta._ingest_cursor_needs_reconcile = True
+        replay_with_delta._ingest_messages(active_context + [{"role": "user", "content": "followup"}])
+        rows = replay_with_delta._store.get_session_messages("ingest-session")
+        assert len(rows) == 2
+        assert rows[-1]["content"] == "followup"
+
     def test_non_tool_externalized_placeholder_sanitizes_role_metadata_for_ref_parsing(self, tmp_path):
         import hermes_lcm.tools as lcm_tools
 


### PR DESCRIPTION
## Summary
- Return bounded externalized stubs in the active context when newly ingested messages exceed the payload threshold.
- Keep the raw payload externalized while preserving replay identity for restart/idempotency paths.
- Add regressions for active oversized payload replay, including the audited singleton externalized-stub replay case.

## Why
- Large payload externalization already protects SQLite/FTS storage, but the no-op active-context path could still hand the raw oversized payload back to the provider.
- Returning the stub immediately keeps active context bounded without losing raw recovery through the external payload reference.
- The replay guard prevents the stub itself from being re-ingested as a duplicate row after restart.

## Validation
- [x] Focused validation: `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m pytest tests/test_lcm_core.py::TestIngestExternalization::test_compress_returns_externalized_stub_for_oversized_active_tail tests/test_lcm_core.py::TestIngestExternalization -q` -> `8 passed, 20 warnings`
- [x] Default validation:
  - [x] `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m pytest tests -q` -> `842 passed, 57 warnings`
  - [x] `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m compileall -q .`
  - [x] `python3 -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD`
- [x] Workflow validation, if workflows changed: not applicable; no workflows changed.
- [x] Added-line private/secret hygiene scan -> `0` hits.

## Notes
- Validation used a minimal local `agent.context_engine` stub because this plugin repository is tested standalone outside the Hermes host package.
- No external payload raw content is added to doctor/status output by this PR.

Refs #
