### PR TITLE
fix: complete auto-derive focus topic with demote old topics (mirror upstream hermes-agent #44687 + #44454)

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -84,7 +84,7 @@ _SESSION_END_BUSY_TIMEOUT_MS = 50
 
 # Auto-focus topic derivation: infer a compact focus hint from the most recent
 # real user turns so that summarization can prioritise current user intent.
-# Mirrors Hermes upstream fix/compression-auto-focus-topic (#44674 branch).
+# Mirrors Hermes upstream fix/compression-auto-focus-topic (#44687 branch).
 _AUTO_FOCUS_MAX_TURNS = 3
 _AUTO_FOCUS_TURN_MAX_CHARS = 260
 _AUTO_FOCUS_MAX_CHARS = 700

--- a/escalation.py
+++ b/escalation.py
@@ -148,8 +148,10 @@ def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
 # so headings influence LLM attention rather than being hard reference-only
 # markers.  The practical effect is that LLMs naturally down-weight content
 # under "Historical" headings, but no code path enforces the boundary.
-# (hermes-agent issue #9631 / PR #44687 — iterative compaction kept completed
-#  topics alive because no structural demote signal existed.)
+# (hermes-agent issue #9631: iterative compaction kept completed topics alive.
+#  PR #44687 adds auto-derive focus topic; PR #44454 salvaged #44345/#41650
+#  and introduced HISTORICAL_*_HEADING constants [8f8cad7ec / d5e2fbf24]
+#  for structural demote of stale/completed topics.)
 _HISTORICAL_HEADING_MARKERS = (
     "## Historical Task Snapshot",
     "## Historical In-Progress State",
@@ -162,9 +164,10 @@ _HISTORICAL_HEADING_MARKERS = (
 def _build_l1_focus_brief(focus_topic: str) -> str:
     """Build L1 focus guidance with explicit demote instructions for stale topics.
 
-    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44687)
-    which adds "demote old topics" to prevent iterative compaction from keeping
-    completed topics alive and overriding the current active topic (issue #9631).
+    Mirrors upstream hermes-agent PR #44687 (auto-derive focus topic) and
+    PR #44454 (historical heading constants + stale-task demotion) to prevent
+    iterative compaction from keeping completed topics alive and overriding
+    the current active topic (issue #9631).
     """
     topic = _normalized_focus_topic(focus_topic)
     if not topic:
@@ -189,7 +192,8 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
 def _build_l2_focus_brief(focus_topic: str) -> str:
     """Build L2 focus guidance with explicit demote instructions for stale topics.
 
-    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44687).
+    Mirrors upstream hermes-agent PR #44687 (auto-focus) and PR #44454
+    (historical heading constants + stale-task demotion).
     """
     topic = _normalized_focus_topic(focus_topic)
     if not topic:

--- a/escalation.py
+++ b/escalation.py
@@ -142,10 +142,12 @@ def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
 
 
 # Historical section headings — mirror upstream hermes-agent constants so that
-# the summariser can use them as structural anchors for demoting stale content.
-# When a summary section carries one of these headings, the agent treats its
-# contents as reference-only and will NOT resume that work unless the latest
-# user message explicitly requests it.
+# the summariser has consistent structural anchors for grouping stale content.
+# These headings act as summariser guidance, not an enforced active-context
+# contract: _assemble_context() passes node.summary through as ordinary content,
+# so headings influence LLM attention rather than being hard reference-only
+# markers.  The practical effect is that LLMs naturally down-weight content
+# under "Historical" headings, but no code path enforces the boundary.
 # (hermes-agent issue #9631 / PR #44674 — iterative compaction kept completed
 #  topics alive because no structural demote signal existed.)
 _HISTORICAL_HEADING_MARKERS = frozenset((
@@ -179,6 +181,8 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
         "mark them under one of these historical headings: {markers}.\n"
         "Frame them as STALE context — the agent must NOT resume that work unless the latest user message\n"
         "explicitly asks for it. If fully resolved, reduce to a one-line bullet or omit.\n"
+        "Exception: active blockers or handoff state should NOT be demoted even if they are absent from the\n"
+        "latest turns. Keep blockers and pending handoffs outside historical headings so the agent can still act on them.\n"
     ).format(markers=markers)
 
 
@@ -201,6 +205,8 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         "Place non-current work under: {markers}.\n"
         "These sections are STALE — the agent must not act on them unless the latest user message explicitly\n"
         "requests it. Reduce resolved topics to one-liners or drop.\n"
+        "Exception: active blockers and pending handoff state should NOT be demoted even when absent from recent\n"
+        "turns. Keep them outside historical headings so the agent retains awareness of unresolved constraints.\n"
     ).format(markers=markers)
 
 

--- a/escalation.py
+++ b/escalation.py
@@ -141,6 +141,22 @@ def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
     return normalized[: max(0, max_chars - 1)].rstrip() + "…"
 
 
+# Historical section headings — mirror upstream hermes-agent constants so that
+# the summariser can use them as structural anchors for demoting stale content.
+# When a summary section carries one of these headings, the agent treats its
+# contents as reference-only and will NOT resume that work unless the latest
+# user message explicitly requests it.
+# (hermes-agent issue #9631 / PR #44674 — iterative compaction kept completed
+#  topics alive because no structural demote signal existed.)
+_HISTORICAL_HEADING_MARKERS = frozenset((
+    "## Historical Task Snapshot",
+    "## Historical In-Progress State",
+    "## Historical Pending User Asks",
+    "## Historical Remaining Work",
+    "## Completed Actions (historical)",
+))
+
+
 def _build_l1_focus_brief(focus_topic: str) -> str:
     """Build L1 focus guidance with explicit demote instructions for stale topics.
 
@@ -151,19 +167,19 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
     topic = _normalized_focus_topic(focus_topic)
     if not topic:
         return ""
+    markers = " / ".join(f"'{m}'" for m in _HISTORICAL_HEADING_MARKERS)
     return (
         "Focus brief:\n"
         f"Primary focus: {topic}\n"
         "Preserve concrete decisions, constraints, files, commands, identifiers, and current state for this focus.\n"
-        "Spend roughly 60-70% of the summary budget on the focus when relevant.\n"
+        "Spend roughly 60-70% of the summary token budget on the focus when relevant.\n"
         "\n"
         "Demote old / completed topics:\n"
         "If the summary contains tasks, questions, or remaining work that are no longer active in the latest turns,\n"
-        "mark them as historical reference only. Use a section heading like '## Historical Remaining Work' or\n"
-        "'## Completed Actions (for reference only)' and frame them as STALE context. The agent must NOT resume\n"
-        "stale tasks unless the latest user message explicitly asks for it. If the old topic has been fully resolved,\n"
-        "reduce it to a one-line bullet or omit it entirely.\n"
-    )
+        "mark them under one of these historical headings: {markers}.\n"
+        "Frame them as STALE context — the agent must NOT resume that work unless the latest user message\n"
+        "explicitly asks for it. If fully resolved, reduce to a one-line bullet or omit.\n"
+    ).format(markers=markers)
 
 
 def _build_l2_focus_brief(focus_topic: str) -> str:
@@ -174,6 +190,7 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
     topic = _normalized_focus_topic(focus_topic)
     if not topic:
         return ""
+    markers = " / ".join(f"'{m}'" for m in _HISTORICAL_HEADING_MARKERS)
     return (
         "Focus brief:\n"
         f"Primary focus: {topic}\n"
@@ -181,9 +198,10 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         "Keep other active tasks only when they are current blockers or handoff state.\n"
         "\n"
         "Demote old / completed topics:\n"
-        "Mark any non-current tasks as historical/STALE. The agent must not act on them unless explicitly requested\n"
-        "by the latest user message. Reduce resolved topics to one-liners or drop them.\n"
-    )
+        "Place non-current work under: {markers}.\n"
+        "These sections are STALE — the agent must not act on them unless the latest user message explicitly\n"
+        "requests it. Reduce resolved topics to one-liners or drop.\n"
+    ).format(markers=markers)
 
 
 def _summary_model_chain(primary_model: str = "", fallback_models: list[str] | tuple[str, ...] | None = None) -> list[str]:

--- a/escalation.py
+++ b/escalation.py
@@ -142,6 +142,12 @@ def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
 
 
 def _build_l1_focus_brief(focus_topic: str) -> str:
+    """Build L1 focus guidance with explicit demote instructions for stale topics.
+
+    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44674)
+    which adds "demote old topics" to prevent iterative compaction from keeping
+    completed topics alive and overriding the current active topic (issue #9631).
+    """
     topic = _normalized_focus_topic(focus_topic)
     if not topic:
         return ""
@@ -150,11 +156,21 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
         f"Primary focus: {topic}\n"
         "Preserve concrete decisions, constraints, files, commands, identifiers, and current state for this focus.\n"
         "Spend roughly 60-70% of the summary budget on the focus when relevant.\n"
-        "Do not discard unrelated blockers or active tasks just because they are off-focus.\n"
+        "\n"
+        "Demote old / completed topics:\n"
+        "If the summary contains tasks, questions, or remaining work that are no longer active in the latest turns,\n"
+        "mark them as historical reference only. Use a section heading like '## Historical Remaining Work' or\n"
+        "'## Completed Actions (for reference only)' and frame them as STALE context. The agent must NOT resume\n"
+        "stale tasks unless the latest user message explicitly asks for it. If the old topic has been fully resolved,\n"
+        "reduce it to a one-line bullet or omit it entirely.\n"
     )
 
 
 def _build_l2_focus_brief(focus_topic: str) -> str:
+    """Build L2 focus guidance with explicit demote instructions for stale topics.
+
+    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44674).
+    """
     topic = _normalized_focus_topic(focus_topic)
     if not topic:
         return ""
@@ -163,6 +179,10 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         f"Primary focus: {topic}\n"
         "Prefer bullets that preserve decisions, blockers, files, commands, identifiers, and current state for this focus.\n"
         "Keep other active tasks only when they are current blockers or handoff state.\n"
+        "\n"
+        "Demote old / completed topics:\n"
+        "Mark any non-current tasks as historical/STALE. The agent must not act on them unless explicitly requested\n"
+        "by the latest user message. Reduce resolved topics to one-liners or drop them.\n"
     )
 
 

--- a/escalation.py
+++ b/escalation.py
@@ -157,7 +157,6 @@ _HISTORICAL_HEADING_MARKERS = (
     "## Historical In-Progress State",
     "## Historical Pending User Asks",
     "## Historical Remaining Work",
-    "## Completed Actions (historical)",
 )
 
 

--- a/escalation.py
+++ b/escalation.py
@@ -148,21 +148,21 @@ def _normalized_focus_topic(focus_topic: str, max_chars: int = 160) -> str:
 # so headings influence LLM attention rather than being hard reference-only
 # markers.  The practical effect is that LLMs naturally down-weight content
 # under "Historical" headings, but no code path enforces the boundary.
-# (hermes-agent issue #9631 / PR #44674 — iterative compaction kept completed
+# (hermes-agent issue #9631 / PR #44687 — iterative compaction kept completed
 #  topics alive because no structural demote signal existed.)
-_HISTORICAL_HEADING_MARKERS = frozenset((
+_HISTORICAL_HEADING_MARKERS = (
     "## Historical Task Snapshot",
     "## Historical In-Progress State",
     "## Historical Pending User Asks",
     "## Historical Remaining Work",
     "## Completed Actions (historical)",
-))
+)
 
 
 def _build_l1_focus_brief(focus_topic: str) -> str:
     """Build L1 focus guidance with explicit demote instructions for stale topics.
 
-    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44674)
+    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44687)
     which adds "demote old topics" to prevent iterative compaction from keeping
     completed topics alive and overriding the current active topic (issue #9631).
     """
@@ -189,7 +189,7 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
 def _build_l2_focus_brief(focus_topic: str) -> str:
     """Build L2 focus guidance with explicit demote instructions for stale topics.
 
-    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44674).
+    Mirrors upstream hermes-agent fix/compression-auto-focus-topic (#44687).
     """
     topic = _normalized_focus_topic(focus_topic)
     if not topic:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3603,6 +3603,11 @@ class TestEscalation:
         assert "must NOT resume" in prompt
         assert "## Historical Task Snapshot" in prompt
         assert "## Historical Remaining Work" in prompt
+        assert "## Completed Actions (historical)" not in prompt
+        assert (
+            "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
+            "'## Historical Pending User Asks' / '## Historical Remaining Work'"
+        ) in prompt
         # Blocker / handoff exception
         assert "Exception: active blockers or handoff state should NOT be demoted" in prompt
         assert "Keep blockers and pending handoffs outside historical headings" in prompt
@@ -3619,6 +3624,11 @@ class TestEscalation:
         assert "Keep other active tasks only when they are current blockers or handoff state." in prompt
         # Demote + blocker exception
         assert "Demote old / completed topics:" in prompt
+        assert "## Completed Actions (historical)" not in prompt
+        assert (
+            "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
+            "'## Historical Pending User Asks' / '## Historical Remaining Work'"
+        ) in prompt
         assert "Exception: active blockers and pending handoff state should NOT be demoted" in prompt
         assert "Keep them outside historical headings so the agent retains awareness" in prompt
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3598,7 +3598,11 @@ class TestEscalation:
         assert "Focus brief:" in prompt
         assert "Primary focus: database migrations" in prompt
         assert "Preserve concrete decisions, constraints, files, commands, identifiers, and current state for this focus." in prompt
-        assert "Do not discard unrelated blockers or active tasks just because they are off-focus." in prompt
+        assert "Demote old / completed topics:" in prompt
+        assert "STALE context" in prompt
+        assert "must NOT resume" in prompt
+        assert "## Historical Task Snapshot" in prompt
+        assert "## Historical Remaining Work" in prompt
 
     def test_focus_topic_builds_structured_l2_brief(self):
         from hermes_lcm.escalation import _build_l2_prompt

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3603,6 +3603,9 @@ class TestEscalation:
         assert "must NOT resume" in prompt
         assert "## Historical Task Snapshot" in prompt
         assert "## Historical Remaining Work" in prompt
+        # Blocker / handoff exception
+        assert "Exception: active blockers or handoff state should NOT be demoted" in prompt
+        assert "Keep blockers and pending handoffs outside historical headings" in prompt
 
     def test_focus_topic_builds_structured_l2_brief(self):
         from hermes_lcm.escalation import _build_l2_prompt
@@ -3614,6 +3617,10 @@ class TestEscalation:
         assert "Primary focus: release blockers" in prompt
         assert "Prefer bullets that preserve decisions, blockers, files, commands, identifiers, and current state for this focus." in prompt
         assert "Keep other active tasks only when they are current blockers or handoff state." in prompt
+        # Demote + blocker exception
+        assert "Demote old / completed topics:" in prompt
+        assert "Exception: active blockers and pending handoff state should NOT be demoted" in prompt
+        assert "Keep them outside historical headings so the agent retains awareness" in prompt
 
     def test_focus_topic_is_normalized_and_bounded_in_prompts(self):
         from hermes_lcm.escalation import _build_l1_prompt


### PR DESCRIPTION
## Summary

Completes the Hermes-LCM auto-focus compression parity work by adding stale-topic demotion guidance to the L1 and L2 focus briefs.

This now splits the upstream provenance correctly: Hermes Agent PR #44687 covers auto-derived focus topics, while PR #44454 covers the historical heading and stale-task demotion behavior from #44345 and #41650.

The historical heading marker list now matches the upstream `HISTORICAL_*_HEADING` constants exactly and stays ordered so generated prompt guidance is deterministic.

## Why

Hermes Agent issue #9631 was the same failure shape we saw here: iterative compaction kept completed or stale topics alive with too much weight, so the agent could resume old work instead of following the latest user turn.

Hermes-LCM had already migrated the auto-focus side, but not the structural demotion side. This adds that missing guidance while preserving the blocker and handoff exception, so unresolved constraints do not get hidden just because they are absent from the latest few turns.

## Notes

Hermes-LCM injects this through `_build_l1_focus_brief()` and `_build_l2_focus_brief()` rather than the upstream `ContextCompressor` prompt template. The intent is the same, but the integration point is plugin-specific.

## Validation

- `python3 -m py_compile engine.py escalation.py`
- `python3 -m compileall -q .`
- `git diff --check origin/main...HEAD`
- `python3 -m pytest tests/test_lcm_core.py::TestEscalation tests/test_auto_focus_topic.py -q` → 23 passed
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` → 658 passed
- `python3 -m pytest -q` → 984 passed
- `bash -lc 'ulimit -n 1024 && python3 -m pytest -q'` → 984 passed
- PYTHONHASHSEED marker-order check across `1`, `2`, `3`, `100`, and `random` → stable
- GitHub CI on `ca6a3fc` → green across workflow-lint and Python 3.11, 3.12, 3.13, 3.14

Refs #257
