### PR TITLE
feat: align summary timeout diagnostics

### DIFF
--- a/config.py
+++ b/config.py
@@ -116,6 +116,65 @@ def _hermes_compression_threshold(default: float) -> float:
         return default
 
 
+def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
+    """Read Hermes auxiliary.compression.timeout when no LCM override is present.
+
+    Hermes uses seconds for the auxiliary compression timeout, while LCM stores
+    the summary timeout in milliseconds. Aligning the default keeps LCM summary
+    calls from timing out earlier than the host compression route unless
+    ``LCM_SUMMARY_TIMEOUT_MS`` is explicitly configured.
+    """
+    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    cfg_path = home / "config.yaml"
+    try:
+        text = cfg_path.read_text()
+        if yaml is not None:
+            cfg = yaml.safe_load(text) or {}
+            auxiliary = cfg.get("auxiliary") or {}
+            compression = auxiliary.get("compression") or {}
+            value = compression.get("timeout")
+            if value is None:
+                return default
+            return int(float(value) * 1000)
+
+        in_auxiliary = False
+        in_compression = False
+        auxiliary_indent = None
+        compression_indent = None
+        for raw_line in text.splitlines():
+            line = raw_line.split("#", 1)[0].rstrip()
+            if not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip(" \t"))
+            stripped = line.strip()
+            if indent == 0:
+                in_auxiliary = stripped == "auxiliary:"
+                in_compression = False
+                auxiliary_indent = None
+                compression_indent = None
+                continue
+            if not in_auxiliary:
+                continue
+            if auxiliary_indent is None:
+                auxiliary_indent = indent
+            if indent == auxiliary_indent and stripped == "compression:":
+                in_compression = True
+                compression_indent = None
+                continue
+            if not in_compression:
+                continue
+            if compression_indent is None:
+                compression_indent = indent
+            if indent != compression_indent or ":" not in stripped:
+                continue
+            key, raw_value = stripped.split(":", 1)
+            if key == "timeout":
+                return int(float(raw_value.strip().strip("'\"")) * 1000)
+        return default
+    except Exception:
+        return default
+
+
 @dataclass
 class LCMConfig:
     """All tunables for the LCM engine."""
@@ -323,7 +382,10 @@ class LCMConfig:
         )
         c.expansion_model = _str("LCM_EXPANSION_MODEL", c.expansion_model)
         c.expansion_context_tokens = _int("LCM_EXPANSION_CONTEXT_TOKENS", c.expansion_context_tokens)
-        c.summary_timeout_ms = _int("LCM_SUMMARY_TIMEOUT_MS", c.summary_timeout_ms)
+        c.summary_timeout_ms = _int(
+            "LCM_SUMMARY_TIMEOUT_MS",
+            _hermes_auxiliary_compression_timeout_ms(c.summary_timeout_ms),
+        )
         c.expansion_timeout_ms = _int("LCM_EXPANSION_TIMEOUT_MS", c.expansion_timeout_ms)
         c.database_path = _str("LCM_DATABASE_PATH", c.database_path)
         c.new_session_retain_depth = _int("LCM_NEW_SESSION_RETAIN_DEPTH", c.new_session_retain_depth)

--- a/config.py
+++ b/config.py
@@ -157,8 +157,12 @@ def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
                 continue
             if auxiliary_indent is None:
                 auxiliary_indent = indent
-            if indent == auxiliary_indent and stripped == "compression:":
-                in_compression = True
+            if indent == auxiliary_indent:
+                if stripped == "compression:":
+                    in_compression = True
+                    compression_indent = None
+                    continue
+                in_compression = False
                 compression_indent = None
                 continue
             if not in_compression:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -557,6 +557,48 @@ class TestConfig:
 
         assert c.context_threshold == 0.68
 
+    def test_from_env_reads_hermes_auxiliary_compression_timeout_when_lcm_env_missing(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "auxiliary:\n  compression:\n    timeout: 120\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_SUMMARY_TIMEOUT_MS", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.summary_timeout_ms == 120_000
+
+    def test_from_env_summary_timeout_env_overrides_hermes_auxiliary_timeout(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "auxiliary:\n  compression:\n    timeout: 120\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "45000")
+
+        c = LCMConfig.from_env()
+
+        assert c.summary_timeout_ms == 45_000
+
+    def test_from_env_reads_auxiliary_timeout_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "auxiliary:\n  compression:\n    timeout: '120'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_SUMMARY_TIMEOUT_MS", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.summary_timeout_ms == 120_000
+
     def test_from_env_lcm_threshold_env_overrides_hermes_config(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -599,6 +599,26 @@ class TestConfig:
 
         assert c.summary_timeout_ms == 120_000
 
+    def test_from_env_auxiliary_timeout_without_pyyaml_ignores_sibling_timeout(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "auxiliary:\n"
+            "  compression:\n"
+            "    model: gpt-5.5\n"
+            "  extraction:\n"
+            "    timeout: '120'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_SUMMARY_TIMEOUT_MS", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.summary_timeout_ms == 60_000
+
     def test_from_env_lcm_threshold_env_overrides_hermes_config(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -222,6 +222,7 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["last_compression_noop_reason"] == ""
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
     assert payload["runtime_identity"]["database_path_source"] == "config.database_path"
+    assert payload["config"]["summary_timeout_ms"] == 60_000
 
 
 def test_update_model_updates_runtime_metadata_and_context_window(engine):
@@ -727,6 +728,28 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
     assert payload["runtime_identity"]["plugin_version"] == "0.15.0"
     assert "plugin_git_commit" in payload["runtime_identity"]
+
+
+def test_lcm_doctor_warns_on_extreme_summary_compression_ratios(engine):
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=0,
+        summary="tiny",
+        token_count=100,
+        source_token_count=180_000,
+        source_ids=[],
+        source_type="messages",
+        created_at=1.0,
+    ))
+
+    payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+    check = next(item for item in payload["checks"] if item["check"] == "summary_quality")
+
+    assert check["status"] == "warn"
+    assert check["detail"]["extreme_ratio_nodes"] == 1
+    assert check["detail"]["tiny_large_source_nodes"] == 1
+    assert check["detail"]["worst_nodes"][0]["node_id"] == 1
+    assert check["detail"]["worst_nodes"][0]["compression_ratio"] == 1800.0
 
 class TestEscalationStripReasoning:
     """Regression tests for thinking-model reasoning-tag stripping in

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -746,10 +746,44 @@ def test_lcm_doctor_warns_on_extreme_summary_compression_ratios(engine):
     check = next(item for item in payload["checks"] if item["check"] == "summary_quality")
 
     assert check["status"] == "warn"
+    assert check["detail"]["session_id"] == "test-session"
     assert check["detail"]["extreme_ratio_nodes"] == 1
     assert check["detail"]["tiny_large_source_nodes"] == 1
     assert check["detail"]["worst_nodes"][0]["node_id"] == 1
     assert check["detail"]["worst_nodes"][0]["compression_ratio"] == 1800.0
+
+
+def test_lcm_doctor_summary_quality_ignores_other_sessions(engine):
+    engine._dag.add_node(SummaryNode(
+        session_id="other-session",
+        depth=0,
+        summary="tiny",
+        token_count=100,
+        source_token_count=180_000,
+        source_ids=[],
+        source_type="messages",
+        created_at=1.0,
+    ))
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=0,
+        summary="healthy enough",
+        token_count=1_000,
+        source_token_count=20_000,
+        source_ids=[],
+        source_type="messages",
+        created_at=2.0,
+    ))
+
+    payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+    check = next(item for item in payload["checks"] if item["check"] == "summary_quality")
+
+    assert check["status"] == "pass"
+    assert check["detail"]["session_id"] == "test-session"
+    assert check["detail"]["total_nodes"] == 1
+    assert check["detail"]["extreme_ratio_nodes"] == 0
+    assert check["detail"]["tiny_large_source_nodes"] == 0
+    assert check["detail"]["worst_nodes"][0]["session_id"] == "test-session"
 
 class TestEscalationStripReasoning:
     """Regression tests for thinking-model reasoning-tag stripping in

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -785,6 +785,27 @@ def test_lcm_doctor_summary_quality_ignores_other_sessions(engine):
     assert check["detail"]["tiny_large_source_nodes"] == 0
     assert check["detail"]["worst_nodes"][0]["session_id"] == "test-session"
 
+def test_lcm_doctor_summary_quality_flags_zero_token_large_source(engine):
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=0,
+        summary="",
+        token_count=0,
+        source_token_count=180_000,
+        source_ids=[],
+        source_type="messages",
+        created_at=1.0,
+    ))
+
+    payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+    check = next(item for item in payload["checks"] if item["check"] == "summary_quality")
+
+    assert check["status"] == "warn"
+    assert check["detail"]["tiny_large_source_nodes"] == 1
+    assert check["detail"]["extreme_ratio_nodes"] == 0
+    assert check["detail"]["worst_nodes"][0]["token_count"] == 0
+    assert check["detail"]["worst_nodes"][0]["compression_ratio"] is None
+
 class TestEscalationStripReasoning:
     """Regression tests for thinking-model reasoning-tag stripping in
     escalation._call_llm_for_summary. Some thinking models (MiniMax-M2.7,

--- a/tools.py
+++ b/tools.py
@@ -1455,8 +1455,13 @@ def _summary_quality_stats(engine: "LCMEngine", session_id: str) -> dict[str, An
         """
         SELECT node_id, session_id, depth, token_count, source_token_count
         FROM summary_nodes
-        WHERE session_id = ? AND token_count > 0 AND source_token_count > 0
-        ORDER BY CAST(source_token_count AS REAL) / token_count DESC
+        WHERE session_id = ? AND source_token_count > 0
+        ORDER BY
+            CASE WHEN token_count <= 0 THEN 1 ELSE 0 END DESC,
+            CASE WHEN token_count > 0
+                 THEN CAST(source_token_count AS REAL) / token_count
+                 ELSE source_token_count
+            END DESC
         LIMIT 5
         """,
         (session_id,),
@@ -1467,7 +1472,7 @@ def _summary_quality_stats(engine: "LCMEngine", session_id: str) -> dict[str, An
             COUNT(*),
             COALESCE(SUM(source_token_count), 0),
             COALESCE(SUM(token_count), 0),
-            SUM(CASE WHEN token_count > 0 AND source_token_count >= 100000
+            SUM(CASE WHEN source_token_count >= 100000
                       AND token_count < 500 THEN 1 ELSE 0 END),
             SUM(CASE WHEN token_count > 0
                       AND CAST(source_token_count AS REAL) / token_count >= 400
@@ -1489,7 +1494,11 @@ def _summary_quality_stats(engine: "LCMEngine", session_id: str) -> dict[str, An
     )
     worst_nodes = []
     for node_id, session_id, depth, token_count, source_token_count in rows:
-        ratio = round(float(source_token_count) / float(token_count), 1) if token_count else 0.0
+        ratio = (
+            round(float(source_token_count) / float(token_count), 1)
+            if token_count and token_count > 0
+            else None
+        )
         worst_nodes.append({
             "node_id": int(node_id),
             "session_id": session_id,

--- a/tools.py
+++ b/tools.py
@@ -1446,8 +1446,8 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     )
 
 
-def _summary_quality_stats(engine: "LCMEngine") -> dict[str, Any]:
-    """Return read-only summary compression quality diagnostics."""
+def _summary_quality_stats(engine: "LCMEngine", session_id: str) -> dict[str, Any]:
+    """Return read-only summary compression quality diagnostics for one session."""
     conn = engine._dag._conn
     if conn is None:
         raise RuntimeError("LCM DAG connection is not initialized")
@@ -1455,10 +1455,11 @@ def _summary_quality_stats(engine: "LCMEngine") -> dict[str, Any]:
         """
         SELECT node_id, session_id, depth, token_count, source_token_count
         FROM summary_nodes
-        WHERE token_count > 0 AND source_token_count > 0
+        WHERE session_id = ? AND token_count > 0 AND source_token_count > 0
         ORDER BY CAST(source_token_count AS REAL) / token_count DESC
         LIMIT 5
-        """
+        """,
+        (session_id,),
     ).fetchall()
     totals = conn.execute(
         """
@@ -1472,7 +1473,9 @@ def _summary_quality_stats(engine: "LCMEngine") -> dict[str, Any]:
                       AND CAST(source_token_count AS REAL) / token_count >= 400
                      THEN 1 ELSE 0 END)
         FROM summary_nodes
-        """
+        WHERE session_id = ?
+        """,
+        (session_id,),
     ).fetchone()
     total_nodes = int(totals[0] or 0)
     total_source_tokens = int(totals[1] or 0)
@@ -1497,6 +1500,7 @@ def _summary_quality_stats(engine: "LCMEngine") -> dict[str, Any]:
         })
     return {
         "total_nodes": total_nodes,
+        "session_id": session_id,
         "total_source_tokens": total_source_tokens,
         "total_summary_tokens": total_summary_tokens,
         "overall_compression_ratio": overall_ratio,
@@ -1823,7 +1827,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         })
 
     try:
-        summary_quality = _summary_quality_stats(engine)
+        summary_quality = _summary_quality_stats(engine, session_id)
         degraded_count = (
             summary_quality.get("extreme_ratio_nodes", 0)
             + summary_quality.get("tiny_large_source_nodes", 0)

--- a/tools.py
+++ b/tools.py
@@ -1446,6 +1446,76 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     )
 
 
+def _summary_quality_stats(engine: "LCMEngine") -> dict[str, Any]:
+    """Return read-only summary compression quality diagnostics."""
+    conn = engine._dag._conn
+    if conn is None:
+        raise RuntimeError("LCM DAG connection is not initialized")
+    rows = conn.execute(
+        """
+        SELECT node_id, session_id, depth, token_count, source_token_count
+        FROM summary_nodes
+        WHERE token_count > 0 AND source_token_count > 0
+        ORDER BY CAST(source_token_count AS REAL) / token_count DESC
+        LIMIT 5
+        """
+    ).fetchall()
+    totals = conn.execute(
+        """
+        SELECT
+            COUNT(*),
+            COALESCE(SUM(source_token_count), 0),
+            COALESCE(SUM(token_count), 0),
+            SUM(CASE WHEN token_count > 0 AND source_token_count >= 100000
+                      AND token_count < 500 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN token_count > 0
+                      AND CAST(source_token_count AS REAL) / token_count >= 400
+                     THEN 1 ELSE 0 END)
+        FROM summary_nodes
+        """
+    ).fetchone()
+    total_nodes = int(totals[0] or 0)
+    total_source_tokens = int(totals[1] or 0)
+    total_summary_tokens = int(totals[2] or 0)
+    tiny_large_source_nodes = int(totals[3] or 0)
+    extreme_ratio_nodes = int(totals[4] or 0)
+    overall_ratio = (
+        round(total_source_tokens / total_summary_tokens, 1)
+        if total_summary_tokens > 0
+        else 0.0
+    )
+    worst_nodes = []
+    for node_id, session_id, depth, token_count, source_token_count in rows:
+        ratio = round(float(source_token_count) / float(token_count), 1) if token_count else 0.0
+        worst_nodes.append({
+            "node_id": int(node_id),
+            "session_id": session_id,
+            "depth": int(depth),
+            "source_token_count": int(source_token_count or 0),
+            "token_count": int(token_count or 0),
+            "compression_ratio": ratio,
+        })
+    return {
+        "total_nodes": total_nodes,
+        "total_source_tokens": total_source_tokens,
+        "total_summary_tokens": total_summary_tokens,
+        "overall_compression_ratio": overall_ratio,
+        "extreme_ratio_threshold": 400,
+        "tiny_large_source_threshold": {
+            "source_token_count_min": 100000,
+            "token_count_max": 500,
+        },
+        "extreme_ratio_nodes": extreme_ratio_nodes,
+        "tiny_large_source_nodes": tiny_large_source_nodes,
+        "worst_nodes": worst_nodes,
+        "recommendation": (
+            "Inspect worst_nodes with lcm_expand; tiny summaries for very large sources often indicate degraded fallback summarization."
+            if extreme_ratio_nodes or tiny_large_source_nodes
+            else "summary compression ratios are within the diagnostic thresholds"
+        ),
+    }
+
+
 def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     """Quick health overview of the LCM engine for the current session."""
     engine = _require_engine(kwargs)
@@ -1534,6 +1604,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "max_depth": engine._config.incremental_max_depth,
             "condensation_fanin": engine._config.condensation_fanin,
             "summary_model": engine._config.summary_model or "(auxiliary)",
+            "summary_timeout_ms": engine._config.summary_timeout_ms,
             "expansion_model": engine._config.expansion_model or "(summary model)",
         },
         "session_filters": {
@@ -1747,6 +1818,24 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     except Exception as e:
         checks.append({
             "check": "orphaned_dag_nodes",
+            "status": "fail",
+            "detail": str(e),
+        })
+
+    try:
+        summary_quality = _summary_quality_stats(engine)
+        degraded_count = (
+            summary_quality.get("extreme_ratio_nodes", 0)
+            + summary_quality.get("tiny_large_source_nodes", 0)
+        )
+        checks.append({
+            "check": "summary_quality",
+            "status": "warn" if degraded_count else "pass",
+            "detail": summary_quality,
+        })
+    except Exception as e:
+        checks.append({
+            "check": "summary_quality",
             "status": "fail",
             "detail": str(e),
         })


### PR DESCRIPTION
## Why

LCM summary calls could still use the plugin default 60 second timeout even when the host had a longer `auxiliary.compression.timeout` configured. That makes timeout diagnosis confusing because the host route and LCM summary route do not show the same effective budget.

This also adds a small doctor signal for suspiciously tiny summaries created from very large source payloads. Those cases are worth surfacing because they can indicate degraded fallback summarization rather than healthy compaction.

## What changed

* `LCMConfig.from_env()` now uses Hermes `auxiliary.compression.timeout` as the default summary timeout when `LCM_SUMMARY_TIMEOUT_MS` is not set.
* `LCM_SUMMARY_TIMEOUT_MS` still wins when explicitly configured.
* The no PyYAML fallback parser now stays scoped to `auxiliary.compression` and ignores sibling auxiliary timeouts.
* `lcm_status` now exposes the effective `summary_timeout_ms`.
* `lcm_doctor` now includes a read only `summary_quality` check for the foreground session, with worst compression samples and an actionable recommendation.
* Zero token summaries with very large source payloads count as suspicious tiny summaries, while ratio math still avoids division by zero.

## Validation

* `python -m pytest tests/test_lcm_core.py::TestConfig::test_from_env_reads_hermes_auxiliary_compression_timeout_when_lcm_env_missing tests/test_lcm_core.py::TestConfig::test_from_env_summary_timeout_env_overrides_hermes_auxiliary_timeout tests/test_lcm_core.py::TestConfig::test_from_env_reads_auxiliary_timeout_without_pyyaml tests/test_lcm_core.py::TestConfig::test_from_env_auxiliary_timeout_without_pyyaml_ignores_sibling_timeout tests/test_lcm_engine.py::test_lcm_doctor_warns_on_extreme_summary_compression_ratios tests/test_lcm_engine.py::test_lcm_doctor_summary_quality_ignores_other_sessions tests/test_lcm_engine.py::test_lcm_doctor_summary_quality_flags_zero_token_large_source tests/test_lcm_engine.py::test_lcm_tool_status_includes_optional_cache_usage_metrics -q -o 'addopts='`
* `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_ingest_protection.py tests/test_lcm_command.py tests/test_path_security.py -q -o 'addopts='`
* `python -m pytest tests -q -o 'addopts='`
* `python -m compileall -q .`
* `git diff --check`
* Branch runtime smoke loaded this worktree's plugin modules and verified `summary_timeout_ms=120000`, zero token summary warning behavior, and sibling auxiliary timeout isolation.
* GitHub CI is green on `fc3b1f7`.
* Fresh Codex review on `fc3b1f7` is clean, with bot `+1` and zero unresolved Codex threads.
