### PR TITLE
fix: harden WAL durability and graceful-close checkpoints

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -601,13 +601,17 @@ class SummaryDAG:
             search_rank=row[12] if len(row) > 12 else None,
         )
 
-    def close(self):
+    def close(self) -> None:
         conn = getattr(self, "_conn", None)
         if conn:
+            try:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            except sqlite3.Error:
+                pass
             conn.close()
             self._conn = None
 
-    def __del__(self):  # pragma: no cover - defensive resource cleanup
+    def __del__(self) -> None:  # pragma: no cover - defensive resource cleanup
         try:
             self.close()
         except Exception:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -48,8 +48,34 @@ class ExternalContentFtsSpec:
 
 
 def configure_connection(conn: sqlite3.Connection) -> None:
+    """Configure SQLite connection for crash-safe multi-process WAL usage.
+
+    In a multi-agent deployment (gateway process + CLI sessions + sub-agents),
+    every process opens its own sqlite3.Connection pointing at the same
+    lcm.db file.  These settings ensure the database survives unexpected
+    termination of any one process without corrupting the B-tree.
+
+    Key design decisions:
+    - journal_mode=WAL  : writes go to a separate log; readers never block.
+    - synchronous=FULL  : fsync before every write transaction commit so the
+                          WAL survives power loss / crash.  WAL + FULL is
+                          crash-safe by SQLite guarantee.
+    - wal_autocheckpoint=500 : after 500 WAL pages (~2 MB) SQLite will
+                               automatically checkpoint.  Keeps WAL bounded
+                               even if a long-lived session forgets to close.
+    - journal_size_limit=67108864 (64 MiB) : once the WAL grows past this
+                                              threshold SQLite forces a
+                                              passive checkpoint to cap it.
+    - mmap_size=268435456 (256 MiB)        : memory-map reads so concurrent
+                                              readers cache WAL pages in RAM
+                                              instead of re-reading disk.
+    """
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=FULL")
     conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA wal_autocheckpoint=500")
+    conn.execute("PRAGMA journal_size_limit=67108864")
+    conn.execute("PRAGMA mmap_size=268435456")
 
 
 def ensure_metadata_table(conn: sqlite3.Connection) -> None:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -49,13 +49,15 @@ class ExternalContentFtsSpec:
 
 
 def configure_connection(conn: sqlite3.Connection) -> None:
-    """Configure SQLite connection for improved crash safety with WAL.
+    """Configure SQLite connection for WAL durability and hygiene.
 
     In a multi-agent deployment (gateway process + CLI sessions + sub-agents),
     every process opens its own sqlite3.Connection pointing at the same
-    lcm.db file.  These settings improve durability and WAL hygiene but do
-    NOT fully solve inter-process WAL coordination — that requires graceful
-    application-level shutdown (see ``MessageStore.close()`` etc.).
+    lcm.db file.  These settings improve committed-write durability and WAL
+    hygiene, but do NOT make sibling processes safe from an unexpected process
+    death.  Abnormal exit still depends on normal SQLite WAL recovery;
+    application-level checkpoints only run during graceful shutdown (see
+    ``MessageStore.close()`` etc.).
 
     Key design decisions:
     - journal_mode=WAL  : writes go to a separate log; readers never block.

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -48,27 +48,34 @@ class ExternalContentFtsSpec:
 
 
 def configure_connection(conn: sqlite3.Connection) -> None:
-    """Configure SQLite connection for crash-safe multi-process WAL usage.
+    """Configure SQLite connection for improved crash safety with WAL.
 
     In a multi-agent deployment (gateway process + CLI sessions + sub-agents),
     every process opens its own sqlite3.Connection pointing at the same
-    lcm.db file.  These settings ensure the database survives unexpected
-    termination of any one process without corrupting the B-tree.
+    lcm.db file.  These settings improve durability and WAL hygiene but do
+    NOT fully solve inter-process WAL coordination — that requires graceful
+    application-level shutdown (see ``MessageStore.close()`` etc.).
 
     Key design decisions:
     - journal_mode=WAL  : writes go to a separate log; readers never block.
-    - synchronous=FULL  : fsync before every write transaction commit so the
-                          WAL survives power loss / crash.  WAL + FULL is
-                          crash-safe by SQLite guarantee.
-    - wal_autocheckpoint=500 : after 500 WAL pages (~2 MB) SQLite will
-                               automatically checkpoint.  Keeps WAL bounded
-                               even if a long-lived session forgets to close.
-    - journal_size_limit=67108864 (64 MiB) : once the WAL grows past this
-                                              threshold SQLite forces a
-                                              passive checkpoint to cap it.
+    - synchronous=FULL  : fsync both the WAL and the WAL index before every
+                          write transaction commit.  WAL + FULL is the only
+                          combination SQLite guarantees survives power loss
+                          without data loss (NORMAL may lose the WAL index).
+    - wal_autocheckpoint=500 : after 500 WAL pages (~2 MB) SQLite will try
+                               an automatic passive checkpoint.  This is a
+                               best-effort hint — it is silently skipped when
+                               another connection holds a read transaction.
+                               Under checkpoint starvation WAL can grow well
+                               beyond this trigger.
+    - journal_size_limit=67108864 (64 MiB) : limits the WAL file size after
+                                             a successful checkpoint or reset.
+                                             It does NOT force a checkpoint
+                                             or cap growth while another
+                                             connection holds an old WAL
+                                             end mark.
     - mmap_size=268435456 (256 MiB)        : memory-map reads so concurrent
-                                              readers cache WAL pages in RAM
-                                              instead of re-reading disk.
+                                              readers cache WAL pages in RAM.
     """
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=FULL")

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -59,6 +59,10 @@ class LifecycleStateStore:
     def close(self) -> None:
         conn = getattr(self, "_conn", None)
         if conn is not None:
+            try:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            except sqlite3.Error:
+                pass
             conn.close()
             self._conn = None
 

--- a/store.py
+++ b/store.py
@@ -1015,13 +1015,21 @@ class MessageStore:
 
     # -- Lifecycle ----------------------------------------------------------
 
-    def close(self):
+    def close(self) -> None:
         conn = getattr(self, "_conn", None)
         if conn:
+            # Graceful shutdown: checkpoint WAL so other processes don't see
+            # an incomplete transaction log when we release the connection.
+            # We use PASSIVE so we don't block if another reader is active —
+            # it will just leave remaining WAL pages for the next writer.
+            try:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            except sqlite3.Error:
+                pass  # best-effort only; don't let this mask the real close()
             conn.close()
             self._conn = None
 
-    def __del__(self):  # pragma: no cover - defensive resource cleanup
+    def __del__(self) -> None:  # pragma: no cover - defensive resource cleanup
         try:
             self.close()
         except Exception:

--- a/store.py
+++ b/store.py
@@ -1018,10 +1018,9 @@ class MessageStore:
     def close(self) -> None:
         conn = getattr(self, "_conn", None)
         if conn:
-            # Graceful shutdown: checkpoint WAL so other processes don't see
-            # an incomplete transaction log when we release the connection.
-            # We use PASSIVE so we don't block if another reader is active —
-            # it will just leave remaining WAL pages for the next writer.
+            # Graceful shutdown hygiene: checkpoint committed WAL frames before
+            # releasing the connection.  This does not run on crash/kill, and
+            # PASSIVE can leave frames behind when another reader is active.
             try:
                 conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             except sqlite3.Error:

--- a/tests/test_crash_safe_wal.py
+++ b/tests/test_crash_safe_wal.py
@@ -1,0 +1,178 @@
+"""Tests for crash-safe WAL configuration and graceful close behavior.
+
+These tests verify the PRAGMAs applied by ``configure_connection()`` and
+the best-effort passive WAL checkpoint performed by ``close()`` on all three
+SQLite helpers.
+
+Covers the regression described in PR #237 — multi-process deployments where
+one process can die without checkpointing its WAL, leaving sibling processes
+with an incomplete log.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.db_bootstrap import configure_connection
+from hermes_lcm.store import MessageStore
+from hermes_lcm.dag import SummaryDAG
+from hermes_lcm.lifecycle_state import LifecycleStateStore
+
+
+# --------------------------------------------------------------------------- #
+#  configure_connection PRAGMA verification
+# --------------------------------------------------------------------------- #
+
+
+class TestConfigureConnectionPragmas:
+    """Assert that configure_connection() sets the intended PRAGMAs."""
+
+    @pytest.fixture()
+    def db_path(self, tmp_path: Path):
+        """Return a temp file path for an on-disk database (WAL requires a
+        real file — :memory: silently reports journal_mode='memory')."""
+        return tmp_path / "test.db"
+
+    def test_journal_mode_is_wal(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode == "wal", f"expected journal_mode=wal, got {mode!r}"
+
+    def test_synchronous_is_full(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        # PRAGMA synchronous returns an integer: 0=OFF, 1=NORMAL, 2=FULL
+        val = conn.execute("PRAGMA synchronous").fetchone()[0]
+        conn.close()
+        assert val == 2, f"expected synchronous=FULL (2), got {val}"
+
+    def test_busy_timeout(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        val = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        conn.close()
+        assert val == 30_000, f"expected busy_timeout=30000, got {val}"
+
+    def test_wal_autocheckpoint(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        # After setting, PRAGMA wal_autocheckpoint returns the NEW value.
+        val = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
+        conn.close()
+        assert val == 500, f"expected wal_autocheckpoint=500, got {val}"
+
+    def test_journal_size_limit(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        val = conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+        conn.close()
+        assert val == 67_108_864, f"expected journal_size_limit=67108864, got {val}"
+
+    def test_mmap_size(self, db_path: Path):
+        conn = sqlite3.connect(str(db_path))
+        configure_connection(conn)
+        val = conn.execute("PRAGMA mmap_size").fetchone()[0]
+        conn.close()
+        assert val == 268_435_456, f"expected mmap_size=268435456, got {val}"
+
+
+# --------------------------------------------------------------------------- #
+#  Graceful close — WAL checkpoint on close
+# --------------------------------------------------------------------------- #
+
+
+class TestGracefulClose:
+    """Verify that close() performs a best-effort passive WAL checkpoint
+    without raising."""
+
+    def _write_and_get_wal_size(self, db_path: Path) -> int:
+        """Return WAL file size in bytes (0 if no WAL)."""
+        wal = Path(str(db_path) + "-wal")
+        return wal.stat().st_size if wal.exists() else 0
+
+    # -- MessageStore -------------------------------------------------------
+
+    def test_message_store_close_runs_checkpoint(self, tmp_path: Path):
+        db = tmp_path / "store.db"
+        store = MessageStore(db)
+        store.append("sess", {"role": "user", "content": "hello"})
+        assert db.exists()
+        store.close()
+        # After close the WAL should be small or non-existent (all frames
+        # checkpointed by the passive call).
+        wal_size = self._write_and_get_wal_size(db)
+        assert wal_size < 4096, (
+            f"WAL still {wal_size} bytes after MessageStore.close(); "
+            "checkpoint may not have run"
+        )
+
+    def test_message_store_close_is_idempotent(self, tmp_path: Path):
+        db = tmp_path / "store.db"
+        store = MessageStore(db)
+        store.close()
+        store.close()  # should not raise
+
+    # -- SummaryDAG ---------------------------------------------------------
+
+    def test_summary_dag_close_runs_checkpoint(self, tmp_path: Path):
+        db = tmp_path / "dag.db"
+        dag = SummaryDAG(db)
+        # Insert a minimal summary node so the WAL has content
+        conn = dag._conn
+        assert conn is not None
+        conn.execute(
+            "INSERT INTO summary_nodes (session_id, depth, summary, "
+            "source_ids, source_type, created_at, earliest_at, latest_at) "
+            "VALUES ('sess', 0, 'summary', '[]', 'messages', 0.0, 0.0, 0.0)"
+        )
+        conn.commit()
+        dag.close()
+        wal_size = self._write_and_get_wal_size(db)
+        assert wal_size < 4096, (
+            f"WAL still {wal_size} bytes after SummaryDAG.close(); "
+            "checkpoint may not have run"
+        )
+
+    # -- LifecycleStateStore ------------------------------------------------
+
+    def test_lifecycle_state_close_runs_checkpoint(self, tmp_path: Path):
+        db = tmp_path / "lifecycle.db"
+        lc = LifecycleStateStore(db)
+        lc.bind_session("sess")
+        lc.close()
+        wal_size = self._write_and_get_wal_size(db)
+        assert wal_size < 4096, (
+            f"WAL still {wal_size} bytes after LifecycleStateStore.close(); "
+            "checkpoint may not have run"
+        )
+
+    # -- Masking check ------------------------------------------------------
+
+    def test_message_store_close_does_not_mask_sqlite_error(self, tmp_path: Path):
+        """close() should not silently swallow a broken connection — it only
+        ignores errors from the checkpoint attempt itself, not from the
+        underlying close."""
+        db = tmp_path / "store.db"
+        store = MessageStore(db)
+        # Manually invalidate the connection so close() has nothing to do
+        store._conn = None
+        store.close()  # should not raise
+
+    def test_summary_dag_close_does_not_mask_sqlite_error(self, tmp_path: Path):
+        db = tmp_path / "dag.db"
+        dag = SummaryDAG(db)
+        dag._conn = None
+        dag.close()  # should not raise
+
+    def test_lifecycle_state_close_does_not_mask_sqlite_error(self, tmp_path: Path):
+        db = tmp_path / "lifecycle.db"
+        lc = LifecycleStateStore(db)
+        lc._conn = None
+        lc.close()  # should not raise

--- a/tests/test_crash_safe_wal.py
+++ b/tests/test_crash_safe_wal.py
@@ -1,12 +1,12 @@
-"""Tests for crash-safe WAL configuration and graceful close behavior.
+"""Tests for WAL durability configuration and graceful-close hygiene.
 
 These tests verify the PRAGMAs applied by ``configure_connection()`` and
 the best-effort passive WAL checkpoint performed by ``close()`` on all three
 SQLite helpers.
 
-Covers the regression described in PR #237 — multi-process deployments where
-one process can die without checkpointing its WAL, leaving sibling processes
-with an incomplete log.
+This covers the PR #237 hardening path without overclaiming it: graceful close
+can checkpoint committed WAL frames best-effort, while unexpected process death
+still depends on SQLite WAL recovery.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Add SQLite WAL hardening in `configure_connection()`: `synchronous=FULL`, `wal_autocheckpoint=500`, `journal_size_limit=67108864`, and `mmap_size=268435456`.
- Add best-effort passive WAL checkpoints during graceful `close()` for `MessageStore`, `SummaryDAG`, and `LifecycleStateStore`.
- Add focused coverage for the configured PRAGMAs, graceful-close checkpoint paths, idempotent close behavior, and null-connection close paths.
- Maintainer follow-up narrowed the comments and tests so the branch does not claim crash/kill-safe multiprocess coordination.

## Why
In multi-agent deployments, gateway processes, CLI sessions, and sub-agents can open separate SQLite connections to the same `lcm.db`. The existing setup already used WAL and a busy timeout, but did not explicitly request FULL synchronous durability or checkpoint on graceful helper close.

This PR improves the common committed-write and graceful-shutdown path:
- `synchronous=FULL` gives SQLite the stronger WAL durability mode for committed transactions.
- `wal_autocheckpoint=500` asks SQLite to try automatic passive checkpoints after a bounded page threshold.
- `journal_size_limit=67108864` limits WAL size only after a successful checkpoint or reset.
- Graceful `close()` attempts `PRAGMA wal_checkpoint(PASSIVE)` before releasing each helper connection.

Important limits:
- Passive checkpoints are best effort and may do nothing while active readers hold an old WAL end mark.
- `journal_size_limit` does not force a checkpoint and does not cap WAL growth under checkpoint starvation.
- `close()` checkpoints run only on graceful shutdown.
- Unexpected process death still depends on SQLite WAL recovery.
- Bounded multiprocess WAL coordination, if needed, is separate follow-up work.

## Validation
Maintainer validation on the refreshed branch, merged with current `main` `38420d3546cca2dcd5e027adee0444ea8bec6be4`:

- [x] `python -m pytest tests/test_crash_safe_wal.py tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 630 passed
- [x] `python -m pytest -q` -> 909 passed
- [x] `prlimit --nofile=1024:1024 -- python -m pytest -q` -> 909 passed
- [x] `python -m compileall -q .`
- [x] `python -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check origin/main...HEAD`

Prior contributor validation also covered:
- configured PRAGMA values
- graceful-close checkpoint paths
- production recovery of the reported corrupted DB using SQLite `.recover`

## Notes
I picked this up in-place to keep the original PR and contributor credit intact while getting the branch current and narrowing the WAL guarantees after review.

Original production report and implementation came from @redashes1984 in this PR. The maintainer follow-up is limited to current-main refresh, claim precision, and validation.

Thank you to Tosko4 for reproducing the checkpoint-starvation case and clarifying the exact `journal_size_limit` and passive-checkpoint limits.

References:
- SQLite WAL crash recovery: https://www.sqlite.org/wal.html#crash_recovery
- SQLite PRAGMA synchronous: https://www.sqlite.org/pragma.html#pragma_synchronous
