### PR TITLE
fix: throttle startup FTS integrity-check to cut launch time

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ environment variables:
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for one summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for one `lcm_expand_query` synthesis call |
 | `LCM_DATABASE_PATH` | auto | SQLite database path, profile-scoped by default |
+| `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` | `24` | Minimum hours between startup FTS5 deep integrity-checks (O(index size)). `0` checks every startup (previous behavior); a negative value never checks on startup. Structural checks always run regardless. |
 | `LCM_ENABLE_SLASH_COMMAND` | `false` | Enable the optional `/lcm` operator command surface |
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
 

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -7,6 +7,7 @@ same schema-version marker, PRAGMA settings, and FTS repair behavior.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -301,9 +302,14 @@ def _integrity_check_interval_hours() -> float:
     if raw is None:
         return DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
     try:
-        return float(raw)
+        value = float(raw)
     except (TypeError, ValueError):
         return DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
+    if not math.isfinite(value):
+        # nan/inf would suppress startup checks indefinitely once a marker
+        # exists; treat non-finite values as invalid.
+        return DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
+    return value
 
 
 def _integrity_marker_key(spec: ExternalContentFtsSpec) -> str:
@@ -357,14 +363,21 @@ def _should_run_integrity_check(
 
 
 def _fts_needs_rebuild(
-    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+    conn: sqlite3.Connection,
+    spec: ExternalContentFtsSpec,
+    *,
+    now: float | None = None,
+    throttle: bool = False,
 ) -> bool:
     if _fts_needs_rebuild_structural(conn, spec):
         return True
     # Structurally sound: the FTS5 integrity-check is O(index size) and was the
-    # dominant startup cost on large databases (issue #235). Throttle it to at
-    # most once per interval; structural checks above still run every startup.
-    if not _should_run_integrity_check(conn, spec, now=now):
+    # dominant startup cost on large databases (issue #235). On the startup path
+    # (``throttle=True``) skip it when already checked within the interval.
+    # Explicit repair (e.g. ``/lcm doctor repair apply``) uses ``throttle=False``
+    # so it always runs the deep check and can fix same-row-count drift that the
+    # structural checks cannot see.
+    if throttle and not _should_run_integrity_check(conn, spec, now=now):
         return False
     result = check_external_content_fts_integrity(conn, spec)
     if result["status"] == "pass":
@@ -474,11 +487,15 @@ def external_content_fts_needs_repair(conn: sqlite3.Connection, spec: ExternalCo
 
 
 def repair_external_content_fts(
-    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+    conn: sqlite3.Connection,
+    spec: ExternalContentFtsSpec,
+    *,
+    now: float | None = None,
+    throttle: bool = False,
 ) -> dict[str, bool]:
     rebuilt = False
     degraded = False
-    if _fts_needs_rebuild(conn, spec, now=now):
+    if _fts_needs_rebuild(conn, spec, now=now, throttle=throttle):
         db_path = conn.execute("PRAGMA database_list").fetchone()
         if db_path:
             db_file = db_path[2]
@@ -520,7 +537,9 @@ def repair_external_content_fts(
 def ensure_external_content_fts(
     conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
 ) -> None:
-    repair_external_content_fts(conn, spec, now=now)
+    # Startup path: throttle the deep integrity-check. Explicit repair callers
+    # use ``repair_external_content_fts(..., throttle=False)`` for a forced check.
+    repair_external_content_fts(conn, spec, now=now, throttle=True)
 
 
 def run_versioned_migrations(conn: sqlite3.Connection) -> None:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import sqlite3
+import time
 from typing import Iterable, Sequence
 
 logger = logging.getLogger(__name__)
@@ -269,8 +270,14 @@ def _fts_needs_rebuild_structural(conn: sqlite3.Connection, spec: ExternalConten
         content_count = conn.execute(
             f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.content_table)}"
         ).fetchone()[0]
+        # For an external-content FTS5 table, ``COUNT(*) FROM <fts>`` reads
+        # through to the content table (so it can never reveal a lagging index)
+        # and is O(index size). The ``<fts>_docsize`` shadow table holds the
+        # true indexed-document count and is a cheap ordinary-table count. Its
+        # existence is already guaranteed by the shadow-table check above.
+        docsize_table = f"{spec.table_name}_docsize"
         fts_count = conn.execute(
-            f"SELECT COUNT(*) FROM {quote_sql_identifier(spec.table_name)}"
+            f"SELECT COUNT(*) FROM {quote_sql_identifier(docsize_table)}"
         ).fetchone()[0]
         if int(content_count or 0) != int(fts_count or 0):
             return True
@@ -280,10 +287,89 @@ def _fts_needs_rebuild_structural(conn: sqlite3.Connection, spec: ExternalConten
     return False
 
 
-def _fts_needs_rebuild(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+INTEGRITY_CHECK_INTERVAL_ENV = "LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS"
+DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS = 24.0
+
+
+def _integrity_check_interval_hours() -> float:
+    """Hours between startup FTS deep integrity-checks.
+
+    ``0`` checks on every startup (previous behavior); a negative value never
+    checks on startup (relies on structural checks + LIKE fallback + doctor).
+    """
+    raw = os.environ.get(INTEGRITY_CHECK_INTERVAL_ENV)
+    if raw is None:
+        return DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
+
+
+def _integrity_marker_key(spec: ExternalContentFtsSpec) -> str:
+    return f"fts_integrity_checked_at:{spec.table_name}"
+
+
+def _load_integrity_checked_at(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec
+) -> float | None:
+    ensure_metadata_table(conn)
+    row = conn.execute(
+        "SELECT value FROM metadata WHERE key = ?",
+        (_integrity_marker_key(spec),),
+    ).fetchone()
+    if not row or row[0] is None:
+        return None
+    try:
+        return float(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def _record_integrity_checked(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+) -> None:
+    ensure_metadata_table(conn)
+    current = time.time() if now is None else now
+    conn.execute(
+        """
+        INSERT INTO metadata(key, value)
+        VALUES(?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (_integrity_marker_key(spec), str(current)),
+    )
+
+
+def _should_run_integrity_check(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+) -> bool:
+    hours = _integrity_check_interval_hours()
+    if hours == 0:
+        return True
+    if hours < 0:
+        return False
+    last = _load_integrity_checked_at(conn, spec)
+    if last is None:
+        return True
+    current = time.time() if now is None else now
+    return (current - last) >= hours * 3600.0
+
+
+def _fts_needs_rebuild(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+) -> bool:
     if _fts_needs_rebuild_structural(conn, spec):
         return True
-    return check_external_content_fts_integrity(conn, spec)["status"] == "fail"
+    # Structurally sound: the FTS5 integrity-check is O(index size) and was the
+    # dominant startup cost on large databases (issue #235). Throttle it to at
+    # most once per interval; structural checks above still run every startup.
+    if not _should_run_integrity_check(conn, spec, now=now):
+        return False
+    result = check_external_content_fts_integrity(conn, spec)
+    if result["status"] == "pass":
+        _record_integrity_checked(conn, spec, now=now)
+    return result["status"] == "fail"
 
 
 def check_external_content_fts_integrity(
@@ -387,10 +473,12 @@ def external_content_fts_needs_repair(conn: sqlite3.Connection, spec: ExternalCo
     return _fts_needs_rebuild_structural(conn, spec) or _fts_missing_triggers(conn, spec)
 
 
-def repair_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> dict[str, bool]:
+def repair_external_content_fts(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+) -> dict[str, bool]:
     rebuilt = False
     degraded = False
-    if _fts_needs_rebuild(conn, spec):
+    if _fts_needs_rebuild(conn, spec, now=now):
         db_path = conn.execute("PRAGMA database_list").fetchone()
         if db_path:
             db_file = db_path[2]
@@ -421,12 +509,18 @@ def repair_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentF
     triggers_were_missing = _fts_missing_triggers(conn, spec)
     for trigger_sql in spec.trigger_sqls:
         conn.execute(trigger_sql)
+    if rebuilt:
+        # A freshly rebuilt index is known-consistent; record the marker so the
+        # next startup can skip the deep integrity-check within the interval.
+        _record_integrity_checked(conn, spec, now=now)
     conn.commit()
     return {"rebuilt": rebuilt, "degraded": degraded, "triggers_recreated": triggers_were_missing}
 
 
-def ensure_external_content_fts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> None:
-    repair_external_content_fts(conn, spec)
+def ensure_external_content_fts(
+    conn: sqlite3.Connection, spec: ExternalContentFtsSpec, *, now: float | None = None
+) -> None:
+    repair_external_content_fts(conn, spec, now=now)
 
 
 def run_versioned_migrations(conn: sqlite3.Connection) -> None:

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -1,0 +1,178 @@
+"""Tests for FTS startup integrity-check throttling (issue #235).
+
+The FTS5 ``integrity-check`` is O(index size) and was run unconditionally on
+every startup where the index already exists and is structurally sound,
+dominating launch time on large databases. These tests pin the throttled
+behavior: the deep check runs at most once per configurable interval, while the
+cheap structural checks always run.
+
+Note on behavior model: a brand-new database takes the ``structural -> rebuild``
+path and does NOT run integrity-check; the expensive check only fires on
+subsequent startups of an existing, structurally-sound index. The tests build
+the index first, then exercise the existing-index path.
+"""
+
+import sqlite3
+import time
+
+import pytest
+
+from hermes_lcm import db_bootstrap
+from hermes_lcm.db_bootstrap import (
+    ExternalContentFtsSpec,
+    ensure_external_content_fts,
+)
+
+INTERVAL_ENV = "LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS"
+MARKER_KEY = "fts_integrity_checked_at:messages_fts"
+
+
+def _make_conn(tmp_path, name="t.db"):
+    conn = sqlite3.connect(str(tmp_path / name))
+    conn.executescript(
+        """
+        CREATE TABLE messages (
+            store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT
+        );
+        INSERT INTO messages(content) VALUES ('hello world');
+        INSERT INTO messages(content) VALUES ('second searchable message');
+        """
+    )
+    return conn
+
+
+def _spec():
+    return ExternalContentFtsSpec(
+        table_name="messages_fts",
+        content_table="messages",
+        content_rowid="store_id",
+        indexed_column="content",
+        trigger_sqls=(),
+    )
+
+
+@pytest.fixture
+def integrity_calls(monkeypatch):
+    """Spy that counts real integrity-check invocations by table name."""
+    calls = []
+    real = db_bootstrap.check_external_content_fts_integrity
+
+    def spy(conn, spec):
+        calls.append(spec.table_name)
+        return real(conn, spec)
+
+    monkeypatch.setattr(db_bootstrap, "check_external_content_fts_integrity", spy)
+    return calls
+
+
+def _marker(conn):
+    row = conn.execute(
+        "SELECT value FROM metadata WHERE key = ?", (MARKER_KEY,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def test_existing_index_without_marker_runs_check_and_records_marker(tmp_path, integrity_calls):
+    conn = _make_conn(tmp_path)
+    ensure_external_content_fts(conn, _spec())  # builds index (rebuild path)
+    # Simulate an existing DB upgraded to the throttling version: no marker yet.
+    conn.execute("DELETE FROM metadata WHERE key = ?", (MARKER_KEY,))
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, _spec())
+
+    assert integrity_calls == ["messages_fts"]
+    assert _marker(conn) is not None
+    conn.close()
+
+
+def test_fresh_marker_skips_integrity_check(tmp_path, monkeypatch, integrity_calls):
+    monkeypatch.setenv(INTERVAL_ENV, "24")
+    conn = _make_conn(tmp_path)
+    ensure_external_content_fts(conn, _spec())  # build records a fresh marker
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, _spec())
+
+    assert integrity_calls == []  # fresh marker -> deep check skipped
+    conn.close()
+
+
+def test_expired_marker_reruns_integrity_check(tmp_path, monkeypatch, integrity_calls):
+    monkeypatch.setenv(INTERVAL_ENV, "24")
+    conn = _make_conn(tmp_path)
+    ensure_external_content_fts(conn, _spec())
+    # Age the marker well past the 24h interval.
+    conn.execute(
+        "UPDATE metadata SET value = ? WHERE key = ?",
+        (str(time.time() - 100 * 3600), MARKER_KEY),
+    )
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, _spec())
+
+    assert integrity_calls == ["messages_fts"]
+    conn.close()
+
+
+def test_interval_zero_checks_every_init(tmp_path, monkeypatch, integrity_calls):
+    monkeypatch.setenv(INTERVAL_ENV, "0")
+    conn = _make_conn(tmp_path)
+    ensure_external_content_fts(conn, _spec())  # build
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, _spec())
+    ensure_external_content_fts(conn, _spec())
+
+    assert integrity_calls == ["messages_fts", "messages_fts"]
+    conn.close()
+
+
+def test_negative_interval_never_checks_on_startup(tmp_path, monkeypatch, integrity_calls):
+    monkeypatch.setenv(INTERVAL_ENV, "-1")
+    conn = _make_conn(tmp_path)
+    ensure_external_content_fts(conn, _spec())  # build
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, _spec())
+
+    assert integrity_calls == []
+    conn.close()
+
+
+def test_structural_mismatch_rebuilds_despite_fresh_marker(tmp_path, monkeypatch, integrity_calls):
+    monkeypatch.setenv(INTERVAL_ENV, "24")
+    conn = _make_conn(tmp_path)
+    spec = _spec()
+    ensure_external_content_fts(conn, spec)  # build + fresh marker, index has 2 docs
+
+    # Insert a row without a trigger (spec has none): the FTS index now lags
+    # content. Marker is fresh, so the deep integrity-check is throttled, but
+    # the structural check must still detect the desync and rebuild.
+    conn.execute("INSERT INTO messages(content) VALUES ('untracked row')")
+    integrity_calls.clear()
+
+    ensure_external_content_fts(conn, spec)
+
+    assert integrity_calls == []  # repaired via structural path, not deep check
+    assert db_bootstrap._fts_needs_rebuild_structural(conn, spec) is False
+    conn.close()
+
+
+def test_external_content_desync_detected_via_docsize(tmp_path):
+    """Content-vs-index row-count comparison must detect real desync.
+
+    For an external-content FTS5 table, ``COUNT(*) FROM <fts>`` reads through to
+    the content table and cannot reveal a lagging index; ``<fts>_docsize`` holds
+    the true indexed-document count. This guards the switch to docsize.
+    """
+    conn = _make_conn(tmp_path)
+    spec = _spec()
+    ensure_external_content_fts(conn, spec)
+    assert db_bootstrap._fts_needs_rebuild_structural(conn, spec) is False
+
+    # Insert without a trigger: indexed doc count (2) now lags content (3).
+    conn.execute("INSERT INTO messages(content) VALUES ('untracked row')")
+    assert db_bootstrap._fts_needs_rebuild_structural(conn, spec) is True
+    conn.close()

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -176,3 +176,56 @@ def test_external_content_desync_detected_via_docsize(tmp_path):
     conn.execute("INSERT INTO messages(content) VALUES ('untracked row')")
     assert db_bootstrap._fts_needs_rebuild_structural(conn, spec) is True
     conn.close()
+
+
+def test_explicit_repair_fixes_same_count_corruption_despite_fresh_marker(tmp_path, monkeypatch):
+    """`/lcm doctor repair apply` must deep-check/repair regardless of throttle.
+
+    Regression for review on PR #236: the startup throttle must not leak into
+    the explicit repair path. Same-row-count stale drift passes structural
+    checks but fails the FTS5 integrity-check; with a fresh marker the throttle
+    would otherwise skip the repair entirely.
+    """
+    monkeypatch.setenv(INTERVAL_ENV, "24")
+    conn = _make_conn(tmp_path)
+    spec = _spec()
+    ensure_external_content_fts(conn, spec)  # build + fresh marker (startup path)
+
+    # Content changes but the index does not (spec has no update trigger): the
+    # row count is unchanged, so structural checks pass, but the indexed tokens
+    # are stale and the integrity-check fails.
+    conn.execute(
+        "UPDATE messages SET content = 'completely different searchable text' WHERE store_id = 1"
+    )
+    assert db_bootstrap._fts_needs_rebuild_structural(conn, spec) is False
+    assert db_bootstrap.check_external_content_fts_integrity(conn, spec)["status"] == "fail"
+
+    # Explicit repair (doctor path) is unthrottled and must rebuild + fix it.
+    repaired = db_bootstrap.repair_external_content_fts(conn, spec)
+    assert repaired["rebuilt"] is True
+    assert db_bootstrap.check_external_content_fts_integrity(conn, spec)["status"] == "pass"
+    conn.close()
+
+
+def test_startup_throttle_still_skips_explicitly(tmp_path, monkeypatch, integrity_calls):
+    """The throttle remains available on the startup path via throttle=True."""
+    monkeypatch.setenv(INTERVAL_ENV, "24")
+    conn = _make_conn(tmp_path)
+    spec = _spec()
+    ensure_external_content_fts(conn, spec)  # build + fresh marker
+    integrity_calls.clear()
+
+    db_bootstrap.repair_external_content_fts(conn, spec, throttle=True)
+
+    assert integrity_calls == []  # fresh marker -> throttled path skips deep check
+    conn.close()
+
+
+def test_non_finite_interval_falls_back_to_default(monkeypatch):
+    """nan/inf must not parse as a valid interval (would suppress checks forever)."""
+    for value in ("nan", "inf", "-inf", "Infinity"):
+        monkeypatch.setenv(INTERVAL_ENV, value)
+        assert (
+            db_bootstrap._integrity_check_interval_hours()
+            == db_bootstrap.DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
+        )


### PR DESCRIPTION
## Summary
- Throttle the startup FTS5 `integrity-check` (O(index size)) so it runs at most once per interval on the startup path, instead of on every startup of a structurally-sound index. New env `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` (default `24`; `0` = every startup = previous behavior; negative = never). A per-table marker `fts_integrity_checked_at:<table>` is stored in the existing `metadata` table after a successful check or rebuild.
- The throttle is opt-in: `repair_external_content_fts()` / `_fts_needs_rebuild()` default to a forced deep check, so `/lcm doctor repair apply` (which calls `repair_external_content_fts()` directly) stays unthrottled; only `ensure_external_content_fts()` on the startup path passes `throttle=True`.
- Switch the structural content-vs-index row-count comparison from `COUNT(*) FROM <fts>` to `COUNT(*) FROM <fts>_docsize`.
- Reject non-finite `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` values (`nan`/`inf`).

## Why
- On a long-lived DB (328MB, ~54.6k messages) the startup `integrity-check` measured ~81s and dominated launch time (issue #235). It guards against rare physical corruption; paying O(index) on every startup is the wrong frequency.
- `COUNT(*) FROM <fts>` on an external-content FTS5 table reads through to the content table, so it is both O(index size) **and** unable to reveal a lagging index (it always equals the content-table count). `<fts>_docsize` is a cheap ordinary-table count reflecting the true indexed-document count — faster, and it fixes a desync-detection blind spot.
- Explicit repair must stay unthrottled: same-row-count FTS drift passes structural checks but fails the integrity-check, so `/lcm doctor repair apply` needs the forced deep check to fix it.
- `nan`/`inf` would otherwise parse as a valid interval and suppress startup checks indefinitely once a marker exists.
- Safety nets are preserved: triggers maintain FTS consistency on every write, FTS query failures fall back to LIKE, structural checks run every startup, `/lcm doctor` offers explicit deep repair, and operators can set `0` to restore the prior every-startup behavior. A freshly rebuilt index is treated as verified (marker recorded).

## Validation
- [x] Full suite against the Hermes runtime: `pytest -q` -> `892 passed, 1 skipped, 2 failed`. The 2 failures (`test_path_containment`, `test_path_security`) are pre-existing macOS-only issues (`/tmp` -> `/private/tmp` symlink); they reproduce on clean `main` and exercise `externalize.py` path logic, not this change (diff is `db_bootstrap.py` + its tests + one README line).
- [x] Focused: `pytest tests/test_lcm_core.py tests/test_db_bootstrap_fts.py -q` -> `210 passed`
- [x] `python -m compileall -q .` -> OK
- [x] `git diff --check` -> clean

## Notes
- New `tests/test_db_bootstrap_fts.py` covers: existing index without marker runs the check and records a marker; fresh marker skips; expired marker reruns; `interval=0` checks every startup; negative interval never checks; structural breakage rebuilds despite a fresh marker; docsize-based desync detection; explicit repair fixes same-row-count corruption despite a fresh marker; `throttle=True` still skips; and `nan`/`inf` fall back to the default.
- Scope is intentionally limited to startup verification cost. Periodic FTS5 `'optimize'` (to prevent the segment fragmentation that makes integrity-check and queries degrade over time) is a separate concern and is not included here.

Refs #235
