### PR TITLE
fix: use portable disk space check

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import sqlite3
 import time
 from typing import Iterable, Sequence
@@ -459,9 +460,8 @@ def _drop_fts_artifacts(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) 
 def _check_disk_space(db_path: str) -> bool:
     try:
         parent = os.path.dirname(os.path.abspath(db_path)) or "."
-        usage = os.statvfs(parent)
-        return usage.f_bavail * usage.f_frsize >= _MIN_DISK_SPACE_BYTES
-    except OSError:
+        return shutil.disk_usage(parent).free >= _MIN_DISK_SPACE_BYTES
+    except (OSError, AttributeError):
         return True
 
 

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -14,6 +14,7 @@ the index first, then exercise the existing-index path.
 
 import sqlite3
 import time
+import types
 
 import pytest
 
@@ -229,3 +230,20 @@ def test_non_finite_interval_falls_back_to_default(monkeypatch):
             db_bootstrap._integrity_check_interval_hours()
             == db_bootstrap.DEFAULT_INTEGRITY_CHECK_INTERVAL_HOURS
         )
+
+
+def test_check_disk_space_uses_portable_fallback_when_statvfs_is_unavailable(monkeypatch, tmp_path):
+    """Windows lacks os.statvfs, so startup FTS repair must not crash there."""
+    monkeypatch.delattr(db_bootstrap.os, "statvfs", raising=False)
+    monkeypatch.setattr(
+        db_bootstrap,
+        "shutil",
+        types.SimpleNamespace(
+            disk_usage=lambda path: types.SimpleNamespace(
+                free=db_bootstrap._MIN_DISK_SPACE_BYTES
+            )
+        ),
+        raising=False,
+    )
+
+    assert db_bootstrap._check_disk_space(str(tmp_path / "lcm.db")) is True


### PR DESCRIPTION
## Summary

This fixes a native Windows portability issue in the FTS repair disk-space check.

`os.statvfs()` is POSIX-only. On Windows it is not present, so `_check_disk_space()` can raise `AttributeError` before FTS rebuild or repair can continue. The patch uses `shutil.disk_usage(parent).free` instead, which is the portable stdlib path for the same free-space check.

The existing fail-open behavior is preserved if the disk-space probe itself cannot run.

## Why

A Windows user reported that Hermes-LCM may not load on a native Windows host because this disk-space probe uses a POSIX-only API. The check is only meant to avoid starting an FTS rebuild when free disk space is very low, so it should not make the plugin unusable on platforms where `statvfs` is unavailable.

Using `shutil.disk_usage()` keeps the same free-space guard on Linux/macOS while taking the supported stdlib path on Windows.

## Validation

```text
python3 -m pytest tests/test_db_bootstrap_fts.py::test_check_disk_space_uses_portable_fallback_when_statvfs_is_unavailable -q
python3 -m pytest tests/test_db_bootstrap_fts.py -q
python3 -m pytest -q
python3 -m py_compile db_bootstrap.py tests/test_db_bootstrap_fts.py
git diff --check
```

Full suite result: `896 passed, 1 warning`.
