### PR TITLE
docs: clarify LCM database path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ environment variables:
 | `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Context budget used by the auxiliary LLM for `lcm_expand_query` |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for one summarization call |
 | `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for one `lcm_expand_query` synthesis call |
-| `LCM_DATABASE_PATH` | auto | SQLite database path, profile-scoped by default |
+| `LCM_DATABASE_PATH` | auto | SQLite database path. Empty config resolves to `HERMES_HOME/lcm.db`; plugin installs or operators may set this env var to another profile-scoped path such as `~/.hermes/hermes-lcm.db`. |
 | `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` | `24` | Minimum hours between startup FTS5 deep integrity-checks (O(index size)). `0` checks every startup (previous behavior); a negative value never checks on startup. Structural checks always run regardless. |
 | `LCM_ENABLE_SLASH_COMMAND` | `false` | Enable the optional `/lcm` operator command surface |
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |

--- a/config.py
+++ b/config.py
@@ -311,7 +311,7 @@ class LCMConfig:
     expansion_timeout_ms: int = 120_000
 
     # -- Storage ---
-    database_path: str = ""       # empty = auto (~/.hermes/lcm.db)
+    database_path: str = ""       # empty = HERMES_HOME/lcm.db; LCM_DATABASE_PATH may override
 
     # -- Session carry-over ---
     # Depth retained after /new (-1 = all, 0 = nothing, 2 = keep d2+)


### PR DESCRIPTION
## Summary
- Clarify that empty `database_path` resolves to `HERMES_HOME/lcm.db`.
- Document that `LCM_DATABASE_PATH` can override that default, including plugin/operator paths such as `~/.hermes/hermes-lcm.db`.

## Why
- Fixes stale operator-facing wording that made plugin installs look contradictory when `lcm_doctor` reported an env-overridden database path.

## Validation
- [x] Focused validation: `python -m pytest -q tests/test_lcm_core.py::TestConfig` -> `21 passed`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: not applicable

## Notes
- Docs/comment-only fix. No runtime behavior changed.
- Full test suite skipped because this PR only changes docs and a config comment.

Fixes #246
