### PR TITLE
fix: preserve source lineage after long sessions

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3412,10 +3412,23 @@ class LCMEngine(ContextEngine):
         content from older already-compacted history cannot hijack the mapping.
         Synthetic summary messages simply fail to match and are skipped.
         """
-        candidates = [
-            stored for stored in self._store.get_session_messages(self._session_id)
-            if stored["store_id"] > self._last_compacted_store_id
-        ]
+        candidates: list[Dict[str, Any]] = []
+        next_candidate_after = self._last_compacted_store_id
+        candidates_exhausted = False
+
+        def ensure_candidate_loaded(index: int) -> bool:
+            nonlocal next_candidate_after, candidates_exhausted
+            while index >= len(candidates) and not candidates_exhausted:
+                page = self._store.get_session_messages_after(
+                    self._session_id,
+                    after_store_id=next_candidate_after,
+                )
+                if not page:
+                    candidates_exhausted = True
+                    break
+                candidates.extend(page)
+                next_candidate_after = page[-1]["store_id"]
+            return index < len(candidates)
 
         ids: list[int] = []
         store_idx = 0
@@ -3423,7 +3436,7 @@ class LCMEngine(ContextEngine):
             message_identity = self._message_replay_identity(msg)
             wanted_cleanup_identity = self._active_cleanup_replay_identity(message_identity)
             probe_idx = store_idx
-            while probe_idx < len(candidates):
+            while ensure_candidate_loaded(probe_idx):
                 stored = candidates[probe_idx]
                 stored_identity = self._message_replay_identity(stored, stored_row=True)
                 if stored_identity == message_identity:

--- a/store.py
+++ b/store.py
@@ -549,6 +549,18 @@ class MessageStore:
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    def get_session_messages_after(self, session_id: str,
+                                   after_store_id: int = 0,
+                                   limit: int = 10000) -> List[Dict[str, Any]]:
+        """Get session messages after a store_id, ordered by store_id."""
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+               WHERE session_id = ? AND store_id > ?
+               ORDER BY store_id LIMIT ?""",
+            (session_id, after_store_id, limit),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def get_session_tail(self, session_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
         """Get the latest messages for a session, returned in store order."""
         if limit <= 0:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4025,6 +4025,33 @@ class TestEngineCompress:
         finally:
             esc._call_llm_for_summary = original_fn
 
+    def test_source_mapping_finds_rows_after_default_session_message_limit(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "lcm_long_source_lineage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("long-session", platform="cli", context_length=200000)
+
+            historical_messages = [
+                {"role": "user", "content": f"already compacted message {idx}"}
+                for idx in range(10_000)
+            ]
+            uncompacted_messages = [
+                {"role": "assistant", "content": f"uncompacted message {idx}"}
+                for idx in range(3)
+            ]
+            inserted_ids = instance._store.append_batch(
+                "long-session",
+                historical_messages + uncompacted_messages,
+                [1] * (len(historical_messages) + len(uncompacted_messages)),
+            )
+            instance._last_compacted_store_id = inserted_ids[9_999]
+
+            mapped_ids = instance._get_store_ids_for_messages(uncompacted_messages)
+
+            assert mapped_ids == inserted_ids[10_000:]
+        finally:
+            instance.shutdown()
+
     def test_compress_leaf_node_tracks_source_window_from_message_timestamps(self, engine):
         messages = self._make_long_conversation(20)
         engine._ingest_messages(messages)


### PR DESCRIPTION
## Why

Source lineage should not depend on a session staying under the default raw-message page size. `_get_store_ids_for_messages()` was loading the first 10,000 session rows through `get_session_messages()`, then filtering those rows after `_last_compacted_store_id`.

In a long session, once the compacted frontier moves past that first page, the mapper can miss valid uncompacted rows that are still in the store. That can produce summary nodes without the raw message source ids they actually summarize.

## What changed

- Added `MessageStore.get_session_messages_after()` for ordered paging after a store id.
- Changed source-id mapping to page candidates strictly after `_last_compacted_store_id` instead of loading the first capped session page.
- Added a regression with 10,003 stored rows, where the uncompacted rows sit just past the previous 10,000-row cap.

## Validation

- `python3 -m pytest tests/test_lcm_engine.py::TestEngineCompress::test_source_mapping_finds_rows_after_default_session_message_limit -q` → 1 passed
- `python3 -m pytest tests/test_lcm_engine.py::TestEngineCompress::test_source_mapping_finds_rows_after_default_session_message_limit tests/test_lcm_engine.py::TestEngineCompress::test_compress_leaf_node_tracks_source_window_from_message_timestamps tests/test_lcm_engine.py::TestEngineCompress::test_compress_leaf_node_tracks_source_ids_for_content_part_messages tests/test_lcm_rotate.py::test_rotate_apply_does_not_corrupt_source_lineage_on_next_compress -q` → 4 passed
- `python3 -m pytest tests/test_lcm_engine.py tests/test_lcm_rotate.py tests/test_lcm_core.py -q` → 652 passed, 1 warning
- `python3 -m pytest -q` → 963 passed, 1 warning
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 963 passed, 1 warning
- `python3 -m compileall -q .`
- `python3 -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
