### PR TITLE
perf: avoid duplicate ingest protection

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3380,7 +3380,7 @@ class LCMEngine(ContextEngine):
                 active_replay_messages[absolute_idx] = active_message
 
         estimates = [count_message_tokens(m) for m in protected_messages]
-        self._store.append_batch(
+        self._store._append_protected_batch(
             self._session_id,
             protected_messages,
             estimates,

--- a/store.py
+++ b/store.py
@@ -318,19 +318,36 @@ class MessageStore:
                      token_estimates: List[int] | None = None,
                      source: str = "") -> List[int]:
         """Persist multiple messages in one transaction. Returns store_ids."""
-        if token_estimates is None:
-            token_estimates = [0] * len(messages)
-
         protected_messages = protect_messages_for_ingest(
             messages,
             config=self._ingest_protection_config,
             hermes_home=self._hermes_home,
             session_id=session_id,
         )
+        return self._append_protected_batch(
+            session_id,
+            protected_messages,
+            token_estimates,
+            source=source,
+        )
+
+    def _append_protected_batch(self, session_id: str,
+                                messages: List[Dict[str, Any]],
+                                token_estimates: List[int] | None = None,
+                                source: str = "") -> List[int]:
+        """Persist messages that already passed ingest protection.
+
+        This is an internal fast path for callers that need the protected form
+        before storage, for example to update active replay with raw-payload
+        stubs. Direct callers should use ``append_batch`` so storage-boundary
+        payload protection cannot be bypassed accidentally.
+        """
+        if token_estimates is None:
+            token_estimates = [0] * len(messages)
 
         ids = []
         with self._write_lock, self._conn:
-            for msg, est in zip(protected_messages, token_estimates):
+            for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
                 ts = time.time()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -17,6 +17,7 @@ from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 import hermes_lcm.engine as lcm_engine_module
+import hermes_lcm.store as lcm_store_module
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
 from hermes_lcm.externalize import (
     build_transcript_gc_placeholder,
@@ -103,6 +104,37 @@ def _expand_ref(engine: LCMEngine, ref: str) -> dict:
 
 def _externalized_files(tmp_path: Path) -> list[Path]:
     return sorted((tmp_path / "externalized").glob("*.json"))
+
+
+def test_engine_ingest_does_not_reprotect_messages_in_store(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+
+    def fail_if_store_protects_again(*_args, **_kwargs):
+        raise AssertionError("engine ingest already protected this batch")
+
+    monkeypatch.setattr(lcm_store_module, "protect_messages_for_ingest", fail_if_store_protects_again)
+
+    engine._ingest_messages([{"role": "user", "content": "hello"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert content == "hello"
+
+
+def test_store_append_batch_still_protects_direct_callers(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+    calls = []
+
+    def mark_protected(messages, **_kwargs):
+        calls.append(len(messages))
+        return [dict(message, content="protected by store") for message in messages]
+
+    monkeypatch.setattr(lcm_store_module, "protect_messages_for_ingest", mark_protected)
+
+    ids = engine._store.append_batch("direct-session", [{"role": "user", "content": "raw"}], [1])
+
+    assert calls == [1]
+    stored = engine._store.get(ids[0])
+    assert stored["content"] == "protected by store"
 
 
 def test_sensitive_patterns_disabled_by_default_preserves_lossless_raw_text(tmp_path):


### PR DESCRIPTION
## Why

Engine ingest already protects messages before storage so it can use the protected form for active replay stubs and token estimates. The store then protected the same batch again through `append_batch()`. That repeats the storage-boundary scan on the per-turn ingest path.

This keeps the safe public store API intact while letting the engine skip the duplicate pass when it has already protected the batch.

## What changed

- Added an internal `_append_protected_batch()` store fast path for messages that already passed ingest protection.
- Kept `MessageStore.append_batch()` as the safe direct-call path that always protects before writing.
- Switched engine ingest to the protected fast path after its existing protection step.
- Added regressions for both sides of the contract: engine ingest does not re-protect, direct store callers still do.

## Validation

- `python3 -m pytest tests/test_ingest_protection.py -q` → 99 passed
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_ingest_protection.py -q` → 730 passed, 1 warning
- `python3 -m pytest -q` → 960 passed, 1 warning
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 960 passed, 1 warning
- `python3 -m compileall -q .`
- `python3 -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`

I also ran a small local ingest benchmark against `origin/main`. The branch was slightly faster in wall-clock terms, but the main point is the removed duplicate protection call rather than a claimed headline speedup.
