### PR TITLE
fix: harden externalized payload durability

### DIFF
--- a/externalize.py
+++ b/externalize.py
@@ -45,6 +45,29 @@ def _content_digest_prefix(content: str) -> str:
     return hashlib.sha256((content or "").encode("utf-8")).hexdigest()[:12]
 
 
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    dir_fd = os.open(path, flags)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _missing_directory_components(path: Path) -> list[Path]:
+    missing: list[Path] = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return list(reversed(missing))
+
+
 def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool) -> Path:
     configured = getattr(config, "large_output_externalization_path", "") or ""
     if configured:
@@ -70,7 +93,10 @@ def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool)
             except ValueError:
                 raise ValueError(f"Path {path} is not within allowed base {allowed_base}")
     if create:
+        missing_dirs = _missing_directory_components(path)
         path.mkdir(parents=True, exist_ok=True)
+        for created_dir in missing_dirs:
+            _fsync_directory(created_dir.parent)
         try:
             path.chmod(0o700)
         except OSError as exc:
@@ -78,13 +104,26 @@ def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool)
     return path
 
 
+def _unlink_partial_payload(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Could not remove partial LCM externalized payload %s: %s", path, exc)
+
+
 def _write_externalized_payload(path: Path, payload: Dict[str, Any]) -> None:
     data = json.dumps(payload, ensure_ascii=False, indent=2)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(data)
             fd = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _fsync_directory(path.parent)
+    except OSError:
+        _unlink_partial_payload(path)
+        raise
     finally:
         if fd >= 0:
             os.close(fd)
@@ -211,6 +250,7 @@ def reassign_externalized_payloads(
         try:
             _write_externalized_payload(tmp_path, payload)
             tmp_path.replace(path)
+            _fsync_directory(path.parent)
         except OSError as exc:
             logger.warning("Externalized payload session reassignment skipped for %s: %s", path.name, exc)
             try:

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -19,11 +19,13 @@ from hermes_lcm.engine import LCMEngine
 import hermes_lcm.engine as lcm_engine_module
 import hermes_lcm.store as lcm_store_module
 from hermes_lcm.extraction import sanitize_pre_compaction_tool_arguments
+import hermes_lcm.externalize as externalize_module
 from hermes_lcm.externalize import (
     build_transcript_gc_placeholder,
     externalize_ingest_payload,
     extract_externalized_ref,
     extract_externalized_refs,
+    reassign_externalized_payloads,
 )
 from hermes_lcm.ingest_protection import (
     extract_all_externalized_payload_refs,
@@ -451,6 +453,114 @@ def test_ingest_payload_placeholder_sanitizes_custom_kind_metadata_before_ref(tm
     assert refs == [result["path"].name]
     assert result["path"].name.startswith("20")
     assert "ref=kind-bogus" not in result["path"].name
+
+
+def test_externalized_payload_write_fsyncs_file_and_parent_directory(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+    file_fsync_calls = []
+    fsynced_dirs = []
+
+    monkeypatch.setattr(externalize_module.os, "fsync", lambda fd: file_fsync_calls.append(fd))
+    monkeypatch.setattr(externalize_module, "_fsync_directory", lambda path: fsynced_dirs.append(Path(path)))
+
+    result = externalize_ingest_payload(
+        "durable ingest payload" * 20,
+        role="user",
+        session_id=engine.current_session_id,
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+    )
+
+    assert result is not None
+    assert result["path"].exists()
+    assert file_fsync_calls
+    assert result["path"].parent in fsynced_dirs
+
+
+def test_first_externalized_payload_fsyncs_new_storage_directory_parent(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+    fsynced_dirs = []
+
+    monkeypatch.setattr(externalize_module, "_fsync_directory", lambda path: fsynced_dirs.append(Path(path)))
+
+    result = externalize_ingest_payload(
+        "first durable ingest payload" * 20,
+        role="user",
+        session_id=engine.current_session_id,
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+    )
+
+    assert result is not None
+    assert tmp_path in fsynced_dirs
+    assert tmp_path / "externalized" in fsynced_dirs
+
+
+def test_externalized_payload_fsync_failure_keeps_ingest_payload_inline(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+
+    def fail_fsync(_fd):
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(externalize_module.os, "fsync", fail_fsync)
+
+    result = externalize_ingest_payload(
+        "payload should stay inline when durability fails" * 20,
+        role="user",
+        session_id=engine.current_session_id,
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+    )
+
+    assert result is None
+    assert _externalized_files(tmp_path) == []
+
+
+def test_ingest_keeps_original_content_when_externalized_payload_durability_fails(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+
+    def fail_fsync(_fd):
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(externalize_module.os, "fsync", fail_fsync)
+
+    engine._ingest_messages([{"role": "user", "content": "see image " + DATA_URI}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert DATA_URI in content
+    assert extract_ingest_externalized_refs(content) == []
+    assert _externalized_files(tmp_path) == []
+
+
+def test_externalized_payload_reassignment_fsyncs_replacement(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+    result = externalize_ingest_payload(
+        "payload moved across compression boundary" * 20,
+        role="user",
+        session_id="old-session",
+        field_path="content",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+    )
+    assert result is not None
+
+    fsync_calls = []
+    monkeypatch.setattr(externalize_module.os, "fsync", lambda fd: fsync_calls.append(fd))
+
+    moved = reassign_externalized_payloads(
+        "old-session",
+        "new-session",
+        config=engine._config,
+        hermes_home=str(tmp_path),
+    )
+
+    assert moved == 1
+    assert len(fsync_calls) >= 3
+    payload = json.loads(result["path"].read_text(encoding="utf-8"))
+    assert payload["session_id"] == "new-session"
 
 
 def test_ingest_externalizes_plain_data_uri_user_content_before_sqlite_write(tmp_path):


### PR DESCRIPTION
## Why

Externalized payloads are the lossless escape hatch for oversized content. Once SQLite stores a placeholder that points at a payload file, that file has to be recoverable.

The current write path created the JSON payload and then let SQLite commit the placeholder, but it did not flush the payload file or the directory entries. A crash at the wrong time could leave a durable database row pointing at a missing or truncated payload. That is exactly the kind of quiet lossless failure we should fail closed instead.

## What changed

- Flush and `fsync` externalized payload files before returning placeholders.
- `fsync` parent directories after payload creation, including the first time the externalized storage directory is created.
- On durability failure, remove the partial payload and return `None` so ingest keeps the original content inline instead of committing an unrecoverable placeholder.
- `fsync` the parent directory after externalized payload reassignment replaces the old JSON file.
- Added regressions for file fsync, first-directory fsync, failure fallback, real ingest fallback, and reassignment durability.

This only affects the externalized payload storage boundary. It does not add user-facing chat verbosity.

## Validation

- `python3 -m pytest tests/test_ingest_protection.py::test_externalized_payload_write_fsyncs_file_and_parent_directory tests/test_ingest_protection.py::test_first_externalized_payload_fsyncs_new_storage_directory_parent tests/test_ingest_protection.py::test_externalized_payload_fsync_failure_keeps_ingest_payload_inline tests/test_ingest_protection.py::test_ingest_keeps_original_content_when_externalized_payload_durability_fails tests/test_ingest_protection.py::test_externalized_payload_reassignment_fsyncs_replacement -q` → 5 passed
- `python3 -m pytest tests/test_ingest_protection.py -q` → 104 passed
- `python3 -m pytest tests/test_ingest_protection.py tests/test_lcm_engine.py tests/test_lcm_command.py -q` → 580 passed, 1 warning
- `python3 -m pytest tests/test_crash_safe_wal.py tests/test_lcm_core.py -q` → 227 passed
- `python3 -m pytest -q` → 973 passed, 1 warning
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 973 passed, 1 warning
- `python3 -m compileall -q .`
- `python3 -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
