### PR TITLE
fix: preserve active replay after storage protection

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3142,15 +3142,14 @@ class LCMEngine(ContextEngine):
             estimates,
             source=self._session_platform,
         )
-        active_replay_messages = list(replay_messages)
-        for (absolute_idx, replay_msg), protected_msg in zip(messages_to_store_with_index, protected_messages):
-            active_msg = dict(protected_msg)
-            if "content" not in replay_msg and active_msg.get("content") in (None, ""):
-                active_msg.pop("content", None)
-            active_replay_messages[absolute_idx] = active_msg
         self._ingest_cursor = n
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
-        return active_replay_messages
+        # ``protected_messages`` are storage-only: they may replace inline media,
+        # tool outputs, or base64 substrings with externalized placeholders. The
+        # provider-facing active replay must keep usable original payloads (after
+        # active-only quarantine/redaction above), otherwise image/tool turns can
+        # be corrupted and storage protection alone can trigger no-op compaction.
+        return replay_messages
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
         """Map current raw messages back to store_ids in stable store order.

--- a/engine.py
+++ b/engine.py
@@ -3212,6 +3212,18 @@ class LCMEngine(ContextEngine):
             config=self._config,
             hermes_home=self._hermes_home,
         )
+        active_replay_messages = replay_messages
+        for (absolute_idx, _replay_msg), protected_msg in zip(
+            messages_to_store_with_index,
+            protected_messages,
+        ):
+            if self._protected_message_uses_raw_payload_active_stub(protected_msg):
+                if active_replay_messages is replay_messages:
+                    active_replay_messages = [dict(message) for message in replay_messages]
+                active_message = dict(active_replay_messages[absolute_idx])
+                active_message["content"] = protected_msg["content"]
+                active_replay_messages[absolute_idx] = active_message
+
         estimates = [count_message_tokens(m) for m in protected_messages]
         self._store.append_batch(
             self._session_id,
@@ -3221,12 +3233,19 @@ class LCMEngine(ContextEngine):
         )
         self._ingest_cursor = n
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
-        # ``protected_messages`` are storage-only: they may replace inline media,
-        # tool outputs, or base64 substrings with externalized placeholders. The
-        # provider-facing active replay must keep usable original payloads (after
-        # active-only quarantine/redaction above), otherwise image/tool turns can
-        # be corrupted and storage protection alone can trigger no-op compaction.
-        return replay_messages
+        # Most ``protected_messages`` changes are storage-only: inline media,
+        # tool results, and data/base64 substrings must stay provider-usable in
+        # active replay. Whole-message ``raw_payload`` externalization is the
+        # exception: it intentionally returns a compact active stub so the host
+        # does not replay huge opaque text while SQLite stores only the stub.
+        return active_replay_messages
+
+    @staticmethod
+    def _protected_message_uses_raw_payload_active_stub(message: Dict[str, Any]) -> bool:
+        content = message.get("content")
+        return isinstance(content, str) and content.startswith(
+            "[Externalized payload: kind=raw_payload;"
+        )
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
         """Map current raw messages back to store_ids in stable store order.

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -592,6 +592,67 @@ def test_ingest_does_not_mutate_input_message(tmp_path):
     assert message == original
 
 
+def test_ingest_preserves_provider_active_context_while_protecting_storage(tmp_path):
+    engine = _engine(tmp_path)
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "inspect this image"},
+            {"type": "image_url", "image_url": {"url": DATA_URI}},
+        ],
+    }
+
+    active = engine._ingest_messages([deepcopy(message)])
+
+    assert active == [message]
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+    refs = extract_ingest_externalized_refs(content)
+    assert len(refs) == 1
+    assert _expand_ref(engine, refs[0])["content"] == DATA_URI
+
+
+def test_tool_result_ingest_preserves_active_context_while_protecting_storage(tmp_path):
+    engine = _engine(tmp_path)
+    message = {"role": "tool", "tool_call_id": "call_media", "content": "tool saw " + DATA_URI}
+
+    active = engine._ingest_messages([deepcopy(message)])
+
+    assert active == [message]
+    _store_id, content, _tool_calls = _single_message_row(engine, role="tool")
+    assert "data:image" not in content
+    ref = _extract_ref(content)
+    assert _expand_ref(engine, ref)["content"] == DATA_URI
+
+
+def test_preflight_storage_protection_does_not_force_noop_compaction(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+        context_threshold=0.0001,
+        fresh_tail_count=64,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "preflight-storage-protection-session",
+        platform="cli",
+        conversation_id="preflight-storage-protection-conversation",
+        context_length=200_000,
+    )
+    messages = [
+        {"role": "system", "content": "system anchor"},
+        {"role": "user", "content": "see image " + DATA_URI},
+    ]
+
+    assert engine.should_compress_preflight(deepcopy(messages)) is False
+    assert engine.should_compress_preflight(deepcopy(messages)) is False
+    assert engine._last_compression_status == "noop"
+    assert engine._last_compression_noop_reason == "no eligible raw backlog outside fresh tail"
+    assert engine._store.count_session_load_messages(engine.current_session_id) == 2
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert "data:image" not in content
+
+
 def test_ingest_protection_is_idempotent_for_existing_placeholder(tmp_path):
     engine = _engine(tmp_path)
     engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})


### PR DESCRIPTION
## Summary
- Preserve provider-facing active replay for structured image/media payloads while still externalizing those payloads before SQLite storage.
- Preserve provider-facing active replay for tool-result media payloads while keeping stored rows protected.
- Keep the existing compact active stub behavior for whole-message generic `raw_payload` externalization.
- Prevent media-only storage protection from making repeated preflight checks request no-op compaction.

## Why
- Storage-boundary protection should keep large inline media/base64 out of SQLite, FTS, WAL, and backups.
- That storage protection must not corrupt the active context sent back to providers. Image and tool-result media turns need their original payloads in active replay.
- Generic oversized raw text is different: the established behavior is to return the compact externalized stub in active context so the host does not keep replaying a huge opaque payload while durable storage contains only the protected row.
- This distinguishes those two contracts instead of treating every storage-protection rewrite as storage-only.

## Validation
- [x] RED before follow-up fix: `python -m pytest -q tests/test_lcm_core.py::TestIngestExternalization::test_compress_returns_externalized_stub_for_oversized_active_tail` failed with active replay returning `ACTIVE_RAW_NEEDLE` instead of the `raw_payload` stub.
- [x] Focused raw-payload regression: `python -m pytest -q tests/test_lcm_core.py::TestIngestExternalization::test_compress_returns_externalized_stub_for_oversized_active_tail` -> 1 passed
- [x] Focused media regressions: `python -m pytest -q tests/test_ingest_protection.py::test_ingest_preserves_provider_active_context_while_protecting_storage tests/test_ingest_protection.py::test_tool_result_ingest_preserves_active_context_while_protecting_storage tests/test_ingest_protection.py::test_preflight_storage_protection_does_not_force_noop_compaction` -> 3 passed
- [x] Targeted PR/review slice: `python -m pytest tests/test_ingest_protection.py tests/test_lcm_engine.py -q` -> 491 passed
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 609 passed
  - [x] `python -m pytest -q` -> 868 passed
  - [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> 868 passed
  - [x] `python scripts/lcm_stress_check.py --output "$OUT" --tier release --json` -> `failure_count: 0`, 6 cases
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py scripts/lcm_stress_check.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check origin/main...HEAD` -> passed

## Notes
- Maintainer follow-up pushed in `e25ad61` after merging current `origin/main` into the PR branch.
- The follow-up changes only active replay selection after storage protection. Durable storage externalization semantics are unchanged.
