### PR TITLE
fix: preserve DAG carryover across session drift

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1763,44 +1763,78 @@ class LCMEngine(ContextEngine):
         source_state = old_state
 
         if previous_session_id and previous_session_id != old_session_id:
-            bound_state = self._lifecycle.get_by_session(previous_session_id)
-            bound_conversation_matches = bool(
-                bound_state
-                and (not self._conversation_id or bound_state.conversation_id == self._conversation_id)
+            # Hermes passes the session that actually crossed the compression
+            # boundary as old_session_id. A different bound session can be a
+            # short-lived subagent/cron/WebUI side channel that ran after the
+            # foreground compaction. Prefer the host-authoritative source when
+            # durable lifecycle + DAG evidence proves it belongs to LCM, then
+            # fall back to the older bound-session recovery path.
+            old_has_summary_nodes = bool(self._dag.get_session_nodes(old_session_id))
+            old_conversation_matches = bool(
+                old_state
                 and (
                     not requested_conversation_id
-                    or bound_state.conversation_id == requested_conversation_id
+                    or old_state.conversation_id == requested_conversation_id
                 )
             )
-            bound_is_active_source = bool(
-                bound_state and bound_state.current_session_id == previous_session_id
+            old_is_active_source = bool(
+                old_state and old_state.current_session_id == old_session_id
             )
-            bound_is_finalized_source = bool(
-                bound_state
-                and bound_state.current_session_id is None
-                and bound_state.last_finalized_session_id == previous_session_id
+            old_is_finalized_source = bool(
+                old_state
+                and old_state.current_session_id is None
+                and old_state.last_finalized_session_id == old_session_id
             )
-            bound_has_summary_nodes = bool(self._dag.get_session_nodes(previous_session_id))
-            if (
-                bound_conversation_matches
-                and (bound_is_active_source or bound_is_finalized_source)
-                and bound_has_summary_nodes
-            ):
-                source_session_id = previous_session_id
-                source_state = bound_state
+            old_is_authoritative_source = bool(
+                old_has_summary_nodes
+                and old_conversation_matches
+                and (old_is_active_source or old_is_finalized_source)
+            )
+            if old_is_authoritative_source:
                 logger.warning(
-                    "LCM compression boundary using bound session %s as carry-over source; host old_session_id=%s does not match",
-                    previous_session_id,
+                    "LCM compression boundary using host old_session_id %s as carry-over source despite bound session drift=%s",
                     old_session_id,
+                    previous_session_id,
                 )
             else:
-                source_session_id = ""
-                source_state = None
+                bound_state = self._lifecycle.get_by_session(previous_session_id)
+                bound_conversation_matches = bool(
+                    bound_state
+                    and (not self._conversation_id or bound_state.conversation_id == self._conversation_id)
+                    and (
+                        not requested_conversation_id
+                        or bound_state.conversation_id == requested_conversation_id
+                    )
+                )
+                bound_is_active_source = bool(
+                    bound_state and bound_state.current_session_id == previous_session_id
+                )
+                bound_is_finalized_source = bool(
+                    bound_state
+                    and bound_state.current_session_id is None
+                    and bound_state.last_finalized_session_id == previous_session_id
+                )
+                bound_has_summary_nodes = bool(self._dag.get_session_nodes(previous_session_id))
+                if (
+                    bound_conversation_matches
+                    and (bound_is_active_source or bound_is_finalized_source)
+                    and bound_has_summary_nodes
+                ):
+                    source_session_id = previous_session_id
+                    source_state = bound_state
+                    logger.warning(
+                        "LCM compression boundary using bound session %s as carry-over source; host old_session_id=%s does not match",
+                        previous_session_id,
+                        old_session_id,
+                    )
+                else:
+                    source_session_id = ""
+                    source_state = None
 
         conversation_id = (
             kwargs.get("conversation_id")
-            or self._conversation_id
             or (source_state.conversation_id if source_state else None)
+            or self._conversation_id
             or source_session_id
             or old_session_id
             or session_id

--- a/engine.py
+++ b/engine.py
@@ -1839,16 +1839,22 @@ class LCMEngine(ContextEngine):
             or old_session_id
             or session_id
         )
+        process_local_frontier = (
+            int(self._last_compacted_store_id or 0)
+            if source_session_id and previous_session_id == source_session_id
+            else 0
+        )
+        pending_reset_frontier = int(
+            self._pending_reset_frontier_store_id
+            if self._pending_reset_session_id
+            and self._pending_reset_session_id == source_session_id
+            else 0
+        )
         frontier = max(
-            int(self._last_compacted_store_id or 0),
+            process_local_frontier,
             int(source_state.current_frontier_store_id if source_state else 0),
             int(source_state.last_finalized_frontier_store_id if source_state else 0),
-            int(
-                self._pending_reset_frontier_store_id
-                if self._pending_reset_session_id
-                and self._pending_reset_session_id in {source_session_id, old_session_id, previous_session_id}
-                else 0
-            ),
+            pending_reset_frontier,
         )
         can_reassign = bool(
             source_session_id

--- a/engine.py
+++ b/engine.py
@@ -1758,9 +1758,63 @@ class LCMEngine(ContextEngine):
     ) -> None:
         previous_session_id = self._session_id
         requested_conversation_id = kwargs.get("conversation_id")
-        old_state = self._lifecycle.get_by_session(old_session_id)
-        source_session_id = old_session_id
-        source_state = old_state
+        session_state = self._lifecycle.get_by_session(old_session_id)
+        conversation_state = self._lifecycle.get_by_conversation(old_session_id)
+
+        def _state_conversation_matches(state: Any) -> bool:
+            return bool(
+                state
+                and (
+                    not requested_conversation_id
+                    or state.conversation_id == requested_conversation_id
+                )
+            )
+
+        def _has_summary_nodes(candidate_session_id: str | None) -> bool:
+            return bool(candidate_session_id and self._dag.get_session_nodes(candidate_session_id))
+
+        def _host_source_from_conversation_state(state: Any) -> tuple[str, Any]:
+            if not _state_conversation_matches(state):
+                return "", None
+            if state.current_session_id == old_session_id and _has_summary_nodes(old_session_id):
+                return old_session_id, state
+            if (
+                state.conversation_id == old_session_id
+                and state.current_session_id
+                and _has_summary_nodes(state.current_session_id)
+            ):
+                return state.current_session_id, state
+            if (
+                state.current_session_id is None
+                and state.last_finalized_session_id
+                and _has_summary_nodes(state.last_finalized_session_id)
+            ):
+                return state.last_finalized_session_id, state
+            return "", None
+
+        def _host_source_from_session_state(state: Any) -> tuple[str, Any]:
+            if not _state_conversation_matches(state):
+                return "", None
+            if state.current_session_id == old_session_id and _has_summary_nodes(old_session_id):
+                return old_session_id, state
+            if (
+                state.current_session_id is None
+                and state.last_finalized_session_id == old_session_id
+                and _has_summary_nodes(old_session_id)
+            ):
+                return old_session_id, state
+            return "", None
+
+        host_source_session_id, host_source_state = _host_source_from_conversation_state(
+            conversation_state
+        )
+        if not host_source_session_id:
+            host_source_session_id, host_source_state = _host_source_from_session_state(
+                session_state
+            )
+
+        source_session_id = host_source_session_id or old_session_id
+        source_state = host_source_state or session_state
 
         if previous_session_id and previous_session_id != old_session_id:
             # Hermes passes the session that actually crossed the compression
@@ -1768,32 +1822,15 @@ class LCMEngine(ContextEngine):
             # short-lived subagent/cron/WebUI side channel that ran after the
             # foreground compaction. Prefer the host-authoritative source when
             # durable lifecycle + DAG evidence proves it belongs to LCM, then
-            # fall back to the older bound-session recovery path.
-            old_has_summary_nodes = bool(self._dag.get_session_nodes(old_session_id))
-            old_conversation_matches = bool(
-                old_state
-                and (
-                    not requested_conversation_id
-                    or old_state.conversation_id == requested_conversation_id
-                )
-            )
-            old_is_active_source = bool(
-                old_state and old_state.current_session_id == old_session_id
-            )
-            old_is_finalized_source = bool(
-                old_state
-                and old_state.current_session_id is None
-                and old_state.last_finalized_session_id == old_session_id
-            )
-            old_is_authoritative_source = bool(
-                old_has_summary_nodes
-                and old_conversation_matches
-                and (old_is_active_source or old_is_finalized_source)
-            )
-            if old_is_authoritative_source:
+            # fall back to the older bound-session recovery path. When the host
+            # old_session_id is the durable conversation id, use that row's
+            # current/finalized LCM source instead of unrelated auxiliary rows
+            # where the id appears only as last_finalized_session_id.
+            if host_source_session_id:
                 logger.warning(
-                    "LCM compression boundary using host old_session_id %s as carry-over source despite bound session drift=%s",
+                    "LCM compression boundary using host old_session_id %s as carry-over source=%s despite bound session drift=%s",
                     old_session_id,
+                    host_source_session_id,
                     previous_session_id,
                 )
             else:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7631,6 +7631,94 @@ class TestSessionRollover:
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
         assert expanded["expanded"][0]["content"] == "foreground DAG must survive drift"
 
+    def test_compression_boundary_scopes_frontier_to_host_old_session_when_bound_session_drifted(self, engine):
+        engine.on_session_start(
+            "foreground-old",
+            conversation_id="foreground-conversation",
+            platform="telegram",
+            context_length=200000,
+        )
+        fg_store_id = engine._store.append(
+            "foreground-old",
+            {"role": "user", "content": "foreground frontier must stay scoped"},
+            token_estimate=17,
+            source="telegram",
+        )
+        fg_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-old",
+            depth=0,
+            summary="foreground scoped frontier summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[fg_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = fg_store_id
+        engine._lifecycle.advance_frontier(
+            "foreground-conversation",
+            "foreground-old",
+            fg_store_id,
+        )
+
+        engine.on_session_start(
+            "aux-old",
+            conversation_id="aux-conversation",
+            platform="cron",
+            context_length=200000,
+        )
+        aux_store_id = engine._store.append(
+            "aux-old",
+            {"role": "user", "content": "auxiliary frontier must not leak"},
+            token_estimate=13,
+            source="cron",
+        )
+        aux_node_id = engine._dag.add_node(SummaryNode(
+            session_id="aux-old",
+            depth=0,
+            summary="auxiliary summary should stay put",
+            token_count=5,
+            source_token_count=13,
+            source_ids=[aux_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        assert aux_store_id > fg_store_id
+        engine._last_compacted_store_id = aux_store_id
+        engine._lifecycle.advance_frontier(
+            "aux-conversation",
+            "aux-old",
+            aux_store_id,
+        )
+
+        engine.on_session_start(
+            "foreground-new",
+            boundary_reason="compression",
+            old_session_id="foreground-old",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        lifecycle = engine._lifecycle.get_by_conversation("foreground-conversation")
+        assert lifecycle is not None
+        assert lifecycle.current_session_id == "foreground-new"
+        assert lifecycle.last_finalized_session_id == "foreground-old"
+        assert lifecycle.current_frontier_store_id == fg_store_id
+        assert lifecycle.last_finalized_frontier_store_id == fg_store_id
+        assert engine._last_compacted_store_id == fg_store_id
+        assert engine._store.get_session_count("foreground-old") == 0
+        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._store.get_session_count("aux-old") == 1
+        assert engine._dag.get_session_nodes("foreground-old") == []
+        new_nodes = engine._dag.get_session_nodes("foreground-new")
+        assert [node.node_id for node in new_nodes] == [fg_node_id]
+        aux_node = engine._dag.get_node(aux_node_id)
+        assert aux_node is not None
+        assert aux_node.session_id == "aux-old"
+        aux_state = engine._lifecycle.get_by_conversation("aux-conversation")
+        assert aux_state is not None
+        assert aux_state.current_frontier_store_id == aux_store_id
+
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)
         engine.compression_count = 3

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7719,6 +7719,79 @@ class TestSessionRollover:
         assert aux_state is not None
         assert aux_state.current_frontier_store_id == aux_store_id
 
+    def test_compression_boundary_uses_conversation_row_when_auxiliary_rows_reference_host_id(self, engine):
+        engine.on_session_start(
+            "foreground-active",
+            conversation_id="host-conversation",
+            platform="telegram",
+            context_length=200000,
+        )
+        fg_store_id = engine._store.append(
+            "foreground-active",
+            {"role": "user", "content": "foreground conversation row must win"},
+            token_estimate=17,
+            source="telegram",
+        )
+        fg_node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-active",
+            depth=0,
+            summary="foreground active summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[fg_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = fg_store_id
+        engine._lifecycle.advance_frontier(
+            "host-conversation",
+            "foreground-active",
+            fg_store_id,
+        )
+
+        # Auxiliary lifecycle rows can reference the host conversation id as a
+        # finalized session. They must not outrank the real conversation row
+        # just because their updated_at is newer.
+        engine._lifecycle.record_rollover(
+            "auxiliary-conversation",
+            old_session_id="host-conversation",
+            new_session_id="drifted-auxiliary",
+            finalized_frontier_store_id=99,
+        )
+        engine.on_session_start(
+            "drifted-auxiliary",
+            conversation_id="auxiliary-conversation",
+            platform="cron",
+            context_length=200000,
+        )
+        wrong_state = engine._lifecycle.get_by_session("host-conversation")
+        assert wrong_state is not None
+        assert wrong_state.conversation_id == "auxiliary-conversation"
+
+        engine.on_session_start(
+            "foreground-new",
+            boundary_reason="compression",
+            old_session_id="host-conversation",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        lifecycle = engine._lifecycle.get_by_conversation("host-conversation")
+        assert lifecycle is not None
+        assert lifecycle.current_session_id == "foreground-new"
+        assert lifecycle.last_finalized_session_id == "foreground-active"
+        assert lifecycle.current_frontier_store_id == fg_store_id
+        assert lifecycle.last_finalized_frontier_store_id == fg_store_id
+        assert engine._store.get_session_count("foreground-active") == 0
+        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._dag.get_session_nodes("foreground-active") == []
+        new_nodes = engine._dag.get_session_nodes("foreground-new")
+        assert [node.node_id for node in new_nodes] == [fg_node_id]
+        aux_state = engine._lifecycle.get_by_conversation("auxiliary-conversation")
+        assert aux_state is not None
+        assert aux_state.current_session_id == "drifted-auxiliary"
+        assert aux_state.last_finalized_session_id == "host-conversation"
+
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)
         engine.compression_count = 3

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -7314,6 +7314,90 @@ class TestSessionRollover:
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
         assert expanded["expanded"][0]["content"] == "important LCM-bound context"
 
+    def test_compression_boundary_prefers_active_bound_source_over_stale_finalized_host(self, engine):
+        engine.on_session_start(
+            "lcm-source",
+            platform="telegram",
+            context_length=200000,
+            conversation_id="shared-conversation",
+        )
+        source_store_id = engine._store.append(
+            "lcm-source",
+            {"role": "user", "content": "active bound context must move"},
+            token_estimate=17,
+            source="telegram",
+        )
+        stale_host_store_id = engine._store.append(
+            "old-hermes-session",
+            {"role": "user", "content": "stale finalized host context must stay put"},
+            token_estimate=11,
+            source="telegram",
+        )
+        source_node_id = engine._dag.add_node(SummaryNode(
+            session_id="lcm-source",
+            depth=0,
+            summary="active bound summary",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[source_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        stale_host_node_id = engine._dag.add_node(SummaryNode(
+            session_id="old-hermes-session",
+            depth=0,
+            summary="stale finalized host summary should not move",
+            token_count=5,
+            source_token_count=11,
+            source_ids=[stale_host_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._lifecycle.record_rollover(
+            "shared-conversation",
+            old_session_id="old-hermes-session",
+            new_session_id="lcm-source",
+            finalized_frontier_store_id=stale_host_store_id,
+        )
+        engine._lifecycle.advance_frontier(
+            "shared-conversation",
+            "lcm-source",
+            source_store_id,
+        )
+        lifecycle_before = engine._lifecycle.get_by_conversation("shared-conversation")
+        assert lifecycle_before is not None
+        assert lifecycle_before.current_session_id == "lcm-source"
+        assert lifecycle_before.last_finalized_session_id == "old-hermes-session"
+        engine.compression_count = 2
+        engine.last_prompt_tokens = 1000
+        engine.last_completion_tokens = 50
+        engine.last_total_tokens = 1050
+        engine._last_compacted_store_id = source_store_id
+        engine._ingest_cursor = 2
+
+        engine.on_session_start(
+            "new-hermes-session",
+            boundary_reason="compression",
+            old_session_id="old-hermes-session",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "new-hermes-session"
+        assert engine._conversation_id == "shared-conversation"
+        assert engine._store.get_session_count("lcm-source") == 0
+        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("old-hermes-session") == 1
+        assert engine._dag.get_session_nodes("lcm-source") == []
+        new_nodes = engine._dag.get_session_nodes("new-hermes-session")
+        assert len(new_nodes) == 1
+        assert new_nodes[0].node_id == source_node_id
+        stale_host_node = engine._dag.get_node(stale_host_node_id)
+        assert stale_host_node is not None
+        assert stale_host_node.session_id == "old-hermes-session"
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
+        assert expanded["expanded"][0]["content"] == "active bound context must move"
+
     def test_compression_boundary_uses_finalized_bound_lcm_source_when_host_old_session_differs(self, engine):
         engine.on_session_start("lcm-source", platform="telegram", context_length=200000)
         source_store_id = engine._store.append(
@@ -7481,6 +7565,71 @@ class TestSessionRollover:
         conversation_b = engine._lifecycle.get_by_conversation("conversation-b")
         assert conversation_b is not None
         assert conversation_b.current_session_id == "new-hermes-session"
+
+    def test_compression_boundary_prefers_host_old_session_when_bound_session_drifted(self, engine):
+        engine.on_session_start(
+            "foreground-old",
+            conversation_id="foreground-conversation",
+            platform="telegram",
+            context_length=200000,
+        )
+        store_id = engine._store.append(
+            "foreground-old",
+            {"role": "user", "content": "foreground DAG must survive drift"},
+            token_estimate=17,
+            source="telegram",
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="foreground-old",
+            depth=0,
+            summary="foreground summary before drift",
+            token_count=5,
+            source_token_count=17,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+        engine._lifecycle.advance_frontier(
+            "foreground-conversation",
+            "foreground-old",
+            store_id,
+        )
+
+        # A short-lived session binds after the foreground compaction. It has no
+        # DAG nodes and is not the host-authoritative session that compressed.
+        engine.on_session_start(
+            "short-lived-auxiliary",
+            conversation_id="auxiliary-conversation",
+            platform="cron",
+            context_length=200000,
+        )
+        assert engine._session_id == "short-lived-auxiliary"
+        assert engine._dag.get_session_nodes("short-lived-auxiliary") == []
+
+        engine.on_session_start(
+            "foreground-new",
+            boundary_reason="compression",
+            old_session_id="foreground-old",
+            platform="telegram",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "foreground-new"
+        assert engine._conversation_id == "foreground-conversation"
+        assert engine._store.get_session_count("foreground-old") == 0
+        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._dag.get_session_nodes("foreground-old") == []
+        new_nodes = engine._dag.get_session_nodes("foreground-new")
+        assert [node.node_id for node in new_nodes] == [node_id]
+        assert engine._last_compacted_store_id == store_id
+        lifecycle = engine._lifecycle.get_by_conversation("foreground-conversation")
+        assert lifecycle is not None
+        assert lifecycle.current_session_id == "foreground-new"
+        assert lifecycle.last_finalized_session_id == "foreground-old"
+        assert lifecycle.current_frontier_store_id == store_id
+        expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+        assert expanded["expanded"][0]["content"] == "foreground DAG must survive drift"
 
     def test_compression_boundary_mismatch_resets_session_scoped_state(self, engine):
         engine.on_session_start("bound-session", platform="telegram", context_length=200000)


### PR DESCRIPTION
## Summary
- Prefer Hermes host `old_session_id` as the compression carry-over source only when durable lifecycle state and DAG nodes prove it is the active or finalized LCM source.
- Prefer the durable conversation row when the host-reported `old_session_id` is the conversation id and auxiliary rows also reference that id as `last_finalized_session_id`.
- Keep the older bound-session fallback for stale-host cases where the bound session is the real active/finalized source.
- Scope boundary frontier advancement to the selected carry-over source so an auxiliary drift session cannot leak its process-local frontier into the foreground conversation.
- Add regressions for session-drift recovery, stale-finalized-host safety, larger auxiliary frontier isolation, and auxiliary lifecycle-row contamination.

## Why
- Fixes the #222 production failure mode where `reassign_session_nodes()` never runs after auxiliary session drift, leaving all DAG nodes inaccessible to `lcm_expand`, `lcm_describe`, and `lcm_expand_query` in child sessions.
- Preserves the safety invariant from #79: do not move arbitrary stale host-session nodes unless LCM lifecycle and DAG evidence identify the host `old_session_id` or host conversation row as the compressed source.
- Addresses Codex review feedback that a stale `last_finalized_session_id` with leftover nodes must not outrank the currently bound active LCM source.
- Addresses Tosko4 review feedback that `self._last_compacted_store_id` is process-local and must not be trusted when the selected source is the host `old_session_id` but the bound session has drifted.
- Addresses qxxaa's deployment finding that `get_by_session(old_session_id)` can return a newer unrelated auxiliary row when the host id appears as `last_finalized_session_id` in many auxiliary conversations.

## Validation
- [x] Focused RED check for #222: `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_prefers_host_old_session_when_bound_session_drifted -q` failed before the original fix with `LCM compression boundary skipped carry-over` and `foreground-new != foreground-conversation`
- [x] Focused RED check for Codex finding: `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_prefers_active_bound_source_over_stale_finalized_host -q` failed before the guard refinement with stale host carry-over winning over the active bound source
- [x] Focused RED check for Tosko4 finding: `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_scopes_frontier_to_host_old_session_when_bound_session_drifted -q` failed before the frontier scoping fix with `AssertionError: assert 2 == 1`
- [x] Focused RED check for qxxaa finding: `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_compression_boundary_uses_conversation_row_when_auxiliary_rows_reference_host_id -q` failed before the conversation-row fix with `LCM compression boundary skipped carry-over` and `foreground-active != foreground-new`
- [x] Rebased onto current `origin/main` after #225 landed: base `37ade00b82f9a89c2fe06462d3ba3cbefdcdff5b`, head `d1c6fa39ef9b521e2cebe651ee306e87652f8b47`
- [x] Focused validation: `python -m pytest -q tests/test_lcm_engine.py -k 'compression_boundary_prefers_host_old_session_when_bound_session_drifted or compression_boundary_scopes_frontier_to_host_old_session_when_bound_session_drifted or compression_boundary_uses_conversation_row_when_auxiliary_rows_reference_host_id or compression_boundary_prefers_active_bound_source_over_stale_finalized_host or compression_boundary_uses_bound_lcm_source_when_host_old_session_differs or compression_boundary_uses_finalized_bound_lcm_source_when_host_old_session_differs or compression_boundary_rejects_bound_source_for_explicit_conversation_mismatch'` -> 7 passed
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 609 passed
  - [x] `python -m pytest -q` -> 865 passed
  - [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> 865 passed
  - [x] `python scripts/lcm_stress_check.py --output "$OUT" --tier release --json` -> `failure_count: 0`, 6 cases
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py scripts/lcm_stress_check.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check origin/main...HEAD` -> passed

## Notes
- #225 has landed and this branch is now rebased on top of it.
- Tosko4 approved the fix shape and asked me to review/merge if I agree.

Closes #222
