### PR TITLE
feat: surface heartbeat noise in doctor

### DIFF
--- a/command.py
+++ b/command.py
@@ -970,6 +970,7 @@ def _doctor_text(engine) -> str:
             "suspicious_base64_like_rows": [],
             "quarantined_assistant_rows": [],
             "suspicious_repetitive_assistant_rows": [],
+            "heartbeat_noise_rows": [],
         }
         externalized_stats = {
             "externalized_payload_count": 0,
@@ -1155,6 +1156,7 @@ def _doctor_text(engine) -> str:
         f"suspicious_base64_like_rows: {payload_risks['suspicious_base64_like_rows']}",
         f"quarantined_assistant_rows: {payload_risks['quarantined_assistant_rows']}",
         f"suspicious_repetitive_assistant_rows: {payload_risks['suspicious_repetitive_assistant_rows']}",
+        f"heartbeat_noise_rows: {payload_risks['heartbeat_noise_rows']}",
         f"sensitive_patterns_enabled: {_fmt_bool(protection.get('enabled'))}",
         f"sensitive_patterns: {', '.join(protection.get('patterns') or []) or '(none)'}",
         f"sensitive_patterns_source: {protection.get('source', 'default')}",

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -92,6 +92,11 @@ _QUARANTINED_ASSISTANT_MIN_CHARS = 65_536
 _QUARANTINED_ASSISTANT_MIN_TOKENS = 1_000
 _WORD_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 _REPETITION_SEGMENT_SPLIT_RE = re.compile(r"(?:\n+|(?<=[.!?])\s+)")
+_HEARTBEAT_NOISE_RE = re.compile(
+    r"^(?:still\s+working|working\s+on\s+it|processing|checking|one\s+moment|ping|heartbeat|no\s+update)(?:[.!…\s-]*)$",
+    re.IGNORECASE,
+)
+_HEARTBEAT_NOISE_MAX_CHARS = 256
 _GENERIC_BASE64_MIN_CHARS = 4096
 _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
 _SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
@@ -313,6 +318,25 @@ def _normalized_repetition_segments(text: str) -> list[str]:
         if len(normalized) >= 32:
             segments.append(normalized)
     return segments
+
+
+def heartbeat_noise_reason(role: str, text: str) -> str | None:
+    """Return a read-only doctor category for short heartbeat/progress noise.
+
+    This intentionally does not drive ingest protection or cleanup. It only
+    surfaces metadata-only candidates for operator review.
+    """
+    role = str(role or "")
+    if role not in {"assistant", "tool", "system"}:
+        return None
+    if not isinstance(text, str):
+        return None
+    normalized = re.sub(r"\s+", " ", text.strip())
+    if not normalized or len(normalized) > _HEARTBEAT_NOISE_MAX_CHARS:
+        return None
+    if _HEARTBEAT_NOISE_RE.match(normalized):
+        return "heartbeat_progress"
+    return None
 
 
 def assistant_output_quarantine_reason(text: str) -> str | None:
@@ -1086,6 +1110,37 @@ def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
         if len(suspicious_repetitive_assistant_rows) >= limit:
             break
 
+    heartbeat_noise_rows = []
+    for row in conn.execute(
+        """
+        SELECT store_id, session_id, source, role, COALESCE(length(content), 0) AS content_len, content
+        FROM messages
+        WHERE role IN ('assistant', 'tool', 'system')
+          AND COALESCE(length(content), 0) BETWEEN 1 AND ?
+          AND (
+            lower(trim(content)) GLOB 'still working*'
+            OR lower(trim(content)) GLOB 'working on it*'
+            OR lower(trim(content)) GLOB 'processing*'
+            OR lower(trim(content)) GLOB 'checking*'
+            OR lower(trim(content)) GLOB 'one moment*'
+            OR lower(trim(content)) GLOB 'ping*'
+            OR lower(trim(content)) GLOB 'heartbeat*'
+            OR lower(trim(content)) GLOB 'no update*'
+          )
+        ORDER BY store_id ASC
+        LIMIT ?
+        """,
+        (_HEARTBEAT_NOISE_MAX_CHARS, candidate_cap),
+    ).fetchall():
+        _store_id, _session_id, _source, role, _length, value = row
+        reason = heartbeat_noise_reason(str(role or ""), value if isinstance(value, str) else "")
+        if reason:
+            heartbeat_noise_rows.append(
+                make_row(row, field="content", length_key="content_len", category=reason)
+            )
+        if len(heartbeat_noise_rows) >= limit:
+            break
+
     return {
         "largest_content_rows": [
             make_row(row, field="content", length_key="content_len", category="largest_content")
@@ -1106,6 +1161,7 @@ def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:
         "suspicious_base64_like_rows": generic_rows,
         "quarantined_assistant_rows": quarantined_assistant_rows,
         "suspicious_repetitive_assistant_rows": suspicious_repetitive_assistant_rows,
+        "heartbeat_noise_rows": heartbeat_noise_rows,
     }
 
 def externalized_payload_stats(config, hermes_home: str = "") -> dict[str, Any]:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -207,6 +207,64 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "plugin_git_commit:" in result
 
 
+def test_lcm_doctor_reports_heartbeat_noise_rows_without_mutating_or_leaking_content(engine):
+    engine._store.append("heartbeat-session", {"role": "assistant", "content": "Still working..."}, token_estimate=2)
+    engine._store.append("heartbeat-session", {"role": "user", "content": "Still working..."}, token_estimate=2)
+    before = engine._store.get_session_count("heartbeat-session")
+
+    result = handle_lcm_command("doctor", engine)
+    after = engine._store.get_session_count("heartbeat-session")
+
+    assert after == before
+    assert "heartbeat_noise_rows:" in result
+    assert "heartbeat_progress" in result
+    assert "Still working" not in result
+
+
+def test_lcm_doctor_tool_reports_heartbeat_noise_as_read_only_payload_detail(engine):
+    engine._store.append("heartbeat-session", {"role": "assistant", "content": "Still working..."}, token_estimate=2)
+    engine._store.append("heartbeat-session", {"role": "user", "content": "Still working..."}, token_estimate=2)
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    payload = next(check for check in doctor["checks"] if check["check"] == "payload_storage")
+    rows = payload["detail"]["heartbeat_noise_rows"]
+
+    assert payload["status"] == "warn"
+    assert rows == [
+        {
+            "store_id": 1,
+            "session_id": "heartbeat-session",
+            "source": "unknown",
+            "role": "assistant",
+            "field": "content",
+            "length": 16,
+            "content_len": 16,
+            "suspicious_category": "heartbeat_progress",
+        }
+    ]
+    assert "Still working" not in json.dumps(payload)
+
+
+def test_lcm_doctor_finds_heartbeat_noise_after_many_short_nonmatches(engine):
+    for idx in range(120):
+        engine._store.append(
+            "heartbeat-session",
+            {"role": "assistant", "content": f"normal short status {idx}"},
+            token_estimate=2,
+        )
+    engine._store.append("heartbeat-session", {"role": "assistant", "content": "Still working..."}, token_estimate=2)
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    payload = next(check for check in doctor["checks"] if check["check"] == "payload_storage")
+    rows = payload["detail"]["heartbeat_noise_rows"]
+
+    assert payload["status"] == "warn"
+    assert len(rows) == 1
+    assert rows[0]["suspicious_category"] == "heartbeat_progress"
+    assert rows[0]["store_id"] == 121
+    assert "Still working" not in json.dumps(payload)
+
+
 def test_lcm_doctor_flags_header_only_database_schema(engine):
     db_path = _replace_with_header_only_sqlite_db(engine)
 

--- a/tools.py
+++ b/tools.py
@@ -1690,6 +1690,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             + len(payload_risks["suspicious_data_uri_tool_calls_rows"])
             + len(payload_risks["suspicious_base64_like_rows"])
             + len(payload_risks["suspicious_repetitive_assistant_rows"])
+            + len(payload_risks["heartbeat_noise_rows"])
         )
         checks.append({
             "check": "payload_storage",


### PR DESCRIPTION
## Summary
- Add a read-only `heartbeat_noise_rows` diagnostic to the SQLite payload-risk scan.
- Surface heartbeat/progress noise counts in `/lcm doctor` text and the `lcm_doctor` tool payload-storage details.
- Keep the detection metadata-only: no raw heartbeat text is emitted, and no rows are mutated.

## Why
- Short assistant/tool/system progress rows such as `Still working...` can accumulate and are useful to detect during doctor scans.
- This PR intentionally stops at observability. It does not prune, redact, quarantine, externalize, or rewrite any stored message rows.
- The scan prefilters likely heartbeat/progress prefixes before applying a conservative regex, so late matches behind many short nonmatches are still counted.

## Validation
- [x] Focused validation: `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m pytest tests/test_lcm_command.py::test_lcm_doctor_reports_heartbeat_noise_rows_without_mutating_or_leaking_content tests/test_lcm_command.py::test_lcm_doctor_tool_reports_heartbeat_noise_as_read_only_payload_detail tests/test_lcm_command.py::test_lcm_doctor_finds_heartbeat_noise_after_many_short_nonmatches -q` -> `3 passed, 32 warnings`
- [x] Broader validation: `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m pytest tests/test_lcm_command.py tests/test_ingest_protection.py -q` -> `136 passed, 77 warnings`
- [x] Default validation:
  - [x] `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m pytest tests -q` -> `844 passed, 252 warnings`
  - [x] `PYTHONPATH="/tmp/tars-lcm-agent-stub:${PYTHONPATH:-}" python3 -m compileall -q .`
  - [x] `python3 -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD`
- [x] Workflow validation, if workflows changed: not applicable; no workflows changed.
- [x] Added-line private/secret hygiene scan -> `0` hits.

## Notes
- Validation used a minimal local `agent.context_engine` stub because this plugin repository is tested standalone outside the Hermes host package.
- The new diagnostic ignores user rows and reports only counts/threshold status, not message content.

Refs #
