### PR TITLE
fix: isolate LCM engine state per agent

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -4,6 +4,7 @@ Implements the ContextEngine ABC. Replaces the built-in ContextCompressor
 with a DAG-based summarization system that preserves every message.
 """
 
+import copy
 import inspect
 import json
 import logging
@@ -386,6 +387,25 @@ class LCMEngine(ContextEngine):
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
         self._auxiliary_session_lock = threading.RLock()
+
+    def clone_for_agent(self) -> "LCMEngine":
+        """Return a fresh runtime engine for one AIAgent instance.
+
+        Hermes registers plugin context engines process-wide, while gateway
+        runtimes may keep multiple cached AIAgent instances alive at once
+        (different platforms, chats, cron jobs, etc.).  LCM stores mutable
+        session binding and ingest cursor state on the engine object itself, so
+        sharing one registered instance across agents can let one conversation
+        rebind another conversation's raw-message ingest and lifecycle state.
+
+        The clone shares the same durable SQLite database path/configuration,
+        but gets independent session/cursor/lifecycle runtime state. Hermes core
+        calls update_model() on the returned engine before on_session_start().
+        """
+        return type(self)(
+            config=copy.deepcopy(self._config),
+            hermes_home=self._hermes_home,
+        )
 
     def _resolve_db_path(self, hermes_home: str = "") -> Path:
         """Resolve the SQLite path for the active Hermes profile/home."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ if pkg_name not in sys.modules:
             sub_mod = importlib.util.module_from_spec(sub_spec)
             sub_mod.__package__ = pkg_name
             sys.modules[sub_name] = sub_mod
+            setattr(mod, py_file.stem, sub_mod)
             try:
                 sub_spec.loader.exec_module(sub_mod)
             except Exception:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4457,3 +4457,58 @@ class TestExtraction:
             assert "s2" in content
         finally:
             ext_module._call_extraction_llm = original
+
+
+class TestLCMEngineCloning:
+    def test_clone_for_agent_isolates_session_binding_while_sharing_store(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-clone.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        first_agent = prototype.clone_for_agent()
+        second_agent = prototype.clone_for_agent()
+        assert first_agent is not prototype
+        assert second_agent is not prototype
+        assert first_agent is not second_agent
+
+        first_agent.on_session_start(
+            "agent-a-session",
+            platform="alpha",
+            conversation_id="agent:main:alpha:dm:1",
+        )
+        second_agent.on_session_start(
+            "agent-b-session",
+            platform="beta",
+            conversation_id="agent:main:beta:dm:2",
+        )
+
+        first_agent.on_session_end(
+            "agent-a-session",
+            [
+                {"role": "user", "content": "alpha question"},
+                {"role": "assistant", "content": "alpha answer"},
+            ],
+        )
+
+        rows = sqlite3.connect(config.database_path).execute(
+            "SELECT session_id, source, role, content FROM messages ORDER BY store_id"
+        ).fetchall()
+        assert rows == [
+            ("agent-a-session", "alpha", "user", "alpha question"),
+            ("agent-a-session", "alpha", "assistant", "alpha answer"),
+        ]
+
+        lifecycle = LifecycleStateStore(config.database_path)
+        try:
+            first_state = lifecycle.get_by_conversation("agent:main:alpha:dm:1")
+            second_state = lifecycle.get_by_conversation("agent:main:beta:dm:2")
+            assert first_state is not None
+            assert first_state.current_session_id is None
+            assert first_state.last_finalized_session_id == "agent-a-session"
+            assert second_state is not None
+            assert second_state.current_session_id == "agent-b-session"
+            assert second_state.last_finalized_session_id is None
+        finally:
+            lifecycle.close()
+            for engine in (prototype, first_agent, second_agent):
+                engine.shutdown()


### PR DESCRIPTION
## Summary

- Add `LCMEngine.clone_for_agent()` so Hermes can create one runtime LCM engine per `AIAgent`.
- The clone shares the configured SQLite database path/configuration but gets isolated session binding, lifecycle, and ingest cursor state.
- Add a regression proving two cloned engines can bind different conversations and finalizing one does not write/finalize the other.
- Fix the test package shim so monkeypatch paths like `hermes_lcm.db_bootstrap...` resolve through the parent package.

## Why

`LCMEngine` stores mutable runtime state on the engine object (`_session_id`, `_conversation_id`, ingest cursor/frontier, foreground markers). Hermes gateway can keep multiple cached agents alive at once. If all agents reuse the one plugin-registered engine object, one conversation can rebind another conversation's LCM ingest/finalization state.

This is the preferred LCM-side shape for #243 because it isolates the full runtime engine instead of trying to scope selected mutable fields on a shared object.

This pairs with NousResearch/hermes-agent#42683, which adds the host-side optional clone hook. Without that host change, this method is harmless but not called by Hermes core.

## Validation

Current PR head: `6c00c13f382147f6b42e1e23ebfbb5347ecb6fe0`
Current base used for refresh: `66cb6c78fe82b0f18f0d94734acd6d307b846276`

- [x] Focused validation: `python -m pytest -q tests/test_lcm_core.py::TestLCMEngineCloning::test_clone_for_agent_isolates_session_binding_while_sharing_store` -> `1 passed, 21 warnings`
- [x] Focused/default slice: `python -m pytest -q tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_host_capability.py` -> `639 passed, 46 warnings`
- [x] Default validation: `python -m pytest -q` -> `921 passed, 60 warnings`
- [x] Low-fd default validation: `prlimit --nofile=1024:1024 -- python -m pytest -q` -> `921 passed, 60 warnings`
- [x] `python -m compileall -q .` -> passed
- [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
- [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
- [x] `git diff --check origin/main...HEAD` -> passed

## Notes

- Original implementation and regression are by @the3asic in this PR.
- Maintainer refresh merged current `main` into the contributor branch so authorship/history is preserved.
- This should use `Refs #243`, not a closing keyword, until the host-side clone hook in NousResearch/hermes-agent#42683 lands and is verified.
- Follow-up review should verify Hermes Agent calls `clone_for_agent()` before per-agent `update_model()` / `on_session_start()`, and that slash/status command routing does not keep pointing at the unused prototype engine.

Refs #243
