### PR TITLE
refactor: share diagnostic helper logic

### DIFF
--- a/command.py
+++ b/command.py
@@ -13,6 +13,7 @@ from .db_bootstrap import (
     inspect_lcm_schema_health,
     repair_external_content_fts,
 )
+from .diagnostics import _has_lifecycle_fragmentation, _state_db_path_for_engine
 from .ingest_protection import (
     externalized_payload_stats,
     scan_externalized_payload_integrity,
@@ -31,50 +32,6 @@ from .presets import (
 )
 from .session_patterns import build_session_match_keys, matches_session_pattern
 from .store import build_message_fts_spec
-
-
-def _state_db_path_for_engine(engine) -> Path:
-    hermes_home = getattr(engine, "_hermes_home", "") or ""
-    if hermes_home:
-        resolved = Path(hermes_home).expanduser().resolve() / "state.db"
-        # Check containment within allowed base only when restriction is active
-        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
-        if env_base:
-            allowed_base = Path(env_base).expanduser().resolve()
-            try:
-                resolved.relative_to(allowed_base)
-            except ValueError:
-                raise ValueError(
-                    f"hermes_home {hermes_home} resolves to {resolved} which is not within allowed base {allowed_base}"
-                )
-        return resolved
-    db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
-    return db_path.parent / "state.db"
-
-
-def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
-    direct_mismatch_keys = (
-        "lifecycle_current_missing_in_lcm_any",
-        "lifecycle_last_finalized_missing_in_lcm_any",
-        "lifecycle_current_missing_in_state",
-        "lifecycle_last_finalized_missing_in_state",
-        "lcm_message_sessions_missing_in_state",
-        "lcm_node_sessions_missing_in_state",
-    )
-    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
-    missing_lifecycle_reference_keys = (
-        "message_sessions_without_lifecycle_reference",
-        "node_sessions_without_lifecycle_reference",
-    )
-    return (
-        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
-        or (
-            lifecycle_rows > 0
-            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
-        )
-        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
-    )
-
 
 def _fmt_bool(value: Any) -> str:
     return "yes" if bool(value) else "no"

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,0 +1,60 @@
+"""Shared read-only diagnostic helpers for LCM tools and commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def state_db_path_for_engine(engine: Any) -> Path:
+    """Return the Hermes state database path for an LCM engine.
+
+    The path is read-only diagnostic input. When ``LCM_HERMES_BASE_DIR`` is
+    configured, enforce the same containment guard for all diagnostic surfaces.
+    """
+    hermes_home = getattr(engine, "_hermes_home", "") or ""
+    if hermes_home:
+        resolved = Path(hermes_home).expanduser().resolve() / "state.db"
+        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+        if env_base:
+            allowed_base = Path(env_base).expanduser().resolve()
+            try:
+                resolved.relative_to(allowed_base)
+            except ValueError:
+                raise ValueError(
+                    f"hermes_home {hermes_home} resolves to {resolved} which is not within allowed base {allowed_base}"
+                )
+        return resolved
+    db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
+    return db_path.parent / "state.db"
+
+
+def has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
+    """Return whether lifecycle diagnostics should be treated as warning evidence."""
+    direct_mismatch_keys = (
+        "lifecycle_current_missing_in_lcm_any",
+        "lifecycle_last_finalized_missing_in_lcm_any",
+        "lifecycle_current_missing_in_state",
+        "lifecycle_last_finalized_missing_in_state",
+        "lcm_message_sessions_missing_in_state",
+        "lcm_node_sessions_missing_in_state",
+    )
+    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
+    missing_lifecycle_reference_keys = (
+        "message_sessions_without_lifecycle_reference",
+        "node_sessions_without_lifecycle_reference",
+    )
+    return (
+        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
+        or (
+            lifecycle_rows > 0
+            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
+        )
+        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
+    )
+
+
+# Backward-compatible private aliases for existing command/tool internals and tests.
+_state_db_path_for_engine = state_db_path_for_engine
+_has_lifecycle_fragmentation = has_lifecycle_fragmentation

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -59,12 +59,14 @@ def test_hermes_home_outside_allowed_base_rejected(monkeypatch):
         allowed_base = tmpdir
         monkeypatch.setenv("LCM_HERMES_BASE_DIR", allowed_base)
 
-        from hermes_lcm.command import _state_db_path_for_engine
+        from hermes_lcm.command import _state_db_path_for_engine as command_state_db_path
+        from hermes_lcm.tools import _state_db_path_for_engine as tools_state_db_path
 
         # Create a mock engine with hermes_home outside allowed base
         class MockEngine:
             _hermes_home = "/etc"
 
         engine = MockEngine()
-        with pytest.raises(ValueError, match="not within allowed base"):
-            _state_db_path_for_engine(engine)
+        for state_db_path_for_engine in (command_state_db_path, tools_state_db_path):
+            with pytest.raises(ValueError, match="not within allowed base"):
+                state_db_path_for_engine(engine)

--- a/tools.py
+++ b/tools.py
@@ -14,6 +14,7 @@ from .externalize import (
     find_externalized_payload_for_message,
     load_externalized_payload,
 )
+from .diagnostics import _has_lifecycle_fragmentation, _state_db_path_for_engine
 from .dag import build_nodes_fts_spec
 from .db_bootstrap import check_external_content_fts_integrity, inspect_lcm_schema_health
 from .extraction import sanitize_pre_compaction_content
@@ -67,39 +68,6 @@ def _combined_result_sort_key(result: dict[str, Any], sort: str) -> tuple:
     if result.get("type") == "message":
         return (-sort_timestamp, type_bias, role_bias, rank_value, 0.0, float("inf"))
     return (-sort_timestamp, type_bias, 0, rank_value, 0.0, role_bias)
-
-
-def _state_db_path_for_engine(engine: "LCMEngine") -> Path:
-    hermes_home = getattr(engine, "_hermes_home", "") or ""
-    if hermes_home:
-        return Path(hermes_home).expanduser() / "state.db"
-    db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
-    return db_path.parent / "state.db"
-
-
-def _has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
-    direct_mismatch_keys = (
-        "lifecycle_current_missing_in_lcm_any",
-        "lifecycle_last_finalized_missing_in_lcm_any",
-        "lifecycle_current_missing_in_state",
-        "lifecycle_last_finalized_missing_in_state",
-        "lcm_message_sessions_missing_in_state",
-        "lcm_node_sessions_missing_in_state",
-    )
-    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
-    missing_lifecycle_reference_keys = (
-        "message_sessions_without_lifecycle_reference",
-        "node_sessions_without_lifecycle_reference",
-    )
-    return (
-        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
-        or (
-            lifecycle_rows > 0
-            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
-        )
-        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
-    )
-
 
 def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
     engine = kwargs.get("engine")


### PR DESCRIPTION
## Why

The command and tool diagnostics were starting to grow the same logic in two places. That makes LCM operator output easy to drift: `/lcm doctor` can classify or guard a situation one way while the `lcm_doctor` tool reports it slightly differently. For diagnostics that agents and humans both use, that kind of split is exactly where stale warnings and unsafe recommendations sneak in.

## Summary

This extracts two read-only diagnostic helpers that were duplicated between `/lcm doctor` and `lcm_doctor`: state database path resolution and lifecycle-fragmentation warning classification.

The command and tool paths now use the same implementation. That also applies the existing `LCM_HERMES_BASE_DIR` containment guard consistently to the tool-side state database lookup, where it previously did not share the command-side check.

No repair, cleanup, lifecycle mutation, or output contract change is added here.

## Validation

`python -m pytest tests/test_path_security.py tests/test_path_resolution.py tests/test_lcm_command.py tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_reports_lifecycle_fragmentation_without_mutating tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_warns_when_existing_state_db_is_unreadable tests/test_lcm_engine.py::test_lcm_tool_status_reports_lifecycle_fragmentation_summary -q -o 'addopts='`

`python -m pytest tests -q -o 'addopts='`

`python -m compileall -q .`

`git diff --check`

A read-only Codex blocker audit also found no blockers after the new helper file was staged.