### PR TITLE
feat: add Codex Spark LCM preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,10 @@ mutations. With `LCM_ENABLE_SLASH_COMMAND=true`, use:
 
 ```text
 /lcm preset show codex_gpt_long_context
+/lcm preset show codex_spark_context
 /lcm preset suggest
 /lcm preset apply codex_gpt_long_context --dry-run
+/lcm preset apply codex_spark_context --dry-run
 ```
 
 `/lcm preset show` reports the shipped preset metadata, benchmark provenance,
@@ -296,11 +298,17 @@ write files, change process state, or override explicit parseable
 preset-managed `LCM_*` environment variables. Invalid preset-managed env values
 are reported as invalid instead of being treated as active runtime overrides.
 
-The current `codex_gpt_long_context` dry-run preview is:
+The current runtime preset dry-run previews are:
 
 ```text
+# codex_gpt_long_context: near-272k GPT/Codex routes
 LCM_CONTEXT_THRESHOLD=0.75
 LCM_FRESH_TAIL_COUNT=24
+LCM_LEAF_CHUNK_TOKENS=8000
+
+# codex_spark_context: near-128k GPT-5.3 Codex Spark routes
+LCM_CONTEXT_THRESHOLD=0.75
+LCM_FRESH_TAIL_COUNT=16
 LCM_LEAF_CHUNK_TOKENS=8000
 ```
 

--- a/benchmarking/policies.py
+++ b/benchmarking/policies.py
@@ -46,6 +46,16 @@ def builtin_policies() -> list[LCMPolicy]:
             notes="Initial benchmark candidate for GPT/Codex long-context routes.",
         ),
         LCMPolicy(
+            name="codex_spark_context",
+            context_length=128_000,
+            context_threshold=0.75,
+            fresh_tail_count=16,
+            leaf_chunk_tokens=8_000,
+            target_after_compaction=0.55,
+            policy_version="1",
+            notes="Benchmark candidate for GPT-5.3 Codex Spark / 128k Codex-style routes.",
+        ),
+        LCMPolicy(
             name="pressure_smoke",
             context_length=300,
             context_threshold=0.30,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,6 +35,7 @@ When no `--policy` is supplied, the harness loads built-in policies:
 
 - `baseline_272k`, current long-context baseline
 - `codex_gpt_long_context`, initial GPT/Codex long-context benchmark candidate
+- `codex_spark_context`, GPT-5.3 Codex Spark / 128k benchmark candidate
 - `pressure_smoke`, a deliberately small benchmark-only policy that proves pressure/chatter metrics trigger compaction
 
 The committed policy files in `benchmarks/policies/` are the canonical benchmark inputs. Compare the GPT/Codex candidate against baseline with committed fixtures:
@@ -60,11 +61,21 @@ python scripts/lcm_benchmark.py \
   --json
 ```
 
+The 128k Spark preset uses the same pressure-probe shape with a smaller fresh tail to preserve post-compaction headroom under the lower trigger:
+
+```bash
+python scripts/lcm_benchmark.py \
+  --synthetic-fixture spark_pressure_probe:42:4:1000 \
+  --policy benchmarks/policies/codex_spark_context.yaml \
+  --output benchmarks/runs/codex-spark-pressure \
+  --json
+```
+
 Synthetic fixture specs use `name:pairs:canaries:filler_words` and are deterministic. They are bounded to 250 message pairs and 2,000 filler words so typos do not create huge benchmark outputs. Benchmark output directories should be fresh or cleaned between runs because the harness refuses to reuse non-empty per-run directories.
 
 The committed `summary_timeout_probe` and `summary_refusal_probe` fixtures are small pilot fixtures for summary-provider failure-mode accounting. Their `benchmark_profile` records `summary_level` and `summary_failure_mode` metadata so reports can group timeout/refusal fallback scenarios without embedding provider calls or secrets in fixture content.
 
-`codex_gpt_long_context` is a benchmark candidate and now has an inspectable dry-run preset surface. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
+`codex_gpt_long_context` and `codex_spark_context` are benchmark candidates and now have inspectable dry-run preset surfaces. `pressure_smoke` is not a runtime preset recommendation. It is a control policy for validating benchmark signals.
 
 ## Output files
 

--- a/benchmarks/policies/codex_spark_context.yaml
+++ b/benchmarks/policies/codex_spark_context.yaml
@@ -1,0 +1,12 @@
+name: codex_spark_context
+context_length: 128000
+context_threshold: 0.75
+fresh_tail_count: 16
+leaf_chunk_tokens: 8000
+condensation_fanin: 4
+incremental_max_depth: 1
+dynamic_leaf_chunk_enabled: false
+target_after_compaction: 0.55
+min_turns_between_compactions: 0
+policy_version: "1"
+notes: "Benchmark candidate for GPT-5.3 Codex Spark / 128k Codex-style routes."

--- a/presets.py
+++ b/presets.py
@@ -84,11 +84,50 @@ _CODEX_GPT_LONG_CONTEXT = LCMPreset(
     ),
 )
 
+_CODEX_SPARK_CONTEXT = LCMPreset(
+    name="codex_spark_context",
+    family="GPT/Codex Spark 128k",
+    description="Benchmark-backed candidate for GPT-5.3 Codex Spark / 128k Codex-style routes.",
+    policy_path="benchmarks/policies/codex_spark_context.yaml",
+    policy_version="1",
+    runtime_env={
+        "context_threshold": 0.75,
+        "fresh_tail_count": 16,
+        "leaf_chunk_tokens": 8_000,
+    },
+    unsupported_runtime_fields={
+        "target_after_compaction": 0.55,
+    },
+    applies_to=(
+        "GPT-5.3 Codex Spark on Codex OAuth routes",
+        "large context windows near 128k tokens",
+        "workloads where Spark's smaller effective window needs more post-compaction headroom",
+    ),
+    provenance={
+        "benchmark_version": "2",
+        "fixture_suite": ["spark_pressure_probe:42:4:1000"],
+        "metric_summary": {
+            "score": 92.5,
+            "baseline_score": 72.5,
+            "retrieval_canary_recall": 1.0,
+            "baseline_repeated_compaction_risk_count": 1,
+            "candidate_repeated_compaction_risk_count": 0,
+            "candidate_min_post_compaction_headroom_tokens": 39_704,
+            "candidate_prompt_tokens_after": 56_296,
+        },
+        "evidence": "Deterministic 128k pressure replay; 16-message tail avoided repeated compaction risk with 39,704 token headroom.",
+    },
+    notes=(
+        "Benchmark-only candidate for the 128k Codex Spark route. "
+        "No live provider tuning or automatic config mutation is performed."
+    ),
+)
+
 
 def shipped_presets() -> list[LCMPreset]:
     """Return the shipped, inspectable preset catalog."""
 
-    return [_CODEX_GPT_LONG_CONTEXT]
+    return [_CODEX_GPT_LONG_CONTEXT, _CODEX_SPARK_CONTEXT]
 
 
 def get_preset(name: str | None = None) -> LCMPreset | None:
@@ -282,6 +321,11 @@ def suggest_preset_for_engine(engine: Any) -> tuple[LCMPreset | None, str]:
         return (
             _CODEX_GPT_LONG_CONTEXT,
             "context-window match for GPT/Codex candidate; verify provider/model family before applying",
+        )
+    if 110_000 <= context_length < 200_000:
+        return (
+            _CODEX_SPARK_CONTEXT,
+            "context-window match for GPT/Codex Spark candidate; verify provider/model family before applying",
         )
     return None, f"no shipped benchmarked preset matches context_length {context_length}"
 

--- a/tests/test_benchmarking_types.py
+++ b/tests/test_benchmarking_types.py
@@ -109,6 +109,12 @@ def test_builtin_policies_include_baseline_codex_policy_and_pressure_smoke():
     assert policies["codex_gpt_long_context"].leaf_chunk_tokens == 8_000
     assert policies["codex_gpt_long_context"].target_after_compaction == 0.55
     assert policies["codex_gpt_long_context"].policy_version == "1"
+    assert policies["codex_spark_context"].context_length == 128_000
+    assert policies["codex_spark_context"].context_threshold == 0.75
+    assert policies["codex_spark_context"].fresh_tail_count == 16
+    assert policies["codex_spark_context"].leaf_chunk_tokens == 8_000
+    assert policies["codex_spark_context"].target_after_compaction == 0.55
+    assert policies["codex_spark_context"].policy_version == "1"
     assert policies["pressure_smoke"].context_length < 1_000
     assert policies["pressure_smoke"].policy_version == "1"
 
@@ -121,11 +127,20 @@ def test_committed_codex_gpt_long_context_policy_matches_builtin_policy():
     assert "benchmark candidate" in policy.notes
 
 
+def test_committed_codex_spark_context_policy_matches_builtin_policy():
+    policy = load_policy("benchmarks/policies/codex_spark_context.yaml")
+    builtin = {item.name: item for item in builtin_policies()}["codex_spark_context"]
+
+    assert policy == builtin
+    assert "GPT-5.3 Codex Spark" in policy.notes
+
+
 def test_committed_policy_files_match_builtin_policies():
     builtins = {item.name: item for item in builtin_policies()}
     policy_paths = [
         "benchmarks/policies/baseline.yaml",
         "benchmarks/policies/codex_gpt_long_context.yaml",
+        "benchmarks/policies/codex_spark_context.yaml",
         "benchmarks/policies/pressure_smoke.yaml",
     ]
 

--- a/tests/test_lcm_preset_command.py
+++ b/tests/test_lcm_preset_command.py
@@ -59,6 +59,29 @@ def test_lcm_preset_show_exposes_codex_provenance_without_mutating_config(tmp_pa
     assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
 
 
+def test_lcm_preset_show_exposes_spark_provenance_without_mutating_config(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    engine = _engine(tmp_path, context_length=128_000)
+    before = (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+    result = handle_lcm_command("preset show codex_spark_context", engine)
+
+    assert "LCM preset show" in result
+    assert "preset: codex_spark_context" in result
+    assert "policy_version: 1" in result
+    assert "benchmark_version: 2" in result
+    assert "fixture_suite: spark_pressure_probe:42:4:1000" in result
+    assert "score: 92.5" in result
+    assert "baseline_score: 72.5" in result
+    assert "policy_path: benchmarks/policies/codex_spark_context.yaml" in result
+    assert "large context windows near 128k tokens" in result
+    assert "LCM_CONTEXT_THRESHOLD=0.75" in result
+    assert "LCM_FRESH_TAIL_COUNT=16" in result
+    assert "LCM_LEAF_CHUNK_TOKENS=8000" in result
+    assert "runtime_mutation: no" in result
+    assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+
 def test_lcm_preset_suggest_reports_explicit_operator_config_precedence(tmp_path, monkeypatch):
     _clear_preset_env(monkeypatch)
     monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "99")
@@ -73,6 +96,22 @@ def test_lcm_preset_suggest_reports_explicit_operator_config_precedence(tmp_path
     assert "match_confidence: context-only" in result
     assert "explicit_overrides: LCM_FRESH_TAIL_COUNT" in result
     assert "LCM_FRESH_TAIL_COUNT: keep explicit value 99 (preset 24)" in result
+    assert "note: suggestion only; no live config was changed" in result
+
+
+def test_lcm_preset_suggest_reports_spark_for_128k_context_window(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    engine = _engine(tmp_path, context_length=128_000)
+
+    result = handle_lcm_command("preset suggest", engine)
+
+    assert "LCM preset suggest" in result
+    assert "suggested_preset: codex_spark_context" in result
+    assert "reason: context-window match for GPT/Codex Spark candidate; verify provider/model family before applying" in result
+    assert "match_confidence: context-only" in result
+    assert "LCM_CONTEXT_THRESHOLD=0.75" in result
+    assert "LCM_FRESH_TAIL_COUNT=16" in result
+    assert "LCM_LEAF_CHUNK_TOKENS=8000" in result
     assert "note: suggestion only; no live config was changed" in result
 
 
@@ -107,6 +146,23 @@ def test_lcm_preset_apply_requires_dry_run_and_does_not_mutate_config(tmp_path, 
     assert "LCM_LEAF_CHUNK_TOKENS=8000" in dry_run
     assert "unsupported_runtime_fields: target_after_compaction=0.55" in dry_run
     assert "note: no live config was changed" in dry_run
+    assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+
+def test_lcm_preset_apply_spark_dry_run_uses_benchmarked_128k_values(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    engine = _engine(tmp_path, context_length=128_000)
+    before = (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
+
+    result = handle_lcm_command("preset apply codex_spark_context --dry-run", engine)
+
+    assert "LCM preset apply" in result
+    assert "status: dry-run" in result
+    assert "preset: codex_spark_context" in result
+    assert "LCM_CONTEXT_THRESHOLD=0.75" in result
+    assert "LCM_FRESH_TAIL_COUNT=16" in result
+    assert "LCM_LEAF_CHUNK_TOKENS=8000" in result
+    assert "unsupported_runtime_fields: target_after_compaction=0.55" in result
     assert before == (engine._config.context_threshold, engine._config.fresh_tail_count, engine._config.leaf_chunk_tokens)
 
 


### PR DESCRIPTION
## Summary
- Add `codex_spark_context` as a benchmark-backed LCM policy and inspectable preset for GPT-5.3 Codex Spark / near-128k Codex routes.
- Route 110k to sub-200k context windows to the Spark preset while keeping `codex_gpt_long_context` for 200k+ windows.
- Update `/lcm preset` coverage and benchmark docs for the new policy.

## Why
- Spark resolves to a smaller effective context window than the existing 272k GPT/Codex preset.
- The deterministic 128k pressure replay favors a 16-message fresh tail: it keeps retrieval recall at 1.0 and leaves 39,704 tokens of post-compaction headroom under the 96,000-token trigger.
- The scaled 128k baseline with a 64-message tail overflows after compaction and keeps repeated-compaction risk.

## Validation
- [x] Focused validation: `pytest tests/test_lcm_preset_command.py tests/test_benchmarking_types.py tests/test_benchmarking_report.py tests/test_benchmarking_cli.py -q` -> `36 passed`
- [x] Spark pressure replay: `python scripts/lcm_benchmark.py --synthetic-fixture spark_pressure_probe:42:4:1000 --policy baseline_128k.yaml --policy benchmarks/policies/codex_spark_context.yaml --json` -> `codex_spark_context@1 score 92.5`, `baseline_128k@1 score 72.5`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> included in focused default batch, `645 passed`
  - [x] `pytest -q` -> `872 passed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `872 passed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- No workflow files changed, so `actionlint` was not run.
- This does not make presets auto-apply. `/lcm preset apply` remains dry-run only.
- `target_after_compaction=0.55` remains benchmark provenance, not a runtime setting.

Related: #189
