### PR TITLE
feat: classify lifecycle fragmentation diagnostics

### DIFF
--- a/command.py
+++ b/command.py
@@ -1089,6 +1089,19 @@ def _doctor_text(engine) -> str:
         )
         if lifecycle_stats.get("state_db_error"):
             observations.append(f"lifecycle_fragmentation_state_db_error: {lifecycle_stats['state_db_error']}")
+        classification = lifecycle_stats.get("classification") or {}
+        categories = classification.get("categories") or []
+        if classification:
+            observations.append(
+                "lifecycle_fragmentation_classification: "
+                f"{classification.get('status', 'unknown')}; {len(categories)} categories need review"
+            )
+            for category in categories:
+                sample = ",".join(category.get("sample_session_ids") or []) or "(none)"
+                observations.append(
+                    "lifecycle_category "
+                    f"{category.get('name')}: count={category.get('count', 0)} sample={sample}"
+                )
         if _has_lifecycle_fragmentation(lifecycle_stats):
             recommended_actions.append(
                 "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state"

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -423,6 +423,7 @@ class LifecycleStateStore:
                 stats["state_db_error"] = f"state database not found: {path}"
 
         stats["classification"] = self._classify_fragmentation(
+            lifecycle_rows=stats["lifecycle_rows"],
             lifecycle_current_sessions=lifecycle_current_sessions,
             lifecycle_last_finalized_sessions=lifecycle_last_finalized_sessions,
             message_sessions=message_sessions,
@@ -438,6 +439,7 @@ class LifecycleStateStore:
     @staticmethod
     def _classify_fragmentation(
         *,
+        lifecycle_rows: int,
         lifecycle_current_sessions: set[str],
         lifecycle_last_finalized_sessions: set[str],
         message_sessions: set[str],
@@ -487,20 +489,21 @@ class LifecycleStateStore:
             description="Lifecycle finalized-session references that no longer have raw messages or summary nodes in LCM.",
             recommended_action="Inspect samples before cleanup; only remove with an explicit backup-first lifecycle cleanup flow.",
         )
-        add_category(
-            "lcm_message_sessions_without_lifecycle_reference",
-            message_sessions - lifecycle_referenced_sessions,
-            severity="notice",
-            description="Raw-message sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
-            recommended_action="Usually safe as historical retained context; investigate only if the sessions should belong to an active conversation.",
-        )
-        add_category(
-            "lcm_node_sessions_without_lifecycle_reference",
-            node_sessions - lifecycle_referenced_sessions,
-            severity="notice",
-            description="Summary-node sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
-            recommended_action="Usually safe as historical retained context; verify expand/search still work before considering cleanup.",
-        )
+        if lifecycle_rows > 0:
+            add_category(
+                "lcm_message_sessions_without_lifecycle_reference",
+                message_sessions - lifecycle_referenced_sessions,
+                severity="notice",
+                description="Raw-message sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
+                recommended_action="Usually safe as historical retained context; investigate only if the sessions should belong to an active conversation.",
+            )
+            add_category(
+                "lcm_node_sessions_without_lifecycle_reference",
+                node_sessions - lifecycle_referenced_sessions,
+                severity="notice",
+                description="Summary-node sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
+                recommended_action="Usually safe as historical retained context; verify expand/search still work before considering cleanup.",
+            )
 
         if state_db_read_success:
             add_category(

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -353,6 +353,8 @@ class LifecycleStateStore:
         message_sessions = _session_ids("SELECT DISTINCT session_id FROM messages WHERE session_id IS NOT NULL")
         node_sessions = _session_ids("SELECT DISTINCT session_id FROM summary_nodes WHERE session_id IS NOT NULL")
         lcm_any_sessions = message_sessions | node_sessions
+        state_sessions: set[str] = set()
+        state_db_read_success = False
         lifecycle_current_sessions = _session_ids(
             "SELECT DISTINCT current_session_id FROM lcm_lifecycle_state WHERE current_session_id IS NOT NULL"
         )
@@ -403,6 +405,7 @@ class LifecycleStateStore:
                     finally:
                         state_conn.close()
                     state_sessions = {str(row[0]) for row in state_rows if row[0]}
+                    state_db_read_success = True
                     stats.update({
                         "state_sessions_total": len(state_sessions),
                         "lifecycle_current_missing_in_state": len(lifecycle_current_sessions - state_sessions),
@@ -419,7 +422,122 @@ class LifecycleStateStore:
             else:
                 stats["state_db_error"] = f"state database not found: {path}"
 
+        stats["classification"] = self._classify_fragmentation(
+            lifecycle_current_sessions=lifecycle_current_sessions,
+            lifecycle_last_finalized_sessions=lifecycle_last_finalized_sessions,
+            message_sessions=message_sessions,
+            node_sessions=node_sessions,
+            lcm_any_sessions=lcm_any_sessions,
+            lifecycle_referenced_sessions=lifecycle_referenced_sessions,
+            state_sessions=state_sessions,
+            state_db_read_success=state_db_read_success,
+        )
+
         return stats
+
+    @staticmethod
+    def _classify_fragmentation(
+        *,
+        lifecycle_current_sessions: set[str],
+        lifecycle_last_finalized_sessions: set[str],
+        message_sessions: set[str],
+        node_sessions: set[str],
+        lcm_any_sessions: set[str],
+        lifecycle_referenced_sessions: set[str],
+        state_sessions: set[str],
+        state_db_read_success: bool,
+    ) -> dict[str, Any]:
+        """Bucket lifecycle mismatches into operator-readable read-only categories."""
+
+        def sample(session_ids: set[str], limit: int = 5) -> list[str]:
+            return sorted(session_ids)[:limit]
+
+        categories: list[dict[str, Any]] = []
+
+        def add_category(
+            name: str,
+            session_ids: set[str],
+            *,
+            severity: str,
+            description: str,
+            recommended_action: str,
+        ) -> None:
+            if not session_ids:
+                return
+            categories.append({
+                "name": name,
+                "severity": severity,
+                "count": len(session_ids),
+                "sample_session_ids": sample(session_ids),
+                "description": description,
+                "recommended_action": recommended_action,
+            })
+
+        add_category(
+            "stale_lifecycle_current",
+            lifecycle_current_sessions - lcm_any_sessions,
+            severity="warn",
+            description="Lifecycle current-session references that no longer have raw messages or summary nodes in LCM.",
+            recommended_action="Inspect samples before cleanup; these are often old or ephemeral lifecycle rows, not automatic corruption.",
+        )
+        add_category(
+            "stale_lifecycle_finalized",
+            lifecycle_last_finalized_sessions - lcm_any_sessions,
+            severity="warn",
+            description="Lifecycle finalized-session references that no longer have raw messages or summary nodes in LCM.",
+            recommended_action="Inspect samples before cleanup; only remove with an explicit backup-first lifecycle cleanup flow.",
+        )
+        add_category(
+            "lcm_message_sessions_without_lifecycle_reference",
+            message_sessions - lifecycle_referenced_sessions,
+            severity="notice",
+            description="Raw-message sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
+            recommended_action="Usually safe as historical retained context; investigate only if the sessions should belong to an active conversation.",
+        )
+        add_category(
+            "lcm_node_sessions_without_lifecycle_reference",
+            node_sessions - lifecycle_referenced_sessions,
+            severity="notice",
+            description="Summary-node sessions exist in LCM but are not referenced by current or finalized lifecycle state.",
+            recommended_action="Usually safe as historical retained context; verify expand/search still work before considering cleanup.",
+        )
+
+        if state_db_read_success:
+            add_category(
+                "lcm_message_sessions_missing_in_state",
+                message_sessions - state_sessions,
+                severity="notice",
+                description="LCM raw-message sessions are absent from the Hermes session database.",
+                recommended_action="Treat as retained or imported context unless the session should still be browsable in host session history.",
+            )
+            add_category(
+                "lcm_node_sessions_missing_in_state",
+                node_sessions - state_sessions,
+                severity="notice",
+                description="LCM summary-node sessions are absent from the Hermes session database.",
+                recommended_action="Keep read-only; this can happen after host session pruning while LCM retained summaries remain useful.",
+            )
+            add_category(
+                "state_only_sessions",
+                state_sessions - lcm_any_sessions,
+                severity="notice",
+                description="Hermes host sessions exist without raw messages or summary nodes in LCM.",
+                recommended_action="Usually benign for sessions outside LCM scope, ignored sessions, or sessions that never reached durable LCM ingest.",
+            )
+
+        warn_count = sum(1 for item in categories if item["severity"] == "warn")
+        status = "warn" if warn_count else ("notice" if categories else "pass")
+        summary = (
+            "no lifecycle fragmentation categories detected"
+            if not categories
+            else f"{len(categories)} lifecycle fragmentation categories need review"
+        )
+        return {
+            "read_only": True,
+            "status": status,
+            "summary": summary,
+            "categories": categories,
+        }
 
     def record_debt(
         self,

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -479,6 +479,11 @@ def test_lcm_doctor_reports_lifecycle_fragmentation_as_read_only_observation(eng
     assert "current_missing_in_state=1" in result
     assert "node_sessions_missing_in_state=1" in result
     assert "state_sessions_missing_in_lcm_any=1" in result
+    assert "lifecycle_fragmentation_classification: warn; 4 categories need review" in result
+    assert "lifecycle_category stale_lifecycle_current: count=1 sample=missing-current" in result
+    assert "lifecycle_category stale_lifecycle_finalized: count=1 sample=missing-final" in result
+    assert "lifecycle_category lcm_node_sessions_missing_in_state: count=1 sample=node-missing-in-state" in result
+    assert "lifecycle_category state_only_sessions: count=1 sample=state-only" in result
     assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" in result
     assert "read-only" in result
     assert engine._lifecycle.row_count() == 2

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2259,6 +2259,21 @@ class TestLifecycleStateStore:
         assert stats["state_sessions_missing_in_lcm_any"] == 1
         assert stats["state_db_checked"] is True
         assert stats["state_db_error"] == ""
+        classification = stats["classification"]
+        assert classification["status"] == "warn"
+        assert classification["read_only"] is True
+        assert classification["summary"] == "4 lifecycle fragmentation categories need review"
+        categories = {item["name"]: item for item in classification["categories"]}
+        assert categories["stale_lifecycle_current"]["count"] == 1
+        assert categories["stale_lifecycle_current"]["sample_session_ids"] == ["missing-current"]
+        assert categories["stale_lifecycle_finalized"]["count"] == 1
+        assert categories["stale_lifecycle_finalized"]["sample_session_ids"] == ["missing-final"]
+        assert categories["lcm_node_sessions_missing_in_state"]["count"] == 1
+        assert categories["lcm_node_sessions_missing_in_state"]["sample_session_ids"] == ["node-only"]
+        assert categories["state_only_sessions"]["count"] == 1
+        assert categories["state_only_sessions"]["sample_session_ids"] == ["state-only"]
+        assert categories["stale_lifecycle_current"]["recommended_action"]
+        assert not any(item["name"] == "lcm_message_sessions_without_lifecycle_reference" for item in classification["categories"])
 
         # Read-only diagnostic: no lifecycle rows were mutated or removed.
         assert state.row_count() == 2
@@ -2284,15 +2299,28 @@ class TestLifecycleStateStore:
         assert stats["message_sessions_without_lifecycle_current"] == 1
         assert stats["message_sessions_without_lifecycle_reference"] == 0
         assert stats["node_sessions_without_lifecycle_reference"] == 0
+        assert stats["classification"]["status"] == "pass"
+        assert stats["classification"]["categories"] == []
 
         state.close()
 
     def test_lifecycle_fragmentation_stats_reports_existing_malformed_state_db(self, tmp_path):
         db_path = tmp_path / "lifecycle-malformed-state.db"
         state_db = tmp_path / "state.db"
-        MessageStore(db_path)
-        SummaryDAG(db_path)
+        store = MessageStore(db_path)
+        dag = SummaryDAG(db_path)
         state = LifecycleStateStore(db_path)
+        store.append("message-session", {"role": "user", "content": "stored"}, source="cli")
+        dag.add_node(SummaryNode(
+            session_id="node-session",
+            depth=0,
+            summary="stored node",
+            token_count=5,
+            source_token_count=5,
+            source_ids=[],
+            source_type="messages",
+            created_at=1.0,
+        ))
         state_db.write_text("not sqlite")
 
         stats = state.get_fragmentation_stats(state_db_path=state_db)
@@ -2300,6 +2328,10 @@ class TestLifecycleStateStore:
         assert stats["state_db_checked"] is True
         assert stats["state_db_error"]
         assert stats["read_only"] is True
+        categories = {item["name"]: item for item in stats["classification"]["categories"]}
+        assert "lcm_message_sessions_missing_in_state" not in categories
+        assert "lcm_node_sessions_missing_in_state" not in categories
+        assert "state_only_sessions" not in categories
         assert state.row_count() == 0
 
         state.close()

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2281,6 +2281,33 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_lifecycle_fragmentation_stats_does_not_classify_legacy_lcm_rows_without_lifecycle_state(self, tmp_path):
+        db_path = tmp_path / "legacy-lcm-without-lifecycle.db"
+        store = MessageStore(db_path)
+        dag = SummaryDAG(db_path)
+        state = LifecycleStateStore(db_path)
+        store.append("legacy-message-session", {"role": "user", "content": "legacy"}, source="cli")
+        dag.add_node(SummaryNode(
+            session_id="legacy-node-session",
+            depth=0,
+            summary="legacy summary",
+            token_count=5,
+            source_token_count=5,
+            source_ids=[],
+            source_type="messages",
+            created_at=1.0,
+        ))
+
+        stats = state.get_fragmentation_stats()
+
+        assert stats["lifecycle_rows"] == 0
+        assert stats["message_sessions_without_lifecycle_reference"] == 1
+        assert stats["node_sessions_without_lifecycle_reference"] == 1
+        assert stats["classification"]["status"] == "pass"
+        assert stats["classification"]["categories"] == []
+
+        state.close()
+
     def test_lifecycle_fragmentation_stats_treats_last_finalized_message_session_as_referenced(self, tmp_path):
         db_path = tmp_path / "lifecycle-finalized-message-reference.db"
         store = MessageStore(db_path)


### PR DESCRIPTION
## Why

Long-running LCM installs can accumulate lifecycle rows, retained LCM sessions, and host session history that no longer line up perfectly. The old doctor output exposed the raw counts, but it did not explain which mismatches were stale lifecycle references, retained context, host-only sessions, or expected historical residue. That made normal dogfood wear look too much like database corruption.

## Summary

`lcm_doctor` now adds a read-only lifecycle fragmentation classification. It groups stale lifecycle references, retained LCM sessions without lifecycle references, LCM sessions missing from host session history, and host-only sessions. Each category includes bounded sample session ids and operator-facing guidance.

This stays diagnostic only. It does not add cleanup or repair behavior.

The follow-up commit also gates the retained-session categories on the presence of lifecycle rows. Legacy or fresh databases with retained LCM messages but no lifecycle state no longer get a misleading lifecycle-reference notice.

## Validation

`python -m pytest tests/test_lcm_core.py::TestLifecycleStateStore::test_lifecycle_fragmentation_stats_does_not_classify_legacy_lcm_rows_without_lifecycle_state tests/test_lcm_core.py::TestLifecycleStateStore::test_lifecycle_fragmentation_stats_compare_lifecycle_to_lcm_content_and_state_db tests/test_lcm_command.py::test_lcm_doctor_warns_on_lcm_sessions_without_lifecycle_references -q -o 'addopts='`

`python -m pytest tests/test_lcm_core.py tests/test_lcm_command.py -q -o 'addopts='`

`python -m pytest tests -q -o 'addopts='`

`python -m compileall -q .`

`git diff --check`

Full local suite result after the Codex follow-up: 873 passed, 1 warning.