### PR TITLE
Fix conversation-scoped runtime state for shared LCM engines

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -386,6 +386,14 @@ class LCMEngine(ContextEngine):
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
+        # Hermes gateways can run many conversations concurrently in one
+        # process while the plugin manager exposes one shared context-engine
+        # instance. Keep mutable compression/session cursors scoped by logical
+        # conversation so one thread cannot steal another thread's _session_id
+        # before compress() persists raw rows or DAG nodes.
+        self._runtime_state_lock = threading.RLock()
+        self._runtime_state_by_conversation: dict[str, dict[str, Any]] = {}
+        self._runtime_conversation_by_session: dict[str, str] = {}
 
     def _resolve_db_path(self, hermes_home: str = "") -> Path:
         """Resolve the SQLite path for the active Hermes profile/home."""
@@ -416,6 +424,132 @@ class LCMEngine(ContextEngine):
                 except Exception:
                     logger.debug("LCM failed closing %s during profile rebind", attr, exc_info=True)
 
+    def _runtime_state_field_names(self) -> tuple[str, ...]:
+        """Fields that are process-local but logically scoped to one chat/thread."""
+        return (
+            "_session_id",
+            "_session_platform",
+            "_foreground_session_id",
+            "_foreground_session_platform",
+            "_foreground_conversation_id",
+            "_conversation_id",
+            "_session_match_keys",
+            "_session_ignored",
+            "_session_stateless",
+            "_ignored_message_count",
+            "_last_compacted_store_id",
+            "_ingest_cursor",
+            "_ingest_cursor_needs_reconcile",
+            "_last_ingest_reconciliation",
+            "last_prompt_tokens",
+            "last_completion_tokens",
+            "last_total_tokens",
+            "last_input_tokens",
+            "last_output_tokens",
+            "last_cache_read_tokens",
+            "last_cache_write_tokens",
+            "last_reasoning_tokens",
+            "cache_metrics_available",
+            "compression_count",
+            "_context_probed",
+            "_context_probe_persistable",
+            "_last_overflow_recovery_failed",
+            "_last_condensation_suppressed_reason",
+            "_last_compression_status",
+            "_last_compression_noop_reason",
+            "_last_boundary_skip_time",
+            "_pending_reset_session_id",
+            "_pending_reset_conversation_id",
+            "_pending_reset_frontier_store_id",
+        )
+
+    def _capture_runtime_state(self) -> dict[str, Any]:
+        state: dict[str, Any] = {}
+        for name in self._runtime_state_field_names():
+            value = getattr(self, name)
+            if isinstance(value, list):
+                value = list(value)
+            elif isinstance(value, dict):
+                value = dict(value)
+            state[name] = value
+        return state
+
+    def _restore_runtime_state(self, state: dict[str, Any]) -> None:
+        for name, value in state.items():
+            if isinstance(value, list):
+                value = list(value)
+            elif isinstance(value, dict):
+                value = dict(value)
+            setattr(self, name, value)
+
+    def _remember_runtime_state_for_current_binding(self) -> None:
+        conversation_id = str(self._conversation_id or "")
+        session_id = str(self._session_id or "")
+        if not conversation_id:
+            return
+        self._runtime_state_by_conversation[conversation_id] = self._capture_runtime_state()
+        if session_id:
+            self._runtime_conversation_by_session[session_id] = conversation_id
+
+    def _forget_all_runtime_states(self) -> None:
+        self._runtime_state_by_conversation.clear()
+        self._runtime_conversation_by_session.clear()
+
+    def _gateway_context_value(self, name: str) -> str:
+        try:
+            import importlib
+
+            session_context = importlib.import_module("gateway.session_context")
+            get_session_env = getattr(session_context, "get_session_env")
+            return str(get_session_env(name, "") or "")
+        except Exception:
+            return str(os.environ.get(name, "") or "")
+
+    def _resolve_runtime_conversation_id(
+        self,
+        *,
+        session_id: str | None = None,
+        conversation_id: str | None = None,
+    ) -> str:
+        explicit_conversation_id = str(conversation_id or "")
+        if explicit_conversation_id:
+            return explicit_conversation_id
+
+        session_key = self._gateway_context_value("HERMES_SESSION_KEY")
+        if session_key in self._runtime_state_by_conversation:
+            return session_key
+
+        explicit_session_id = str(session_id or "")
+        for candidate in (
+            explicit_session_id,
+            self._gateway_context_value("HERMES_SESSION_ID"),
+        ):
+            if candidate and candidate in self._runtime_conversation_by_session:
+                return self._runtime_conversation_by_session[candidate]
+
+        return str(self._conversation_id or "")
+
+    @contextmanager
+    def _scoped_runtime_state(
+        self,
+        *,
+        session_id: str | None = None,
+        conversation_id: str | None = None,
+    ) -> Iterator[None]:
+        """Bind the shared engine to the caller's conversation for one operation."""
+        with self._runtime_state_lock:
+            target_conversation_id = self._resolve_runtime_conversation_id(
+                session_id=session_id,
+                conversation_id=conversation_id,
+            )
+            target_state = self._runtime_state_by_conversation.get(target_conversation_id)
+            if target_state is not None and self._conversation_id != target_conversation_id:
+                self._restore_runtime_state(target_state)
+            try:
+                yield
+            finally:
+                self._remember_runtime_state_for_current_binding()
+
     def _reset_profile_runtime_state(self) -> None:
         """Clear process-local session state that cannot cross profile homes."""
         self._session_id = ""
@@ -427,6 +561,7 @@ class LCMEngine(ContextEngine):
         self._session_match_keys = []
         self._session_ignored = False
         self._session_stateless = False
+        self._forget_all_runtime_states()
         self._clear_pending_reset_boundary()
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.clear()
@@ -599,6 +734,8 @@ class LCMEngine(ContextEngine):
         self.last_cache_read_tokens = int(usage.get("cache_read_tokens", 0) or 0)
         self.last_cache_write_tokens = int(usage.get("cache_write_tokens", 0) or 0)
         self.last_reasoning_tokens = int(usage.get("reasoning_tokens", 0) or 0)
+        with self._runtime_state_lock:
+            self._remember_runtime_state_for_current_binding()
 
     @property
     def cache_read_ratio(self) -> float:
@@ -820,8 +957,29 @@ class LCMEngine(ContextEngine):
 
         raise RuntimeError("adaptive leaf rescue exhausted without a valid chunk")
 
-    def compress(self, messages: List[Dict[str, Any]],
-                 current_tokens: int = None,
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        *,
+        session_id: str | None = None,
+        conversation_id: str | None = None,
+        **_host_kwargs: Any,
+    ) -> List[Dict[str, Any]]:
+        """Main compaction entry point with conversation-scoped runtime binding."""
+        with self._scoped_runtime_state(
+            session_id=session_id,
+            conversation_id=conversation_id,
+        ):
+            return self._compress_bound(
+                messages,
+                current_tokens=current_tokens,
+                focus_topic=focus_topic,
+            )
+
+    def _compress_bound(self, messages: List[Dict[str, Any]],
+                 current_tokens: Optional[int] = None,
                  focus_topic: Optional[str] = None) -> List[Dict[str, Any]]:
         """Main compaction entry point.
 
@@ -1954,6 +2112,19 @@ class LCMEngine(ContextEngine):
         self._log_session_filter_diagnostics()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
+        conversation_id = str(kwargs.get("conversation_id") or "")
+        with self._runtime_state_lock:
+            target_conversation_id = self._resolve_runtime_conversation_id(
+                session_id=session_id,
+                conversation_id=conversation_id or None,
+            )
+            target_state = self._runtime_state_by_conversation.get(target_conversation_id)
+            if target_state is not None and self._conversation_id != target_conversation_id:
+                self._restore_runtime_state(target_state)
+            self._on_session_start_bound(session_id, **kwargs)
+            self._remember_runtime_state_for_current_binding()
+
+    def _on_session_start_bound(self, session_id: str, **kwargs) -> None:
         if "hermes_home" in kwargs:
             self._rebind_storage_for_home(str(kwargs.get("hermes_home") or ""))
 

--- a/tests/test_context_scoped_runtime.py
+++ b/tests/test_context_scoped_runtime.py
@@ -1,0 +1,182 @@
+import sqlite3
+import types
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _make_engine(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_context_scope.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=1,
+        dynamic_leaf_chunk_enabled=False,
+        extraction_enabled=False,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+
+    def fake_summary(self, chunk, focus_topic=None):
+        joined = " | ".join(str(m.get("content", "")) for m in chunk)
+        return chunk, 123, f"SUMMARY_FROM_{joined}", "fake", 1
+
+    engine._summarize_leaf_chunk_with_rescue = types.MethodType(fake_summary, engine)
+    return engine
+
+
+def _rows(tmp_path, query):
+    con = sqlite3.connect(tmp_path / "lcm_context_scope.db")
+    con.row_factory = sqlite3.Row
+    try:
+        return [dict(row) for row in con.execute(query)]
+    finally:
+        con.close()
+
+
+def test_shared_engine_compress_uses_gateway_conversation_context(tmp_path, monkeypatch):
+    engine = _make_engine(tmp_path)
+
+    engine.on_session_start(
+        "A-session",
+        platform="discord",
+        conversation_id="conv-A-thread",
+        context_length=200000,
+    )
+    engine.on_session_start(
+        "B-session",
+        platform="discord",
+        conversation_id="conv-B-thread",
+        context_length=200000,
+    )
+
+    # Simulate a cached AIAgent turn: no fresh on_session_start() runs for A,
+    # but the gateway's task-local session key identifies the active thread.
+    monkeypatch.setattr(
+        engine,
+        "_gateway_context_value",
+        lambda name: "conv-A-thread" if name == "HERMES_SESSION_KEY" else "",
+    )
+
+    engine.compress(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "A_ONLY_user_1"},
+            {"role": "assistant", "content": "A_ONLY_assistant_1"},
+            {"role": "user", "content": "A_ONLY_tail"},
+        ],
+        current_tokens=999999,
+    )
+
+    messages = _rows(
+        tmp_path,
+        "select session_id, role, content from messages order by store_id",
+    )
+    nodes = _rows(
+        tmp_path,
+        "select session_id, summary from summary_nodes order by node_id",
+    )
+    lifecycle = _rows(
+        tmp_path,
+        "select conversation_id, current_session_id, current_frontier_store_id "
+        "from lcm_lifecycle_state order by conversation_id",
+    )
+
+    assert {row["session_id"] for row in messages} == {"A-session"}
+    assert nodes == [
+        {
+            "session_id": "A-session",
+            "summary": "SUMMARY_FROM_A_ONLY_user_1 | A_ONLY_assistant_1",
+        }
+    ]
+    assert lifecycle == [
+        {
+            "conversation_id": "conv-A-thread",
+            "current_session_id": "A-session",
+            "current_frontier_store_id": 3,
+        },
+        {
+            "conversation_id": "conv-B-thread",
+            "current_session_id": "B-session",
+            "current_frontier_store_id": 0,
+        },
+    ]
+
+
+def test_compression_boundary_updates_the_scoped_conversation_state(tmp_path, monkeypatch):
+    engine = _make_engine(tmp_path)
+
+    engine.on_session_start(
+        "A-old",
+        platform="discord",
+        conversation_id="conv-A-thread",
+        context_length=200000,
+    )
+    monkeypatch.setattr(
+        engine,
+        "_gateway_context_value",
+        lambda name: "conv-A-thread" if name == "HERMES_SESSION_KEY" else "",
+    )
+    engine.compress(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "A_OLD_user"},
+            {"role": "assistant", "content": "A_OLD_assistant"},
+            {"role": "user", "content": "A_OLD_tail"},
+        ],
+        current_tokens=999999,
+    )
+
+    engine.on_session_start(
+        "B-session",
+        platform="discord",
+        conversation_id="conv-B-thread",
+        context_length=200000,
+    )
+    engine.on_session_start(
+        "A-child",
+        platform="discord",
+        conversation_id="conv-A-thread",
+        boundary_reason="compression",
+        old_session_id="A-old",
+        context_length=200000,
+    )
+
+    monkeypatch.setattr(
+        engine,
+        "_gateway_context_value",
+        lambda name: "conv-A-thread" if name == "HERMES_SESSION_KEY" else "",
+    )
+    engine.compress(
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "A_CHILD_user"},
+            {"role": "assistant", "content": "A_CHILD_assistant"},
+            {"role": "user", "content": "A_CHILD_tail"},
+        ],
+        current_tokens=999999,
+    )
+
+    nodes = _rows(
+        tmp_path,
+        "select session_id, summary from summary_nodes order by node_id",
+    )
+    lifecycle = _rows(
+        tmp_path,
+        "select conversation_id, current_session_id, last_finalized_session_id "
+        "from lcm_lifecycle_state order by conversation_id",
+    )
+
+    assert [row["session_id"] for row in nodes] == ["A-child", "A-child"]
+    assert "A_CHILD_user" in nodes[1]["summary"]
+    assert lifecycle == [
+        {
+            "conversation_id": "conv-A-thread",
+            "current_session_id": "A-child",
+            "last_finalized_session_id": "A-old",
+        },
+        {
+            "conversation_id": "conv-B-thread",
+            "current_session_id": "B-session",
+            "last_finalized_session_id": None,
+        },
+    ]


### PR DESCRIPTION
## Summary

Fixes #243.

This PR prevents a shared `LCMEngine` instance from writing compression output to the wrong session/conversation when Hermes gateway serves multiple logical conversations concurrently in one process.

## Why

Hermes gateway can reuse one process-wide context-engine instance across multiple logical conversations. The current host integration calls:

```python
agent.context_compressor.compress(messages, current_tokens=..., focus_topic=...)
```

without passing the current session/conversation into `compress()`. That means `compress()` relies on mutable engine fields such as `_session_id`, `_conversation_id`, `_ingest_cursor`, and `_last_compacted_store_id`.

In concurrent gateway traffic, another conversation can call `on_session_start()` and overwrite those fields before a cached agent calls `compress()`. When that happens, the wrong session/conversation can receive:

- raw message rows,
- summary DAG nodes,
- lifecycle frontier updates.

This is particularly risky because the bad write happens before compression-boundary recovery has a chance to correct session drift.

## What changed

- Add per-conversation runtime state snapshots for session/cursor/compression/lifecycle bookkeeping fields.
- Bind the shared engine to the active conversation for `compress()` using:
  1. explicit `compress(..., session_id=..., conversation_id=...)` kwargs,
  2. Hermes gateway task-local `HERMES_SESSION_KEY` via dynamic import of `gateway.session_context`,
  3. known session-to-conversation mapping,
  4. current bound conversation as fallback.
- Keep `compress(messages, current_tokens=..., focus_topic=...)` backward compatible.
- Keep `on_session_start()` behavior compatible with existing callers: after session start the engine remains bound to that session.
- Refresh scoped runtime state after `update_from_response()`.
- Add regression coverage for cached-agent/shared-engine contamination and compression-boundary continuation.

## Validation

Passed:

```bash
python3 -m py_compile engine.py tests/test_context_scoped_runtime.py
python3 -m pytest tests/test_context_scoped_runtime.py tests/test_lcm_engine.py tests/test_lcm_command.py tests/test_lcm_core.py -q
# 650 passed, 1 warning
```

Full suite note:

```bash
python3 -m pytest -q
# 909 passed, 2 failed, 1 warning
```

The two failures also reproduce when run alone and appear orthogonal to this PR:

- `tests/test_ingest_protection.py::test_import_lossless_claw_externalizes_legacy_data_uri_content`
- `tests/test_ingest_protection.py::test_import_lossless_claw_respects_externalization_path_env`

They involve lossless-claw importer externalized-payload path/content expectations, not conversation-scoped runtime state.