### PR TITLE
docs: use raw URL for demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Demo
 
-[Watch the short Hermes-LCM explainer](docs/hermes-lcm-demo.mp4).
+[Watch/download the short Hermes-LCM explainer](https://github.com/stephenschoettler/hermes-lcm/raw/main/docs/hermes-lcm-demo.mp4).
 
 A short explainer showing how Hermes-LCM persists sessions, compacts older turns into a summary DAG, and keeps exact details recoverable with tools like `lcm_grep`, `lcm_expand_query`, and `lcm_doctor`.
 


### PR DESCRIPTION
## Summary
- Change the README demo link to the raw MP4 URL

## Why
- GitHub's blob viewer refuses to preview the repo MP4 with: "Sorry about that, but we can't show files that are this big right now."
- The raw URL bypasses the blob viewer and opens/downloads the MP4 directly.

## Validation
- [x] Focused validation: `curl -L --range 0-255 https://github.com/stephenschoettler/hermes-lcm/raw/main/docs/hermes-lcm-demo.mp4` -> returned MP4 header bytes
- [x] Focused validation: `git diff --check` -> passed
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [ ] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- README-only change; no code paths changed.

Refs #
