### PR TITLE
chore: release v0.14.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Version and branch
       description: hermes-lcm version, branch, commit, or release tag.
-      placeholder: v0.14.0, main, or commit SHA
+      placeholder: v0.14.1, main, or commit SHA
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.14.0 (7 tools)
+  ✓ hermes-lcm v0.14.1 (7 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.14.0
+version: 0.14.1
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -162,7 +162,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.14.0" in result
+    assert "plugin_version: 0.14.1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -202,7 +202,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.14.0" in result
+    assert "plugin_version: 0.14.1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -657,7 +657,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.14.0"
+    assert identity["plugin_version"] == "0.14.1"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -683,11 +683,11 @@ def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
 
     initial = engine_mod._plugin_metadata()
     assert initial["name"] == "hermes-lcm"
-    assert initial["version"] == "0.14.0"
+    assert initial["version"] == "0.14.1"
 
-    updated = original.replace('version: "0.14.0"', 'version: "9.9.9-test"')
+    updated = original.replace('version: "0.14.1"', 'version: "9.9.9-test"')
     if updated == original:
-        updated = original.replace('version: 0.14.0', 'version: 9.9.9-test')
+        updated = original.replace('version: 0.14.1', 'version: 9.9.9-test')
     assert updated != original
 
     try:
@@ -725,7 +725,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.14.0"
+    assert payload["runtime_identity"]["plugin_version"] == "0.14.1"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 class TestEscalationStripReasoning:

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -141,7 +141,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.14.0"
+    assert identity["plugin_version"] == "0.14.1"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]


### PR DESCRIPTION
## Summary
- Bumps `hermes-lcm` from 0.14.0 to 0.14.1.
- Prepares the tag-driven release `v0.14.1`.

## Changes since v0.14.0
- docs: add Hermes-LCM demo video
- docs: use raw URL for demo video
- test: guard public lcm tool contract drift (#221)
- ci: fix release workflow token header (#220)
- fix: prevent compression cascade on session split (#217)
- test: add deterministic LCM stress release check (#223)
- test: add lifecycle soak stress scenario (#225)
- fix: preserve DAG carryover across session drift (#224)
- fix: preserve active replay after storage protection (#226)

## Version files
- `plugin.yaml`
- `README.md`
- `tests/test_lcm_command.py`
- `tests/test_lcm_engine.py`
- `tests/test_packaging_install.py`
- `.github/ISSUE_TEMPLATE/bug_report.yml`

## Validation
- [x] Focused release validation: `python -m pytest tests/test_lcm_command.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `460 passed, 45 warnings in 38.26s`
- [x] Default validation: `python -m pytest -q` -> `868 passed, 59 warnings in 56.08s`
- [x] Low-FD validation: `prlimit --nofile=1024:1024 -- python -m pytest -q` -> `868 passed, 59 warnings in 55.77s`
- [x] `python -m compileall -q .` -> passed
- [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
- [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
- [x] `git diff --check origin/main...HEAD` -> passed
- [x] Release stress check: `python scripts/lcm_stress_check.py --output /tmp/hermes-lcm-stress-release-20260601-121302-1577956 --tier release --json` -> `failure_count: 0`
- [ ] Workflow validation, if workflows changed: N/A, no workflow files changed

## Release path
After this PR lands on `main` and CI is green, run the explicit release-tag step to push annotated tag `v0.14.1`. The existing release workflow will create the GitHub release from that tag.

Refs #217, #220, #221, #223, #224, #225, #226
