### PR TITLE
feat: report externalized payload ref integrity

### DIFF
--- a/command.py
+++ b/command.py
@@ -13,7 +13,12 @@ from .db_bootstrap import (
     inspect_lcm_schema_health,
     repair_external_content_fts,
 )
-from .ingest_protection import externalized_payload_stats, scan_sqlite_payload_risks, sensitive_pattern_status
+from .ingest_protection import (
+    externalized_payload_stats,
+    scan_externalized_payload_integrity,
+    scan_sqlite_payload_risks,
+    sensitive_pattern_status,
+)
 from .dag import build_nodes_fts_spec
 from .presets import (
     explicit_operator_overrides,
@@ -961,6 +966,11 @@ def _doctor_text(engine) -> str:
     try:
         payload_risks = scan_sqlite_payload_risks(store_conn)
         externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
+        externalized_integrity = scan_externalized_payload_integrity(
+            store_conn,
+            engine._config,
+            hermes_home=engine._hermes_home,
+        )
     except Exception:  # pragma: no cover - defensive
         payload_risks = {
             "largest_content_rows": [],
@@ -979,6 +989,14 @@ def _doctor_text(engine) -> str:
             "externalized_payload_dir": "",
             "latest_externalized_payload_path": "",
             "latest_externalized_payload_mtime": 0,
+        }
+        externalized_integrity = {
+            "externalized_payload_refs_total": 0,
+            "externalized_payload_refs_existing": 0,
+            "externalized_payload_refs_missing": 0,
+            "externalized_payload_files_unreferenced": 0,
+            "missing_externalized_payload_refs": [],
+            "unreferenced_externalized_payload_files": [],
         }
         issues.append("payload_storage")
     clean_scan = _scan_clean_candidates(engine)
@@ -1001,6 +1019,7 @@ def _doctor_text(engine) -> str:
 
     observations: list[str] = []
     recommended_actions: list[str] = []
+    missing_externalized_refs = int(externalized_integrity.get("externalized_payload_refs_missing", 0) or 0)
 
     if schema_health.get("error"):
         observations.append(f"schema_core_tables: error: {schema_health['error']}")
@@ -1036,6 +1055,15 @@ def _doctor_text(engine) -> str:
         recommended_actions.append("create a safety snapshot first with `/lcm backup`")
     else:
         observations.append("cleanup_candidates: none")
+
+    if missing_externalized_refs:
+        issues.append("payload_storage")
+        observations.append(
+            f"payload_storage: {missing_externalized_refs} externalized payload ref(s) point to missing JSON files"
+        )
+        recommended_actions.append(
+            "inspect missing externalized payload refs and restore from backups if needed"
+        )
 
     try:
         source_stats = engine._store.get_source_stats()
@@ -1179,6 +1207,12 @@ def _doctor_text(engine) -> str:
         f"externalized_payload_bytes: {externalized_stats['externalized_payload_bytes']}",
         f"externalized_payload_chars: {externalized_stats['externalized_payload_chars']}",
         f"latest_externalized_payload_path: {externalized_stats['latest_externalized_payload_path'] or '(none)'}",
+        f"externalized_payload_refs_total: {externalized_integrity['externalized_payload_refs_total']}",
+        f"externalized_payload_refs_existing: {externalized_integrity['externalized_payload_refs_existing']}",
+        f"externalized_payload_refs_missing: {externalized_integrity['externalized_payload_refs_missing']}",
+        f"externalized_payload_files_unreferenced: {externalized_integrity['externalized_payload_files_unreferenced']}",
+        f"missing_externalized_payload_refs: {externalized_integrity['missing_externalized_payload_refs']}",
+        f"unreferenced_externalized_payload_files: {externalized_integrity['unreferenced_externalized_payload_files']}",
     ]
     if issues:
         lines.append(f"issues: {', '.join(issues)}")

--- a/externalize.py
+++ b/externalize.py
@@ -138,15 +138,20 @@ def build_transcript_gc_placeholder(summary: Dict[str, Any]) -> str:
 
 
 def extract_externalized_ref(text: str) -> str | None:
-    if not text:
-        return None
-    match = _EXTERNALIZED_REF_RE.search(text)
-    if not match:
-        return None
-    ref = match.group(1).strip()
-    if not ref or Path(ref).name != ref:
-        return None
-    return ref
+    refs = extract_externalized_refs(text)
+    return refs[0] if refs else None
+
+
+def extract_externalized_refs(text: str) -> list[str]:
+    if not isinstance(text, str) or not text:
+        return []
+    refs: list[str] = []
+    for match in _EXTERNALIZED_REF_RE.finditer(text):
+        ref = match.group(1).strip()
+        if not ref or "/" in ref or "\\" in ref or Path(ref).name != ref or ref in refs:
+            continue
+        refs.append(ref)
+    return refs
 
 
 def is_externalized_placeholder(text: str) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -15,12 +15,15 @@ import json
 import logging
 import re
 from collections import Counter
+from pathlib import Path
 from typing import Any, Dict, List
 
 from .externalize import (
     externalize_ingest_payload,
     extract_externalized_ref,
+    extract_externalized_refs,
     find_externalized_payload_for_message,
+    get_large_output_storage_dir,
     is_externalized_placeholder,
     load_externalized_payload,
     maybe_externalize_payload,
@@ -146,6 +149,21 @@ def extract_ingest_externalized_refs(text: str) -> list[str]:
     for match in _INGEST_PLACEHOLDER_RE.finditer(text):
         ref = match.group(1).strip()
         if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _is_basename_ref(ref: str) -> bool:
+    return bool(ref) and "/" not in ref and "\\" not in ref and Path(ref).name == ref
+
+
+def extract_all_externalized_payload_refs(text: str) -> list[str]:
+    """Return deduplicated refs from recognized externalized payload placeholders."""
+    if not isinstance(text, str) or not text:
+        return []
+    refs: list[str] = []
+    for ref in extract_ingest_externalized_refs(text) + extract_externalized_refs(text):
+        if _is_basename_ref(ref) and ref not in refs:
             refs.append(ref)
     return refs
 
@@ -962,6 +980,65 @@ def protect_messages_for_ingest(
         )
         for message in messages
     ]
+
+
+def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", limit: int = 5) -> dict[str, Any]:
+    """Compare externalized payload refs stored in messages with JSON files.
+
+    This is intentionally read-only and metadata-only. It does not open payload
+    files except through directory metadata, and row samples never include raw
+    message content or tool-call arguments.
+    """
+
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    existing_files: set[str] = set()
+    if storage_dir.exists() and storage_dir.is_dir():
+        existing_files = {path.name for path in storage_dir.glob("*.json") if path.is_file()}
+
+    referenced_refs: set[str] = set()
+    first_location_by_ref: dict[str, dict[str, Any]] = {}
+    for store_id, session_id, source, role, content, tool_calls in conn.execute(
+        """
+        SELECT store_id, session_id, source, role, content, tool_calls
+        FROM messages
+        WHERE COALESCE(content, '') LIKE '%ref=%]%'
+           OR COALESCE(tool_calls, '') LIKE '%ref=%]%'
+        ORDER BY store_id ASC
+        """
+    ).fetchall():
+        for field, value in (("content", content), ("tool_calls", tool_calls)):
+            if not isinstance(value, str):
+                continue
+            for ref in extract_all_externalized_payload_refs(value):
+                referenced_refs.add(ref)
+                first_location_by_ref.setdefault(
+                    ref,
+                    {
+                        "store_id": int(store_id),
+                        "session_id": session_id,
+                        "source": source,
+                        "role": role,
+                        "field": field,
+                        "externalized_ref": ref,
+                    },
+                )
+
+    missing_refs = sorted(ref for ref in referenced_refs if ref not in existing_files)
+    existing_ref_count = sum(1 for ref in referenced_refs if ref in existing_files)
+    unreferenced_files = sorted(ref for ref in existing_files if ref not in referenced_refs)
+
+    return {
+        "externalized_payload_refs_total": len(referenced_refs),
+        "externalized_payload_refs_existing": existing_ref_count,
+        "externalized_payload_refs_missing": len(missing_refs),
+        "externalized_payload_files_unreferenced": len(unreferenced_files),
+        "missing_externalized_payload_refs": [
+            first_location_by_ref[ref] for ref in missing_refs[:limit] if ref in first_location_by_ref
+        ],
+        "unreferenced_externalized_payload_files": [
+            {"externalized_ref": ref} for ref in unreferenced_files[:limit]
+        ],
+    }
 
 
 def scan_sqlite_payload_risks(conn, *, limit: int = 5) -> dict[str, Any]:

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -18,8 +18,18 @@ from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 import hermes_lcm.engine as lcm_engine_module
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
-from hermes_lcm.externalize import build_transcript_gc_placeholder, externalize_ingest_payload, extract_externalized_ref
-from hermes_lcm.ingest_protection import extract_ingest_externalized_refs, redact_sensitive_text
+from hermes_lcm.externalize import (
+    build_transcript_gc_placeholder,
+    externalize_ingest_payload,
+    extract_externalized_ref,
+    extract_externalized_refs,
+)
+from hermes_lcm.ingest_protection import (
+    extract_all_externalized_payload_refs,
+    extract_ingest_externalized_refs,
+    redact_sensitive_text,
+    scan_externalized_payload_integrity,
+)
 from hermes_lcm.tokens import count_messages_tokens
 
 
@@ -337,6 +347,34 @@ def test_extract_externalized_ref_recovers_tool_and_non_tool_placeholders():
     ]
 
     assert [extract_externalized_ref(value) for value in placeholders] == [
+        "tool.json",
+        "tool-gc.json",
+        "raw.json",
+        "raw-gc.json",
+    ]
+
+
+def test_extract_all_externalized_payload_refs_recovers_real_placeholders_only():
+    text = "\n".join(
+        [
+            "[Externalized LCM ingest payload: kind=ingest_payload; field=content; chars=1; bytes=1; ref=ingest.json]",
+            "[Externalized tool output: tool_call_id=call_1; chars=1200; bytes=1200; ref=tool.json]",
+            "[GC'd externalized tool output: tool_call_id=call_1; chars=1200; ref=tool-gc.json]",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1200; bytes=1200; ref=raw.json]",
+            "[GC'd externalized payload: kind=raw_payload; role=assistant; chars=1200; ref=raw-gc.json]",
+            "docs mention ref=docs.json without the real placeholder prefix",
+            "[Externalized payload example: ref=example.json]",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1; ref=nested/not-basename.json]",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1; ref=nested\\not-basename.json]",
+            "[Externalized LCM ingest payload: kind=ingest_payload; field=content; chars=1; bytes=1; ref=../escape.json]",
+            "[Externalized LCM ingest payload: kind=ingest_payload; field=content; chars=1; bytes=1; ref=..\\escape.json]",
+            "[Externalized tool output: tool_call_id=call_1; chars=1200; bytes=1200; ref=tool.json]",
+        ]
+    )
+
+    assert extract_externalized_refs(text) == ["tool.json", "tool-gc.json", "raw.json", "raw-gc.json"]
+    assert extract_all_externalized_payload_refs(text) == [
+        "ingest.json",
         "tool.json",
         "tool-gc.json",
         "raw.json",
@@ -1650,6 +1688,151 @@ def test_lcm_doctor_reports_externalized_payload_stats(tmp_path):
     externalized_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
     assert externalized_check["detail"]["externalized_payload_count"] == 1
     assert externalized_check["detail"]["externalized_payload_bytes"] > 0
+
+
+def test_externalized_payload_integrity_scan_reports_missing_and_unreferenced_refs_without_payload_previews(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    for ref, content in {
+        "ingest-present.json": "present ingest payload",
+        "legacy-present.json": "present legacy payload",
+        "orphan.json": "UNREFERENCED_RAW_PAYLOAD",
+    }.items():
+        (storage_dir / ref).write_text(json.dumps({"content": content, "content_chars": len(content)}))
+
+    content = "\n".join(
+        [
+            "[Externalized LCM ingest payload: kind=ingest_payload; field=content; chars=1; bytes=1; ref=ingest-present.json]",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1; bytes=1; ref=missing-raw.json]",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1; ref=nested/not-counted.json]",
+            "docs mention ref=doc-only.json but not in a real placeholder",
+        ]
+    )
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "arguments": "[GC'd externalized tool output: tool_call_id=call_1; chars=1; ref=legacy-present.json]"
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            content,
+            None,
+            tool_calls,
+            None,
+            1.0,
+            5,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+    before_rows = engine._store._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    before_files = sorted(path.name for path in storage_dir.glob("*.json"))
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert engine._store._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == before_rows
+    assert sorted(path.name for path in storage_dir.glob("*.json")) == before_files
+    assert detail["externalized_payload_refs_total"] == 3
+    assert detail["externalized_payload_refs_existing"] == 2
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["externalized_payload_files_unreferenced"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "telegram",
+            "role": "assistant",
+            "field": "content",
+            "externalized_ref": "missing-raw.json",
+        }
+    ]
+    assert detail["unreferenced_externalized_payload_files"] == [{"externalized_ref": "orphan.json"}]
+    encoded = json.dumps(detail)
+    assert "UNREFERENCED_RAW_PAYLOAD" not in encoded
+    assert "doc-only.json" not in encoded
+    assert "not-counted.json" not in encoded
+
+
+def test_externalized_payload_integrity_scan_detects_embedded_content_placeholder_with_trailing_text(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "user",
+            "see image [Externalized LCM ingest payload: kind=media_payload; field=content; chars=1; bytes=1; ref=missing-embedded.json] please inspect",
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "telegram",
+            "role": "user",
+            "field": "content",
+            "externalized_ref": "missing-embedded.json",
+        }
+    ]
+
+
+def test_lcm_doctor_warns_on_missing_externalized_payload_refs_when_inline_payloads_are_clean(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "[Externalized payload: kind=raw_payload; role=assistant; chars=1; bytes=1; ref=missing-doctor.json]",
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    json_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+
+    payload_check = next(check for check in json_result["checks"] if check["check"] == "payload_storage")
+    assert payload_check["status"] == "warn"
+    assert payload_check["detail"]["suspicious_data_uri_content_rows"] == []
+    assert payload_check["detail"]["suspicious_base64_like_rows"] == []
+    assert payload_check["detail"]["externalized_payload_refs_total"] == 1
+    assert payload_check["detail"]["externalized_payload_refs_missing"] == 1
+    assert payload_check["detail"]["missing_externalized_payload_refs"][0]["externalized_ref"] == "missing-doctor.json"
 
 
 BROKEN_ASSISTANT_MARKER = "BROKEN_ASSISTANT_LOOP_MARKER_196"

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -245,6 +245,38 @@ def test_lcm_doctor_tool_reports_heartbeat_noise_as_read_only_payload_detail(eng
     assert "Still working" not in json.dumps(payload)
 
 
+def test_lcm_doctor_text_reports_missing_externalized_payload_refs(engine):
+    storage_dir = Path(engine._hermes_home) / "lcm-large-outputs"
+    storage_dir.mkdir(parents=True)
+    (storage_dir / "referenced.json").write_text(json.dumps({"content": "stored", "content_chars": 6}))
+    (storage_dir / "unreferenced.json").write_text(json.dumps({"content": "orphaned", "content_chars": 8}))
+    engine._store.append(
+        "externalized-integrity-session",
+        {
+            "role": "assistant",
+            "content": "\n".join(
+                [
+                    "[Externalized LCM ingest payload: kind=ingest_payload; field=content; chars=6; bytes=6; ref=referenced.json]",
+                    "[GC'd externalized payload: kind=raw_payload; role=assistant; chars=10; ref=missing.json]",
+                ]
+            ),
+        },
+        token_estimate=2,
+    )
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "externalized_payload_refs_total: 2" in result
+    assert "externalized_payload_refs_existing: 1" in result
+    assert "externalized_payload_refs_missing: 1" in result
+    assert "externalized_payload_files_unreferenced: 1" in result
+    assert "missing_externalized_payload_refs:" in result
+    assert "missing.json" in result
+    assert "inspect missing externalized payload refs and restore from backups if needed" in result
+    assert "stored" not in result
+    assert "orphaned" not in result
+
+
 def test_lcm_doctor_finds_heartbeat_noise_after_many_short_nonmatches(engine):
     for idx in range(120):
         engine._store.append(

--- a/tools.py
+++ b/tools.py
@@ -21,6 +21,7 @@ from .ingest_protection import (
     externalized_payload_stats,
     extract_ingest_externalized_refs,
     restore_ingest_payload_placeholders,
+    scan_externalized_payload_integrity,
     scan_sqlite_payload_risks,
     sensitive_pattern_status,
 )
@@ -1685,6 +1686,11 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         })
         payload_risks = scan_sqlite_payload_risks(engine._store._conn)
         externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
+        externalized_integrity = scan_externalized_payload_integrity(
+            engine._store._conn,
+            engine._config,
+            hermes_home=engine._hermes_home,
+        )
         suspicious_count = (
             len(payload_risks["suspicious_data_uri_content_rows"])
             + len(payload_risks["suspicious_data_uri_tool_calls_rows"])
@@ -1692,12 +1698,14 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             + len(payload_risks["suspicious_repetitive_assistant_rows"])
             + len(payload_risks["heartbeat_noise_rows"])
         )
+        missing_externalized_refs = int(externalized_integrity.get("externalized_payload_refs_missing", 0) or 0)
         checks.append({
             "check": "payload_storage",
-            "status": "warn" if suspicious_count else "pass",
+            "status": "warn" if suspicious_count or missing_externalized_refs else "pass",
             "detail": {
                 **payload_risks,
                 **externalized_stats,
+                **externalized_integrity,
             },
         })
     except Exception as e:


### PR DESCRIPTION
## Why

LCM can keep references to externalized payload files for long-running or migrated installations. When those files drift, get pruned, or never make it to disk, the database can still look structurally healthy while lossless recovery for those specific payloads is no longer complete. The previous payload diagnostics warned about large inline rows, but they did not verify whether externalized refs in stored messages still had matching files.

## Summary

This adds read-only integrity diagnostics for externalized payload references. `lcm_doctor` and `/lcm doctor` now compare payload refs stored in message rows against JSON files in the configured externalized-payload directory.

The scan handles ingest placeholders, legacy externalized payload/tool-output placeholders, and GC placeholders. It reports counts for referenced, existing, missing, and unreferenced payload files, with bounded metadata-only samples for missing refs and unreferenced files.

This stays diagnostic only. It does not add cleanup, repair, backfill, or payload mutation behavior.

Missing referenced payload files now warn in `lcm_doctor` and show as an issue in `/lcm doctor`. Orphaned files are reported as evidence without becoming an automatic warning.

## Validation

`python -m pytest tests/test_ingest_protection.py tests/test_lcm_command.py tests/test_lcm_engine.py -q -o 'addopts='`

`python -m pytest tests -q -o 'addopts='`

`python -m compileall -q .`

`git diff --check`

I also ran a read-only Codex blocker audit after the final diff. It found no blockers.