### PR TITLE
fix(config): tune compaction defaults and add lcm.context_threshold config priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ environment variables:
 
 | Variable | Default | Use |
 |----------|---------|-----|
-| `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of the context window that triggers LCM compaction |
-| `LCM_FRESH_TAIL_COUNT` | `64` | Recent messages protected from compaction |
+| `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
+| `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
+| `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Raw-backlog floor before leaf compaction; with dynamic chunking enabled, the base chunk target |
 | `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Enable chunk-sized leaf compaction passes instead of compacting the whole non-tail raw backlog per pass |
 | `LCM_DYNAMIC_LEAF_CHUNK_MAX` | `40000` | Upper bound for dynamic leaf chunk targets |
@@ -384,9 +385,10 @@ Common questions:
 
 **Should I leave the default threshold on a 1M-token model?**
 
-Not always. The default `0.75` means compaction may wait until roughly `750000`
-prompt tokens on a true 1M effective window. That can be intentional if you want
-maximum live context, but it is expensive and delays DAG construction.
+Not always. The default `0.35` means compaction starts around `350000` prompt
+tokens on a true 1M effective window. That leaves far more headroom for new
+content but compacts more aggressively, which can shorten recall of older
+details.
 
 **Should I change leaf chunk settings first?**
 

--- a/config.py
+++ b/config.py
@@ -62,13 +62,16 @@ def _config_bool_disabled(value) -> bool:
 
 
 def _hermes_compression_threshold(default: float) -> float:
-    """Read Hermes compression.threshold when no LCM env override is present.
+    """Read lcm.context_threshold or Hermes compression.threshold from config.yaml.
+
+    Priority when no ``LCM_CONTEXT_THRESHOLD`` env var is set:
+      1. ``lcm.context_threshold`` (LCM-specific override in config.yaml)
+      2. ``compression.threshold`` (Hermes global setting, unless compression disabled)
 
     Hermes gateways may load ``~/.hermes/config.yaml`` without exporting every
-    setting into the process environment. Falling back to the main Hermes
-    compression threshold keeps LCM aligned with the active agent config while
-    still allowing ``LCM_CONTEXT_THRESHOLD`` to override it explicitly. Disabled
-    Hermes compression should not leak its threshold into LCM.
+    setting into the process environment. The ``lcm.context_threshold`` key lets
+    operators tune LCM compaction independently of the Hermes compression setting.
+    Disabled Hermes compression should not leak its threshold into LCM.
     """
     home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
     cfg_path = home / "config.yaml"
@@ -76,16 +79,20 @@ def _hermes_compression_threshold(default: float) -> float:
         text = cfg_path.read_text()
         if yaml is not None:
             cfg = yaml.safe_load(text) or {}
+            # lcm.context_threshold takes priority over compression.threshold
+            lcm_val = (cfg.get("lcm") or {}).get("context_threshold")
+            if lcm_val is not None:
+                return float(lcm_val)
             compression = cfg.get("compression") or {}
             if _config_bool_disabled(compression.get("enabled")):
                 return default
-            value = compression.get("threshold")
-            if value is None:
-                return default
-            return float(value)
+            comp_val = compression.get("threshold")
+            if comp_val is not None:
+                return float(comp_val)
+            return default
 
+        in_lcm = False
         in_compression = False
-        direct_indent = None
         compression_disabled = False
         threshold_value = None
         for raw_line in text.splitlines():
@@ -93,22 +100,20 @@ def _hermes_compression_threshold(default: float) -> float:
             if not line.strip():
                 continue
             if not line.startswith((" ", "\t")):
-                in_compression = line.strip() == "compression:"
-                direct_indent = None
+                stripped = line.strip()
+                in_lcm = stripped == "lcm:"
+                in_compression = stripped == "compression:"
                 continue
-            if not in_compression:
-                continue
-            indent = len(line) - len(line.lstrip(" \t"))
-            if direct_indent is None:
-                direct_indent = indent
-            if indent != direct_indent or ":" not in line:
-                continue
-            key, raw_value = line.strip().split(":", 1)
-            value = raw_value.strip().strip("'\"")
-            if key == "enabled" and _config_bool_disabled(value):
-                compression_disabled = True
-            elif key == "threshold":
-                threshold_value = value
+            if in_lcm and line.strip().startswith("context_threshold:"):
+                return float(line.split(":", 1)[1].strip().strip("'\""))
+            if in_compression:
+                key_part = line.strip()
+                if key_part.startswith("enabled:"):
+                    raw_val = key_part.split(":", 1)[1].strip().strip("'\"")
+                    if _config_bool_disabled(raw_val):
+                        compression_disabled = True
+                elif key_part.startswith("threshold:"):
+                    threshold_value = line.split(":", 1)[1].strip().strip("'\"")
         if compression_disabled or threshold_value is None:
             return default
         return float(threshold_value)
@@ -184,15 +189,15 @@ class LCMConfig:
     """All tunables for the LCM engine."""
 
     # -- Fresh tail: recent messages never compacted ---
-    fresh_tail_count: int = 64
+    fresh_tail_count: int = 32
 
     # -- Compaction thresholds ---
     # Max source tokens in a leaf chunk before summarization triggers
     leaf_chunk_tokens: int = 20_000
     # Fraction of context window that triggers compaction (0.0–1.0)
-    context_threshold: float = 0.75
+    context_threshold: float = 0.35
     # Max condensation depth (-1 = unlimited, 0 = leaf only)
-    incremental_max_depth: int = 1
+    incremental_max_depth: int = 3
     # How many same-depth summaries trigger condensation
     condensation_fanin: int = 4
     # When enabled, leaf compaction may use a larger working chunk size based on backlog pressure

--- a/config.py
+++ b/config.py
@@ -92,7 +92,9 @@ def _hermes_compression_threshold(default: float) -> float:
             return default
 
         in_lcm = False
+        lcm_indent = None
         in_compression = False
+        comp_indent = None
         compression_disabled = False
         threshold_value = None
         for raw_line in text.splitlines():
@@ -103,17 +105,29 @@ def _hermes_compression_threshold(default: float) -> float:
                 stripped = line.strip()
                 in_lcm = stripped == "lcm:"
                 in_compression = stripped == "compression:"
+                lcm_indent = None
+                comp_indent = None
                 continue
-            if in_lcm and line.strip().startswith("context_threshold:"):
-                return float(line.split(":", 1)[1].strip().strip("'\""))
+            indent = len(line) - len(line.lstrip(" \t"))
+            if in_lcm:
+                if lcm_indent is None:
+                    lcm_indent = indent
+                if indent == lcm_indent and ":" in line:
+                    key, raw_value = line.strip().split(":", 1)
+                    if key == "context_threshold":
+                        return float(raw_value.strip().strip("'\""))
+                continue
             if in_compression:
-                key_part = line.strip()
-                if key_part.startswith("enabled:"):
-                    raw_val = key_part.split(":", 1)[1].strip().strip("'\"")
-                    if _config_bool_disabled(raw_val):
-                        compression_disabled = True
-                elif key_part.startswith("threshold:"):
-                    threshold_value = line.split(":", 1)[1].strip().strip("'\"")
+                if comp_indent is None:
+                    comp_indent = indent
+                if indent != comp_indent or ":" not in line:
+                    continue
+                key, raw_value = line.strip().split(":", 1)
+                value = raw_value.strip().strip("'\"")
+                if key == "enabled" and _config_bool_disabled(value):
+                    compression_disabled = True
+                elif key == "threshold":
+                    threshold_value = value
         if compression_disabled or threshold_value is None:
             return default
         return float(threshold_value)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -775,6 +775,47 @@ class TestConfig:
 
         assert c.context_threshold == 0.42
 
+    def test_from_env_nested_lcm_context_threshold_ignored(self, monkeypatch, tmp_path):
+        """Deeply nested context_threshold under lcm: should NOT be matched.
+
+        Regression test: the no-yaml fallback parser must track indentation
+        so that only direct children of the lcm: section are considered.
+        """
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        # context_threshold nested under lcm > subsection — must be ignored
+        (hermes_home / "config.yaml").write_text(
+            "lcm:\n  subsection:\n    context_threshold: 0.99\n"
+            "compression:\n  enabled: true\n  threshold: 0.60\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        # Must fall through to compression.threshold, NOT the nested 0.99
+        assert c.context_threshold == 0.60
+
+    def test_from_env_nested_compression_threshold_ignored(self, monkeypatch, tmp_path):
+        """Deeply nested threshold under compression: should NOT be matched."""
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  enabled: true\n  subsection:\n    threshold: 0.99\n  threshold: 0.55\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.55
+
 
 class TestSessionPatterns:
     def test_compile_pattern_wildcards(self):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -422,9 +422,9 @@ class TestProviderPrefixedAuxiliaryCalls:
 class TestConfig:
     def test_defaults(self):
         c = LCMConfig()
-        assert c.fresh_tail_count == 64
+        assert c.fresh_tail_count == 32
         assert c.leaf_chunk_tokens == 20_000
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
         assert c.condensation_fanin == 4
         assert c.dynamic_leaf_chunk_enabled is False
         assert c.dynamic_leaf_chunk_max == 40_000
@@ -538,9 +538,9 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.fresh_tail_count == 64
+        assert c.fresh_tail_count == 32
         assert c.leaf_chunk_tokens == 20_000
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
         assert c.max_assembly_tokens == 0
         assert c.reserve_tokens_floor == 0
         assert c.expansion_context_tokens == 32_000
@@ -641,7 +641,7 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
 
     def test_from_env_ignores_numeric_zero_disabled_hermes_threshold(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
@@ -654,7 +654,7 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
 
     def test_from_env_ignores_numeric_zero_float_disabled_hermes_threshold(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
@@ -667,7 +667,7 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
 
     def test_from_env_numeric_one_keeps_hermes_threshold_fallback(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
@@ -696,7 +696,7 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
 
     def test_from_env_ignores_numeric_zero_float_without_pyyaml(self, monkeypatch, tmp_path):
         import hermes_lcm.config as config_mod
@@ -712,7 +712,7 @@ class TestConfig:
 
         c = LCMConfig.from_env()
 
-        assert c.context_threshold == 0.75
+        assert c.context_threshold == 0.35
 
     def test_from_env_numeric_one_float_keeps_threshold_without_pyyaml(self, monkeypatch, tmp_path):
         import hermes_lcm.config as config_mod
@@ -743,6 +743,37 @@ class TestConfig:
         c = LCMConfig.from_env()
 
         assert c.context_threshold == 0.68
+
+    def test_from_env_lcm_section_overrides_compression_section(self, monkeypatch, tmp_path):
+        """lcm.context_threshold in config.yaml takes priority over compression.threshold."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "lcm:\n  context_threshold: 0.40\ncompression:\n  enabled: true\n  threshold: 0.80\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.40
+
+    def test_from_env_lcm_section_overrides_without_pyyaml(self, monkeypatch, tmp_path):
+        """lcm: section parsed correctly when pyyaml is unavailable."""
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "lcm:\n  context_threshold: '0.42'\ncompression:\n  enabled: true\n  threshold: '0.80'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.42
 
 
 class TestSessionPatterns:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -425,6 +425,7 @@ class TestConfig:
         assert c.fresh_tail_count == 32
         assert c.leaf_chunk_tokens == 20_000
         assert c.context_threshold == 0.35
+        assert c.incremental_max_depth == 3
         assert c.condensation_fanin == 4
         assert c.dynamic_leaf_chunk_enabled is False
         assert c.dynamic_leaf_chunk_max == 40_000

--- a/tests/test_lcm_preset_command.py
+++ b/tests/test_lcm_preset_command.py
@@ -191,5 +191,5 @@ def test_lcm_preset_dry_run_does_not_honor_invalid_env_overrides(tmp_path, monke
     assert "explicit_overrides: (none)" in suggest
     assert "invalid_overrides: LCM_FRESH_TAIL_COUNT=abc" in suggest
     for result in (suggest, apply):
-        assert "LCM_FRESH_TAIL_COUNT=24 (invalid current value abc ignored by runtime; runtime value 64)" in result
+        assert "LCM_FRESH_TAIL_COUNT=24 (invalid current value abc ignored by runtime; runtime value 32)" in result
         assert "keep explicit value abc" not in result


### PR DESCRIPTION
## Summary

- Tune LCM compaction defaults for large-context models (200k+ tokens)
- Add `lcm.context_threshold` config key with priority over `compression.threshold`
- Restore indent tracking in no-yaml fallback parser for correct nesting behavior

## Why

Default LCM compaction settings cause context overflow on large context windows. With `context_threshold=0.75`, LCM waits until 75% of the context window is consumed before compacting — too late for models that error on hard context limits. `incremental_max_depth=1` produces flat DAGs, preventing hierarchical summarization. `fresh_tail_count=64` shields too many recent messages per cycle.

There was also no way to tune LCM compaction independently of Hermes `compression.threshold` via `config.yaml`. Operators had to use the `LCM_CONTEXT_THRESHOLD` environment variable as the only override.

**Default changes:**

| Setting | Old | New | Rationale |
|---|---|---|---|
| `context_threshold` | 0.75 | 0.35 | Compaction fires at 35% of context window (~71k tokens on 204k ctx) |
| `fresh_tail_count` | 64 | 32 | Fewer messages shielded per cycle, more room for useful history |
| `incremental_max_depth` | 1 | 3 | Enables hierarchical DAG: leaf → d1 → d2 → d3 |

**Config priority:** `LCM_CONTEXT_THRESHOLD` env → `lcm.context_threshold` (config.yaml) → `compression.threshold` (config.yaml, unless disabled) → dataclass default (0.35).

## Validation

- [x] Focused validation: `pytest tests/test_lcm_core.py::TestConfig -v` → 21 passed (0.65s)
- [x] Default validation: `pytest tests/test_lcm_core.py tests/test_lcm_preset_command.py -q` → all pass
- [x] CI (all 4 Python versions + workflow-lint): all green
- [x] `git diff --check` → clean
- [x] Regression tests for `lcm.context_threshold` priority (with and without pyyaml)
- [x] Regression tests for nested key indent tracking in no-yaml fallback parser

## Notes

- **Risk:** Medium — changing defaults affects users who haven't explicitly set these values. However, the old defaults were broken for any context window >150k tokens. Users who explicitly set `LCM_CONTEXT_THRESHOLD` or `compression.threshold` are unaffected.
- **Blast radius:** Users on small-context models (<8k tokens) may see slightly more frequent compaction. Fix: set `lcm.context_threshold: 0.75` in `config.yaml` to restore old behavior.
- The no-yaml fallback parser originally had indent tracking (`direct_indent`) that was lost in the initial commit. Restored in follow-up commit with regression tests.

Refs #