### PR TITLE
perf: aggregate DAG status stats

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -306,6 +306,66 @@ class SummaryDAG:
         ).fetchone()
         return row[0] if row else 0
 
+    def get_session_node_count(self, session_id: str) -> int:
+        """Count summary nodes for a session without loading node rows."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM summary_nodes WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return int(row[0] if row else 0)
+
+    def get_session_depth_stats(self, session_id: str) -> Dict[int, Dict[str, int]]:
+        """Aggregate per-depth node/token stats for a session."""
+        rows = self._conn.execute(
+            """SELECT depth,
+                      COUNT(*) AS count,
+                      COALESCE(SUM(token_count), 0) AS tokens,
+                      COALESCE(SUM(source_token_count), 0) AS source_tokens
+               FROM summary_nodes
+               WHERE session_id = ?
+               GROUP BY depth
+               ORDER BY depth""",
+            (session_id,),
+        ).fetchall()
+        return {
+            int(row[0]): {
+                "count": int(row[1] or 0),
+                "tokens": int(row[2] or 0),
+                "source_tokens": int(row[3] or 0),
+            }
+            for row in rows
+        }
+
+    def get_session_depth_samples(
+        self,
+        session_id: str,
+        *,
+        per_depth_limit: int = 20,
+        depths: List[int] | None = None,
+    ) -> Dict[int, List[SummaryNode]]:
+        """Return a bounded ordered sample of nodes per depth."""
+        if per_depth_limit <= 0:
+            return {}
+        if depths is None:
+            depth_rows = self._conn.execute(
+                """SELECT DISTINCT depth FROM summary_nodes
+                   WHERE session_id = ?
+                   ORDER BY depth""",
+                (session_id,),
+            ).fetchall()
+            depths = [int(row[0]) for row in depth_rows]
+
+        samples: Dict[int, List[SummaryNode]] = {}
+        for depth in depths:
+            rows = self._conn.execute(
+                """SELECT * FROM summary_nodes
+                   WHERE session_id = ? AND depth = ?
+                   ORDER BY created_at LIMIT ?""",
+                (session_id, depth, per_depth_limit),
+            ).fetchall()
+            samples[int(depth)] = [self._row_to_node(row) for row in rows]
+        return samples
+
     def get_uncondensed_at_depth(self, session_id: str, depth: int,
                                   limit: int = 100) -> List[SummaryNode]:
         """Get nodes at a depth that haven't been condensed yet.

--- a/engine.py
+++ b/engine.py
@@ -2493,7 +2493,7 @@ class LCMEngine(ContextEngine):
             status["rotate_backup_error"] = str(exc)
         if session_id:
             status["store_messages"] = self._store.get_session_count(session_id)
-            status["dag_nodes"] = len(self._dag.get_session_nodes(session_id))
+            status["dag_nodes"] = self._dag.get_session_node_count(session_id)
             status["session_platform"] = self.current_session_platform
             status["session_ignored"] = self.current_session_ignored
             status["session_stateless"] = self.current_session_stateless

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -98,6 +98,119 @@ def test_lcm_status_json_reports_runtime_context_indicators(engine):
     assert payload["threshold_tokens"] == int(200000 * engine._config.context_threshold)
 
 
+def test_lcm_status_uses_dag_aggregates_without_loading_all_nodes(engine, monkeypatch):
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=0,
+        summary="leaf",
+        token_count=10,
+        source_token_count=100,
+        source_ids=[1],
+        source_type="messages",
+        created_at=1.0,
+        expand_hint="Expand for details about: leaf",
+    ))
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=1,
+        summary="parent",
+        token_count=5,
+        source_token_count=100,
+        source_ids=[1],
+        source_type="nodes",
+        created_at=2.0,
+        expand_hint="Expand for details about: parent",
+    ))
+
+    def fail_get_session_nodes(*_args, **_kwargs):
+        raise AssertionError("status should use aggregate DAG queries")
+
+    monkeypatch.setattr(engine._dag, "get_session_nodes", fail_get_session_nodes)
+
+    status = engine.get_status()
+    payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+
+    assert status["dag_nodes"] == 2
+    assert payload["dag"]["total_nodes"] == 2
+    assert payload["dag"]["total_tokens"] == 15
+    assert payload["dag"]["depths"] == {
+        "d0": {"count": 1, "tokens": 10, "source_tokens": 100},
+        "d1": {"count": 1, "tokens": 5, "source_tokens": 100},
+    }
+
+
+def test_lcm_describe_overview_uses_dag_aggregates_without_loading_all_nodes(engine, monkeypatch):
+    for idx in range(25):
+        engine._dag.add_node(SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary=f"leaf {idx}",
+            token_count=idx + 1,
+            source_token_count=10,
+            source_ids=[idx + 1],
+            source_type="messages",
+            created_at=float(idx + 1),
+            expand_hint=f"Expand for details about: leaf {idx}",
+        ))
+    engine._dag.add_node(SummaryNode(
+        session_id="test-session",
+        depth=1,
+        summary="parent",
+        token_count=7,
+        source_token_count=250,
+        source_ids=[1, 2],
+        source_type="nodes",
+        created_at=30.0,
+        expand_hint="Expand for details about: parent",
+    ))
+
+    def fail_get_session_nodes(*_args, **_kwargs):
+        raise AssertionError("describe overview should use aggregate DAG queries")
+
+    monkeypatch.setattr(engine._dag, "get_session_nodes", fail_get_session_nodes)
+
+    overview = json.loads(lcm_tools.lcm_describe({}, engine=engine))
+
+    assert overview["depths"]["d0"]["count"] == 25
+    assert overview["depths"]["d0"]["total_tokens"] == sum(range(1, 26))
+    assert overview["depths"]["d0"]["total_source_tokens"] == 250
+    assert len(overview["depths"]["d0"]["nodes"]) == 20
+    assert overview["depths"]["d1"]["count"] == 1
+    assert overview["depths"]["d1"]["nodes"][0]["expand_hint"] == "Expand for details about: parent"
+
+
+def test_lcm_status_and_describe_count_more_than_default_node_page(engine):
+    node_count = 1005
+    for idx in range(node_count):
+        engine._dag.add_node(SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary=f"leaf {idx}",
+            token_count=1,
+            source_token_count=2,
+            source_ids=[idx + 1],
+            source_type="messages",
+            created_at=float(idx + 1),
+            expand_hint=f"Expand for details about: leaf {idx}",
+        ))
+
+    status = engine.get_status()
+    payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+    overview = json.loads(lcm_tools.lcm_describe({}, engine=engine))
+
+    assert status["dag_nodes"] == node_count
+    assert payload["dag"]["total_nodes"] == node_count
+    assert payload["dag"]["depths"]["d0"] == {
+        "count": node_count,
+        "tokens": node_count,
+        "source_tokens": node_count * 2,
+    }
+    assert overview["depths"]["d0"]["count"] == node_count
+    assert overview["depths"]["d0"]["total_tokens"] == node_count
+    assert overview["depths"]["d0"]["total_source_tokens"] == node_count * 2
+    assert len(overview["depths"]["d0"]["nodes"]) == 20
+
+
 def test_lcm_status_json_reports_effective_config_sources(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes_home"
     hermes_home.mkdir()

--- a/tools.py
+++ b/tools.py
@@ -1007,26 +1007,31 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
         info = engine._dag.describe_subtree(node_id)
         return json.dumps(info)
 
-    all_nodes = engine._dag.get_session_nodes(session_id)
+    depth_stats = engine._dag.get_session_depth_stats(session_id)
+    depth_samples = engine._dag.get_session_depth_samples(
+        session_id,
+        per_depth_limit=20,
+        depths=list(depth_stats),
+    )
     overview = {
         "session_id": session_id,
         "store_message_count": engine._store.get_session_count(session_id),
         "depths": {},
     }
 
-    for depth in sorted({node.depth for node in all_nodes}):
-        nodes = [node for node in all_nodes if node.depth == depth]
+    for depth, stats in sorted(depth_stats.items()):
+        nodes = depth_samples.get(depth, [])
         overview["depths"][f"d{depth}"] = {
-            "count": len(nodes),
-            "total_tokens": sum(node.token_count for node in nodes),
-            "total_source_tokens": sum(node.source_token_count for node in nodes),
+            "count": stats["count"],
+            "total_tokens": stats["tokens"],
+            "total_source_tokens": stats["source_tokens"],
             "nodes": [
                 {
                     "node_id": node.node_id,
                     "token_count": node.token_count,
                     "expand_hint": node.expand_hint,
                 }
-                for node in nodes[:20]
+                for node in nodes
             ],
         }
 
@@ -1553,16 +1558,11 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     store_tokens = engine._store.get_session_token_total(session_id)
 
     # DAG stats by depth
-    all_nodes = engine._dag.get_session_nodes(session_id)
-    depths: dict[int, dict] = {}
-    for node in all_nodes:
-        d = depths.setdefault(node.depth, {"count": 0, "tokens": 0, "source_tokens": 0})
-        d["count"] += 1
-        d["tokens"] += node.token_count
-        d["source_tokens"] += node.source_token_count
+    depths = engine._dag.get_session_depth_stats(session_id)
 
     total_dag_tokens = sum(d["tokens"] for d in depths.values())
     total_source_tokens = sum(d["source_tokens"] for d in depths.values())
+    total_dag_nodes = sum(d["count"] for d in depths.values())
     compression_ratio = round(total_source_tokens / total_dag_tokens, 1) if total_dag_tokens > 0 else 0
     full_status = engine.get_status()
     lifecycle = full_status.get("lifecycle")
@@ -1603,7 +1603,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "estimated_tokens": store_tokens,
         },
         "dag": {
-            "total_nodes": len(all_nodes),
+            "total_nodes": total_dag_nodes,
             "total_tokens": total_dag_tokens,
             "compression_ratio": f"{compression_ratio}:1",
             "depths": {


### PR DESCRIPTION
## Why

`/lcm status` and `lcm_describe` should stay cheap and truthful as the DAG grows. The overview paths were still loading summary nodes through `get_session_nodes()`, which defaults to a 1,000-node page.

That means large sessions could report incomplete DAG counts and token totals, and routine diagnostics paid to materialize node objects that only existed to be counted.

## What changed

- Added SQL aggregate helpers for session DAG node counts and per-depth token stats.
- Added bounded per-depth sampling for `lcm_describe` overview nodes.
- Switched `engine.get_status()`, `lcm_status`, and `lcm_describe` overview to use aggregate queries instead of loading session nodes.
- Added regressions that make `get_session_nodes()` fail during status/describe overview, plus a 1,005-node case proving counts and totals go past the old default page limit.

The output shape stays the same. The difference is that the numbers now represent the whole session DAG.

## Validation

- `python3 -m pytest tests/test_lcm_command.py::test_lcm_status_uses_dag_aggregates_without_loading_all_nodes tests/test_lcm_command.py::test_lcm_describe_overview_uses_dag_aggregates_without_loading_all_nodes tests/test_lcm_command.py::test_lcm_status_and_describe_count_more_than_default_node_page -q` → 3 passed
- `python3 -m pytest tests/test_lcm_command.py tests/test_lcm_core.py -q` → 272 passed
- `python3 -m pytest -q` → 966 passed, 1 warning
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 966 passed, 1 warning
- `python3 -m compileall -q .`
- `python3 -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
