### PR TITLE
fix: skip unbacked active summary scaffolds

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1061,16 +1061,29 @@ class LCMEngine(ContextEngine):
                     compressed,
                     assembly_cap_override=recovery_assembly_cap,
                 )
-            sanitized_messages = self._sanitize_active_context_messages(
-                working_messages,
-                insert_missing_tool_stubs=False,
-            )
+            if dropped_replayed_scaffold_messages:
+                leading_anchor_count = self._leading_anchor_count(working_messages)
+                anchor_leading_count = self._leading_anchor_count(anchor_source_messages)
+                self._pending_context_anchor_messages = anchor_source_messages[anchor_leading_count:]
+                try:
+                    sanitized_messages = self._assemble_context(
+                        working_messages[0] if leading_anchor_count else None,
+                        working_messages[leading_anchor_count:],
+                        assembly_cap_override=recovery_assembly_cap,
+                    )
+                finally:
+                    self._pending_context_anchor_messages = None
+            else:
+                sanitized_messages = self._sanitize_active_context_messages(
+                    working_messages,
+                    insert_missing_tool_stubs=False,
+                )
             if sanitized_messages != working_messages:
                 # _ingest_messages() already advanced the cursor to the original
                 # active-context length. If the host continues from a sanitized
-                # context, keeping the old cursor could make the next appended
-                # messages look already ingested. This applies to content-only
-                # cleanup as well as dropped-message cleanup.
+                # or reassembled context, keeping the old cursor could make the
+                # next appended messages look already ingested. This applies to
+                # content-only cleanup as well as dropped-message cleanup.
                 self._ingest_cursor = len(sanitized_messages)
                 self._last_compression_status = "sanitized"
                 self._last_compression_noop_reason = ""

--- a/engine.py
+++ b/engine.py
@@ -897,6 +897,7 @@ class LCMEngine(ContextEngine):
         anchor_source_messages = list(working_messages)
         pressure_messages = messages if len(messages) == len(working_messages) else working_messages
         leaf_compacted_this_turn = False
+        dropped_replayed_scaffold_messages = False
         leaf_passes = 0
         critical_budget_pressure = self._critical_budget_pressure_reached(
             observed_tokens=observed_prompt_tokens,
@@ -934,6 +935,22 @@ class LCMEngine(ContextEngine):
             if fresh_tail_start <= leading_anchor_count:
                 noop_reason = "no eligible raw backlog outside fresh tail"
                 break
+
+            candidate_start = leading_anchor_count
+            while (
+                candidate_start < fresh_tail_start
+                and self._is_replayed_context_scaffold_message(working_messages[candidate_start])
+            ):
+                candidate_start += 1
+            if candidate_start > leading_anchor_count:
+                dropped_replayed_scaffold_messages = True
+                working_messages = working_messages[:leading_anchor_count] + working_messages[candidate_start:]
+                pressure_messages = pressure_messages[:leading_anchor_count] + pressure_messages[candidate_start:]
+                n = len(working_messages)
+                fresh_tail_start = max(0, n - self._config.fresh_tail_count)
+                if fresh_tail_start <= leading_anchor_count:
+                    noop_reason = "selected leaf chunk lacks raw store lineage"
+                    break
 
             candidate_raw = working_messages[leading_anchor_count:fresh_tail_start]
             if not candidate_raw:
@@ -1058,6 +1075,11 @@ class LCMEngine(ContextEngine):
                 self._last_compression_status = "sanitized"
                 self._last_compression_noop_reason = ""
             else:
+                if dropped_replayed_scaffold_messages:
+                    # The active context changed even though no new leaf node was
+                    # written. Keep the cursor aligned with the returned context
+                    # so the next appended turn is ingested instead of skipped.
+                    self._ingest_cursor = len(sanitized_messages)
                 self._last_compression_status = "noop"
                 self._last_compression_noop_reason = noop_reason
                 logger.info("LCM compression no-op: %s", noop_reason)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3612,6 +3612,51 @@ class TestEngineCompress:
         assert engine._last_compression_status == "sanitized"
         assert engine._last_compression_noop_reason == ""
 
+    def test_compress_drops_unbacked_active_summary_marker_without_leaf_node(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Synthetic active summaries must not become leaf nodes with source_ids=[]."""
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=10,
+            database_path=str(tmp_path / "lcm_unbacked_active_summary.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("summary-marker-session", platform="telegram", context_length=200000)
+        instance._ingest_cursor = 3
+        instance._ingest_cursor_needs_reconcile = False
+
+        def fail_summary(**_kwargs):
+            raise AssertionError("unbacked synthetic summaries must not be summarized as raw leaves")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_summary)
+
+        active_summary_marker = (
+            "[Recent Summary (d0, node 123)]\n"
+            + ("prior compressed details " * 1000)
+            + "\n[Expand for details: prior details]"
+        )
+        messages = [
+            {"role": "assistant", "content": active_summary_marker},
+            {"role": "user", "content": "fresh tail question"},
+            {"role": "assistant", "content": "fresh tail answer"},
+        ]
+
+        try:
+            result = instance.compress(messages)
+            nodes = instance._dag.get_session_nodes("summary-marker-session")
+        finally:
+            instance.shutdown()
+
+        assert result == messages[1:]
+        assert len(result) < len(messages)
+        assert instance._ingest_cursor == len(result)
+        assert nodes == []
+        assert instance._last_compression_status == "noop"
+        assert "raw store lineage" in instance._last_compression_noop_reason
+
     def test_compress_handles_multimodal_first_user_message_without_system(self, engine, monkeypatch):
         """Gateway sessions may pass conversation messages without a leading system prompt."""
         def mock_summary(**kwargs):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3657,6 +3657,68 @@ class TestEngineCompress:
         assert instance._last_compression_status == "noop"
         assert "raw store lineage" in instance._last_compression_noop_reason
 
+    def test_compress_reassembles_backed_active_summary_marker_on_noop(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Backed active summaries must stay visible when scaffold cleanup no-ops."""
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=10,
+            database_path=str(tmp_path / "lcm_backed_active_summary.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("backed-summary-session", platform="telegram", context_length=200000)
+
+        summary_text = "backed compressed details\nExpand for details about: backed prior"
+        node_id = instance._dag.add_node(
+            SummaryNode(
+                session_id="backed-summary-session",
+                depth=0,
+                summary=summary_text,
+                token_count=3,
+                source_token_count=50,
+                source_ids=[1],
+                source_type="messages",
+                created_at=time.time(),
+                earliest_at=time.time(),
+                latest_at=time.time(),
+                expand_hint="backed prior",
+            )
+        )
+        instance._ingest_cursor = 3
+        instance._ingest_cursor_needs_reconcile = False
+
+        def fail_summary(**_kwargs):
+            raise AssertionError("backed active summaries should be reassembled, not summarized")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_summary)
+
+        active_summary_marker = (
+            f"[Recent Summary (d0, node {node_id})]\n"
+            f"{summary_text}\n"
+            "[Expand for details: backed prior]"
+        )
+        messages = [
+            {"role": "assistant", "content": active_summary_marker},
+            {"role": "user", "content": "fresh tail question"},
+            {"role": "assistant", "content": "fresh tail answer"},
+        ]
+
+        try:
+            result = instance.compress(messages)
+            nodes = instance._dag.get_session_nodes("backed-summary-session")
+        finally:
+            instance.shutdown()
+
+        assert result == messages
+        assert len(nodes) == 1
+        assert nodes[0].node_id == node_id
+        assert instance._ingest_cursor == len(result)
+        assert instance._last_compression_status == "sanitized"
+        assert instance._last_compression_noop_reason == ""
+
     def test_compress_handles_multimodal_first_user_message_without_system(self, engine, monkeypatch):
         """Gateway sessions may pass conversation messages without a leading system prompt."""
         def mock_summary(**kwargs):


### PR DESCRIPTION
## Summary
- Skip replayed LCM context scaffold messages at the head of the compaction candidate window before selecting a raw leaf.
- Reassemble active context from the DAG when scaffold cleanup reaches a no-op, so backed summary nodes stay visible.
- Keep the ingest cursor aligned when scaffold cleanup returns a shorter active context without writing a new leaf node.
- Add regressions for both unbacked active markers and backed summary markers.

## Why
- Synthetic active summary markers already point at existing DAG lineage. They are not raw store rows.
- Treating one as the oldest raw leaf candidate can create a new leaf node with empty lineage and an ineffective visible `N -> N` compression result.
- Skipping replayed scaffolds prevents empty-lineage leaves. Reassembling on no-op preserves real DAG-backed summaries instead of dropping compacted history.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py::TestEngineCompress::test_compress_drops_unbacked_active_summary_marker_without_leaf_node tests/test_lcm_engine.py::TestEngineCompress::test_compress_reassembles_backed_active_summary_marker_on_noop tests/test_lcm_engine.py::TestStoreIdMapping::test_source_ids_correct_after_second_compaction tests/test_lcm_engine.py::TestStoreIdMapping::test_repeated_content_maps_to_later_store_rows tests/test_lcm_engine.py::TestSessionRollover::test_frontier_marker_only_advances_after_successful_leaf_compaction -q` -> 5 passed
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 631 passed
  - [x] `python -m pytest -q` -> 923 passed
  - [x] `bash -lc 'ulimit -n 1024 && python -m pytest -q'` -> 923 passed
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: not applicable, no workflow changes

## Notes
- Addressed Codex review on preserving backed summaries during no-op compression in `585cc75`.
- The host-side TUI usage and manual gateway compress source-attribution reports are separate integration trackers.

Fixes #252
