### PR TITLE
fix: preserve raw session ownership across compression rollover

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -33,7 +33,6 @@ from .externalize import (
     find_externalized_payload_for_message,
     load_externalized_payload,
     maybe_externalize_tool_output,
-    reassign_externalized_payloads,
 )
 from .extraction import (
     extract_before_compaction,
@@ -2056,21 +2055,17 @@ class LCMEngine(ContextEngine):
                 source_session_id,
                 frontier_store_id=frontier,
             )
-            moved_messages = self._store.reassign_session_messages(source_session_id, session_id)
+            # Compression rollover carries derived context forward, but raw
+            # messages remain owned by the session that produced them. Moving
+            # raw rows here makes session-scoped transcript recovery report the
+            # old/child session as missing even though its payload was only
+            # reassigned to the next compression segment.
             moved_nodes = self._dag.reassign_session_nodes(source_session_id, session_id)
-            moved_payloads = reassign_externalized_payloads(
-                source_session_id,
-                session_id,
-                config=self._config,
-                hermes_home=self._hermes_home,
-            )
             logger.debug(
-                "LCM compression boundary continued %s -> %s: moved %d messages, %d DAG nodes, %d externalized payloads",
+                "LCM compression boundary continued %s -> %s: carried %d DAG nodes; preserved raw message ownership",
                 source_session_id,
                 session_id,
-                moved_messages,
                 moved_nodes,
-                moved_payloads,
             )
         elif old_session_id:
             logger.warning(

--- a/tests/test_compression_boundary.py
+++ b/tests/test_compression_boundary.py
@@ -1,0 +1,79 @@
+import json
+import time
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryNode
+from hermes_lcm.engine import LCMEngine
+
+
+def test_compression_boundary_carries_summaries_without_moving_raw_messages(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    try:
+        engine.on_session_start(
+            "parent-session",
+            platform="discord",
+            conversation_id="discord-thread",
+            context_length=200_000,
+        )
+        store_ids = engine._store.append_batch(
+            "parent-session",
+            [
+                {"role": "user", "content": "raw parent payload"},
+                {"role": "assistant", "content": "raw assistant payload"},
+            ],
+            source="discord",
+        )
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="parent-session",
+                depth=0,
+                summary="summary carried across compression boundary",
+                token_count=8,
+                source_token_count=12,
+                source_ids=store_ids,
+                source_type="messages",
+                created_at=time.time(),
+                earliest_at=time.time(),
+                latest_at=time.time(),
+                expand_hint="Expand for raw parent payload",
+            )
+        )
+        externalized_dir = tmp_path / "externalized"
+        externalized_dir.mkdir()
+        payload_path = externalized_dir / "payload.json"
+        payload_path.write_text(
+            json.dumps(
+                {
+                    "kind": "ingest_payload",
+                    "role": "tool",
+                    "session_id": "parent-session",
+                    "content": "large raw payload",
+                    "created_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        engine.on_session_start(
+            "child-session",
+            platform="discord",
+            conversation_id="discord-thread",
+            context_length=200_000,
+            boundary_reason="compression",
+            old_session_id="parent-session",
+        )
+
+        assert engine._store.get_session_count("parent-session") == 2
+        assert engine._store.get_session_count("child-session") == 0
+        assert engine._dag.get_session_nodes("parent-session") == []
+        child_nodes = engine._dag.get_session_nodes("child-session")
+        assert len(child_nodes) == 1
+        assert child_nodes[0].source_ids == store_ids
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        assert payload["session_id"] == "parent-session"
+    finally:
+        engine.shutdown()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5280,8 +5280,8 @@ class TestSessionRollover:
         assert moved == 1
         assert engine._session_id == "compress-rollover-new"
         assert engine._conversation_id == old_conversation_id
-        assert engine._store.get_session_count("compress-rollover-old") == 0
-        assert engine._store.get_session_count("compress-rollover-new") == 1
+        assert engine._store.get_session_count("compress-rollover-old") == 1
+        assert engine._store.get_session_count("compress-rollover-new") == 0
         assert engine._dag.get_session_nodes("compress-rollover-old") == []
         new_nodes = engine._dag.get_session_nodes("compress-rollover-new")
         assert [node.node_id for node in new_nodes] == [node_id]
@@ -5534,7 +5534,8 @@ class TestSessionRollover:
 
         assert engine._session_id == "foreground-continuation"
         assert engine._conversation_id == foreground_conversation_id
-        assert engine._store.get_session_count("foreground-continuation") == 1
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("foreground-continuation") == 0
         assert engine._dag.get_session_nodes("foreground-session") == []
         assert [
             node.node_id for node in engine._dag.get_session_nodes("foreground-continuation")
@@ -6237,7 +6238,8 @@ class TestSessionRollover:
         assert engine._session_id == "reused-continuation"
         assert engine._conversation_id == conversation_id
         assert engine._thread_context_session_id() == ""
-        assert engine._store.get_session_count("reused-continuation") == 1
+        assert engine._store.get_session_count("reused-session") == 1
+        assert engine._store.get_session_count("reused-continuation") == 0
         assert engine._dag.get_session_nodes("reused-session") == []
         assert [
             node.node_id for node in engine._dag.get_session_nodes("reused-continuation")
@@ -6615,7 +6617,8 @@ class TestSessionRollover:
         ]
         engine.on_session_end("background-review-session", background_messages)
 
-        assert engine._store.get_session_count("foreground-continuation") == 2
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert engine._store.get_session_count("foreground-continuation") == 1
         assert engine._store.get_session_count("background-review-session") == 0
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
 
@@ -7535,15 +7538,15 @@ class TestSessionRollover:
         assert engine.last_total_tokens == 1050
         assert engine._last_compacted_store_id == store_id
         assert engine._ingest_cursor == 2
-        assert engine._store.get_session_count("old-session") == 0
-        assert engine._store.get_session_count("new-session") == 1
+        assert engine._store.get_session_count("old-session") == 1
+        assert engine._store.get_session_count("new-session") == 0
         assert engine._dag.get_session_nodes("old-session") == []
         new_nodes = engine._dag.get_session_nodes("new-session")
         assert len(new_nodes) == 1
         assert new_nodes[0].summary == "pre-rollover summary"
 
         status = engine.get_status()
-        assert status["store_messages"] == 1
+        assert status["store_messages"] == 0
         assert status["dag_nodes"] == 1
         assert status["compression_count"] == 1
         assert status["lifecycle"]["current_session_id"] == "new-session"
@@ -7611,8 +7614,8 @@ class TestSessionRollover:
         assert engine.last_total_tokens == 1050
         assert engine._last_compacted_store_id == source_store_id
         assert engine._ingest_cursor == 2
-        assert engine._store.get_session_count("lcm-source") == 0
-        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
         assert engine._store.get_session_count("old-hermes-session") == 1
         assert engine._dag.get_session_nodes("lcm-source") == []
         new_nodes = engine._dag.get_session_nodes("new-hermes-session")
@@ -7624,7 +7627,7 @@ class TestSessionRollover:
         assert stale_host_node.session_id == "old-hermes-session"
 
         status = engine.get_status()
-        assert status["store_messages"] == 1
+        assert status["store_messages"] == 0
         assert status["dag_nodes"] == 1
         assert status["compression_count"] == 2
         expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": source_node_id}))
@@ -7701,8 +7704,8 @@ class TestSessionRollover:
 
         assert engine._session_id == "new-hermes-session"
         assert engine._conversation_id == "shared-conversation"
-        assert engine._store.get_session_count("lcm-source") == 0
-        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
         assert engine._store.get_session_count("old-hermes-session") == 1
         assert engine._dag.get_session_nodes("lcm-source") == []
         new_nodes = engine._dag.get_session_nodes("new-hermes-session")
@@ -7784,8 +7787,8 @@ class TestSessionRollover:
         assert engine.last_total_tokens == 1050
         assert engine._last_compacted_store_id == source_store_id
         assert engine._ingest_cursor == 2
-        assert engine._store.get_session_count("lcm-source") == 0
-        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
         assert engine._store.get_session_count("old-hermes-session") == 1
         assert engine._dag.get_session_nodes("lcm-source") == []
         new_nodes = engine._dag.get_session_nodes("new-hermes-session")
@@ -7955,8 +7958,8 @@ class TestSessionRollover:
         assert engine.compression_count == 3
         assert engine._last_compacted_store_id == source_store_id
         assert engine._ingest_cursor == 2
-        assert engine._store.get_session_count("lcm-source") == 0
-        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
         assert engine._store.get_session_count("old-hermes-session") == 1
         assert engine._dag.get_session_nodes("lcm-source") == []
         new_nodes = engine._dag.get_session_nodes("new-hermes-session")
@@ -8191,8 +8194,8 @@ class TestSessionRollover:
         # Fallback activated — nodes transferred, source conv wins
         assert engine._conversation_id == "conversation-x"
         assert engine.compression_count == 3
-        assert engine._store.get_session_count("lcm-source") == 0
-        assert engine._store.get_session_count("new-hermes-session") == 1
+        assert engine._store.get_session_count("lcm-source") == 1
+        assert engine._store.get_session_count("new-hermes-session") == 0
         assert engine._dag.get_session_nodes("lcm-source") == []
         new_nodes = engine._dag.get_session_nodes("new-hermes-session")
         assert len(new_nodes) == 1
@@ -8335,8 +8338,8 @@ class TestSessionRollover:
 
         assert engine._session_id == "foreground-new"
         assert engine._conversation_id == "foreground-conversation"
-        assert engine._store.get_session_count("foreground-old") == 0
-        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._store.get_session_count("foreground-old") == 1
+        assert engine._store.get_session_count("foreground-new") == 0
         assert engine._dag.get_session_nodes("foreground-old") == []
         new_nodes = engine._dag.get_session_nodes("foreground-new")
         assert [node.node_id for node in new_nodes] == [node_id]
@@ -8424,8 +8427,8 @@ class TestSessionRollover:
         assert lifecycle.current_frontier_store_id == fg_store_id
         assert lifecycle.last_finalized_frontier_store_id == fg_store_id
         assert engine._last_compacted_store_id == fg_store_id
-        assert engine._store.get_session_count("foreground-old") == 0
-        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._store.get_session_count("foreground-old") == 1
+        assert engine._store.get_session_count("foreground-new") == 0
         assert engine._store.get_session_count("aux-old") == 1
         assert engine._dag.get_session_nodes("foreground-old") == []
         new_nodes = engine._dag.get_session_nodes("foreground-new")
@@ -8500,8 +8503,8 @@ class TestSessionRollover:
         assert lifecycle.last_finalized_session_id == "foreground-active"
         assert lifecycle.current_frontier_store_id == fg_store_id
         assert lifecycle.last_finalized_frontier_store_id == fg_store_id
-        assert engine._store.get_session_count("foreground-active") == 0
-        assert engine._store.get_session_count("foreground-new") == 1
+        assert engine._store.get_session_count("foreground-active") == 1
+        assert engine._store.get_session_count("foreground-new") == 0
         assert engine._dag.get_session_nodes("foreground-active") == []
         new_nodes = engine._dag.get_session_nodes("foreground-new")
         assert [node.node_id for node in new_nodes] == [fg_node_id]
@@ -8537,7 +8540,7 @@ class TestSessionRollover:
         assert engine._last_compacted_store_id == 0
         assert engine._ingest_cursor == 0
 
-    def test_compression_boundary_reassigns_externalized_payload_session_metadata(self, tmp_path):
+    def test_compression_boundary_preserves_externalized_payload_session_metadata(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_compression_externalized.db"),
             large_output_externalization_enabled=True,
@@ -8581,9 +8584,9 @@ class TestSessionRollover:
             context_length=200000,
         )
 
-        assert json.loads(payload_file.read_text())["session_id"] == "new-session"
+        assert json.loads(payload_file.read_text())["session_id"] == "old-session"
         result = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
-        assert result["expanded"][0]["externalized"]["session_id"] == "new-session"
+        assert result["expanded"][0]["externalized"]["session_id"] == "old-session"
         assert result["expanded"][0]["externalized"]["tool_call_id"] == "call_big"
 
     def test_rollover_session_records_durable_lifecycle_state_idempotently(self, engine):


### PR DESCRIPTION
## Summary
- Preserve raw session ownership across compression rollover.
- Compression continuation now carries derived DAG summary nodes forward without reassigning raw `messages` rows or externalized payload metadata to the continuation session.
- Added regression coverage for the compression boundary ownership invariant and updated existing rollover assertions.

## Why
- Before this change, `_continue_compression_boundary()` reassigned raw message rows, summary DAG nodes, and externalized payload JSON metadata from the producing session to the continuation session.
- That made old/source sessions look empty or missing after compression even though their payloads had only been moved across the boundary.
- It also rewrote externalized payload metadata to the continuation session even when the payload was produced in the previous segment.
- The intended invariant is sharper: raw transcript data and large-payload provenance stay with the session that produced them; only derived compressed context moves forward.
- Keeping that boundary explicit makes session-scoped recovery, debugging, and future archaeology line up with where data actually came from.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py::TestSessionRollover tests/test_compression_boundary.py -q` -> `80 passed in 20.10s`
- [x] Adjacent validation: `python -m pytest tests/test_lcm_command.py tests/test_lcm_rotate.py tests/test_crash_safe_wal.py tests/test_lcm_core.py tests/test_lcm_engine.py::TestSessionRollover tests/test_compression_boundary.py -q` -> `385 passed in 161.65s`
- [x] Syntax validation: `python -m py_compile engine.py tests/test_lcm_engine.py tests/test_compression_boundary.py` -> passed
- [x] Whitespace validation: `git diff --check origin/main...HEAD` -> passed
- [x] CI validation: GitHub Actions `workflow-lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`, and `test (3.14)` -> passed
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- Default validation items not checked above were not run locally as exact commands; the PR instead ran focused rollover coverage, adjacent LCM suites, syntax checks, whitespace checks, and the full GitHub Actions matrix.
- No workflow files changed, so `actionlint` was not run locally.

Refs #
