### PR TITLE
fix: per-turn ingest for WebUI sessions + batch timestamp dedup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -137,4 +137,30 @@ def register(ctx):
     else:
         logger.info("LCM slash command registration unavailable on this Hermes host; continuing without /lcm")
 
+    # Register a post_llm_call hook so every completed turn is persisted to
+    # the durable store, regardless of whether compression triggers.  Without
+    # this, short WebUI conversations (which never expire and may never hit
+    # the compression threshold) are invisible to LCM forever.
+    #
+    # The hook fires once per turn after the tool-calling loop completes and
+    # receives conversation_history including the assistant response.  The
+    # existing _ingest_messages cursor prevents duplicates if compress() runs
+    # later the same turn.
+    try:
+        from hermes_cli.plugins import get_plugin_manager as _get_pm
+        _mgr = _get_pm()
+
+        def _on_post_llm_call(**kwargs):
+            history = kwargs.get("conversation_history")
+            if history:
+                try:
+                    engine.ingest(history)
+                except Exception as exc:
+                    logger.debug("LCM post_llm_call ingest error: %s", exc)
+
+        _mgr._hooks.setdefault("post_llm_call", []).append(_on_post_llm_call)
+        logger.debug("LCM registered post_llm_call hook for per-turn ingest")
+    except Exception as exc:
+        logger.debug("LCM could not register post_llm_call hook: %s", exc)
+
     logger.info("LCM plugin loaded — lossless context management active")

--- a/engine.py
+++ b/engine.py
@@ -651,7 +651,7 @@ class LCMEngine(ContextEngine):
     def ingest(self, messages: List[Dict[str, Any]]) -> None:
         """Persist messages to the durable store every turn.
 
-        Called by the host (turn_context) so messages land in LCM
+        Called by the post_llm_call plugin hook so messages land in LCM
         regardless of whether compression triggers — short WebUI
         conversations never hit the compression threshold and never
         expire like Telegram sessions do, so without this they'd never

--- a/engine.py
+++ b/engine.py
@@ -648,6 +648,31 @@ class LCMEngine(ContextEngine):
         self._last_boundary_skip_time = 0
         return False
 
+    def ingest(self, messages: List[Dict[str, Any]]) -> None:
+        """Persist messages to the durable store every turn.
+
+        Called by the host (turn_context) so messages land in LCM
+        regardless of whether compression triggers — short WebUI
+        conversations never hit the compression threshold and never
+        expire like Telegram sessions do, so without this they'd never
+        be ingested.
+
+        Uses the same _ingest_messages cursor as compress(), so if
+        compression runs later the same turn, already-ingested messages
+        are skipped (no duplicates).
+        """
+        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
+            return
+        if self._session_id and messages:
+            try:
+                self._ingest_messages(messages)
+                logger.debug(
+                    "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
+                    self._session_id, len(messages), self._ingest_cursor,
+                )
+            except Exception as e:
+                logger.warning("Ingest during per-turn ingest(): %s", e)
+
     def should_compress(self, prompt_tokens: int = None) -> bool:
         if self._session_ignored or self._session_stateless or self._thread_context_stateless():
             return False

--- a/store.py
+++ b/store.py
@@ -333,7 +333,7 @@ class MessageStore:
             for msg, est in zip(protected_messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
-                ts = time.time()  # ← Each message gets its own timestamp!
+                ts = time.time()
                 cur = self._conn.execute(
                     """INSERT INTO messages
                        (session_id, source, role, content, tool_call_id, tool_calls,

--- a/store.py
+++ b/store.py
@@ -329,11 +329,11 @@ class MessageStore:
         )
 
         ids = []
-        ts = time.time()
         with self._write_lock, self._conn:
             for msg, est in zip(protected_messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
+                ts = time.time()  # ← Each message gets its own timestamp!
                 cur = self._conn.execute(
                     """INSERT INTO messages
                        (session_id, source, role, content, tool_call_id, tool_calls,

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2072,6 +2072,26 @@ class TestMessageStore:
         # unlimited search — i.e. the sort order is deterministic.
         assert [result["store_id"] for result in short_results] == [result["store_id"] for result in long_results[:5]]
 
+    def test_append_batch_timestamps_are_unique_per_row(self, store):
+        """Regression: each message in a batch must get its own timestamp.
+
+        The old code called time.time() once before the loop, giving every
+        message in the batch the same timestamp.  This broke date-based
+        queries (journal entries, time-range filtering).
+        """
+        n = 50
+        ids = store.append_batch(
+            "ts-sess",
+            [{"role": "user", "content": f"msg {i}"} for i in range(n)],
+        )
+        timestamps = [store.get(sid)["timestamp"] for sid in ids]
+        # All timestamps must be distinct — no two rows share the same value.
+        assert len(set(timestamps)) == n, (
+            f"Expected {n} unique timestamps, got {len(set(timestamps))}"
+        )
+        # Strictly non-decreasing (clock may tick between rows).
+        assert timestamps == sorted(timestamps)
+
     def test_search_hybrid_clamps_future_timestamps_consistently(self, store):
         now = time.time()
         future = now + (60 * 24 * 3600)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2062,12 +2062,14 @@ class TestMessageStore:
                 }
             ],
         )
-        timestamp = store.get(ids[0])["timestamp"]
 
         short_results = store.search("alpha beta gamma", session_id="sess1", limit=5, sort="recency")
         long_results = store.search("alpha beta gamma", session_id="sess1", limit=200, sort="recency")
 
-        assert [result["timestamp"] for result in short_results] == [timestamp] * len(short_results)
+        # With per-message timestamps (fix for batch timestamp dedup), messages
+        # no longer share identical timestamps.  The stability invariant is that
+        # the top-N results from a limited search match the first N of an
+        # unlimited search — i.e. the sort order is deterministic.
         assert [result["store_id"] for result in short_results] == [result["store_id"] for result in long_results[:5]]
 
     def test_search_hybrid_clamps_future_timestamps_consistently(self, store):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3505,6 +3505,110 @@ class TestEngineIngest:
         assert count == 2  # not duplicated
 
 
+class TestPerTurnIngest:
+    """Regression: per-turn ingest via post_llm_call hook."""
+
+    def test_below_threshold_turn_persists_without_compression(self, tmp_path):
+        """A short conversation that never hits the compression threshold
+        must still be persisted to the store when ingest() is called."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "below-threshold.db"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=100,
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start("webui-short", platform="webui", context_length=200000)
+        try:
+            messages = [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+            # Simulate what the post_llm_call hook does
+            eng.ingest(messages)
+
+            count = eng._store.get_session_count("webui-short")
+            assert count == 3, f"Expected 3 messages persisted, got {count}"
+
+            # Verify compression did NOT fire
+            assert eng.compression_count == 0
+        finally:
+            eng.shutdown()
+
+    def test_ingest_then_compress_no_duplicate_rows(self, tmp_path):
+        """Ingesting via post_llm_call and then compressing in the same turn
+        must not produce duplicate rows.  The existing cursor dedup ensures
+        already-ingested messages are skipped."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "no-dup.db"),
+            fresh_tail_count=2,
+            leaf_chunk_tokens=50,
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start("dup-test", platform="webui", context_length=200000)
+        try:
+            # Build a long conversation that WILL trigger compression
+            messages = [{"role": "system", "content": "You are helpful."}]
+            for i in range(20):
+                messages.append({"role": "user", "content": f"Q{i}: " + "x" * 200})
+                messages.append({"role": "assistant", "content": f"A{i}: " + "y" * 200})
+
+            # Step 1: post_llm_call hook ingests
+            eng.ingest(messages)
+            count_after_ingest = eng._store.get_session_count("dup-test")
+            assert count_after_ingest > 0
+
+            # Step 2: preflight compression runs (same turn)
+            eng.compress(messages)
+            count_after_compress = eng._store.get_session_count("dup-test")
+
+            # No new rows from messages already ingested
+            assert count_after_compress == count_after_ingest, (
+                f"Duplicate rows: {count_after_compress} after compress vs "
+                f"{count_after_ingest} after ingest"
+            )
+        finally:
+            eng.shutdown()
+
+    def test_ignored_session_ingest_persists_nothing(self, tmp_path):
+        """Ingest must be a no-op for ignored sessions."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "ignored-ingest.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start("cron_999", platform="cron", context_length=1000)
+        try:
+            messages = [
+                {"role": "user", "content": "ignored"},
+                {"role": "assistant", "content": "also ignored"},
+            ]
+            eng.ingest(messages)
+
+            assert eng._store.get_session_count("cron_999") == 0
+        finally:
+            eng.shutdown()
+
+    def test_stateless_session_ingest_persists_nothing(self, tmp_path):
+        """Ingest must be a no-op for stateless sessions."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "stateless-ingest.db"),
+            stateless_session_patterns=["telegram:*"],
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start("debug", platform="telegram", context_length=1000)
+        try:
+            messages = [
+                {"role": "user", "content": "stateless"},
+                {"role": "assistant", "content": "also stateless"},
+            ]
+            eng.ingest(messages)
+
+            assert eng._store.get_session_count("debug") == 0
+        finally:
+            eng.shutdown()
+
+
 class TestEngineCompress:
     def _make_long_conversation(self, n_turns=20):
         """Build a conversation with enough messages to trigger compaction."""


### PR DESCRIPTION
## Summary

Two fixes for LCM message persistence:

1. **Per-turn ingest (`__init__.py` + `engine.py`):** Register a `post_llm_call` plugin hook that calls `engine.ingest(conversation_history)` after every completed turn.  Messages land in the durable store regardless of whether compression triggers.  The existing `_ingest_messages` cursor prevents duplicates if `compress()` runs later the same turn.

2. **Batch timestamp dedup (`store.py`):** Move `time.time()` inside the for-loop in `append_batch()` so each message gets its own unique timestamp.

## Why

### 1. WebUI messages never reach LCM

LCM only ingests messages when (a) compression triggers, (b) `on_session_end` fires, or (c) an LCM tool is called.  Telegram sessions expire → cleanup → `on_session_end()` → ingest.  But WebUI sessions stay alive forever in the browser, and short conversations never hit the compression threshold.  Result: **WebUI messages from short conversations are invisible to LCM forever** — journal crons, cross-session search, and memory providers all miss them.

### 2. Batch timestamp collision

`append_batch()` calculated `time.time()` **once** before the loop and reused it for ALL messages in the batch.  Result: 50-122+ messages sharing identical timestamps, breaking all date-based queries (journal entries pull wrong days, time-range filtering returns wrong results).

## Validation

- [x] Focused validation: `python3 -m compileall -q .` → clean
- [x] Focused validation: `git diff --check` → clean
- [x] Default validation: `pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q` → 630 passed, 1 warning (deprecation), 0 failed (1 pre-existing timeout unrelated to this change)
- [x] `python -m compileall -q .` → clean

## Regressions

Five deterministic regression tests added:

- `test_append_batch_timestamps_are_unique_per_row` — 50-message batch, all timestamps distinct and non-decreasing
- `test_below_threshold_turn_persists_without_compression` — 3-message conversation persisted, compression count stays 0
- `test_ingest_then_compress_no_duplicate_rows` — ingest then compress on a long conversation, row count unchanged
- `test_ignored_session_ingest_persists_nothing` — `cron:*` pattern, ingest is a no-op
- `test_stateless_session_ingest_persists_nothing` — `telegram:*` pattern, ingest is a no-op

## Architecture

The `post_llm_call` hook is registered from the LCM plugin's `register()` function via `get_plugin_manager()._hooks`.  It fires once per turn after the tool-calling loop completes and receives `conversation_history` including the assistant response.  This is a **self-contained LCM-local fix** — no companion hermes-agent PR is required.

`_ingest_messages()` is called from:
1. `compress()` — only when threshold exceeded
2. `on_session_end()` — only on session expiry
3. `handle_tool_call()` — only when LCM tools invoked
4. **`post_llm_call` hook** (new) — unconditionally every turn

The existing cursor-based dedup means if `compress()` runs later the same turn, already-ingested messages are skipped.

## Notes

- Zero extra LLM calls — `_ingest_messages()` is pure SQLite writes.  LLM calls only happen inside `compress()` for summarization.
- The companion hermes-agent PR (#47243) that added `ingest()` calls from `turn_context.py` is **no longer needed** — the hook approach is self-contained.