### PR TITLE
feat: expand query with recursive evidence

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -278,8 +278,9 @@ LCM_EXPAND_QUERY = {
     "name": "lcm_expand_query",
     "description": (
         "Answer a natural-language question using expanded LCM context from the current session. Provide a prompt, and either "
-        "query matching summaries to expand or explicit node_ids to inspect. Uses the expansion path "
+        "query matching summaries/raw messages to expand or explicit node_ids to inspect. Uses the expansion path "
         "instead of the summarization path so retrieval/synthesis can use a different model or timeout. "
+        "When expanding parent summary nodes, it recursively descends the DAG under the context budget to include leaf evidence where possible. "
         "Prefer this for questions about the active conversation after compaction; for cross-session recall, use session_search first."
     ),
     "parameters": {

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12341,6 +12341,110 @@ class TestEngineTools:
         serialized_context = json.dumps(captured["context_blocks"])
         assert "PHOENIXRAWONLY appears only in the raw message" in serialized_context
 
+    def test_handle_expand_query_keeps_raw_snippets_out_of_synthesis_context(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "raw snippet answer"
+
+        def fake_store_search(query, session_id=None, limit=5):
+            return [
+                {
+                    "store_id": 123,
+                    "session_id": session_id or "test-session",
+                    "source": "telegram",
+                    "role": "user",
+                    "timestamp": 1,
+                    "content": "A",
+                    "snippet": "UNBUDGETED RAW SNIPPET LEAK",
+                    "search_rank": 1,
+                }
+            ]
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        monkeypatch.setattr(engine._store, "search", fake_store_search)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw detail?",
+                    "query": "anything",
+                    "max_tokens": 20,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert result["answer"] == "raw snippet answer"
+        assert result["raw_matches"][0]["snippet"] == "UNBUDGETED RAW SNIPPET LEAK"
+        assert "UNBUDGETED RAW SNIPPET LEAK" not in serialized_context
+        raw_block = next(block for block in captured["context_blocks"] if block["type"] == "raw_messages")
+        assert "snippet" not in raw_block["messages"][0]
+
+    def test_handle_expand_query_deduped_raw_hit_does_not_leak_snippet(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "deduped raw answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "DEDUPEDRAW message evidence"},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="summary points at deduped raw evidence",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        def fake_store_search(query, session_id=None, limit=5):
+            return [
+                {
+                    "store_id": store_id,
+                    "session_id": session_id or "test-session",
+                    "source": "telegram",
+                    "role": "user",
+                    "timestamp": 1,
+                    "content": "DEDUPEDRAW message evidence",
+                    "snippet": "DEDUPED RAW SNIPPET SHOULD NOT LEAK",
+                    "search_rank": 1,
+                }
+            ]
+
+        monkeypatch.setattr(engine._store, "search", fake_store_search)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw detail?",
+                    "node_ids": [node_id],
+                    "query": "DEDUPEDRAW",
+                    "max_tokens": 20,
+                    "context_max_tokens": 1000,
+                },
+            )
+        )
+
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert result["answer"] == "deduped raw answer"
+        assert "DEDUPEDRAW message evidence" in serialized_context
+        assert "DEDUPED RAW SNIPPET SHOULD NOT LEAK" not in serialized_context
+        assert not any(block.get("type") == "raw_messages" for block in captured["context_blocks"])
+        assert result["raw_matches"] == []
+
     def test_handle_expand_query_raw_hit_truncation_returns_store_expand_cursor(self, engine, monkeypatch):
         import hermes_lcm.tokens as token_utils
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12233,6 +12233,145 @@ class TestEngineTools:
         assert second["expanded"][0]["content_offset"] == 1
         assert second["pagination"]["next_content_offset"] == 2
 
+    def test_handle_expand_query_recursively_descends_parent_nodes_to_leaf_messages(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "recursive answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "LEAF RAW SECRET zeta detail"},
+        )
+        leaf_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="leaf summary mentions broad topic only",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        middle_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=1,
+                summary="middle summary points at leaf",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[leaf_id],
+                source_type="nodes",
+                created_at=2,
+            )
+        )
+        parent_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=2,
+                summary="parent summary points at middle",
+                token_count=10,
+                source_token_count=30,
+                source_ids=[middle_id],
+                source_type="nodes",
+                created_at=3,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What exact leaf detail is present?",
+                    "node_ids": [parent_id],
+                    "max_tokens": 20,
+                    "context_max_tokens": 1000,
+                },
+            )
+        )
+
+        assert result["answer"] == "recursive answer"
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert "LEAF RAW SECRET zeta detail" in serialized_context
+        assert any(block.get("type") == "child_messages" for block in captured["context_blocks"])
+
+    def test_handle_expand_query_uses_raw_hits_when_summary_search_misses(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "raw bridge answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "PHOENIXRAWONLY appears only in the raw message"},
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="summary deliberately omits the distinctive raw identifier",
+                token_count=10,
+                source_token_count=10,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What mentions PHOENIX?",
+                    "query": "PHOENIXRAWONLY",
+                    "max_tokens": 20,
+                    "context_max_tokens": 1000,
+                },
+            )
+        )
+
+        assert result["answer"] == "raw bridge answer"
+        assert result["raw_matches"]
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert "PHOENIXRAWONLY appears only in the raw message" in serialized_context
+
+    def test_handle_expand_query_raw_hit_truncation_returns_store_expand_cursor(self, engine, monkeypatch):
+        import hermes_lcm.tokens as token_utils
+
+        def fake_count_tokens(text):
+            return 0 if not text else len(text) + 1
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            return "raw cursor answer"
+
+        monkeypatch.setattr(token_utils, "count_tokens", fake_count_tokens)
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "PHOENIXRAWCURSOR has a longer raw detail"},
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What mentions PHOENIX?",
+                    "query": "PHOENIXRAWCURSOR",
+                    "max_tokens": 20,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        raw_page = next(item for item in result["context_pagination"] if item["type"] == "raw_messages")
+        assert raw_page["expand_args"] == {"store_id": store_id, "content_offset": 1}
+
     def test_handle_expand_query_advances_content_cursor_when_context_budget_cannot_fit_character(self, engine, monkeypatch):
         import hermes_lcm.tokens as token_utils
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12299,6 +12299,100 @@ class TestEngineTools:
         assert "LEAF RAW SECRET zeta detail" in serialized_context
         assert any(block.get("type") == "child_messages" for block in captured["context_blocks"])
 
+    def test_handle_expand_query_deep_parent_reaches_leaf_messages(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "deep recursive answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "DEEP LEAF RAW SECRET omega detail"},
+        )
+        child_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="leaf summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        for depth in range(1, 7):
+            child_id = engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=depth,
+                    summary=f"depth {depth} summary",
+                    token_count=5,
+                    source_token_count=5 * (depth + 1),
+                    source_ids=[child_id],
+                    source_type="nodes",
+                    created_at=depth + 1,
+                )
+            )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What exact deep leaf detail is present?",
+                    "node_ids": [child_id],
+                    "max_tokens": 20,
+                    "context_max_tokens": 1000,
+                },
+            )
+        )
+
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert result["answer"] == "deep recursive answer"
+        assert "DEEP LEAF RAW SECRET omega detail" in serialized_context
+        assert sum(block.get("type") == "descendant_child_nodes" for block in captured["context_blocks"]) >= 5
+        assert any(block.get("type") == "child_messages" for block in captured["context_blocks"])
+
+    def test_expand_query_descendant_collection_handles_zero_token_deep_chain_without_recursion(self, engine):
+        store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "ZERO TOKEN DEEP LEAF evidence"},
+        )
+        child_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="",
+                token_count=0,
+                source_token_count=0,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        for depth in range(1, 1105):
+            child_id = engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=depth,
+                    summary="",
+                    token_count=0,
+                    source_token_count=0,
+                    source_ids=[child_id],
+                    source_type="nodes",
+                    created_at=depth + 1,
+                )
+            )
+
+        root = engine._dag.get_node(child_id)
+        blocks = lcm_tools._collect_context_blocks_for_node(engine, root, max_tokens=32000)
+
+        serialized_context = json.dumps(blocks)
+        assert "ZERO TOKEN DEEP LEAF evidence" in serialized_context
+        assert any(block.get("type") == "child_messages" for block in blocks)
+
     def test_handle_expand_query_uses_raw_hits_when_summary_search_misses(self, engine, monkeypatch):
         captured = {}
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12593,6 +12593,100 @@ class TestEngineTools:
         assert raw_item["tool_call_id"] == "call_123"
         assert raw_item["tool_name"] == "expensive_tool"
 
+    def test_handle_expand_query_raw_hit_context_windows_around_match(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "raw tail answer"
+
+        content = "prefix-noise " * 80 + "TAILMATCH exact evidence"
+
+        def fake_store_search(query, session_id=None, limit=5):
+            return [
+                {
+                    "store_id": 789,
+                    "session_id": session_id or "test-session",
+                    "source": "telegram",
+                    "role": "user",
+                    "timestamp": 1,
+                    "content": content,
+                    "snippet": "TAILMATCH exact evidence",
+                    "search_rank": 1,
+                }
+            ]
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        monkeypatch.setattr(engine._store, "search", fake_store_search)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw detail?",
+                    "query": "TAILMATCH",
+                    "max_tokens": 20,
+                    "context_max_tokens": 6,
+                },
+            )
+        )
+
+        raw_block = next(block for block in captured["context_blocks"] if block["type"] == "raw_messages")
+        raw_item = raw_block["messages"][0]
+        assert result["answer"] == "raw tail answer"
+        assert "TAILMATCH" in raw_item["content"]
+        assert raw_item["content_offset"] == content.index("TAILMATCH")
+        assert raw_item["match_window_offset"] == content.index("TAILMATCH")
+        assert "prefix-noise" not in raw_item["content"]
+
+    def test_handle_expand_query_raw_hit_match_window_uses_sanitized_query_terms(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "raw sanitized answer"
+
+        content = "match unrelated prefix-noise " * 40 + "tail match exact evidence"
+
+        def fake_store_search(query, session_id=None, limit=5):
+            return [
+                {
+                    "store_id": 790,
+                    "session_id": session_id or "test-session",
+                    "source": "telegram",
+                    "role": "user",
+                    "timestamp": 1,
+                    "content": content,
+                    "snippet": "tail match exact evidence",
+                    "search_rank": 1,
+                }
+            ]
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        monkeypatch.setattr(engine._store, "search", fake_store_search)
+
+        for query in ["tail-match", "tail.match", "tail/match", "tail:match", "tail(match)"]:
+            captured.clear()
+            result = json.loads(
+                engine.handle_tool_call(
+                    "lcm_expand_query",
+                    {
+                        "prompt": "What raw detail?",
+                        "query": query,
+                        "max_tokens": 20,
+                        "context_max_tokens": 6,
+                    },
+                )
+            )
+
+            raw_block = next(block for block in captured["context_blocks"] if block["type"] == "raw_messages")
+            raw_item = raw_block["messages"][0]
+            assert result["answer"] == "raw sanitized answer"
+            assert "tail match" in raw_item["content"]
+            assert raw_item["content_offset"] == content.index("tail match")
+            assert raw_item["match_window_offset"] == content.index("tail match")
+            assert "match unrelated" not in raw_item["content"]
+
     def test_handle_expand_query_raw_hit_truncation_returns_store_expand_cursor(self, engine, monkeypatch):
         import hermes_lcm.tokens as token_utils
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12390,8 +12390,14 @@ class TestEngineTools:
         blocks = lcm_tools._collect_context_blocks_for_node(engine, root, max_tokens=32000)
 
         serialized_context = json.dumps(blocks)
-        assert "ZERO TOKEN DEEP LEAF evidence" in serialized_context
-        assert any(block.get("type") == "child_messages" for block in blocks)
+        assert "ZERO TOKEN DEEP LEAF evidence" not in serialized_context
+        assert len(blocks) < 1105
+        assert lcm_tools._context_content_token_count(blocks) <= 33000
+        path_blocks = [block for block in blocks if "source_path" in block]
+        assert path_blocks
+        assert max(len(block["source_path"]) for block in path_blocks) <= 8
+        assert any(block.get("source_path_truncated") is True for block in path_blocks)
+        assert any(block.get("source_path_depth", 0) > len(block["source_path"]) for block in path_blocks)
 
     def test_handle_expand_query_uses_raw_hits_when_summary_search_misses(self, engine, monkeypatch):
         captured = {}
@@ -12538,6 +12544,54 @@ class TestEngineTools:
         assert "DEDUPED RAW SNIPPET SHOULD NOT LEAK" not in serialized_context
         assert not any(block.get("type") == "raw_messages" for block in captured["context_blocks"])
         assert result["raw_matches"] == []
+
+    def test_handle_expand_query_keeps_raw_tool_calls_out_of_synthesis_context(self, engine, monkeypatch):
+        captured = {}
+
+        def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
+            captured["context_blocks"] = context_blocks
+            return "raw tool call answer"
+
+        def fake_store_search(query, session_id=None, limit=5):
+            return [
+                {
+                    "store_id": 456,
+                    "session_id": session_id or "test-session",
+                    "source": "telegram",
+                    "role": "assistant",
+                    "timestamp": 1,
+                    "content": "A",
+                    "tool_calls": [{"function": {"arguments": "UNBUDGETED TOOL ARGUMENT LEAK" * 20}}],
+                    "tool_call_id": "call_123",
+                    "tool_name": "expensive_tool",
+                    "search_rank": 1,
+                }
+            ]
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        monkeypatch.setattr(engine._store, "search", fake_store_search)
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What raw detail?",
+                    "query": "anything",
+                    "max_tokens": 20,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        serialized_context = json.dumps(captured["context_blocks"])
+        raw_block = next(block for block in captured["context_blocks"] if block["type"] == "raw_messages")
+        raw_item = raw_block["messages"][0]
+        assert result["answer"] == "raw tool call answer"
+        assert "UNBUDGETED TOOL ARGUMENT LEAK" not in serialized_context
+        assert "tool_calls" not in raw_item
+        assert raw_item["tool_calls_omitted"] is True
+        assert raw_item["tool_call_id"] == "call_123"
+        assert raw_item["tool_name"] == "expensive_tool"
 
     def test_handle_expand_query_raw_hit_truncation_returns_store_expand_cursor(self, engine, monkeypatch):
         import hermes_lcm.tokens as token_utils

--- a/tools.py
+++ b/tools.py
@@ -517,6 +517,90 @@ def _expand_child_nodes(
     )
 
 
+def _collect_descendant_evidence_blocks(
+    engine: "LCMEngine",
+    node,
+    max_tokens: int,
+    *,
+    hydrate_externalized_content: bool = False,
+    max_depth: int = 4,
+    visited_node_ids: set[int] | None = None,
+    source_path: list[dict[str, int]] | None = None,
+) -> list[dict[str, Any]]:
+    if max_tokens <= 0 or max_depth <= 0 or node.source_type != "nodes":
+        return []
+    if visited_node_ids is None:
+        visited_node_ids = set()
+    if source_path is None:
+        source_path = []
+    visited_node_ids.add(int(node.node_id))
+
+    blocks: list[dict[str, Any]] = []
+    budget_used = 0
+    for source_index, child_id in enumerate(node.source_ids):
+        if budget_used >= max_tokens:
+            break
+        child = engine._dag.get_node(child_id)
+        if child is None or child.session_id != engine.current_session_id:
+            continue
+        child_node_id = int(child.node_id)
+        if child_node_id in visited_node_ids:
+            continue
+        child_path = [*source_path, {"node_id": int(node.node_id), "source_index": source_index}]
+        remaining_tokens = max(0, max_tokens - budget_used)
+        if child.source_type == "messages":
+            messages, pagination = _expand_message_sources(
+                engine,
+                child,
+                max_tokens=remaining_tokens,
+                hydrate_externalized_content=hydrate_externalized_content,
+            )
+            if messages or pagination.get("has_more"):
+                block = {
+                    "type": "child_messages",
+                    "parent_node_id": node.node_id,
+                    "node_id": child.node_id,
+                    "depth": child.depth,
+                    "source_index": source_index,
+                    "source_path": child_path,
+                    "messages": messages,
+                    "pagination": pagination,
+                }
+                blocks.append(block)
+                budget_used += _context_content_token_count([block])
+            continue
+
+        if child.source_type == "nodes":
+            children, pagination = _expand_child_nodes(engine, child, max_tokens=remaining_tokens)
+            if children or pagination.get("has_more"):
+                block = {
+                    "type": "descendant_child_nodes",
+                    "parent_node_id": node.node_id,
+                    "node_id": child.node_id,
+                    "depth": child.depth,
+                    "source_index": source_index,
+                    "source_path": child_path,
+                    "children": children,
+                    "pagination": pagination,
+                }
+                blocks.append(block)
+                budget_used += _context_content_token_count([block])
+            if budget_used >= max_tokens:
+                break
+            nested = _collect_descendant_evidence_blocks(
+                engine,
+                child,
+                max_tokens=max(0, max_tokens - budget_used),
+                hydrate_externalized_content=hydrate_externalized_content,
+                max_depth=max_depth - 1,
+                visited_node_ids={*visited_node_ids, child_node_id},
+                source_path=child_path,
+            )
+            blocks.extend(nested)
+            budget_used += _context_content_token_count(nested)
+    return blocks
+
+
 def _collect_context_blocks_for_node(
     engine: "LCMEngine",
     node,
@@ -566,8 +650,104 @@ def _collect_context_blocks_for_node(
                     "pagination": pagination,
                 }
             )
+        used_tokens = _context_content_token_count(blocks)
+        descendant_tokens = max(0, max_tokens - used_tokens)
+        if descendant_tokens > 0:
+            blocks.extend(
+                _collect_descendant_evidence_blocks(
+                    engine,
+                    node,
+                    max_tokens=descendant_tokens,
+                    hydrate_externalized_content=hydrate_externalized_content,
+                )
+            )
 
     return blocks
+
+
+def _collect_raw_match_context_block(
+    engine: "LCMEngine",
+    rows: list[dict[str, Any]],
+    max_tokens: int,
+    *,
+    exclude_store_ids: set[int] | None = None,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    from .tokens import count_tokens
+
+    exclude_store_ids = exclude_store_ids or set()
+    messages: list[dict[str, Any]] = []
+    matches: list[dict[str, Any]] = []
+    budget_used = 0
+    has_more = False
+    next_store_id: int | None = None
+    for row in rows:
+        store_id = row.get("store_id")
+        if store_id in exclude_store_ids:
+            continue
+        remaining_tokens = max(0, max_tokens - budget_used)
+        if remaining_tokens <= 0:
+            has_more = True
+            next_store_id = store_id if isinstance(store_id, int) else None
+            break
+        content = str(row.get("content") or "")
+        content_slice = _slice_content_for_response(content, remaining_tokens)
+        content = content_slice["content"]
+        item = {
+            "store_id": store_id,
+            "session_id": row.get("session_id") or "",
+            "source": row.get("source") or "",
+            "role": row.get("role"),
+            "timestamp": row.get("timestamp", 0),
+            **content_slice,
+            "content_source": "raw_search_hit",
+            "snippet": row.get("snippet") or "",
+            "search_rank": row.get("search_rank"),
+        }
+        if row.get("tool_call_id"):
+            item["tool_call_id"] = row.get("tool_call_id")
+        if row.get("tool_calls"):
+            item["tool_calls"] = row.get("tool_calls")
+        if row.get("tool_name"):
+            item["tool_name"] = row.get("tool_name")
+        messages.append(item)
+        matches.append(
+            {
+                "store_id": store_id,
+                "role": row.get("role"),
+                "snippet": row.get("snippet") or content[:300],
+                "search_rank": row.get("search_rank"),
+            }
+        )
+        budget_used += count_tokens(content)
+        if content_slice["has_more"]:
+            has_more = True
+            break
+
+    if not messages and not has_more:
+        return None, matches
+    block = {
+        "type": "raw_messages",
+        "messages": messages,
+        "pagination": {
+            "has_more": has_more,
+            "returned_sources": len(messages),
+            "total_sources": len(rows),
+            "next_store_id": next_store_id,
+        },
+    }
+    return block, matches
+
+
+def _collect_store_ids_from_context_blocks(blocks: list[dict[str, Any]]) -> set[int]:
+    store_ids: set[int] = set()
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        for message in block.get("messages", []) or []:
+            store_id = message.get("store_id")
+            if isinstance(store_id, int):
+                store_ids.add(store_id)
+    return store_ids
 
 
 def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
@@ -577,11 +757,11 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
     for block in blocks:
         if block.get("type") == "summary":
             total += count_tokens(str(block.get("summary") or ""))
-        elif block.get("type") == "messages":
+        elif block.get("type") in {"messages", "child_messages", "raw_messages"}:
             for message in block.get("messages", []):
                 total += count_tokens(str(message.get("content") or ""))
                 total += count_tokens(str(message.get("transcript_content") or ""))
-        elif block.get("type") == "child_nodes":
+        elif block.get("type") in {"child_nodes", "descendant_child_nodes"}:
             total += sum(count_tokens(str(child.get("summary") or "")) for child in block.get("children", []))
     return total
 
@@ -1258,11 +1438,13 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     max_results, max_results_error = _parse_int_arg("max_results", 5)
     if max_results_error:
         return json.dumps({"error": max_results_error})
+    max_results = max(1, int(max_results or 5))
 
     query = str(args.get("query") or "").strip()
     raw_node_ids = args.get("node_ids") or []
 
     nodes = []
+    raw_results: list[dict[str, Any]] = []
     if raw_node_ids:
         for node_id in raw_node_ids:
             try:
@@ -1274,17 +1456,19 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                 nodes.append(node)
     elif query:
         nodes = engine._dag.search(query, session_id=engine.current_session_id, limit=max_results)
+        raw_results = engine._store.search(query, session_id=engine.current_session_id, limit=max_results)
     else:
         return json.dumps({"error": "Provide either query or node_ids"})
 
-    if not nodes:
+    if not nodes and not raw_results:
         return json.dumps(
             {
                 "prompt": prompt,
                 "query": query,
-                "answer": "No matching summaries found in the current session.",
+                "answer": "No matching summaries or raw messages found in the current session.",
                 "node_ids": [],
                 "matches": [],
+                "raw_matches": [],
             }
         )
 
@@ -1300,6 +1484,20 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
         )
         context_blocks.extend(node_blocks)
         context_budget_used += _context_content_token_count(node_blocks)
+
+    raw_matches: list[dict[str, Any]] = []
+    if raw_results:
+        seen_store_ids = _collect_store_ids_from_context_blocks(context_blocks)
+        remaining_context_tokens = max(0, context_max_tokens - context_budget_used)
+        raw_block, raw_matches = _collect_raw_match_context_block(
+            engine,
+            raw_results,
+            max_tokens=remaining_context_tokens,
+            exclude_store_ids=seen_store_ids,
+        )
+        if raw_block is not None:
+            context_blocks.append(raw_block)
+            context_budget_used += _context_content_token_count([raw_block])
 
     context_pagination = []
     for block in context_blocks:
@@ -1317,14 +1515,14 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             )
             continue
 
-        if block_type == "child_nodes":
+        if block_type in {"child_nodes", "descendant_child_nodes"}:
             for child in block.get("children", []):
                 if child.get("summary_truncated"):
                     child_node_id = child.get("node_id")
                     context_pagination.append(
                         {
                             "node_id": block.get("node_id"),
-                            "type": "child_summary",
+                            "type": "child_summary" if block_type == "child_nodes" else "descendant_child_summary",
                             "child_node_id": child_node_id,
                             "source_index": child.get("source_index"),
                             "summary_truncated": True,
@@ -1341,7 +1539,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "type": block_type,
             "pagination": pagination,
         }
-        if block_type == "messages":
+        if block_type in {"messages", "child_messages"}:
             truncated_message = next(
                 (message for message in block.get("messages", []) if message.get("content_truncated")),
                 None,
@@ -1371,7 +1569,22 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                     "source_offset": pagination.get("next_source_offset") or 0,
                     "content_offset": pagination.get("next_content_offset") or 0,
                 }
-        elif block_type == "child_nodes":
+        elif block_type == "raw_messages":
+            truncated_message = next(
+                (message for message in block.get("messages", []) if message.get("content_truncated")),
+                None,
+            )
+            if truncated_message:
+                item["store_id"] = truncated_message.get("store_id")
+                item["content_source"] = truncated_message.get("content_source")
+                item["expand_args"] = {
+                    "store_id": truncated_message.get("store_id"),
+                    "content_offset": truncated_message.get("next_content_offset") or 0,
+                }
+            elif pagination.get("next_store_id"):
+                item["store_id"] = pagination.get("next_store_id")
+                item["expand_args"] = {"store_id": pagination.get("next_store_id")}
+        elif block_type in {"child_nodes", "descendant_child_nodes"}:
             item["expand_args"] = {
                 "node_id": block.get("node_id"),
                 "source_offset": pagination.get("next_source_offset") or 0,
@@ -1408,6 +1621,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "context_pagination": context_pagination,
             "node_ids": node_ids,
             "matches": matches,
+            "raw_matches": raw_matches,
         }
         if include_timeout:
             payload["timeout_seconds"] = timeout
@@ -1447,6 +1661,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "context_pagination": context_pagination,
             "node_ids": node_ids,
             "matches": matches,
+            "raw_matches": raw_matches,
         }
     )
 

--- a/tools.py
+++ b/tools.py
@@ -517,6 +517,17 @@ def _expand_child_nodes(
     )
 
 
+def _bounded_source_path_payload(source_path: list[dict[str, int]]) -> dict[str, Any]:
+    path_tail = source_path[-8:]
+    payload: dict[str, Any] = {
+        "source_path": path_tail,
+        "source_path_depth": len(source_path),
+    }
+    if len(path_tail) < len(source_path):
+        payload["source_path_truncated"] = True
+    return payload
+
+
 def _collect_descendant_evidence_blocks(
     engine: "LCMEngine",
     node,
@@ -580,7 +591,7 @@ def _collect_descendant_evidence_blocks(
                     "node_id": child.node_id,
                     "depth": child.depth,
                     "source_index": source_index,
-                    "source_path": child_path,
+                    **_bounded_source_path_payload(child_path),
                     "messages": messages,
                     "pagination": pagination,
                 }
@@ -597,7 +608,7 @@ def _collect_descendant_evidence_blocks(
                     "node_id": child.node_id,
                     "depth": child.depth,
                     "source_index": source_index,
-                    "source_path": child_path,
+                    **_bounded_source_path_payload(child_path),
                     "children": children,
                     "pagination": pagination,
                 }
@@ -712,7 +723,7 @@ def _collect_raw_match_context_block(
         if row.get("tool_call_id"):
             item["tool_call_id"] = row.get("tool_call_id")
         if row.get("tool_calls"):
-            item["tool_calls"] = row.get("tool_calls")
+            item["tool_calls_omitted"] = True
         if row.get("tool_name"):
             item["tool_name"] = row.get("tool_name")
         messages.append(item)
@@ -763,7 +774,19 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
     for block in blocks:
         if block.get("type") == "summary":
             total += count_tokens(str(block.get("summary") or ""))
-        elif block.get("type") in {"messages", "child_messages", "raw_messages"}:
+        if "source_path" in block:
+            total += count_tokens(
+                json.dumps(
+                    {
+                        "source_path": block.get("source_path") or [],
+                        "source_path_depth": block.get("source_path_depth"),
+                        "source_path_truncated": block.get("source_path_truncated", False),
+                    },
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+            )
+        if block.get("type") in {"messages", "child_messages", "raw_messages"}:
             for message in block.get("messages", []):
                 total += count_tokens(str(message.get("content") or ""))
                 total += count_tokens(str(message.get("transcript_content") or ""))

--- a/tools.py
+++ b/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from datetime import datetime
 from pathlib import Path
@@ -218,6 +219,53 @@ def _slice_content_for_response(content: str, max_tokens: int, content_offset: i
         "next_content_offset": next_content_offset if has_more else 0,
         "has_more": has_more,
     }
+
+
+def _query_terms_for_match_window(query: str | None) -> list[str]:
+    if not query:
+        return []
+    terms: list[str] = []
+    normalized_query = " ".join(re.findall(r"\w+", query))
+    if normalized_query:
+        terms.append(normalized_query)
+
+    def add_term(term: str) -> None:
+        term = term.strip()
+        if not term:
+            return
+        terms.append(term)
+        parts = [part for part in re.split(r"[^\w]+", term) if part]
+        if len(parts) > 1:
+            terms.append(" ".join(parts))
+        terms.extend(part for part in parts if len(part) >= 2)
+
+    for quoted in re.findall(r'"([^"]+)"', query):
+        add_term(quoted)
+    for token in re.findall(r"[\w][\w:-]*\*?", query):
+        token = token.rstrip("*").strip()
+        if not token or token.upper() in {"AND", "OR", "NOT", "NEAR"}:
+            continue
+        if ":" in token:
+            token = token.rsplit(":", 1)[-1]
+        if len(token) >= 2:
+            add_term(token)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for term in sorted(terms, key=len, reverse=True):
+        key = term.casefold()
+        if key not in seen:
+            seen.add(key)
+            unique.append(term)
+    return unique
+
+
+def _content_offset_for_query_match(content: str, query: str | None) -> int:
+    folded = content.casefold()
+    for term in _query_terms_for_match_window(query):
+        index = folded.find(term.casefold())
+        if index >= 0:
+            return index
+    return 0
 
 
 def _full_content_slice(content: str, content_offset: int = 0) -> dict[str, Any]:
@@ -688,6 +736,7 @@ def _collect_raw_match_context_block(
     rows: list[dict[str, Any]],
     max_tokens: int,
     *,
+    query: str | None = None,
     exclude_store_ids: set[int] | None = None,
 ) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
     from .tokens import count_tokens
@@ -708,7 +757,8 @@ def _collect_raw_match_context_block(
             next_store_id = store_id if isinstance(store_id, int) else None
             break
         content = str(row.get("content") or "")
-        content_slice = _slice_content_for_response(content, remaining_tokens)
+        match_offset = _content_offset_for_query_match(content, query)
+        content_slice = _slice_content_for_response(content, remaining_tokens, content_offset=match_offset)
         content = content_slice["content"]
         item = {
             "store_id": store_id,
@@ -722,6 +772,8 @@ def _collect_raw_match_context_block(
         }
         if row.get("tool_call_id"):
             item["tool_call_id"] = row.get("tool_call_id")
+        if match_offset:
+            item["match_window_offset"] = match_offset
         if row.get("tool_calls"):
             item["tool_calls_omitted"] = True
         if row.get("tool_name"):
@@ -1522,6 +1574,7 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             engine,
             raw_results,
             max_tokens=remaining_context_tokens,
+            query=query,
             exclude_store_ids=seen_store_ids,
         )
         if raw_block is not None:

--- a/tools.py
+++ b/tools.py
@@ -523,30 +523,48 @@ def _collect_descendant_evidence_blocks(
     max_tokens: int,
     *,
     hydrate_externalized_content: bool = False,
-    max_depth: int = 4,
     visited_node_ids: set[int] | None = None,
     source_path: list[dict[str, int]] | None = None,
+    remaining_node_visits: list[int] | None = None,
 ) -> list[dict[str, Any]]:
-    if max_tokens <= 0 or max_depth <= 0 or node.source_type != "nodes":
+    if max_tokens <= 0 or node.source_type != "nodes":
         return []
     if visited_node_ids is None:
         visited_node_ids = set()
     if source_path is None:
         source_path = []
-    visited_node_ids.add(int(node.node_id))
+    if remaining_node_visits is None:
+        # Budget and cycle detection are the primary limits. Keep a high,
+        # budget-scaled guard so corrupt zero-token DAGs cannot make expansion
+        # walk an unbounded number of nodes while normal deep summaries still
+        # reach their leaf evidence.
+        remaining_node_visits = [max(64, int(max_tokens) * 4)]
+    if remaining_node_visits[0] <= 0:
+        return []
 
     blocks: list[dict[str, Any]] = []
     budget_used = 0
-    for source_index, child_id in enumerate(node.source_ids):
-        if budget_used >= max_tokens:
-            break
+    root_node_id = int(node.node_id)
+    stack: list[tuple[Any, list[dict[str, int]], set[int], int]] = [
+        (node, source_path, {*visited_node_ids, root_node_id}, 0)
+    ]
+
+    while stack and budget_used < max_tokens and remaining_node_visits[0] > 0:
+        current, current_path, current_visited, source_index = stack.pop()
+        if source_index >= len(current.source_ids):
+            continue
+
+        stack.append((current, current_path, current_visited, source_index + 1))
+        child_id = current.source_ids[source_index]
         child = engine._dag.get_node(child_id)
         if child is None or child.session_id != engine.current_session_id:
             continue
         child_node_id = int(child.node_id)
-        if child_node_id in visited_node_ids:
+        if child_node_id in current_visited:
             continue
-        child_path = [*source_path, {"node_id": int(node.node_id), "source_index": source_index}]
+
+        remaining_node_visits[0] -= 1
+        child_path = [*current_path, {"node_id": int(current.node_id), "source_index": source_index}]
         remaining_tokens = max(0, max_tokens - budget_used)
         if child.source_type == "messages":
             messages, pagination = _expand_message_sources(
@@ -558,7 +576,7 @@ def _collect_descendant_evidence_blocks(
             if messages or pagination.get("has_more"):
                 block = {
                     "type": "child_messages",
-                    "parent_node_id": node.node_id,
+                    "parent_node_id": current.node_id,
                     "node_id": child.node_id,
                     "depth": child.depth,
                     "source_index": source_index,
@@ -575,7 +593,7 @@ def _collect_descendant_evidence_blocks(
             if children or pagination.get("has_more"):
                 block = {
                     "type": "descendant_child_nodes",
-                    "parent_node_id": node.node_id,
+                    "parent_node_id": current.node_id,
                     "node_id": child.node_id,
                     "depth": child.depth,
                     "source_index": source_index,
@@ -585,19 +603,8 @@ def _collect_descendant_evidence_blocks(
                 }
                 blocks.append(block)
                 budget_used += _context_content_token_count([block])
-            if budget_used >= max_tokens:
-                break
-            nested = _collect_descendant_evidence_blocks(
-                engine,
-                child,
-                max_tokens=max(0, max_tokens - budget_used),
-                hydrate_externalized_content=hydrate_externalized_content,
-                max_depth=max_depth - 1,
-                visited_node_ids={*visited_node_ids, child_node_id},
-                source_path=child_path,
-            )
-            blocks.extend(nested)
-            budget_used += _context_content_token_count(nested)
+            if budget_used < max_tokens and remaining_node_visits[0] > 0:
+                stack.append((child, child_path, {*current_visited, child_node_id}, 0))
     return blocks
 
 

--- a/tools.py
+++ b/tools.py
@@ -700,7 +700,6 @@ def _collect_raw_match_context_block(
             "timestamp": row.get("timestamp", 0),
             **content_slice,
             "content_source": "raw_search_hit",
-            "snippet": row.get("snippet") or "",
             "search_rank": row.get("search_rank"),
         }
         if row.get("tool_call_id"):


### PR DESCRIPTION
## Why

The LCM paper frames summaries as a navigable DAG, not as the final answer. A high-level summary should help the engine find the right part of history, then the retrieval path should descend toward the supporting leaf evidence under a bounded context budget.

`lcm_expand_query` was still too shallow for that. It expanded matching summary nodes by one level, so a parent summary could expose only child summaries while the raw leaf messages stayed out of the synthesis context. It also searched only summaries when a query was supplied, which meant an exact raw detail could be missed if the summary text did not preserve that exact token.

## What changed

- `lcm_expand_query` now recursively descends summary-node sources under the existing context budget, with cycle guards, current-session node checks, and an explicit-stack traversal so deep retained/imported DAGs can still reach leaf evidence.
- Parent summary expansion can now include leaf message evidence through `child_messages` context blocks.
- Query mode now searches both summary nodes and raw messages in the current session.
- Raw-message matches are added as bounded `raw_messages` context when summary search misses or when exact raw evidence is useful.
- Raw-message context now windows around the query match instead of blindly slicing from the message prefix, including punctuation-sanitized query forms such as `tail-match` and `tail.match`.
- Raw-message truncation now returns actionable `lcm_expand(store_id=..., content_offset=...)` pagination instead of repeating the same query from the beginning.
- Raw FTS snippets remain in returned `raw_matches` metadata, but are kept out of synthesis `context_blocks` so they cannot bypass the context budget.
- Descendant `source_path` metadata is bounded and charged to the context budget, so pathological zero-token DAGs cannot serialize unbounded path metadata.
- Raw search-hit `tool_calls` payloads are omitted from synthesis context and replaced with `tool_calls_omitted: true` metadata.
- The tool schema now describes that query matching can use summaries and raw messages, and that parent nodes may be recursively descended.

This keeps the behavior plugin-only and bounded. No Hermes Agent changes, no host patches, and no extra end-user chat verbosity.

## Validation

- `python3 -m pytest tests/test_lcm_engine.py::TestEngineTools::test_handle_expand_query_raw_hit_context_windows_around_match tests/test_lcm_engine.py::TestEngineTools::test_handle_expand_query_raw_hit_match_window_uses_sanitized_query_terms tests/test_lcm_engine.py::TestEngineTools::test_handle_expand_query_raw_hit_truncation_returns_store_expand_cursor tests/test_lcm_engine.py::TestEngineTools::test_handle_expand_query_keeps_raw_tool_calls_out_of_synthesis_context -q` → 4 passed
- `python3 -m pytest tests/test_lcm_engine.py -q -k 'expand_query or get_tool_schemas'` → 28 passed, 400 deselected
- `python3 -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py tests/test_tool_contracts.py -q` → 645 passed, 1 warning
- `python3 -m pytest -q` → 983 passed, 1 warning
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 983 passed, 1 warning
- `python3 -m compileall -q .`
- `python3 -m py_compile scripts/import_lossless_claw.py`
- `bash -n scripts/install.sh scripts/update.sh`
- `git diff --check`
- GitHub CI on `9951876`: workflow-lint and Python 3.11, 3.12, 3.13, 3.14 all passed
