### PR TITLE
test: make write-lock concurrency timeout load tolerant

### DIFF
--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2191,9 +2191,17 @@ class TestMessageStore:
         ]
         for t in threads:
             t.start()
+
+        # Slow hardware can make a single worker exceed the old fixed
+        # per-thread 30s join while the write-lock contract is still healthy.
+        # Use one larger wall-clock deadline for the whole storm: enough
+        # headroom for constrained machines, but still bounded for real hangs.
+        deadline = time.monotonic() + 120
         for t in threads:
-            t.join(timeout=30)
-            assert not t.is_alive(), "worker thread did not finish in time"
+            remaining = max(0.0, deadline - time.monotonic())
+            t.join(timeout=remaining)
+        alive_threads = [t.name for t in threads if t.is_alive()]
+        assert alive_threads == [], f"worker threads did not finish in time: {alive_threads!r}"
 
         assert errors == [], f"concurrent workers raised: {errors!r}"
 


### PR DESCRIPTION
## Summary
- Replace the per-thread 30s join in the write-lock concurrency test with one 120s wall-clock deadline for the whole write storm.
- Keep the same 8-thread, 400-write workload and row-count/quick-check assertions.

## Why
- On constrained hardware, one worker can exceed the old fixed per-thread 30s join while the store serialization contract is still healthy.
- A single larger global deadline gives slow machines headroom without making true hangs wait up to 8 separate timeout windows.

## Validation
- [x] Focused validation: `python -m pytest -q tests/test_lcm_core.py::TestMessageStore::test_write_lock_serializes_concurrent_appends` -> `1 passed`
- [x] Focused validation under CPU contention: same pytest command with four `yes` CPU burners spawned by Python -> `1 passed`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q tests/test_lcm_core.py` -> passed
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: not applicable

## Notes
- Test-only change. It does not weaken the concurrency workload or storage assertions.
- Full suite skipped locally because the changed surface is one focused test and PR CI runs the full matrix.

Fixes #248
