### PR TITLE
ci: fix release workflow token header

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           CURRENT_TAG="${{ github.ref_name }}"
           PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -1)
@@ -39,7 +41,7 @@ jobs:
           echo "## Contributors" >> "$GITHUB_OUTPUT"
           if [ -n "$PREV_TAG" ]; then
             CONTRIBUTORS=$(curl -fsSL \
-              -H "Authorization: Bearer ${{ github.token }}" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}" \
               | jq -r '[.commits[].author.login // empty] | unique | .[] | "- @\(.)"')

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_release_workflow_uses_env_backed_github_token_header():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    github_token_expr = "$" + "{{ github.token }}"
+    shell_token_ref = "$" + "{GH_TOKEN}"
+
+    assert f"GH_TOKEN: {github_token_expr}" in workflow
+    assert f"Authorization: Bearer {shell_token_ref}" in workflow
+
+
+def test_release_workflow_does_not_embed_malformed_token_expression():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    shell_token_ref = "$" + "{GH_TOKEN}"
+    auth_lines = [line for line in workflow.splitlines() if "Authorization: Bearer" in line]
+
+    expected_auth = f'              -H "Authorization: Bearer {shell_token_ref}" \\'
+    assert auth_lines == [expected_auth]
+    assert all("github.token" not in line for line in auth_lines)
+    assert all("***" not in line for line in auth_lines)


### PR DESCRIPTION
## Summary
- Fix the release workflow compare API Authorization header by reading `github.token` through step env as `GH_TOKEN`.
- Add a regression test that rejects malformed inline token expressions and redacted-looking `***` in the release workflow auth header.

## Why
- The existing header rendered as a malformed token expression in `.github/workflows/release.yml`.
- Keeping the GitHub expression in `env:` and the shell reference in `curl` avoids broken quoting and makes the intended boundary explicit.

## Validation
- [x] Focused validation: `python -m pytest tests/test_release_workflow.py -q` -> `2 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `601 passed`
  - [x] `pytest -q` -> `847 passed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `847 passed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [x] Workflow validation, if workflows changed: `actionlint` -> passed

## Notes
- Independent pre-commit review approved the staged diff.
- Cross-platform impact: GitHub Actions shell quoting only, no local runtime behavior change.

Refs: none
