### PR TITLE
fix: clarify LCM operability and release checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+This repo also publishes GitHub Releases. This file is the repo-root release surface for operators who want the recent release arc without leaving the checkout.
+
+## Unreleased
+
+- Preserved raw session ownership across compression rollover after `/new`, so carried-over summaries can still expand back to original raw rows. (#269)
+- Current post-v0.18 follow-up state: adoption and operator-readiness hardening. No broad feature lane is active from this changelog entry.
+
+## v0.18.0 - 2026-06-18
+
+Release focus: retrieval depth, durability, status provenance, and long-session correctness.
+
+- Added recursive evidence support for `lcm_expand_query`, improving synthesized answers from expanded LCM context. (#266)
+- Hardened externalized payload durability. (#265)
+- Avoided duplicate ingest protection work on hot paths. (#262)
+- Aggregated DAG status stats for cheaper health surfaces. (#264)
+- Preserved source lineage after long sessions. (#263)
+- Surfaced LCM config provenance in runtime status. (#261)
+- Fixed per-turn ingest for WebUI sessions and batch timestamp deduplication. (#260)
+
+## v0.17.0 - 2026-06-14
+
+Release focus: automatic focus-topic derivation and lifecycle hygiene.
+
+- Added auto-derived focus topics during compression.
+- Added empty lifecycle-row garbage collection to prevent unbounded accumulation. (#256)
+- Improved runtime context indicators.
+
+## v0.16.x - 2026-06
+
+Release focus: engine isolation, WAL durability, database-path clarity, and startup cost control.
+
+- Isolated LCM engine state per agent. (#247)
+- Preferred bound sessions on sibling chains when the host has zero DAG.
+- Tuned compaction defaults and clarified context-threshold ownership. (#245)
+- Clarified `LCM_DATABASE_PATH` override behavior. (#249)
+- Hardened WAL durability and graceful-close checkpoints. (#237)
+- Throttled startup FTS integrity checks to reduce launch time. (#236)
+
+## Links
+
+- GitHub Releases: https://github.com/stephenschoettler/hermes-lcm/releases
+- Release workflow: [`.github/workflows/release.yml`](.github/workflows/release.yml)
+- Validation expectations: [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ Do **not** claim behavior that is only partially implemented. If a filter, featu
 Default validation for code changes:
 
 ```bash
+scripts/validate_release.sh
 pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
 pytest -q
 bash -lc 'ulimit -n 1024 && pytest -q'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,8 @@ PR bodies should use this template. It is mirrored in `.github/PULL_REQUEST_TEMP
 - [ ] Default validation:
   - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
   - [ ] `pytest -q`
-  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
-  - [ ] `python -m compileall -q .`
-  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
-  - [ ] `bash -n scripts/install.sh scripts/update.sh`
-  - [ ] `git diff --check`
+  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-<topic>`
+  - [ ] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
 - [ ] Workflow validation, if workflows changed: `actionlint`
 
 ## Notes
@@ -104,14 +101,12 @@ Do **not** claim behavior that is only partially implemented. If a filter, featu
 Default validation for code changes:
 
 ```bash
-scripts/validate_release.sh
+scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-<topic>
 pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
 pytest -q
-bash -lc 'ulimit -n 1024 && pytest -q'
-python -m compileall -q .
-python -m py_compile scripts/import_lossless_claw.py
-bash -n scripts/install.sh scripts/update.sh
+git diff --check origin/main...HEAD
 git diff --check
+git diff --cached --check
 ```
 
 Workflow changes should also run:

--- a/README.md
+++ b/README.md
@@ -9,88 +9,63 @@
 
 > Bounded context, unbounded memory. Nothing is ever lost.
 
-
-Based on the [LCM paper](https://papers.voltropy.com/LCM) by Ehrlich & Blackman (Voltropy PBC, Feb 2026).
-Inspired by [lossless-claw](https://github.com/martian-engineering/lossless-claw) for OpenClaw.
+Based on the [LCM paper](https://papers.voltropy.com/LCM) by Ehrlich & Blackman (Voltropy PBC, Feb 2026). Inspired by [lossless-claw](https://github.com/martian-engineering/lossless-claw) for OpenClaw.
 
 ---
 
-## The Problem
+## Why this exists
 
-When active context fills up, agents usually replace older turns with a flat
-summary. Details can fall out of the prompt, and recovery depends on a separate
-history path the model may not use.
+When active context fills up, agents usually replace older turns with a flat summary. Details can fall out of the prompt, and recovery depends on a separate history path the model may not use.
+
+`hermes-lcm` persists the conversation, compacts older context into a hierarchical summary DAG, and gives the agent tools to drill back into the exact material that was compacted.
 
 <p align="center">
   <img src="docs/standard_compression.png" alt="Standard compression" width="700">
 </p>
 
-## The Fix
-
-Persist the conversation, compact old context into a hierarchical summary DAG,
-and give the agent tools to drill back into the exact material that was
-compacted.
-
 <p align="center">
   <img src="docs/lcm_compression.png" alt="LCM compression" width="700">
 </p>
 
-<p align="center">
-  <img src="docs/architecture.png" alt="Architecture" width="700">
-</p>
+## What you get
 
-## What It Does
-
-- **SQLite message store** - preserves raw messages by default before compaction
-- **Summary DAG** - compacts older context into depth-aware summary nodes
-- **Bounded recovery** - pages raw messages, child summaries, and externalized payloads without flooding the main context
-- **Agent tools** - `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query`
-- **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
-- **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
-- **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
-- **Sensitive-pattern controls** - optional named redaction of API keys, bearer tokens, passwords, and private keys before LCM stores or summarizes them
-- **Storage-boundary payload guard** - media-ish `data:*;base64` and long base64-looking strings are externalized before LCM writes them to SQLite
-- **Diagnostics** - `lcm_status`, `lcm_doctor`, and optional `/lcm` slash commands
+- SQLite message store for raw-message preservation before compaction
+- Summary DAG for depth-aware long-session condensation
+- Recovery tools: `lcm_grep`, `lcm_load_session`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`
+- Health tools: `lcm_status`, `lcm_doctor`, plus optional `/lcm` slash commands
+- Source-aware retrieval, session controls, large-payload externalization, and optional sensitive-pattern redaction
+- Storage-boundary payload guard for media-ish `data:*;base64` values and oversized base64-like payloads before SQLite writes
 
 ## LCM vs built-in compression
 
-Hermes core may persist original conversation history in `state.db` before
-built-in compression rewrites the active prompt. Built-in compression can still
-be lossy in the active context, but previous content may be recoverable later
-through host-level history tools such as `session_search`.
+Hermes core may persist original conversation history in `state.db` before built-in compression rewrites the active prompt. Built-in compression can still be lossy in the active context, but previous content may be recoverable later through host-level history tools such as `session_search`.
 
-`hermes-lcm` is different because recall is part of the active context engine:
+`hermes-lcm` is different because recall is part of the active context engine: it uses a plugin-local store and DAG built specifically for drill-down, current-session retrieval through LCM tools, and explicit source-lineage/session-boundary rules. Position LCM around retrieval quality, autonomy, and drill-down behavior, not around the false claim that Hermes core has no persisted pre-compression record.
 
-- plugin-local store and DAG built specifically for drill-down
-- current-session retrieval through LCM tools, not an auxiliary cross-session search step
-- explicit source-lineage and session-boundary rules
+## Retrieval and storage contracts
 
-Position LCM around retrieval quality, autonomy, and drill-down behavior. Do not
-claim that Hermes core has no persisted record of pre-compression history.
+LCM tool recall defaults to current-session recall. `lcm_grep` can explicitly opt into bounded archive recovery with `session_scope='all'` for every session in the local LCM database, or `session_scope='session'` with a `session_id` for one known session. Broader LCM scopes only cover historical rows already present in `lcm.db`; use Hermes `session_search` for Hermes-tracked transcript history outside the plugin-local database.
+
+Lossless raw recovery contract: use `lcm_load_session` to enumerate a known session in chronological pages with `after_store_id`, then use `lcm_expand` with `source_offset` or `content_offset` to recover bounded original detail. `lcm_expand_query` uses the fresh context budget configured by `LCM_EXPANSION_CONTEXT_TOKENS` when expanding enough evidence for synthesis.
+
+Storage-boundary payload guard: LCM externalizes media-ish `data:*;base64` payloads and long base64-looking blobs before they cross the SQLite storage boundary. The guard covers raw message `messages.content` and assistant `messages.tool_calls` payloads so large binary-ish data does not get embedded directly in `lcm.db` rows. Doctor output is metadata-only: payload-boundary diagnostics report counts/paths, not raw payload bytes. If bytes already landed in Hermes `state.db`, that is upstream/outside LCM scope; use backup-first cleanup or migration procedures before mutating historical host rows.
 
 ## Requirements
 
 - Hermes Agent with the pluggable context engine slot ([PR #7464](https://github.com/NousResearch/hermes-agent/pull/7464))
 - Python 3.11+
-- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates. `regex` is used if available to apply timeouts to message ignore patterns; if it is not installed, message-level regex filtering is disabled with a warning rather than running unbounded stdlib `re` matches.
+- No required third-party runtime dependencies. `tiktoken` and `regex` are optional accelerators/guards.
 
-## Install
+## Quickstart
 
-Canonical install path: clone `hermes-lcm` as a general user plugin.
+Clone as a general user plugin:
 
 ```bash
 git clone https://github.com/stephenschoettler/hermes-lcm \
   ~/.hermes/plugins/hermes-lcm
 ```
 
-For a profile-specific install:
-
-```bash
-git clone https://github.com/stephenschoettler/hermes-lcm \
-  ~/.hermes/profiles/myprofile/plugins/hermes-lcm
-```
-
-From an existing checkout, install a symlink:
+Or install a symlink from an existing checkout:
 
 ```bash
 ./scripts/install.sh
@@ -98,14 +73,7 @@ From an existing checkout, install a symlink:
 HERMES_PROFILE=myprofile ./scripts/install.sh
 ```
 
-## Activate
-
-The plugin has two names:
-
-- plugin manifest name: `hermes-lcm`
-- runtime context engine name: `lcm`
-
-Both must be configured:
+Enable both the plugin manifest name and the runtime context engine name:
 
 ```yaml
 plugins:
@@ -117,28 +85,6 @@ context:
 ```
 
 Restart Hermes after changing plugin or context-engine config.
-
-## Update
-
-If you cloned directly into the plugin directory:
-
-```bash
-cd ~/.hermes/plugins/hermes-lcm && git pull --ff-only
-```
-
-For a profile-specific install:
-
-```bash
-cd ~/.hermes/profiles/myprofile/plugins/hermes-lcm && git pull --ff-only
-```
-
-If you installed a symlink from a separate checkout:
-
-```bash
-./scripts/update.sh
-```
-
-Restart Hermes after updating.
 
 ## Verify
 
@@ -164,531 +110,46 @@ Provider Plugins:
   Context Engine: lcm
 ```
 
-For source checkouts, `lcm_status`, `/lcm status`, `lcm_doctor`, and
-`/lcm doctor` also report the loaded plugin path and best-effort git identity:
-`plugin_git_commit`, `plugin_git_branch`, and `plugin_git_dirty`.
+For a live session check, send one normal Hermes message after restart, then run `lcm_status` or `/lcm status`. For database/config health, run `lcm_doctor` or `/lcm doctor`.
 
-## Troubleshooting
+If startup logs say LCM tools are available through `context-engine schemas` or mention the `Path B fallback`, that is expected on older Hermes hosts such as Hermes Agent v0.16. The seven `lcm_*` tools remain available through the context-engine path; standalone plugin-registry registration is not required there.
 
-### `hermes plugins` shows `lcm (not found)` but LCM tools exist
+## Update
 
-If `plugins.enabled` contains `hermes-lcm`, `context.engine: lcm` is set, and
-the runtime exposes LCM tools, LCM is loaded. The `lcm (not found)` line is a
-Hermes host discovery/status mismatch, not an LCM storage or compaction failure.
-
-### `/lcm status` looks unbound after restart
-
-After a fresh Hermes restart, `/lcm status` may show `session_id: (unbound)` or
-`threshold_tokens: (uninitialized)`. Send one normal Hermes message first, then
-run `lcm_status` or `/lcm status` again for live per-session fields.
-
-## Configuration
-
-Most installs only need `plugins.enabled` and `context.engine: lcm`. Useful
-environment variables:
-
-| Variable | Default | Use |
-|----------|---------|-----|
-| `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
-| `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
-| `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
-| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Raw-backlog floor before leaf compaction; with dynamic chunking enabled, the base chunk target |
-| `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Enable chunk-sized leaf compaction passes instead of compacting the whole non-tail raw backlog per pass |
-| `LCM_DYNAMIC_LEAF_CHUNK_MAX` | `40000` | Upper bound for dynamic leaf chunk targets |
-| `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after manual `/new` (`-1` all, `0` none) |
-| `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
-| `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
-| `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
-| `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
-| `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
-| `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
-| `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | `0.0` | Disabled at `0.0`; when set, permits critical-pressure bypasses for bounded deferred catch-up and cache-friendly follow-on condensation only |
-| `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
-| `LCM_SUMMARY_FALLBACK_MODELS` | empty | Comma-separated summarization models tried after `LCM_SUMMARY_MODEL` or the auxiliary task default fails |
-| `LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `2` | Consecutive failed summarization calls before a route is skipped temporarily |
-| `LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS` | `300` | Seconds to skip an open summary route before retrying it |
-| `LCM_EXPANSION_MODEL` | summary model / auxiliary | Override `lcm_expand_query` synthesis model |
-| `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Context budget used by the auxiliary LLM for `lcm_expand_query` |
-| `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for one summarization call |
-| `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for one `lcm_expand_query` synthesis call |
-| `LCM_DATABASE_PATH` | auto | SQLite database path. Empty config resolves to `HERMES_HOME/lcm.db`; plugin installs or operators may set this env var to another profile-scoped path such as `~/.hermes/hermes-lcm.db`. |
-| `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` | `24` | Minimum hours between startup FTS5 deep integrity-checks (O(index size)). `0` checks every startup (previous behavior); a negative value never checks on startup. Structural checks always run regardless. |
-| `LCM_ENABLE_SLASH_COMMAND` | `false` | Enable the optional `/lcm` operator command surface |
-| `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
-| `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
-| `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires (default 200 so fresh installs skip the work) |
-| `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
-
-Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
-
-Sensitive-pattern handling is disabled by default so ordinary LCM storage and
-`lcm_expand` remain lossless. When `LCM_SENSITIVE_PATTERNS_ENABLED=true`, matched
-secret values are replaced with metadata-only placeholders before SQLite, FTS,
-summaries, active replay, and externalized payload JSON receive the content. This
-is intentionally not lossless for matching values: the raw matched secret is
-unrecoverable after redaction.
-
-Supported named catalog entries are:
-
-- `api_key`: `api_key`, `api_token`, `access_token`, `secret_key`, and
-  `client_secret` assignments or JSON keys.
-- `bearer_token`: `Bearer ...` strings and token-like JSON keys.
-- `password_assignment`: `password`, `passwd`, `pwd`, and `passphrase`
-  assignments or JSON keys, including quoted values with spaces.
-- `private_key`: PEM private-key blocks.
-
-Redaction is forward-only. Enabling it does not rewrite existing SQLite rows,
-FTS shadow tables, DAG summaries, or externalized payload JSON that were written
-before the setting was enabled. Non-password placeholders include a short
-truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
-the digest to avoid making password-like values easier to dictionary-check.
-`lcm_status` and `lcm_doctor` expose the enabled state, configured pattern names,
-unknown names, source, and placeholder format without exposing raw secret values.
-
-### Cache policy boundary
-
-LCM is **cache-friendly**, not fully cache-aware. It may avoid some follow-on
-condensation churn, but current cache usage counters are retrospective status
-data only; they do not tell the plugin whether the next prompt mutation will
-break a hot provider cache. For that reason LCM does **not** implement
-provider/model TTL heuristics, provider-family detection, cache-touch/cache-break
-tracking, TTL delays, or full cache-aware deferred compaction.
-
-`LCM_CRITICAL_BUDGET_PRESSURE_RATIO` is a narrow escape hatch. It is disabled by
-default (`0.0`). When set, LCM compares prompt pressure against the context
-window and only at or above that ratio may bypass the existing polite gates for
-bounded deferred maintenance catch-up and cache-friendly follow-on condensation.
-Below that pressure, simpler existing behavior is preserved. Revisit full
-cache-aware deferred compaction only after Hermes core exposes reliable cache
-state / cache-break signals.
-
-### Threshold ownership
-
-When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
-threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
-compressor. Hermes core `compression.enabled` is still the global gate that
-allows compaction, so leave it enabled when using LCM.
-
-If startup/status output shows a host-side compression percentage that disagrees
-with LCM, trust live LCM status after a normal message has initialized the
-session.
-
-### Preset inspection and dry-run suggestions
-
-Model-aware presets are inspectable, but they are not automatic live config
-mutations. With `LCM_ENABLE_SLASH_COMMAND=true`, use:
-
-```text
-/lcm preset show codex_gpt_long_context
-/lcm preset show codex_spark_context
-/lcm preset suggest
-/lcm preset apply codex_gpt_long_context --dry-run
-/lcm preset apply codex_spark_context --dry-run
-```
-
-`/lcm preset show` reports the shipped preset metadata, benchmark provenance,
-policy file, policy version, and metric summary. `/lcm preset suggest` chooses a
-safe shipped suggestion for the current context window when one exists, and
-labels the current selector as `context-only` when the provider/model family is
-not available to the plugin. `/lcm preset apply ... --dry-run` previews env-var
-settings only; it does not
-write files, change process state, or override explicit parseable
-preset-managed `LCM_*` environment variables. Invalid preset-managed env values
-are reported as invalid instead of being treated as active runtime overrides.
-
-The current runtime preset dry-run previews are:
-
-```text
-# codex_gpt_long_context: near-272k GPT/Codex routes
-LCM_CONTEXT_THRESHOLD=0.75
-LCM_FRESH_TAIL_COUNT=24
-LCM_LEAF_CHUNK_TOKENS=8000
-
-# codex_spark_context: near-128k GPT-5.3 Codex Spark routes
-LCM_CONTEXT_THRESHOLD=0.75
-LCM_FRESH_TAIL_COUNT=16
-LCM_LEAF_CHUNK_TOKENS=8000
-```
-
-`target_after_compaction=0.55` is still benchmark provenance, not a runtime
-setting, because the engine does not expose that live knob yet.
-
-For dashboards and agents, `lcm_status` also exposes the same information under
-`preset_suggestion` as read-only JSON: suggested preset name/family, selection
-reason, match confidence, provenance, explicit override diagnostics, invalid
-override diagnostics, unsupported benchmark-only fields, and the dry-run delta.
-This surface is safe to consume without scraping slash-command text; it does not
-write files, mutate process state, expose local benchmark run paths, or apply
-`LCM_*` environment changes.
-
-### FAQ: tuning LCM for large context windows
-
-Long-context models change the tuning problem. A 1M-token model does not mean
-you always want to spend 750k prompt tokens before LCM starts compacting. Start
-with the active prompt budget you are willing to pay for, then tune the threshold
-around that budget.
-
-The basic calculation is:
-
-```text
-compaction trigger = effective context window * LCM_CONTEXT_THRESHOLD
-```
-
-Or, working backwards:
-
-```text
-LCM_CONTEXT_THRESHOLD = desired compaction trigger / effective context window
-```
-
-Examples, as math rather than universal recommendations:
-
-| Effective context window | Desired trigger | Threshold |
-|--------------------------|-----------------|-----------|
-| `128000` | `96000` | `0.75` |
-| `200000` | `140000` | `0.70` |
-| `400000` | `240000` | `0.60` |
-| `1000000` | `250000` | `0.25` |
-| `1000000` | `400000` | `0.40` |
-| `1000000` | `600000` | `0.60` |
-
-If your Hermes config caps the model's effective `context_length`, tune against
-that effective value instead of the provider's advertised maximum. For example,
-a 1M-token provider with an effective `context_length` of `400000` and
-`LCM_CONTEXT_THRESHOLD=0.60` starts compaction around `240000` prompt tokens.
-
-A reasonable first pass for a true 1M effective window is:
-
-| Goal | Desired trigger | Threshold | Notes |
-|------|-----------------|-----------|-------|
-| Lower spend / earlier DAG building | `200000` to `300000` | `0.20` to `0.30` | Good when cost and latency matter more than maximum live context |
-| Balanced large-context use | `350000` to `500000` | `0.35` to `0.50` | Good starting point for many long-running agents |
-| Keep more raw context active | `600000+` | `0.60+` | Higher token burn, later compaction |
-
-What the main knobs do:
-
-- `LCM_CONTEXT_THRESHOLD` decides when compaction starts. Lower values build the
-  DAG earlier and reduce active prompt burn, but compact more often.
-- `LCM_FRESH_TAIL_COUNT` protects recent messages from compaction. Raise it if
-  your agent often needs the last few tool calls or planning turns verbatim.
-- `LCM_LEAF_CHUNK_TOKENS` is the raw-backlog floor before a leaf compaction pass
-  starts. With the default `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=false`, the pass
-  compacts the whole non-tail raw backlog, not only a chunk of this size.
-- `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true` changes leaf passes into chunk-sized
-  work. In that mode `LCM_LEAF_CHUNK_TOKENS` is the base target and
-  `LCM_DYNAMIC_LEAF_CHUNK_MAX` is the upper bound for a dynamic chunk target.
-- `LCM_EXPANSION_CONTEXT_TOKENS` controls how much recovered material
-  `lcm_expand_query` may feed to the auxiliary model. It does not change what
-  LCM stores.
-- `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED=true` helps when large tool outputs,
-  logs, media payloads, or raw JSON blobs dominate token pressure.
-
-Common questions:
-
-**Should I leave the default threshold on a 1M-token model?**
-
-Not always. The default `0.35` means compaction starts around `350000` prompt
-tokens on a true 1M effective window. That leaves far more headroom for new
-content but compacts more aggressively, which can shorten recall of older
-details.
-
-**Should I change leaf chunk settings first?**
-
-Usually no. Start with `LCM_CONTEXT_THRESHOLD`, `LCM_FRESH_TAIL_COUNT`, and large
-output externalization. Only tune leaf chunking after checking `lcm_status` and
-understanding whether your workload is dominated by huge raw backlog passes. If
-you want chunk-sized leaf passes, enable dynamic leaf chunking explicitly.
-
-**Does compacting earlier hurt recall?**
-
-It changes the tradeoff. More content moves from the live prompt into summaries
-earlier, but raw messages are still stored and recoverable through LCM tools. If
-you need exact details later, use `lcm_grep`, `lcm_describe`, `lcm_expand`, or
-`lcm_expand_query` instead of relying only on the active prompt.
-
-**How do I know whether my settings are working?**
-
-After a normal message has initialized the session, check `lcm_status` for the
-effective context length, threshold tokens, prompt pressure, compression count,
-raw rows, and summary nodes. Run `lcm_doctor` when behavior looks surprising.
-
-### Session pattern syntax
-
-Pattern matching checks multiple keys: raw `session_id`, `platform`, and
-`platform:session_id`.
-
-- `*` matches within one colon-delimited segment
-- `**` can span across colons
-
-Example: `cron:*` can match Hermes cron sessions, while exact raw session IDs
-still work.
-
-### Noise suppression
-
-LCM offers two layers of noise filtering, sized to two different shapes of
-noise:
-
-- **Session-level filters** (`LCM_IGNORE_SESSION_PATTERNS`,
-  `LCM_STATELESS_SESSION_PATTERNS`) catch the case where the noisy traffic
-  arrives as its own session or platform, for example a dedicated `cron:*`
-  session. Match keys cover the session id, the platform, and
-  `platform:session_id`.
-- **Message-level patterns** (`LCM_IGNORE_MESSAGE_PATTERNS`) catch the case
-  where cron alerts or other noise are injected into a normal Telegram or
-  WhatsApp conversation as ordinary user-visible messages. From LCM's
-  perspective the session/platform is `telegram` or `whatsapp`, not `cron`,
-  so only the message content is distinctive.
-
-Message-level patterns are Python regex strings, comma-separated, compiled
-once at engine start. They run against plain message text. For structured
-multimodal payloads, LCM matches against concatenated text parts first, so
-anchored patterns bind to the text an operator sees. If a structured payload
-contains no text parts, matching falls back to the normalized JSON form that
-LCM would have written to the store. Matching messages are skipped before
-storage, so new matching rows do not enter the messages table or FTS index.
-Filtering is role-agnostic by default, since cron alerts can be re-emitted
-under any role depending on the gateway.
-
-Example operator config:
-
-```
-LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
-```
-
-Invalid regex entries are logged at warning level and dropped; the
-surviving patterns in the same list still take effect, so a misconfigured
-entry never crashes ingest. Pattern matching uses a 50 ms per-pattern timeout
-when the optional `regex` package is installed. If `regex` is not installed,
-LCM logs a warning and disables message-level regex filtering rather than
-running unbounded stdlib `re` matches in the ingest path.
-
-One operator-facing limitation to know about:
-
-- **Compaction-window edge.** The filter runs at ingest time. When a
-  matching message is part of the chunk being summarized in the same
-  turn it arrived, the message's text may appear inside the resulting
-  summary node text. In long-running sessions where compaction triggers
-  every several dozen turns, this can affect multiple summary nodes per
-  day rather than only happening rarely. The summary node's `source_ids`
-  will not reference the filtered message (it was never written to the
-  store), so DAG lineage stays clean; only the serialized summary text
-  can carry it. Closing this window is tracked as follow-up work.
-
-`lcm_status` surfaces the full filter contract under `session_filters`, including
-`ignore_session_patterns`, `stateless_session_patterns`, `ignore_message_patterns`,
-their `*_source` fields (`default` or `env`), the current session's `ignored` and
-`stateless` booleans, and a process-lifetime `ignored_message_count` so operators
-can confirm their patterns are loaded and watch how often message filters fire.
-The counter resets on engine restart.
-
-### Large tool-output handling
-
-Externalization for ordinary large tool output is opt-in. When enabled,
-oversized tool results are written to plugin-managed JSON files and referenced
-from summaries. They remain inspectable later through
-`lcm_describe(externalized_ref=...)` and `lcm_expand(externalized_ref=...)`.
-
-The storage-boundary payload guard is separate from that opt-in. LCM always
-scans messages at the store boundary before writing `messages.content` or
-`messages.tool_calls` to SQLite. Inline `data:*;base64,...` payloads and
-conservative long base64-looking runs are replaced with compact placeholders and
-written to the same plugin-managed externalized-payload directory. This is a
-safer default for media-ish payloads: LCM still preserves lossless recovery via
-the placeholder `ref` and `lcm_expand(externalized_ref=...)`, but it does not
-duplicate those payload bytes into `lcm.db`, FTS shadow tables, WAL files, or
-ordinary SQLite backups. If externalization fails, LCM logs a warning and leaves
-the original text inline rather than dropping data.
-
-`lcm_doctor` reports the effective SQLite database path, core schema-table
-presence, SQLite `journal_mode`, `quick_check`, database/WAL sizes, the largest
-content/tool-call rows, suspicious inline `data:*;base64` rows, suspicious long
-base64-looking rows, and aggregate externalized-payload stats.
-Doctor output is metadata-only for these scans; it intentionally does not print
-raw payload previews.
-
-This guard is scoped to LCM's own `lcm.db` write boundary. It does not prevent
-Hermes core, or any other host layer, from writing inline payloads to Hermes
-`state.db`; that is upstream/outside LCM scope. It also does not rewrite
-historical rows already present in `lcm.db`. Cleaning older suspicious rows
-requires a separate backup-first cleanup or migration flow.
-
-Transcript GC is separate and also opt-in. It only rewrites already-externalized,
-already-summarized tool-role rows to compact placeholders. It keeps the same
-`store_id`, keeps payload files, skips pinned messages, and preserves lossless
-recovery through `externalized_ref`. After GC, `lcm_grep` will not match the
-original giant tool blob text directly; search summaries or refs instead.
-
-## Agent Tools
-
-Use these tools for current-session recall after compaction. Use `session_search`
-for earlier separate sessions or broad cross-session history.
-
-| Tool | Use |
-|------|-----|
-| `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Raw-message filters `role`, `time_from`, and `time_to` are pushed into the search query; when any of them is supplied, summary hits are omitted so the filter contract stays exact. Use `session_search` for earlier separate sessions or broad cross-session recall. |
-| `lcm_load_session` | Load one ordered raw-message transcript page for an explicit `session_id`. This is not search: it returns raw rows in `store_id` order, bounded by `limit`, with per-message content bounded by `max_content_chars`, and continues with `after_store_id` from `next_cursor`. |
-| `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
-| `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
-| `lcm_expand_query` | Answer a question using expanded current-session LCM context while returning a bounded answer. |
-| `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
-| `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
-
-### Retrieval contract
-
-LCM retrieval tools default to current-session scope. `lcm_grep` accepts
-`session_scope='all'` or `session_scope='session'` as an explicit opt-in for
-bounded archive search over rows already present in `lcm.db` (raw-message hits
-only). Once a session id is known, `lcm_load_session` can enumerate that session's
-raw transcript in chronological `store_id` pages without a search query. Use
-Hermes `session_search` for broad cross-session history outside the LCM database.
-
-Within the current session, `source` filters raw rows directly and filters
-summary nodes by descendant raw-message source lineage. `unknown` is a real
-source value, not a wildcard. Legacy blank-source rows are treated as `unknown`.
-`role`, `time_from`, and `time_to` are raw-message filters and are applied in the
-message search query before result limiting. `time_from` and `time_to` accept Unix
-seconds or timezone-aware ISO 8601 strings; naive ISO strings are rejected so the
-same query means the same thing across machines. When a raw-message filter is
-active, `lcm_grep` returns raw rows only and reports `summary_results_omitted`.
-
-Carried-over summary nodes can become current-session content after `/new`, but
-their source eligibility still comes from the descendant raw messages. Expanding
-a carried-over current-session node recovers those original raw message sources
-even when the sources still belong to the previous session.
-
-### Lossless raw recovery contract
-
-Tool responses are bounded so one retrieval call cannot flood the main context.
-Lossless recovery means raw content is stored with stable source lineage and can
-be recovered in deterministic pages.
-
-- `lcm_expand(node_id=...)` pages immediate sources with `source_offset` and `source_limit`
-- `lcm_load_session(session_id=...)` pages ordered raw session rows with `after_store_id` and `next_cursor`; each row includes bounded content plus truncation metadata, and large individual rows can be recovered with `lcm_expand(store_id=...)` using `content_offset`
-- oversized raw messages continue with `content_offset`
-- `lcm_expand(externalized_ref=...)` pages payload content with `content_offset`
-- `lcm_expand_query` uses `context_max_tokens` for auxiliary context and reports truncation/pagination hints when needed
-
-### lossless-claw/OpenClaw import utility
-
-`hermes-lcm` includes an opt-in operator script for backfilling raw message rows from a lossless-claw/OpenClaw LCM SQLite database into the local hermes-lcm SQLite store:
+If you cloned directly into the plugin directory:
 
 ```bash
-python scripts/import_lossless_claw.py \
-  --source-db ~/.openclaw/path/to/lcm.db \
-  --target-db ~/.hermes/lcm.db \
-  --agent sammy
+cd ~/.hermes/plugins/hermes-lcm && git pull --ff-only
 ```
 
-The script is intentionally conservative:
-
-- dry-run is the default; pass `--apply` to write
-- run it against an explicit target DB path, preferably while Hermes is stopped for that profile
-- writes create a timestamped target DB backup first when the target already exists
-- only raw messages are imported; summary DAG import is out of scope
-- imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:<source-session>`
-- the default provenance identity is the concrete source `conversations.session_id`, preserving source session boundaries even when many conversations share one `session_key`
-- pass `--session-identity session_key` only when you intentionally want conversations with the same source session key grouped into one imported LCM session
-- reruns are idempotent for the same `--import-id`; the default `import_id` is path-derived, so pass a stable `--import-id` if you may import the same copied DB from different paths
-- changing `--agent`, `--namespace`, or `--session-identity` under the same `--import-id` is treated as the same import and will skip already-tracked source messages; use a new `--import-id` for a different mapping
-- no OpenClaw config or separate secret tables are imported, but raw transcripts and tool payloads are imported and may contain sensitive user data
-
-This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
-
-## Slash Commands
-
-Slash commands are disabled by default. Enable them only in trusted operator
-contexts:
+If you installed a symlink from a separate checkout:
 
 ```bash
-export LCM_ENABLE_SLASH_COMMAND=1
+./scripts/update.sh
 ```
 
-Available commands:
+Restart Hermes after updating.
 
-- `/lcm` or `/lcm status` - current runtime/session status
-- `/lcm doctor` - read-only health checks
-- `/lcm doctor clean` - read-only scan for obvious junk/noise session candidates
-- `/lcm doctor clean apply` - backup-first cleanup for safe pattern-matched candidates; requires `LCM_DOCTOR_CLEAN_APPLY_ENABLED=true`
-- `/lcm doctor clean lifecycle` - read-only scan for lifecycle rows with zero messages/nodes
-- `/lcm doctor clean lifecycle apply` - backup-first cleanup of empty lifecycle rows; requires `LCM_DOCTOR_CLEAN_APPLY_ENABLED=true`
-- `/lcm doctor repair` - read-only SQLite/FTS repair diagnostics
-- `/lcm doctor repair apply` - backup-first SQLite/FTS repair
-- `/lcm doctor source` - read-only scan for legacy blank-source rows
-- `/lcm doctor source apply` - backup-first normalization of legacy blank-source rows to `unknown`
-- `/lcm doctor retention` - read-only retention analysis
-- `/lcm backup` - timestamped SQLite backup
-- `/lcm rotate` - read-only preview of an in-place tail-preserving compact of the active session
-- `/lcm rotate apply` - backup-first rotate that advances the lifecycle frontier past pre-tail raw messages
-- `/lcm help` - command help
+## Common first-run checks
 
-Apply paths are intentionally narrow and backup-first. Start with diagnostics
-before cleanup or repair.
+- `hermes plugins` shows `hermes-lcm` and context engine `lcm`
+- `lcm_status` reports runtime identity, plugin path, git commit/branch/dirty state, and live session fields after the first message
+- `lcm_doctor` reports database path, SQLite health, FTS state, lifecycle stats, and payload-boundary diagnostics
+- Benchmark entrypoint: `python scripts/lcm_benchmark.py --fixture benchmarks/fixtures/long_history_canaries.json --output /tmp/hermes-lcm-benchmark-smoke --allow-external-output --json`
+- Stress/release smoke entrypoint: `python scripts/lcm_stress_check.py --output /tmp/hermes-lcm-stress-smoke --tier smoke --json`
 
-### Rotate: in-place compact without changing session identity
+## Documentation map
 
-`/lcm rotate` lets an operator compact a long-running session in place without
-changing `session_id` or `conversation_id`. It is the in-session counterpart to
-Hermes-level `/new` (which starts a new session) and to `/lcm doctor clean`
-(which prunes whole junk sessions).
-
-What rotate does:
-
-- preserves the live tail (`LCM_FRESH_TAIL_COUNT` most-recent messages)
-- advances the lifecycle frontier marker past every raw message before the tail,
-  so subsequent bootstrap stops replaying them into the active prompt
-- writes a rolling `*-rotate-latest.sqlite3` backup under the same backup
-  directory as `/lcm backup`, overwriting the previous rotate slot atomically
-  so disk usage stays bounded across repeated rotates
-
-What rotate does not do:
-
-- it does not delete raw messages — pre-tail rows remain in the SQLite store
-  and stay recoverable through `lcm_load_session` and `lcm_expand`, preserving
-  the lossless raw recovery contract
-- it does not invoke the summarization model — rotate is a frontier and backup
-  operation, not a synthesis step. Pre-tail content that was not yet covered by
-  a summary node remains accessible only as raw rows; trigger normal compaction
-  first if you want the pre-tail range covered by summary nodes before rotating
-- it does not change session or conversation identity, run on stateless
-  sessions (`LCM_STATELESS_SESSION_PATTERNS`), or run on ignored sessions
-  (`LCM_IGNORE_SESSION_PATTERNS`) — rotate refuses on both with a clear reason
-
-`lcm_status` and `/lcm status` surface `last_rotate_at` (epoch float, or `null`
-when no rotate has happened) and the rolling backup path so operators can see
-when rotate last ran. The mtime of the rolling backup file is the source of
-truth — no new lifecycle column is added by this feature.
-
-Re-running `/lcm rotate apply` on a session whose frontier is already at or
-ahead of the target boundary reports `status: noop` and is safe to retry.
-A no-op apply does not write a new rolling backup, so the previous
-known-good `*-rotate-latest.sqlite3` snapshot survives idempotent retries.
-
-## How It Works
-
-1. **Ingest** - persist each message in SQLite with FTS metadata
-2. **Compact** - summarize older messages outside the fresh tail into D0 leaf nodes
-3. **Condense** - merge same-depth nodes into higher-depth summaries
-4. **Escalate** - shrink oversize summaries from detailed to bullets to deterministic truncate
-5. **Assemble** - combine system prompt, highest-depth summaries, and fresh tail
-6. **Retrieve** - use LCM tools to drill into compacted history or synthesize from expanded context
+- [Operator guide](docs/operator-guide.md) - install, update, verification, troubleshooting, config, slash commands, rotate
+- [Retrieval tools reference](docs/retrieval-tools.md) - tool contracts, pagination, source filters, lossless raw recovery, OpenClaw import utility
+- [Architecture notes](docs/architecture.md) - feature model, LCM-vs-built-in-compression nuance, internals, development files
+- [Benchmarking and stress checks](benchmarks/README.md) - deterministic replay, preset provenance, scrubbed exports, release stress checks
+- [Release validation](docs/release-validation.md) - local offline validation entrypoint and reusable checklist artifact shape
+- [Packaging and distribution posture](docs/packaging.md) - current clone/symlink decision and when pip-style packaging should be revisited
+- [Changelog](CHANGELOG.md) - recent release arc and post-v0.18 follow-up state
+- [Contributing](CONTRIBUTING.md) - branch, PR, and validation expectations
 
 ## Development
-
-Important files:
-
-```text
-plugin.yaml      manifest
-__init__.py      plugin registration and optional slash-command registration
-engine.py        LCMEngine main orchestrator
-store.py         SQLite message store and FTS
-dag.py           summary DAG and FTS
-config.py        env var defaults and overrides
-command.py       /lcm command handlers
-tools.py         lcm_grep, lcm_load_session, lcm_describe, lcm_expand, lcm_expand_query
-schemas.py       tool schemas shown to the model
-tests/           standalone pytest coverage
-```
 
 Run tests:
 
@@ -697,16 +158,7 @@ pip install pytest
 python -m pytest tests/ -v
 ```
 
-No Hermes Agent checkout is required for the test suite; tests include a
-lightweight ABC stub.
-
-## Contributing
-
-Issues and PRs welcome. Bug fixes and correctness improvements are highest
-priority. New features should be scoped, backwards-compatible, and tested.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, validation, and PR guidance.
-See the [releases page](https://github.com/stephenschoettler/hermes-lcm/releases) for changelogs.
+No Hermes Agent checkout is required for the test suite; tests include a lightweight ABC stub.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -78,10 +78,12 @@ def register(ctx):
     ctx.register_context_engine(engine)
 
     # Register tools via the plugin registry only on hosts that preserve the
-    # active messages=... contract for registered context-engine tools. Current
-    # Hermes Agent handles lcm_* correctly through the native context-engine
-    # schema/dispatch path; registering duplicate names there would shadow that
-    # path and lose current-turn ingest.
+    # active messages=... contract for registered context-engine tools.
+    # Older/current Hermes hosts already expose lcm_* correctly through the
+    # native context-engine schema/dispatch path (Path B). Registering duplicate
+    # names through the plugin registry (Path A) on message-blind hosts would
+    # shadow Path B and lose current-turn ingest, so the Path B fallback is the
+    # expected healthy behavior there.
     _TOOLS = [
         ("lcm_grep", LCM_GREP, "🔍"),
         ("lcm_load_session", LCM_LOAD_SESSION, "📋"),
@@ -105,21 +107,23 @@ def register(ctx):
                 )
             except Exception as exc:
                 logger.warning(
-                    "LCM tool registration failed for %s; "
-                    "continuing with context-engine schemas: %s",
+                    "LCM plugin-registry tool registration for %s did not complete; "
+                    "LCM tools remain available through context-engine schemas: %s",
                     name,
                     exc,
                 )
     elif callable(register_tool):
         logger.info(
-            "LCM plugin tool registration skipped because this Hermes host "
-            "does not advertise messages forwarding for registered "
-            "context-engine tools; continuing with context-engine schemas"
+            "LCM tools are available through context-engine schemas "
+            "(expected Path B fallback on this Hermes host). Standalone "
+            "plugin-registry tool registration (Path A) requires message-aware "
+            "handlers and is not required here."
         )
     else:
         logger.info(
-            "LCM tool registration unavailable on this Hermes host; "
-            "continuing with context-engine schemas"
+            "LCM tools are available through context-engine schemas (Path B); "
+            "plugin-registry tool registration is unavailable on this Hermes "
+            "host and is not required."
         )
 
     register_command = getattr(ctx, "register_command", None)

--- a/benchmarking/replay.py
+++ b/benchmarking/replay.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from .metrics import canary_present, count_active_canaries, normalize_message_content
+from .standalone import ensure_agent_context_engine_importable
 from .types import LCMPolicy, ReplayFixture, ReplayMetrics, SummaryFailureMode, _summary_failure_mode
 
 
@@ -21,6 +22,7 @@ _CANARY_LINE_RE = re.compile(r"\b(CANARY_[A-Z0-9_]+)\s*=\s*([A-Z0-9_:-]+)")
 
 def _ensure_hermes_lcm_package() -> None:
     """Make this source checkout importable as `hermes_lcm` without plugin registration."""
+    ensure_agent_context_engine_importable()
     if "hermes_lcm" in sys.modules:
         return
     spec = importlib.util.spec_from_file_location(

--- a/benchmarking/standalone.py
+++ b/benchmarking/standalone.py
@@ -1,0 +1,114 @@
+"""Standalone checkout helpers for deterministic benchmark/release scripts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def ensure_agent_context_engine_importable() -> None:
+    """Provide the minimal Hermes ContextEngine API when Hermes Agent is absent.
+
+    Release benchmark and stress scripts exercise hermes-lcm directly from a
+    plugin checkout. They only need the ContextEngine base class for inheritance;
+    they do not need a full Hermes Agent install or live plugin host.
+    """
+    try:
+        importlib.import_module("agent.context_engine")
+        return
+    except ModuleNotFoundError as exc:
+        missing = exc.name or ""
+        if missing not in {"agent", "agent.context_engine"}:
+            raise
+
+    agent_module = sys.modules.get("agent")
+    if agent_module is None:
+        agent_module = types.ModuleType("agent")
+        agent_module.__path__ = []  # type: ignore[attr-defined]
+        sys.modules["agent"] = agent_module
+
+    context_module = types.ModuleType("agent.context_engine")
+
+    class ContextEngine:
+        """Small fallback compatible with Hermes Agent's ContextEngine ABC."""
+
+        last_prompt_tokens: int = 0
+        last_completion_tokens: int = 0
+        last_total_tokens: int = 0
+        threshold_tokens: int = 0
+        context_length: int = 0
+        compression_count: int = 0
+        threshold_percent: float = 0.75
+        protect_first_n: int = 3
+        protect_last_n: int = 6
+
+        @property
+        def name(self) -> str:
+            return self.__class__.__name__
+
+        def update_from_response(self, usage):  # pragma: no cover - fallback default
+            self.last_prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            self.last_completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+            self.last_total_tokens = int(usage.get("total_tokens", 0) or 0)
+
+        def should_compress(self, prompt_tokens=None) -> bool:  # pragma: no cover - fallback default
+            return False
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):  # pragma: no cover - fallback default
+            return messages
+
+        def should_compress_preflight(self, messages) -> bool:
+            return False
+
+        def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
+            return False
+
+        def has_content_to_compress(self, messages) -> bool:
+            return True
+
+        def on_session_start(self, session_id: str, **kwargs) -> None:
+            return None
+
+        def on_session_end(self, session_id: str, messages) -> None:
+            return None
+
+        def on_session_reset(self) -> None:
+            self.last_prompt_tokens = 0
+            self.last_completion_tokens = 0
+            self.last_total_tokens = 0
+            self.compression_count = 0
+
+        def get_tool_schemas(self):
+            return []
+
+        def handle_tool_call(self, name: str, args, **kwargs) -> str:
+            import json
+
+            return json.dumps({"error": f"Unknown context engine tool: {name}"})
+
+        def get_status(self):
+            usage_percent = min(100, self.last_prompt_tokens / self.context_length * 100) if self.context_length else 0
+            return {
+                "last_prompt_tokens": self.last_prompt_tokens,
+                "threshold_tokens": self.threshold_tokens,
+                "context_length": self.context_length,
+                "usage_percent": usage_percent,
+                "compression_count": self.compression_count,
+            }
+
+        def update_model(
+            self,
+            model: str,
+            context_length: int,
+            base_url: str = "",
+            api_key: str = "",
+            provider: str = "",
+            api_mode: str = "",
+        ) -> None:
+            self.context_length = context_length
+            self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    setattr(context_module, "ContextEngine", ContextEngine)
+    sys.modules["agent.context_engine"] = context_module
+    setattr(agent_module, "context_engine", context_module)

--- a/benchmarking/stress.py
+++ b/benchmarking/stress.py
@@ -22,6 +22,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from .standalone import ensure_agent_context_engine_importable
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 STRESS_CHECK_VERSION = "1"
 DEFAULT_SCENARIOS = (
@@ -327,6 +329,7 @@ def _clear_hermes_lcm_submodules(pkg: str = "hermes_lcm") -> None:
 
 
 def _ensure_hermes_lcm_package(plugin_dir: Path, *, reload_submodules: bool = False) -> None:
+    ensure_agent_context_engine_importable()
     pkg = "hermes_lcm"
     if pkg in sys.modules:
         module = sys.modules[pkg]

--- a/command.py
+++ b/command.py
@@ -1176,7 +1176,8 @@ def _doctor_text(engine) -> str:
     if source_stats.get("error"):
         triage_checks.append({"check": "source_lineage_hygiene", "status": "fail", "detail": source_stats})
     if lifecycle_stats.get("error") or _has_lifecycle_fragmentation(lifecycle_stats):
-        triage_checks.append({"check": "lifecycle_fragmentation", "status": "warn", "detail": lifecycle_stats})
+        lifecycle_status = "fail" if lifecycle_stats.get("error") else "warn"
+        triage_checks.append({"check": "lifecycle_fragmentation", "status": lifecycle_status, "detail": lifecycle_stats})
     triage_guidance = doctor_guidance_for_checks(triage_checks)
 
     doctor_status = "issues-found" if integrity != "ok" or issues else (

--- a/command.py
+++ b/command.py
@@ -13,7 +13,11 @@ from .db_bootstrap import (
     inspect_lcm_schema_health,
     repair_external_content_fts,
 )
-from .diagnostics import _has_lifecycle_fragmentation, _state_db_path_for_engine
+from .diagnostics import (
+    _has_lifecycle_fragmentation,
+    _state_db_path_for_engine,
+    doctor_guidance_for_checks,
+)
 from .ingest_protection import (
     externalized_payload_stats,
     scan_externalized_payload_integrity,
@@ -1144,6 +1148,37 @@ def _doctor_text(engine) -> str:
             "remove unknown LCM_SENSITIVE_PATTERNS entries or replace them with supported names"
         )
 
+    triage_checks: list[dict[str, Any]] = []
+    if integrity != "ok":
+        triage_checks.append({"check": "database_integrity", "status": "fail", "detail": integrity})
+    if schema_health.get("error") or schema_missing_tables:
+        triage_checks.append({"check": "schema_core_tables", "status": "fail", "detail": schema_health})
+    if store_fts != "ok":
+        triage_checks.append({"check": "messages_fts_integrity", "status": "fail", "detail": store_fts})
+    if node_fts != "ok":
+        triage_checks.append({"check": "nodes_fts_integrity", "status": "fail", "detail": node_fts})
+    if clean_scan["candidates"]:
+        triage_checks.append({"check": "cleanup_candidates", "status": "warn", "detail": clean_scan})
+    if missing_externalized_refs or any(payload_risks.get(key) for key in (
+        "suspicious_data_uri_content_rows",
+        "suspicious_data_uri_tool_calls_rows",
+        "suspicious_base64_like_rows",
+        "suspicious_repetitive_assistant_rows",
+        "heartbeat_noise_rows",
+    )):
+        triage_checks.append({
+            "check": "payload_storage",
+            "status": "warn",
+            "detail": {**payload_risks, **externalized_integrity},
+        })
+    if (protection["enabled"] and not protection["active_patterns"]) or protection["unknown_patterns"]:
+        triage_checks.append({"check": "sensitive_pattern_handling", "status": "warn", "detail": protection})
+    if source_stats.get("error"):
+        triage_checks.append({"check": "source_lineage_hygiene", "status": "fail", "detail": source_stats})
+    if lifecycle_stats.get("error") or _has_lifecycle_fragmentation(lifecycle_stats):
+        triage_checks.append({"check": "lifecycle_fragmentation", "status": "warn", "detail": lifecycle_stats})
+    triage_guidance = doctor_guidance_for_checks(triage_checks)
+
     doctor_status = "issues-found" if integrity != "ok" or issues else (
         "action-recommended" if recommended_actions else "ok"
     )
@@ -1210,6 +1245,17 @@ def _doctor_text(engine) -> str:
     if recommended_actions:
         for item in recommended_actions:
             lines.append(f"- {item}")
+    else:
+        lines.append("- none")
+    lines.append("triage_guidance:")
+    if triage_guidance:
+        for item in triage_guidance:
+            warning_suffix = " warning-only" if item.get("warning_only") else ""
+            lines.append(
+                "- "
+                f"{item['check']}: {item['action']}{warning_suffix} — "
+                f"{item['operator_action']}"
+            )
     else:
         lines.append("- none")
     return "\n".join(lines)

--- a/command.py
+++ b/command.py
@@ -952,6 +952,7 @@ def _doctor_text(engine) -> str:
     except Exception as exc:  # pragma: no cover - defensive
         quick_check = f"error: {exc}"
         issues.append("sqlite_quick_check")
+    payload_storage_error = ""
     try:
         payload_risks = scan_sqlite_payload_risks(store_conn)
         externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
@@ -960,7 +961,8 @@ def _doctor_text(engine) -> str:
             engine._config,
             hermes_home=engine._hermes_home,
         )
-    except Exception:  # pragma: no cover - defensive
+    except Exception as exc:  # pragma: no cover - defensive
+        payload_storage_error = str(exc)
         payload_risks = {
             "largest_content_rows": [],
             "largest_tool_calls_rows": [],
@@ -1053,6 +1055,9 @@ def _doctor_text(engine) -> str:
         recommended_actions.append(
             "inspect missing externalized payload refs and restore from backups if needed"
         )
+    if payload_storage_error:
+        observations.append(f"payload_storage_error: {payload_storage_error}")
+        recommended_actions.append("inspect payload storage diagnostics before cleanup or deletion")
 
     try:
         source_stats = engine._store.get_source_stats()
@@ -1159,17 +1164,20 @@ def _doctor_text(engine) -> str:
         triage_checks.append({"check": "nodes_fts_integrity", "status": "fail", "detail": node_fts})
     if clean_scan["candidates"]:
         triage_checks.append({"check": "cleanup_candidates", "status": "warn", "detail": clean_scan})
-    if missing_externalized_refs or any(payload_risks.get(key) for key in (
+    if payload_storage_error or missing_externalized_refs or any(payload_risks.get(key) for key in (
         "suspicious_data_uri_content_rows",
         "suspicious_data_uri_tool_calls_rows",
         "suspicious_base64_like_rows",
         "suspicious_repetitive_assistant_rows",
         "heartbeat_noise_rows",
     )):
+        detail = {**payload_risks, **externalized_integrity}
+        if payload_storage_error:
+            detail["error"] = payload_storage_error
         triage_checks.append({
             "check": "payload_storage",
-            "status": "warn",
-            "detail": {**payload_risks, **externalized_integrity},
+            "status": "fail" if payload_storage_error else "warn",
+            "detail": detail,
         })
     if (protection["enabled"] and not protection["active_patterns"]) or protection["unknown_patterns"]:
         triage_checks.append({"check": "sensitive_pattern_handling", "status": "warn", "detail": protection})

--- a/dag.py
+++ b/dag.py
@@ -14,6 +14,7 @@ Depth semantics:
 import json
 import logging
 import sqlite3
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -155,6 +156,7 @@ class SummaryDAG:
     def __init__(self, db_path: str | Path):
         self.db_path = Path(db_path)
         self._conn: Optional[sqlite3.Connection] = None
+        self._db_lock = threading.RLock()
         self._init_db()
 
     def _init_db(self):
@@ -207,28 +209,29 @@ class SummaryDAG:
 
     def add_node(self, node: SummaryNode) -> int:
         """Insert a summary node and return its node_id."""
-        cur = self._conn.execute(
-            """INSERT INTO summary_nodes
-               (session_id, depth, summary, token_count, source_token_count,
-                source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                node.session_id,
-                node.depth,
-                node.summary,
-                node.token_count,
-                node.source_token_count,
-                json.dumps(node.source_ids),
-                node.source_type,
-                node.created_at or time.time(),
-                node.earliest_at,
-                node.latest_at,
-                node.expand_hint,
-            ),
-        )
-        self._conn.commit()
-        node.node_id = cur.lastrowid
-        return node.node_id
+        with self._db_lock:
+            cur = self._conn.execute(
+                """INSERT INTO summary_nodes
+                   (session_id, depth, summary, token_count, source_token_count,
+                    source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    node.session_id,
+                    node.depth,
+                    node.summary,
+                    node.token_count,
+                    node.source_token_count,
+                    json.dumps(node.source_ids),
+                    node.source_type,
+                    node.created_at or time.time(),
+                    node.earliest_at,
+                    node.latest_at,
+                    node.expand_hint,
+                ),
+            )
+            self._conn.commit()
+            node.node_id = cur.lastrowid
+            return node.node_id
 
     def delete_below_depth(self, session_id: str, min_depth: int) -> int:
         """Delete all nodes for a session with depth < min_depth.
@@ -281,29 +284,31 @@ class SummaryDAG:
                           depth: int | None = None,
                           limit: int = 1000) -> List[SummaryNode]:
         """Get nodes for a session, optionally filtered by depth."""
-        if depth is not None:
-            rows = self._conn.execute(
-                """SELECT * FROM summary_nodes
-                   WHERE session_id = ? AND depth = ?
-                   ORDER BY created_at LIMIT ?""",
-                (session_id, depth, limit),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                """SELECT * FROM summary_nodes
-                   WHERE session_id = ?
-                   ORDER BY depth, created_at LIMIT ?""",
-                (session_id, limit),
-            ).fetchall()
+        with self._db_lock:
+            if depth is not None:
+                rows = self._conn.execute(
+                    """SELECT * FROM summary_nodes
+                       WHERE session_id = ? AND depth = ?
+                       ORDER BY created_at LIMIT ?""",
+                    (session_id, depth, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT * FROM summary_nodes
+                       WHERE session_id = ?
+                       ORDER BY depth, created_at LIMIT ?""",
+                    (session_id, limit),
+                ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
     def count_at_depth(self, session_id: str, depth: int) -> int:
         """Count nodes at a specific depth for a session."""
-        row = self._conn.execute(
-            """SELECT COUNT(*) FROM summary_nodes
-               WHERE session_id = ? AND depth = ?""",
-            (session_id, depth),
-        ).fetchone()
+        with self._db_lock:
+            row = self._conn.execute(
+                """SELECT COUNT(*) FROM summary_nodes
+                   WHERE session_id = ? AND depth = ?""",
+                (session_id, depth),
+            ).fetchone()
         return row[0] if row else 0
 
     def get_session_node_count(self, session_id: str) -> int:
@@ -373,17 +378,18 @@ class SummaryDAG:
         A node is 'uncondensed' if it's not referenced as a source by
         any higher-depth node.
         """
-        rows = self._conn.execute(
-            """SELECT n.* FROM summary_nodes n
-               WHERE n.session_id = ? AND n.depth = ?
-               AND n.node_id NOT IN (
-                   SELECT json_each.value FROM summary_nodes p,
-                   json_each(p.source_ids)
-                   WHERE p.session_id = ? AND p.depth > ? AND p.source_type = 'nodes'
-               )
-               ORDER BY n.created_at LIMIT ?""",
-            (session_id, depth, session_id, depth, limit),
-        ).fetchall()
+        with self._db_lock:
+            rows = self._conn.execute(
+                """SELECT n.* FROM summary_nodes n
+                   WHERE n.session_id = ? AND n.depth = ?
+                   AND n.node_id NOT IN (
+                       SELECT json_each.value FROM summary_nodes p,
+                       json_each(p.source_ids)
+                       WHERE p.session_id = ? AND p.depth > ? AND p.source_type = 'nodes'
+                   )
+                   ORDER BY n.created_at LIMIT ?""",
+                (session_id, depth, session_id, depth, limit),
+            ).fetchall()
         return [self._row_to_node(r) for r in rows]
 
     # -- Search -------------------------------------------------------------
@@ -418,22 +424,23 @@ class SummaryDAG:
         source_match_cache: dict[int, bool] = {}
         while True:
             try:
-                if session_id is not None:
-                    rows = self._conn.execute(
-                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
-                           JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ? AND n.session_id = ?
-                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (safe_query, session_id, fetch_limit, offset),
-                    ).fetchall()
-                else:
-                    rows = self._conn.execute(
-                        f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
-                           JOIN summary_nodes n ON n.node_id = fts.rowid
-                           WHERE nodes_fts MATCH ?
-                           ORDER BY {order_by} LIMIT ? OFFSET ?""",
-                        (safe_query, fetch_limit, offset),
-                    ).fetchall()
+                with self._db_lock:
+                    if session_id is not None:
+                        rows = self._conn.execute(
+                            f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                               JOIN summary_nodes n ON n.node_id = fts.rowid
+                               WHERE nodes_fts MATCH ? AND n.session_id = ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (safe_query, session_id, fetch_limit, offset),
+                        ).fetchall()
+                    else:
+                        rows = self._conn.execute(
+                            f"""SELECT n.*, rank as search_rank FROM nodes_fts fts
+                               JOIN summary_nodes n ON n.node_id = fts.rowid
+                               WHERE nodes_fts MATCH ?
+                               ORDER BY {order_by} LIMIT ? OFFSET ?""",
+                            (safe_query, fetch_limit, offset),
+                        ).fetchall()
                 scanned_rows += len(rows)
             except sqlite3.Error as exc:
                 logger.warning("FTS node search failed, falling back to LIKE: %s", exc)
@@ -503,12 +510,13 @@ class SummaryDAG:
         nodes: list[SummaryNode] = []
         source_match_cache: dict[int, bool] = {}
         while True:
-            rows = self._conn.execute(
-                f"""SELECT * FROM summary_nodes
-                    WHERE {' AND '.join(where)}
-                    LIMIT ? OFFSET ?""",
-                [*base_args, fetch_limit, offset],
-            ).fetchall()
+            with self._db_lock:
+                rows = self._conn.execute(
+                    f"""SELECT * FROM summary_nodes
+                        WHERE {' AND '.join(where)}
+                        LIMIT ? OFFSET ?""",
+                    [*base_args, fetch_limit, offset],
+                ).fetchall()
             scanned_rows += len(rows)
             for row in rows:
                 node = self._row_to_node(row)
@@ -600,14 +608,15 @@ class SummaryDAG:
         if not node_ids:
             return None, None
         placeholders = ",".join("?" * len(node_ids))
-        row = self._conn.execute(
-            f"""SELECT
-                    MIN(COALESCE(earliest_at, created_at)),
-                    MAX(COALESCE(latest_at, created_at))
-                FROM summary_nodes
-                WHERE node_id IN ({placeholders})""",
-            node_ids,
-        ).fetchone()
+        with self._db_lock:
+            row = self._conn.execute(
+                f"""SELECT
+                        MIN(COALESCE(earliest_at, created_at)),
+                        MAX(COALESCE(latest_at, created_at))
+                    FROM summary_nodes
+                    WHERE node_id IN ({placeholders})""",
+                node_ids,
+            ).fetchone()
         if not row:
             return None, None
         return row[0], row[1]

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -104,14 +104,17 @@ def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
                     "suspicious_repetitive_assistant_rows",
                 )
             )
-        if heartbeat_rows and not missing_refs and not suspicious_rows:
+        if status == "warn" and heartbeat_rows and not missing_refs and not suspicious_rows:
             action = DOCTOR_ACTION_SAFE_IGNORE
             command = "safe to ignore unless heartbeat/progress noise is crowding useful recall; consider message/session filters for future rows"
             rationale = "heartbeat rows are read-only noise diagnostics, not corruption"
         else:
             command = "inspect payload rows/refs; restore missing externalized payload files from backup before deleting or rewriting anything"
-            warning_only = True
-            rationale = "payload warnings may represent preserved user/tool data"
+            if status == "warn":
+                warning_only = True
+                rationale = "payload warnings may represent preserved user/tool data"
+            else:
+                rationale = "payload diagnostic failures mean doctor could not read storage risk state reliably"
     elif name == "sensitive_pattern_handling":
         command = "inspect LCM_SENSITIVE_PATTERNS settings; remove unknown names or configure supported catalog entries"
     elif name == "orphaned_dag_nodes":
@@ -131,8 +134,11 @@ def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
         rationale = "source-lineage failures indicate the doctor could not read attribution state reliably"
     elif name == "lifecycle_fragmentation":
         command = "inspect lifecycle categories; only use explicit backup-first lifecycle cleanup for empty lifecycle rows"
-        warning_only = True
-        rationale = "not every lifecycle/state mismatch is harmful or safe to mutate"
+        if status == "warn":
+            warning_only = True
+            rationale = "not every lifecycle/state mismatch is harmful or safe to mutate"
+        else:
+            rationale = "lifecycle diagnostic failures mean doctor could not read session lifecycle state reliably"
     elif name == "context_pressure":
         action = DOCTOR_ACTION_SAFE_IGNORE
         command = "safe to ignore if compaction proceeds normally; inspect lcm_status only if pressure stays high or compaction loops"

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -122,10 +122,13 @@ def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
         warning_only = True
     elif name == "config_validation":
         command = "inspect LCM_* environment/config values and adjust only intentional operator overrides"
-    elif name == "source_lineage_hygiene":
+    elif name == "source_lineage_hygiene" and status == "warn":
         action = DOCTOR_ACTION_SAFE_IGNORE
         command = "safe to ignore legacy blank-source observations; use `/lcm doctor source` only when you intentionally want backup-first normalization"
         rationale = "legacy blank sources are normalized to unknown for compatibility"
+    elif name == "source_lineage_hygiene":
+        command = "inspect source-lineage diagnostics and SQLite read errors before running any source normalization workflow"
+        rationale = "source-lineage failures indicate the doctor could not read attribution state reliably"
     elif name == "lifecycle_fragmentation":
         command = "inspect lifecycle categories; only use explicit backup-first lifecycle cleanup for empty lifecycle rows"
         warning_only = True

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any
 
 
+DOCTOR_ACTION_SAFE_IGNORE = "safe/ignore"
+DOCTOR_ACTION_INSPECT = "inspect"
+DOCTOR_ACTION_BACKUP_FIRST_CLEANUP = "backup-first cleanup"
+
+
 def state_db_path_for_engine(engine: Any) -> Path:
     """Return the Hermes state database path for an LCM engine.
 
@@ -53,6 +58,106 @@ def has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
         )
         or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
     )
+
+
+def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
+    """Return operator triage guidance for one lcm_doctor check.
+
+    Guidance is deliberately conservative: most warning classes are inspect-only
+    evidence, and any mutation path is framed as preview/backup/apply rather than
+    implied automatic cleanup.
+    """
+    status = str(check.get("status") or "")
+    if status not in {"warn", "fail"}:
+        return None
+
+    name = str(check.get("check") or "unknown")
+    detail = check.get("detail")
+    action = DOCTOR_ACTION_INSPECT
+    command = "inspect the reported detail and confirm the active HERMES_HOME/LCM_DATABASE_PATH"
+    warning_only = False
+    rationale = "operator review required before changing persisted LCM state"
+
+    if name == "database_integrity":
+        command = "stop and inspect the SQLite database path; restore from backup if integrity_check is not ok"
+    elif name == "schema_core_tables":
+        command = "verify HERMES_HOME/LCM_DATABASE_PATH points at the intended LCM database before repair or restore"
+    elif name in {"messages_fts_integrity", "nodes_fts_integrity", "fts_index_sync"}:
+        action = DOCTOR_ACTION_BACKUP_FIRST_CLEANUP
+        command = "run `/lcm doctor repair` first; if it still recommends repair, run `/lcm backup` before `/lcm doctor repair apply`"
+        rationale = "FTS repair is rebuildable, but it still mutates SQLite indexes"
+    elif name == "sqlite_storage":
+        command = "inspect journal/quick_check output and database/WAL size; restore from backup if SQLite reports corruption"
+    elif name == "payload_storage":
+        missing_refs = 0
+        heartbeat_rows = 0
+        suspicious_rows = 0
+        if isinstance(detail, dict):
+            missing_refs = int(detail.get("externalized_payload_refs_missing", 0) or 0)
+            heartbeat_rows = len(detail.get("heartbeat_noise_rows") or [])
+            suspicious_rows = sum(
+                len(detail.get(key) or [])
+                for key in (
+                    "suspicious_data_uri_content_rows",
+                    "suspicious_data_uri_tool_calls_rows",
+                    "suspicious_base64_like_rows",
+                    "suspicious_repetitive_assistant_rows",
+                )
+            )
+        if heartbeat_rows and not missing_refs and not suspicious_rows:
+            action = DOCTOR_ACTION_SAFE_IGNORE
+            command = "safe to ignore unless heartbeat/progress noise is crowding useful recall; consider message/session filters for future rows"
+            rationale = "heartbeat rows are read-only noise diagnostics, not corruption"
+        else:
+            command = "inspect payload rows/refs; restore missing externalized payload files from backup before deleting or rewriting anything"
+            warning_only = True
+            rationale = "payload warnings may represent preserved user/tool data"
+    elif name == "sensitive_pattern_handling":
+        command = "inspect LCM_SENSITIVE_PATTERNS settings; remove unknown names or configure supported catalog entries"
+    elif name == "orphaned_dag_nodes":
+        command = "inspect affected DAG/source IDs; do not auto-delete summaries without confirming recall impact"
+        warning_only = True
+    elif name == "summary_quality":
+        command = "inspect worst_nodes and retrieval behavior; treat as summary quality evidence, not cleanup input"
+        warning_only = True
+    elif name == "config_validation":
+        command = "inspect LCM_* environment/config values and adjust only intentional operator overrides"
+    elif name == "source_lineage_hygiene":
+        action = DOCTOR_ACTION_SAFE_IGNORE
+        command = "safe to ignore legacy blank-source observations; use `/lcm doctor source` only when you intentionally want backup-first normalization"
+        rationale = "legacy blank sources are normalized to unknown for compatibility"
+    elif name == "lifecycle_fragmentation":
+        command = "inspect lifecycle categories; only use explicit backup-first lifecycle cleanup for empty lifecycle rows"
+        warning_only = True
+        rationale = "not every lifecycle/state mismatch is harmful or safe to mutate"
+    elif name == "context_pressure":
+        action = DOCTOR_ACTION_SAFE_IGNORE
+        command = "safe to ignore if compaction proceeds normally; inspect lcm_status only if pressure stays high or compaction loops"
+        warning_only = True
+        rationale = "context pressure is an operating state, not persisted-state corruption"
+    elif name == "cleanup_candidates":
+        action = DOCTOR_ACTION_BACKUP_FIRST_CLEANUP
+        command = "run `/lcm doctor clean` first; if candidates are expected junk/noise, run `/lcm backup` before `/lcm doctor clean apply`"
+        rationale = "candidate cleanup deletes rows and must stay preview-and-backup gated"
+
+    return {
+        "check": name,
+        "status": status,
+        "action": action,
+        "operator_action": command,
+        "warning_only": warning_only,
+        "rationale": rationale,
+    }
+
+
+def doctor_guidance_for_checks(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return actionable guidance for warning/failing lcm_doctor checks."""
+    guidance = []
+    for check in checks:
+        item = doctor_guidance_for_check(check)
+        if item is not None:
+            guidance.append(item)
+    return guidance
 
 
 # Backward-compatible private aliases for existing command/tool internals and tests.

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -119,10 +119,16 @@ def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
         command = "inspect LCM_SENSITIVE_PATTERNS settings; remove unknown names or configure supported catalog entries"
     elif name == "orphaned_dag_nodes":
         command = "inspect affected DAG/source IDs; do not auto-delete summaries without confirming recall impact"
-        warning_only = True
+        if status == "warn":
+            warning_only = True
+        else:
+            rationale = "DAG diagnostic failures mean doctor could not read summary/source state reliably"
     elif name == "summary_quality":
         command = "inspect worst_nodes and retrieval behavior; treat as summary quality evidence, not cleanup input"
-        warning_only = True
+        if status == "warn":
+            warning_only = True
+        else:
+            rationale = "summary-quality diagnostic failures mean doctor could not read DAG quality state reliably"
     elif name == "config_validation":
         command = "inspect LCM_* environment/config values and adjust only intentional operator overrides"
     elif name == "source_lineage_hygiene" and status == "warn":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# Architecture notes
+
+This page keeps the implementation model and product-positioning nuance outside the quickstart README while preserving the details new operators and reviewers need.
+
+## What It Does
+
+- **SQLite message store** - preserves raw messages by default before compaction
+- **Summary DAG** - compacts older context into depth-aware summary nodes
+- **Bounded recovery** - pages raw messages, child summaries, and externalized payloads without flooding the main context
+- **Agent tools** - `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query`
+- **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
+- **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
+- **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
+- **Sensitive-pattern controls** - optional named redaction of API keys, bearer tokens, passwords, and private keys before LCM stores or summarizes them
+- **Storage-boundary payload guard** - media-ish `data:*;base64` and long base64-looking strings are externalized before LCM writes them to SQLite
+- **Diagnostics** - `lcm_status`, `lcm_doctor`, and optional `/lcm` slash commands
+
+## LCM vs built-in compression
+
+Hermes core may persist original conversation history in `state.db` before
+built-in compression rewrites the active prompt. Built-in compression can still
+be lossy in the active context, but previous content may be recoverable later
+through host-level history tools such as `session_search`.
+
+`hermes-lcm` is different because recall is part of the active context engine:
+
+- plugin-local store and DAG built specifically for drill-down
+- current-session retrieval through LCM tools, not an auxiliary cross-session search step
+- explicit source-lineage and session-boundary rules
+
+Position LCM around retrieval quality, autonomy, and drill-down behavior. Do not
+claim that Hermes core has no persisted record of pre-compression history.
+
+## How It Works
+
+1. **Ingest** - persist each message in SQLite with FTS metadata
+2. **Compact** - summarize older messages outside the fresh tail into D0 leaf nodes
+3. **Condense** - merge same-depth nodes into higher-depth summaries
+4. **Escalate** - shrink oversize summaries from detailed to bullets to deterministic truncate
+5. **Assemble** - combine system prompt, highest-depth summaries, and fresh tail
+6. **Retrieve** - use LCM tools to drill into compacted history or synthesize from expanded context
+
+## Development
+
+Important files:
+
+```text
+plugin.yaml      manifest
+__init__.py      plugin registration and optional slash-command registration
+engine.py        LCMEngine main orchestrator
+store.py         SQLite message store and FTS
+dag.py           summary DAG and FTS
+config.py        env var defaults and overrides
+command.py       /lcm command handlers
+tools.py         lcm_grep, lcm_load_session, lcm_describe, lcm_expand, lcm_expand_query
+schemas.py       tool schemas shown to the model
+tests/           standalone pytest coverage
+```
+
+Run tests:
+
+```bash
+pip install pytest
+python -m pytest tests/ -v
+```
+
+No Hermes Agent checkout is required for the test suite; tests include a
+lightweight ABC stub.
+
+## Related references
+
+- [Operator guide](operator-guide.md)
+- [Retrieval tools reference](retrieval-tools.md)
+- [Benchmarking and stress checks](../benchmarks/README.md)

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,558 @@
+# Operator guide
+
+This page holds the detailed install, activation, configuration, diagnostics, and slash-command reference that used to live in the top-level README. The README stays focused on first-run adoption; this file is the operator reference.
+
+## Requirements
+
+- Hermes Agent with the pluggable context engine slot ([PR #7464](https://github.com/NousResearch/hermes-agent/pull/7464))
+- Python 3.11+
+- No required third-party runtime dependencies. `tiktoken` is used if available; otherwise LCM falls back to character-based token estimates. `regex` is used if available to apply timeouts to message ignore patterns; if it is not installed, message-level regex filtering is disabled with a warning rather than running unbounded stdlib `re` matches.
+
+## Install
+
+Canonical install path: clone `hermes-lcm` as a general user plugin.
+
+```bash
+git clone https://github.com/stephenschoettler/hermes-lcm \
+  ~/.hermes/plugins/hermes-lcm
+```
+
+For a profile-specific install:
+
+```bash
+git clone https://github.com/stephenschoettler/hermes-lcm \
+  ~/.hermes/profiles/myprofile/plugins/hermes-lcm
+```
+
+From an existing checkout, install a symlink:
+
+```bash
+./scripts/install.sh
+# Optional profile-aware install:
+HERMES_PROFILE=myprofile ./scripts/install.sh
+```
+
+## Activate
+
+The plugin has two names:
+
+- plugin manifest name: `hermes-lcm`
+- runtime context engine name: `lcm`
+
+Both must be configured:
+
+```yaml
+plugins:
+  enabled:
+    - hermes-lcm
+
+context:
+  engine: lcm
+```
+
+Restart Hermes after changing plugin or context-engine config.
+
+## Update
+
+If you cloned directly into the plugin directory:
+
+```bash
+cd ~/.hermes/plugins/hermes-lcm && git pull --ff-only
+```
+
+For a profile-specific install:
+
+```bash
+cd ~/.hermes/profiles/myprofile/plugins/hermes-lcm && git pull --ff-only
+```
+
+If you installed a symlink from a separate checkout:
+
+```bash
+./scripts/update.sh
+```
+
+Restart Hermes after updating.
+
+## Verify
+
+Run:
+
+```bash
+hermes plugins
+```
+
+Expected signals:
+
+- plugin list includes `hermes-lcm`
+- selected context engine is `lcm`
+- tool list includes `lcm_grep`, `lcm_load_session`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, and `lcm_doctor`
+
+Typical output:
+
+```text
+Plugins (1):
+  ✓ hermes-lcm v0.18.0 (7 tools)
+
+Provider Plugins:
+  Context Engine: lcm
+```
+
+For source checkouts, `lcm_status`, `/lcm status`, `lcm_doctor`, and
+`/lcm doctor` also report the loaded plugin path and best-effort git identity:
+`plugin_git_commit`, `plugin_git_branch`, and `plugin_git_dirty`.
+
+## Troubleshooting
+
+### `hermes plugins` shows `lcm (not found)` but LCM tools exist
+
+If `plugins.enabled` contains `hermes-lcm`, `context.engine: lcm` is set, and
+the runtime exposes LCM tools, LCM is loaded. The `lcm (not found)` line is a
+Hermes host discovery/status mismatch, not an LCM storage or compaction failure.
+
+### Startup log mentions `context-engine schemas` or `Path B fallback`
+
+This is expected on older Hermes hosts that do not advertise
+`context_engine_tool_handlers_receive_messages`, including Hermes Agent v0.16.
+LCM tools are still available through the context-engine schema/dispatch path
+(Path B). The plugin intentionally avoids standalone plugin-registry tool
+registration (Path A) on those hosts because Path A would shadow Path B and lose
+current-turn ingest.
+
+Healthy signals are the same as above: selected context engine `lcm`, the seven
+`lcm_*` tools in the live tool list, and `lcm_status` / `lcm_doctor` responding
+after one normal message initializes the session.
+
+### `/lcm status` looks unbound after restart
+
+After a fresh Hermes restart, `/lcm status` may show `session_id: (unbound)` or
+`threshold_tokens: (uninitialized)`. Send one normal Hermes message first, then
+run `lcm_status` or `/lcm status` again for live per-session fields.
+
+## Configuration
+
+Most installs only need `plugins.enabled` and `context.engine: lcm`. Useful
+environment variables:
+
+| Variable | Default | Use |
+|----------|---------|-----|
+| `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
+| `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
+| `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
+| `LCM_LEAF_CHUNK_TOKENS` | `20000` | Raw-backlog floor before leaf compaction; with dynamic chunking enabled, the base chunk target |
+| `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Enable chunk-sized leaf compaction passes instead of compacting the whole non-tail raw backlog per pass |
+| `LCM_DYNAMIC_LEAF_CHUNK_MAX` | `40000` | Upper bound for dynamic leaf chunk targets |
+| `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | DAG depth retained after manual `/new` (`-1` all, `0` none) |
+| `LCM_IGNORE_SESSION_PATTERNS` | empty | Comma-separated session globs excluded from LCM storage |
+| `LCM_STATELESS_SESSION_PATTERNS` | empty | Comma-separated session globs kept read-only |
+| `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
+| `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
+| `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
+| `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
+| `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | `0.0` | Disabled at `0.0`; when set, permits critical-pressure bypasses for bounded deferred catch-up and cache-friendly follow-on condensation only |
+| `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
+| `LCM_SUMMARY_FALLBACK_MODELS` | empty | Comma-separated summarization models tried after `LCM_SUMMARY_MODEL` or the auxiliary task default fails |
+| `LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD` | `2` | Consecutive failed summarization calls before a route is skipped temporarily |
+| `LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS` | `300` | Seconds to skip an open summary route before retrying it |
+| `LCM_EXPANSION_MODEL` | summary model / auxiliary | Override `lcm_expand_query` synthesis model |
+| `LCM_EXPANSION_CONTEXT_TOKENS` | `32000` | Context budget used by the auxiliary LLM for `lcm_expand_query` |
+| `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Timeout for one summarization call |
+| `LCM_EXPANSION_TIMEOUT_MS` | `120000` | Timeout for one `lcm_expand_query` synthesis call |
+| `LCM_DATABASE_PATH` | auto | SQLite database path. Empty config resolves to `HERMES_HOME/lcm.db`; plugin installs or operators may set this env var to another profile-scoped path such as `~/.hermes/hermes-lcm.db`. |
+| `LCM_FTS_INTEGRITY_CHECK_INTERVAL_HOURS` | `24` | Minimum hours between startup FTS5 deep integrity-checks (O(index size)). `0` checks every startup (previous behavior); a negative value never checks on startup. Structural checks always run regardless. |
+| `LCM_ENABLE_SLASH_COMMAND` | `false` | Enable the optional `/lcm` operator command surface |
+| `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
+| `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
+| `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires (default 200 so fresh installs skip the work) |
+| `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
+
+Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
+
+Sensitive-pattern handling is disabled by default so ordinary LCM storage and
+`lcm_expand` remain lossless. When `LCM_SENSITIVE_PATTERNS_ENABLED=true`, matched
+secret values are replaced with metadata-only placeholders before SQLite, FTS,
+summaries, active replay, and externalized payload JSON receive the content. This
+is intentionally not lossless for matching values: the raw matched secret is
+unrecoverable after redaction.
+
+Supported named catalog entries are:
+
+- `api_key`: `api_key`, `api_token`, `access_token`, `secret_key`, and
+  `client_secret` assignments or JSON keys.
+- `bearer_token`: `Bearer ...` strings and token-like JSON keys.
+- `password_assignment`: `password`, `passwd`, `pwd`, and `passphrase`
+  assignments or JSON keys, including quoted values with spaces.
+- `private_key`: PEM private-key blocks.
+
+Redaction is forward-only. Enabling it does not rewrite existing SQLite rows,
+FTS shadow tables, DAG summaries, or externalized payload JSON that were written
+before the setting was enabled. Non-password placeholders include a short
+truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
+the digest to avoid making password-like values easier to dictionary-check.
+`lcm_status` and `lcm_doctor` expose the enabled state, configured pattern names,
+unknown names, source, and placeholder format without exposing raw secret values.
+
+### Cache policy boundary
+
+LCM is **cache-friendly**, not fully cache-aware. It may avoid some follow-on
+condensation churn, but current cache usage counters are retrospective status
+data only; they do not tell the plugin whether the next prompt mutation will
+break a hot provider cache. For that reason LCM does **not** implement
+provider/model TTL heuristics, provider-family detection, cache-touch/cache-break
+tracking, TTL delays, or full cache-aware deferred compaction.
+
+`LCM_CRITICAL_BUDGET_PRESSURE_RATIO` is a narrow escape hatch. It is disabled by
+default (`0.0`). When set, LCM compares prompt pressure against the context
+window and only at or above that ratio may bypass the existing polite gates for
+bounded deferred maintenance catch-up and cache-friendly follow-on condensation.
+Below that pressure, simpler existing behavior is preserved. Revisit full
+cache-aware deferred compaction only after Hermes core exposes reliable cache
+state / cache-break signals.
+
+### Threshold ownership
+
+When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
+threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
+compressor. Hermes core `compression.enabled` is still the global gate that
+allows compaction, so leave it enabled when using LCM.
+
+If startup/status output shows a host-side compression percentage that disagrees
+with LCM, trust live LCM status after a normal message has initialized the
+session.
+
+### Preset inspection and dry-run suggestions
+
+Model-aware presets are inspectable, but they are not automatic live config
+mutations. With `LCM_ENABLE_SLASH_COMMAND=true`, use:
+
+```text
+/lcm preset show codex_gpt_long_context
+/lcm preset show codex_spark_context
+/lcm preset suggest
+/lcm preset apply codex_gpt_long_context --dry-run
+/lcm preset apply codex_spark_context --dry-run
+```
+
+`/lcm preset show` reports the shipped preset metadata, benchmark provenance,
+policy file, policy version, and metric summary. `/lcm preset suggest` chooses a
+safe shipped suggestion for the current context window when one exists, and
+labels the current selector as `context-only` when the provider/model family is
+not available to the plugin. `/lcm preset apply ... --dry-run` previews env-var
+settings only; it does not
+write files, change process state, or override explicit parseable
+preset-managed `LCM_*` environment variables. Invalid preset-managed env values
+are reported as invalid instead of being treated as active runtime overrides.
+
+The current runtime preset dry-run previews are:
+
+```text
+# codex_gpt_long_context: near-272k GPT/Codex routes
+LCM_CONTEXT_THRESHOLD=0.75
+LCM_FRESH_TAIL_COUNT=24
+LCM_LEAF_CHUNK_TOKENS=8000
+
+# codex_spark_context: near-128k GPT-5.3 Codex Spark routes
+LCM_CONTEXT_THRESHOLD=0.75
+LCM_FRESH_TAIL_COUNT=16
+LCM_LEAF_CHUNK_TOKENS=8000
+```
+
+`target_after_compaction=0.55` is still benchmark provenance, not a runtime
+setting, because the engine does not expose that live knob yet.
+
+For dashboards and agents, `lcm_status` also exposes the same information under
+`preset_suggestion` as read-only JSON: suggested preset name/family, selection
+reason, match confidence, provenance, explicit override diagnostics, invalid
+override diagnostics, unsupported benchmark-only fields, and the dry-run delta.
+This surface is safe to consume without scraping slash-command text; it does not
+write files, mutate process state, expose local benchmark run paths, or apply
+`LCM_*` environment changes.
+
+### FAQ: tuning LCM for large context windows
+
+Long-context models change the tuning problem. A 1M-token model does not mean
+you always want to spend 750k prompt tokens before LCM starts compacting. Start
+with the active prompt budget you are willing to pay for, then tune the threshold
+around that budget.
+
+The basic calculation is:
+
+```text
+compaction trigger = effective context window * LCM_CONTEXT_THRESHOLD
+```
+
+Or, working backwards:
+
+```text
+LCM_CONTEXT_THRESHOLD = desired compaction trigger / effective context window
+```
+
+Examples, as math rather than universal recommendations:
+
+| Effective context window | Desired trigger | Threshold |
+|--------------------------|-----------------|-----------|
+| `128000` | `96000` | `0.75` |
+| `200000` | `140000` | `0.70` |
+| `400000` | `240000` | `0.60` |
+| `1000000` | `250000` | `0.25` |
+| `1000000` | `400000` | `0.40` |
+| `1000000` | `600000` | `0.60` |
+
+If your Hermes config caps the model's effective `context_length`, tune against
+that effective value instead of the provider's advertised maximum. For example,
+a 1M-token provider with an effective `context_length` of `400000` and
+`LCM_CONTEXT_THRESHOLD=0.60` starts compaction around `240000` prompt tokens.
+
+A reasonable first pass for a true 1M effective window is:
+
+| Goal | Desired trigger | Threshold | Notes |
+|------|-----------------|-----------|-------|
+| Lower spend / earlier DAG building | `200000` to `300000` | `0.20` to `0.30` | Good when cost and latency matter more than maximum live context |
+| Balanced large-context use | `350000` to `500000` | `0.35` to `0.50` | Good starting point for many long-running agents |
+| Keep more raw context active | `600000+` | `0.60+` | Higher token burn, later compaction |
+
+What the main knobs do:
+
+- `LCM_CONTEXT_THRESHOLD` decides when compaction starts. Lower values build the
+  DAG earlier and reduce active prompt burn, but compact more often.
+- `LCM_FRESH_TAIL_COUNT` protects recent messages from compaction. Raise it if
+  your agent often needs the last few tool calls or planning turns verbatim.
+- `LCM_LEAF_CHUNK_TOKENS` is the raw-backlog floor before a leaf compaction pass
+  starts. With the default `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=false`, the pass
+  compacts the whole non-tail raw backlog, not only a chunk of this size.
+- `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true` changes leaf passes into chunk-sized
+  work. In that mode `LCM_LEAF_CHUNK_TOKENS` is the base target and
+  `LCM_DYNAMIC_LEAF_CHUNK_MAX` is the upper bound for a dynamic chunk target.
+- `LCM_EXPANSION_CONTEXT_TOKENS` controls how much recovered material
+  `lcm_expand_query` may feed to the auxiliary model. It does not change what
+  LCM stores.
+- `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED=true` helps when large tool outputs,
+  logs, media payloads, or raw JSON blobs dominate token pressure.
+
+Common questions:
+
+**Should I leave the default threshold on a 1M-token model?**
+
+Not always. The default `0.35` means compaction starts around `350000` prompt
+tokens on a true 1M effective window. That leaves far more headroom for new
+content but compacts more aggressively, which can shorten recall of older
+details.
+
+**Should I change leaf chunk settings first?**
+
+Usually no. Start with `LCM_CONTEXT_THRESHOLD`, `LCM_FRESH_TAIL_COUNT`, and large
+output externalization. Only tune leaf chunking after checking `lcm_status` and
+understanding whether your workload is dominated by huge raw backlog passes. If
+you want chunk-sized leaf passes, enable dynamic leaf chunking explicitly.
+
+**Does compacting earlier hurt recall?**
+
+It changes the tradeoff. More content moves from the live prompt into summaries
+earlier, but raw messages are still stored and recoverable through LCM tools. If
+you need exact details later, use `lcm_grep`, `lcm_describe`, `lcm_expand`, or
+`lcm_expand_query` instead of relying only on the active prompt.
+
+**How do I know whether my settings are working?**
+
+After a normal message has initialized the session, check `lcm_status` for the
+effective context length, threshold tokens, prompt pressure, compression count,
+raw rows, and summary nodes. Run `lcm_doctor` when behavior looks surprising.
+
+### Session pattern syntax
+
+Pattern matching checks multiple keys: raw `session_id`, `platform`, and
+`platform:session_id`.
+
+- `*` matches within one colon-delimited segment
+- `**` can span across colons
+
+Example: `cron:*` can match Hermes cron sessions, while exact raw session IDs
+still work.
+
+### Noise suppression
+
+LCM offers two layers of noise filtering, sized to two different shapes of
+noise:
+
+- **Session-level filters** (`LCM_IGNORE_SESSION_PATTERNS`,
+  `LCM_STATELESS_SESSION_PATTERNS`) catch the case where the noisy traffic
+  arrives as its own session or platform, for example a dedicated `cron:*`
+  session. Match keys cover the session id, the platform, and
+  `platform:session_id`.
+- **Message-level patterns** (`LCM_IGNORE_MESSAGE_PATTERNS`) catch the case
+  where cron alerts or other noise are injected into a normal Telegram or
+  WhatsApp conversation as ordinary user-visible messages. From LCM's
+  perspective the session/platform is `telegram` or `whatsapp`, not `cron`,
+  so only the message content is distinctive.
+
+Message-level patterns are Python regex strings, comma-separated, compiled
+once at engine start. They run against plain message text. For structured
+multimodal payloads, LCM matches against concatenated text parts first, so
+anchored patterns bind to the text an operator sees. If a structured payload
+contains no text parts, matching falls back to the normalized JSON form that
+LCM would have written to the store. Matching messages are skipped before
+storage, so new matching rows do not enter the messages table or FTS index.
+Filtering is role-agnostic by default, since cron alerts can be re-emitted
+under any role depending on the gateway.
+
+Example operator config:
+
+```
+LCM_IGNORE_MESSAGE_PATTERNS=^Cronjob Response:,^>>>Cronjob Response<<<:
+```
+
+Invalid regex entries are logged at warning level and dropped; the
+surviving patterns in the same list still take effect, so a misconfigured
+entry never crashes ingest. Pattern matching uses a 50 ms per-pattern timeout
+when the optional `regex` package is installed. If `regex` is not installed,
+LCM logs a warning and disables message-level regex filtering rather than
+running unbounded stdlib `re` matches in the ingest path.
+
+One operator-facing limitation to know about:
+
+- **Compaction-window edge.** The filter runs at ingest time. When a
+  matching message is part of the chunk being summarized in the same
+  turn it arrived, the message's text may appear inside the resulting
+  summary node text. In long-running sessions where compaction triggers
+  every several dozen turns, this can affect multiple summary nodes per
+  day rather than only happening rarely. The summary node's `source_ids`
+  will not reference the filtered message (it was never written to the
+  store), so DAG lineage stays clean; only the serialized summary text
+  can carry it. Closing this window is tracked as follow-up work.
+
+`lcm_status` surfaces the full filter contract under `session_filters`, including
+`ignore_session_patterns`, `stateless_session_patterns`, `ignore_message_patterns`,
+their `*_source` fields (`default` or `env`), the current session's `ignored` and
+`stateless` booleans, and a process-lifetime `ignored_message_count` so operators
+can confirm their patterns are loaded and watch how often message filters fire.
+The counter resets on engine restart.
+
+### Large tool-output handling
+
+Externalization for ordinary large tool output is opt-in. When enabled,
+oversized tool results are written to plugin-managed JSON files and referenced
+from summaries. They remain inspectable later through
+`lcm_describe(externalized_ref=...)` and `lcm_expand(externalized_ref=...)`.
+
+The storage-boundary payload guard is separate from that opt-in. LCM always
+scans messages at the store boundary before writing `messages.content` or
+`messages.tool_calls` to SQLite. Inline `data:*;base64,...` payloads and
+conservative long base64-looking runs are replaced with compact placeholders and
+written to the same plugin-managed externalized-payload directory. This is a
+safer default for media-ish payloads: LCM still preserves lossless recovery via
+the placeholder `ref` and `lcm_expand(externalized_ref=...)`, but it does not
+duplicate those payload bytes into `lcm.db`, FTS shadow tables, WAL files, or
+ordinary SQLite backups. If externalization fails, LCM logs a warning and leaves
+the original text inline rather than dropping data.
+
+`lcm_doctor` reports the effective SQLite database path, core schema-table
+presence, SQLite `journal_mode`, `quick_check`, database/WAL sizes, the largest
+content/tool-call rows, suspicious inline `data:*;base64` rows, suspicious long
+base64-looking rows, and aggregate externalized-payload stats.
+Doctor output is metadata-only for these scans; it intentionally does not print
+raw payload previews.
+
+`lcm_doctor` JSON includes a top-level `guidance` array for every warning or
+failure. The slash-command text mirrors that as `triage_guidance`. Each item
+maps a warning class to one of three operator actions:
+
+- `safe/ignore`: informational operating state; leave it alone unless it is
+  crowding useful recall or repeatedly surprising operators.
+- `inspect`: read the named rows/session IDs/config before making changes.
+- `backup-first cleanup`: run the read-only preview command, create `/lcm backup`,
+  then run the explicit apply command only if the preview still matches intent.
+
+Warning-only classes should not auto-clean state: `summary_quality`, broad
+`lifecycle_fragmentation`, payload-storage suspicion, and `context_pressure` are
+evidence for review, not proof that mutation is safe.
+
+This guard is scoped to LCM's own `lcm.db` write boundary. It does not prevent
+Hermes core, or any other host layer, from writing inline payloads to Hermes
+`state.db`; that is upstream/outside LCM scope. It also does not rewrite
+historical rows already present in `lcm.db`. Cleaning older suspicious rows
+requires a separate backup-first cleanup or migration flow.
+
+Transcript GC is separate and also opt-in. It only rewrites already-externalized,
+already-summarized tool-role rows to compact placeholders. It keeps the same
+`store_id`, keeps payload files, skips pinned messages, and preserves lossless
+recovery through `externalized_ref`. After GC, `lcm_grep` will not match the
+original giant tool blob text directly; search summaries or refs instead.
+
+## Slash Commands
+
+Slash commands are disabled by default. Enable them only in trusted operator
+contexts:
+
+```bash
+export LCM_ENABLE_SLASH_COMMAND=1
+```
+
+Available commands:
+
+- `/lcm` or `/lcm status` - current runtime/session status
+- `/lcm doctor` - read-only health checks
+- `/lcm doctor clean` - read-only scan for obvious junk/noise session candidates
+- `/lcm doctor clean apply` - backup-first cleanup for safe pattern-matched candidates; requires `LCM_DOCTOR_CLEAN_APPLY_ENABLED=true`
+- `/lcm doctor clean lifecycle` - read-only scan for lifecycle rows with zero messages/nodes
+- `/lcm doctor clean lifecycle apply` - backup-first cleanup of empty lifecycle rows; requires `LCM_DOCTOR_CLEAN_APPLY_ENABLED=true`
+- `/lcm doctor repair` - read-only SQLite/FTS repair diagnostics
+- `/lcm doctor repair apply` - backup-first SQLite/FTS repair
+- `/lcm doctor source` - read-only scan for legacy blank-source rows
+- `/lcm doctor source apply` - backup-first normalization of legacy blank-source rows to `unknown`
+- `/lcm doctor retention` - read-only retention analysis
+- `/lcm backup` - timestamped SQLite backup
+- `/lcm rotate` - read-only preview of an in-place tail-preserving compact of the active session
+- `/lcm rotate apply` - backup-first rotate that advances the lifecycle frontier past pre-tail raw messages
+- `/lcm help` - command help
+
+Apply paths are intentionally narrow and backup-first. Start with diagnostics
+before cleanup or repair.
+
+### Rotate: in-place compact without changing session identity
+
+`/lcm rotate` lets an operator compact a long-running session in place without
+changing `session_id` or `conversation_id`. It is the in-session counterpart to
+Hermes-level `/new` (which starts a new session) and to `/lcm doctor clean`
+(which prunes whole junk sessions).
+
+What rotate does:
+
+- preserves the live tail (`LCM_FRESH_TAIL_COUNT` most-recent messages)
+- advances the lifecycle frontier marker past every raw message before the tail,
+  so subsequent bootstrap stops replaying them into the active prompt
+- writes a rolling `*-rotate-latest.sqlite3` backup under the same backup
+  directory as `/lcm backup`, overwriting the previous rotate slot atomically
+  so disk usage stays bounded across repeated rotates
+
+What rotate does not do:
+
+- it does not delete raw messages — pre-tail rows remain in the SQLite store
+  and stay recoverable through `lcm_load_session` and `lcm_expand`, preserving
+  the lossless raw recovery contract
+- it does not invoke the summarization model — rotate is a frontier and backup
+  operation, not a synthesis step. Pre-tail content that was not yet covered by
+  a summary node remains accessible only as raw rows; trigger normal compaction
+  first if you want the pre-tail range covered by summary nodes before rotating
+- it does not change session or conversation identity, run on stateless
+  sessions (`LCM_STATELESS_SESSION_PATTERNS`), or run on ignored sessions
+  (`LCM_IGNORE_SESSION_PATTERNS`) — rotate refuses on both with a clear reason
+
+`lcm_status` and `/lcm status` surface `last_rotate_at` (epoch float, or `null`
+when no rotate has happened) and the rolling backup path so operators can see
+when rotate last ran. The mtime of the rolling backup file is the source of
+truth — no new lifecycle column is added by this feature.
+
+Re-running `/lcm rotate apply` on a session whose frontier is already at or
+ahead of the target boundary reports `status: noop` and is safe to retry.
+A no-op apply does not write a new rolling backup, so the previous
+known-good `*-rotate-latest.sqlite3` snapshot survives idempotent retries.
+
+## Related references
+
+- [Retrieval tools reference](retrieval-tools.md)
+- [Architecture notes](architecture.md)
+- [Benchmarking and stress checks](../benchmarks/README.md)
+- [Release validation](release-validation.md)
+- [Packaging and distribution posture](packaging.md)

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -455,8 +455,10 @@ Doctor output is metadata-only for these scans; it intentionally does not print
 raw payload previews.
 
 `lcm_doctor` JSON includes a top-level `guidance` array for every warning or
-failure. The slash-command text mirrors that as `triage_guidance`. Each item
-maps a warning class to one of three operator actions:
+failure. The slash-command text also reports `triage_guidance` for the warning
+and failure classes surfaced in the command output, using the same operator
+action vocabulary. Each item maps a warning class to one of three operator
+actions:
 
 - `safe/ignore`: informational operating state; leave it alone unless it is
   crowding useful recall or repeatedly surprising operators.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,39 @@
+# Packaging and distribution posture
+
+## Current decision
+
+`hermes-lcm` intentionally remains a clone-or-symlink Hermes user plugin for now. The supported install path is:
+
+```bash
+git clone https://github.com/stephenschoettler/hermes-lcm \
+  ~/.hermes/plugins/hermes-lcm
+```
+
+For profile-specific installs, clone under `~/.hermes/profiles/<profile>/plugins/hermes-lcm`. For development checkouts, `scripts/install.sh` creates a profile-aware symlink into the active Hermes plugin directory and refuses to overwrite an existing checkout or unrelated symlink.
+
+## Why not pip-style packaging yet?
+
+The repository is a Hermes plugin, not a standalone Python application. Runtime discovery currently depends on:
+
+- `plugin.yaml` declaring the plugin name and registered tools
+- the repo root containing `__init__.py` for Hermes plugin registration
+- the operator placing or symlinking the checkout into Hermes' plugin search path
+- no required third-party runtime dependencies beyond Python 3.11+ and optional accelerators such as `tiktoken` and `regex`
+
+There is no `pyproject.toml` or package metadata today, and that is deliberate until Hermes plugin packaging/discovery has a stable target for pip-installed plugins. Adding generic Python packaging before the host install contract is clear would create a second install story without making first-run activation simpler.
+
+## Next packaging step
+
+Make packaging a separate implementation lane only when one of these is true:
+
+1. Hermes Agent documents a stable pip/distribution entrypoint for plugins.
+2. Users need version-pinned installs without direct git checkouts.
+3. Release automation needs packaged artifacts beyond GitHub tags/releases.
+
+The narrow next step would be packaging metadata plus tests that prove a packaged install still exposes `hermes-lcm`, context engine `lcm`, and all seven LCM tools through `hermes plugins`. Until then, clone/symlink remains the documented path.
+
+## Current install and update references
+
+- Quickstart: [README](../README.md)
+- Detailed install/update/verify: [Operator guide](operator-guide.md)
+- Standalone install script contract: [`tests/test_packaging_install.py`](../tests/test_packaging_install.py)

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,6 +1,6 @@
 # Release validation
 
-Use `scripts/validate_release.sh` as the local release-confidence lane before tagging or publishing hermes-lcm. The script is offline by default: it does not call model providers, does not mutate live Hermes config, and writes all validation artifacts under a fresh output directory.
+Use `scripts/validate_release.sh` as the local release-confidence lane before tagging or publishing hermes-lcm. The script is offline by default: it does not call model providers, does not mutate live Hermes config, routes Python bytecode/cache artifacts under the validation output directory, and writes validation artifacts under a fresh output directory.
 
 ## Command
 
@@ -10,6 +10,8 @@ Prerequisites:
 - Use a Python environment with `pytest` installed. If `python` on `PATH` is not the intended interpreter, set `PYTHON=/path/to/python`.
 - The benchmark and stress gates are standalone-checkout safe: they provide the minimal Hermes Agent `ContextEngine` base class needed for deterministic local validation when Hermes Agent is not importable.
 - On a PR branch with `origin/main` available, the whitespace/conflict-marker gate checks `origin/main...HEAD` instead of only uncommitted working-tree changes, then also checks the local working tree and staged diff. Override with `LCM_RELEASE_DIFF_BASE=<rev-or-range>` when validating against another base.
+- Python validation runs with `PYTHONPYCACHEPREFIX` under the output directory and pytest cache disabled, then records git status before and after validation so release runs do not silently dirty the checkout.
+- The low-file-descriptor full gate lowers the limit to 1024 only when the current shell allows it; locked-down hosts keep their existing lower limit instead of failing before pytest starts.
 
 ```bash
 scripts/validate_release.sh
@@ -42,8 +44,9 @@ Each run creates a fresh directory, by default:
 
 Important files:
 
-- `validation-checklist.md` — scrubbed operator checklist and command summary
+- `validation-checklist.md` — scrubbed operator checklist, command summary, and before/after git status
 - `logs/*.log` — stdout/stderr for each validation command
+- `pycache/` — validation-time Python bytecode cache redirected away from the source tree
 - `benchmark-smoke/summary.json` and `benchmark-smoke/metrics.jsonl` — deterministic benchmark artifacts
 - `stress-smoke/stress-summary.md` and `stress-smoke/results/stress-results.json` — deterministic stress artifacts
 
@@ -66,6 +69,7 @@ The checklist is safe to paste into a release note or PR validation section afte
 - [ ] focused or full pytest passed
 - [ ] deterministic benchmark smoke passed
 - [ ] deterministic stress smoke/release passed
+- [ ] git status before/after validation reviewed
 
 ### Doctor triage
 - [ ] `lcm_doctor` warnings were classified as `safe/ignore`, `inspect`, or `backup-first cleanup`

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -9,6 +9,7 @@ Prerequisites:
 - Run from the repository checkout.
 - Use a Python environment with `pytest` installed. If `python` on `PATH` is not the intended interpreter, set `PYTHON=/path/to/python`.
 - The benchmark and stress gates are standalone-checkout safe: they provide the minimal Hermes Agent `ContextEngine` base class needed for deterministic local validation when Hermes Agent is not importable.
+- On a PR branch with `origin/main` available, the whitespace/conflict-marker gate checks `origin/main...HEAD` instead of only uncommitted working-tree changes, then also checks the local working tree and staged diff. Override with `LCM_RELEASE_DIFF_BASE=<rev-or-range>` when validating against another base.
 
 ```bash
 scripts/validate_release.sh
@@ -16,7 +17,7 @@ scripts/validate_release.sh
 
 Default smoke mode runs the local gates that should be cheap enough for routine operator use:
 
-- `git diff --check`
+- adaptive `git diff --check` over `origin/main...HEAD` on PR branches, plus local working-tree and staged diff checks
 - Python compile checks for the plugin and release scripts
 - shell syntax checks for maintained shell scripts
 - focused pytest coverage for core, command, packaging, benchmark, and stress surfaces

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,0 +1,87 @@
+# Release validation
+
+Use `scripts/validate_release.sh` as the local release-confidence lane before tagging or publishing hermes-lcm. The script is offline by default: it does not call model providers, does not mutate live Hermes config, and writes all validation artifacts under a fresh output directory.
+
+## Command
+
+Prerequisites:
+
+- Run from the repository checkout.
+- Use a Python environment with `pytest` installed. If `python` on `PATH` is not the intended interpreter, set `PYTHON=/path/to/python`.
+- The benchmark and stress gates are standalone-checkout safe: they provide the minimal Hermes Agent `ContextEngine` base class needed for deterministic local validation when Hermes Agent is not importable.
+
+```bash
+scripts/validate_release.sh
+```
+
+Default smoke mode runs the local gates that should be cheap enough for routine operator use:
+
+- `git diff --check`
+- Python compile checks for the plugin and release scripts
+- shell syntax checks for maintained shell scripts
+- focused pytest coverage for core, command, packaging, benchmark, and stress surfaces
+- deterministic benchmark smoke with a synthetic fixture
+- deterministic stress smoke
+
+For pre-tag confidence, run:
+
+```bash
+scripts/validate_release.sh --full
+```
+
+Full mode adds the whole test suite, the low-file-descriptor pytest pass, and the release stress tier. It is intentionally heavier and still avoids provider/network side effects.
+
+## Artifact shape
+
+Each run creates a fresh directory, by default:
+
+```text
+/tmp/hermes-lcm-release-validation-YYYYMMDD-HHMMSS/
+```
+
+Important files:
+
+- `validation-checklist.md` — scrubbed operator checklist and command summary
+- `logs/*.log` — stdout/stderr for each validation command
+- `benchmark-smoke/summary.json` and `benchmark-smoke/metrics.jsonl` — deterministic benchmark artifacts
+- `stress-smoke/stress-summary.md` and `stress-smoke/results/stress-results.json` — deterministic stress artifacts
+
+The checklist is safe to paste into a release note or PR validation section after reviewing any local path values. Do not paste raw logs unless they have been scrubbed for local paths, secrets, and unrelated environment details.
+
+## Checklist template
+
+```md
+## Release validation
+
+- Command: `scripts/validate_release.sh [--full]`
+- Mode: `smoke` or `full`
+- Repo: `<branch>@<commit>`
+- Output dir: `<validation artifact dir>`
+
+### Gates
+- [ ] git diff/whitespace check passed
+- [ ] Python compile checks passed
+- [ ] shell syntax checks passed
+- [ ] focused or full pytest passed
+- [ ] deterministic benchmark smoke passed
+- [ ] deterministic stress smoke/release passed
+
+### Doctor triage
+- [ ] `lcm_doctor` warnings were classified as `safe/ignore`, `inspect`, or `backup-first cleanup`
+- [ ] no warning-only class was auto-cleaned without operator review
+
+### Notes
+- Skipped gates:
+- Warnings reviewed:
+- Recommended next release-confidence step:
+```
+
+## Warning-only boundaries
+
+Doctor warnings should remain warning-only when the runtime cannot prove that mutation is safe:
+
+- summary quality warnings: inspect retrieval/summary behavior; do not rewrite DAG state automatically
+- lifecycle fragmentation: inspect first; only use explicit backup-first lifecycle cleanup for empty lifecycle rows
+- payload-storage suspicion: inspect/restore missing payload files before deleting or rewriting anything
+- context pressure: usually safe to ignore unless compaction is stuck or repeatedly firing
+- legacy blank-source rows: normalized as `unknown` for compatibility; only run source normalization after a backup-first review

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -9,7 +9,7 @@ Prerequisites:
 - Run from the repository checkout.
 - Use a Python environment with `pytest` installed. If `python` on `PATH` is not the intended interpreter, set `PYTHON=/path/to/python`.
 - The benchmark and stress gates are standalone-checkout safe: they provide the minimal Hermes Agent `ContextEngine` base class needed for deterministic local validation when Hermes Agent is not importable.
-- On a PR branch with `origin/main` available, the whitespace/conflict-marker gate checks `origin/main...HEAD` instead of only uncommitted working-tree changes, then also checks the local working tree and staged diff. Override with `LCM_RELEASE_DIFF_BASE=<rev-or-range>` when validating against another base.
+- On a PR branch with `origin/main` available, the whitespace/conflict-marker gate checks `origin/main...HEAD` instead of only uncommitted working-tree changes, then also checks the local working tree and staged diff. Override with `LCM_RELEASE_DIFF_BASE=<rev-or-range>` when validating against another base. If no changed `origin/main...HEAD` range is available but `HEAD` has a parent, the gate checks `HEAD^...HEAD` so a detached release checkout still validates the committed release diff.
 - Python validation runs with `PYTHONPYCACHEPREFIX` under the output directory and pytest cache disabled, then records git status before and after validation so release runs do not silently dirty the checkout.
 - The low-file-descriptor full gate lowers the limit to 1024 only when the current shell allows it; locked-down hosts keep their existing lower limit instead of failing before pytest starts.
 
@@ -19,7 +19,7 @@ scripts/validate_release.sh
 
 Default smoke mode runs the local gates that should be cheap enough for routine operator use:
 
-- adaptive `git diff --check` over `origin/main...HEAD` on PR branches, plus local working-tree and staged diff checks
+- adaptive `git diff --check` over `origin/main...HEAD` on PR branches or `HEAD^...HEAD` in detached/no-base release checkouts, plus local working-tree and staged diff checks
 - Python compile checks for the plugin and release scripts
 - shell syntax checks for maintained shell scripts
 - focused pytest coverage for core, command, packaging, benchmark, and stress surfaces

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -1,0 +1,85 @@
+# Retrieval tools reference
+
+Use this page when you need the exact LCM tool contract or archive-migration notes. For install, activation, and runtime configuration, start with [Operator guide](operator-guide.md).
+
+## Agent Tools
+
+Use these tools for current-session recall after compaction. Use `session_search`
+for earlier separate sessions or broad cross-session history.
+
+| Tool | Use |
+|------|-----|
+| `lcm_grep` | Search current-session raw messages and summaries. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only. Raw-message filters `role`, `time_from`, and `time_to` are pushed into the search query; when any of them is supplied, summary hits are omitted so the filter contract stays exact. Use `session_search` for earlier separate sessions or broad cross-session recall. |
+| `lcm_load_session` | Load one ordered raw-message transcript page for an explicit `session_id`. This is not search: it returns raw rows in `store_id` order, bounded by `limit`, with per-message content bounded by `max_content_chars`, and continues with `after_store_id` from `next_cursor`. |
+| `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
+| `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
+| `lcm_expand_query` | Answer a question using expanded current-session LCM context while returning a bounded answer. |
+| `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
+| `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
+
+### Retrieval contract
+
+LCM retrieval tools default to current-session scope. `lcm_grep` accepts
+`session_scope='all'` or `session_scope='session'` as an explicit opt-in for
+bounded archive search over rows already present in `lcm.db` (raw-message hits
+only). Once a session id is known, `lcm_load_session` can enumerate that session's
+raw transcript in chronological `store_id` pages without a search query. Use
+Hermes `session_search` for broad cross-session history outside the LCM database.
+
+Within the current session, `source` filters raw rows directly and filters
+summary nodes by descendant raw-message source lineage. `unknown` is a real
+source value, not a wildcard. Legacy blank-source rows are treated as `unknown`.
+`role`, `time_from`, and `time_to` are raw-message filters and are applied in the
+message search query before result limiting. `time_from` and `time_to` accept Unix
+seconds or timezone-aware ISO 8601 strings; naive ISO strings are rejected so the
+same query means the same thing across machines. When a raw-message filter is
+active, `lcm_grep` returns raw rows only and reports `summary_results_omitted`.
+
+Carried-over summary nodes can become current-session content after `/new`, but
+their source eligibility still comes from the descendant raw messages. Expanding
+a carried-over current-session node recovers those original raw message sources
+even when the sources still belong to the previous session.
+
+### Lossless raw recovery contract
+
+Tool responses are bounded so one retrieval call cannot flood the main context.
+Lossless recovery means raw content is stored with stable source lineage and can
+be recovered in deterministic pages.
+
+- `lcm_expand(node_id=...)` pages immediate sources with `source_offset` and `source_limit`
+- `lcm_load_session(session_id=...)` pages ordered raw session rows with `after_store_id` and `next_cursor`; each row includes bounded content plus truncation metadata, and large individual rows can be recovered with `lcm_expand(store_id=...)` using `content_offset`
+- oversized raw messages continue with `content_offset`
+- `lcm_expand(externalized_ref=...)` pages payload content with `content_offset`
+- `lcm_expand_query` uses `context_max_tokens` for auxiliary context and reports truncation/pagination hints when needed
+
+### lossless-claw/OpenClaw import utility
+
+`hermes-lcm` includes an opt-in operator script for backfilling raw message rows from a lossless-claw/OpenClaw LCM SQLite database into the local hermes-lcm SQLite store:
+
+```bash
+python scripts/import_lossless_claw.py \
+  --source-db ~/.openclaw/path/to/lcm.db \
+  --target-db ~/.hermes/lcm.db \
+  --agent sammy
+```
+
+The script is intentionally conservative:
+
+- dry-run is the default; pass `--apply` to write
+- run it against an explicit target DB path, preferably while Hermes is stopped for that profile
+- writes create a timestamped target DB backup first when the target already exists
+- only raw messages are imported; summary DAG import is out of scope
+- imported rows keep explicit provenance in `session_id` and `source`, for example `openclaw-lcm:agent:sammy:<source-session>`
+- the default provenance identity is the concrete source `conversations.session_id`, preserving source session boundaries even when many conversations share one `session_key`
+- pass `--session-identity session_key` only when you intentionally want conversations with the same source session key grouped into one imported LCM session
+- reruns are idempotent for the same `--import-id`; the default `import_id` is path-derived, so pass a stable `--import-id` if you may import the same copied DB from different paths
+- changing `--agent`, `--namespace`, or `--session-identity` under the same `--import-id` is treated as the same import and will skip already-tracked source messages; use a new `--import-id` for a different mapping
+- no OpenClaw config or separate secret tables are imported, but raw transcripts and tool payloads are imported and may contain sensitive user data
+
+This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
+
+## Related references
+
+- [Operator guide](operator-guide.md)
+- [Architecture notes](architecture.md)
+- [Benchmarking and stress checks](../benchmarks/README.md)

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -112,6 +112,14 @@ cd "$REPO_ROOT"
 branch="$(git branch --show-current 2>/dev/null || true)"
 commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
 dirty="$(git status --short 2>/dev/null || true)"
+DIFF_CHECK_RANGE="${LCM_RELEASE_DIFF_BASE:-}"
+if [[ -z "$DIFF_CHECK_RANGE" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if git rev-parse --verify origin/main >/dev/null 2>&1 && ! git diff --quiet origin/main...HEAD -- .; then
+    DIFF_CHECK_RANGE="origin/main...HEAD"
+  else
+    DIFF_CHECK_RANGE="HEAD"
+  fi
+fi
 
 cat > "$CHECKLIST" <<EOF
 # hermes-lcm release validation
@@ -119,6 +127,7 @@ cat > "$CHECKLIST" <<EOF
 - generated_at_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 - mode: $MODE
 - repo: ${branch:-detached}@${commit:-unknown}
+- diff_check_range: ${DIFF_CHECK_RANGE:-working-tree}
 - output_dir: $OUTPUT_DIR
 - provider_network_side_effects: none expected
 - live_profile_mutations: none expected
@@ -159,7 +168,15 @@ run_gate() {
   fi
 }
 
-run_gate "git diff check" git diff --check
+if [[ -n "$DIFF_CHECK_RANGE" ]]; then
+  run_gate "git diff check ($DIFF_CHECK_RANGE)" git diff --check "$DIFF_CHECK_RANGE"
+  if [[ "$DIFF_CHECK_RANGE" != "HEAD" ]]; then
+    run_gate "git working tree diff check" git diff --check
+    run_gate "git staged diff check" git diff --cached --check
+  fi
+else
+  run_gate "git diff check" git diff --check
+fi
 run_gate "python compileall" "$PYTHON_BIN" -m compileall -q .
 run_gate "script py_compile" "$PYTHON_BIN" -m py_compile scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py
 run_gate "shell syntax" bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -107,11 +107,18 @@ OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 CHECKLIST="$OUTPUT_DIR/validation-checklist.md"
 FAILURES=()
 
+export PYTHONPYCACHEPREFIX="$OUTPUT_DIR/pycache"
+if [[ -n "${PYTEST_ADDOPTS:-}" ]]; then
+  export PYTEST_ADDOPTS="-p no:cacheprovider $PYTEST_ADDOPTS"
+else
+  export PYTEST_ADDOPTS="-p no:cacheprovider"
+fi
+
 cd "$REPO_ROOT"
 
 branch="$(git branch --show-current 2>/dev/null || true)"
 commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
-dirty="$(git status --short 2>/dev/null || true)"
+dirty_start="$(git status --short 2>/dev/null || true)"
 DIFF_CHECK_RANGE="${LCM_RELEASE_DIFF_BASE:-}"
 if [[ -z "$DIFF_CHECK_RANGE" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if git rev-parse --verify origin/main >/dev/null 2>&1 && ! git diff --quiet origin/main...HEAD -- .; then
@@ -168,6 +175,17 @@ run_gate() {
   fi
 }
 
+run_low_fd_pytest() {
+  local current_limit
+  current_limit="$(ulimit -n 2>/dev/null || true)"
+  if [[ "$current_limit" == "unlimited" ]]; then
+    ulimit -n 1024 2>/dev/null || echo "warning: could not lower file descriptor limit from unlimited to 1024" >&2
+  elif [[ "$current_limit" =~ ^[0-9]+$ ]] && (( current_limit > 1024 )); then
+    ulimit -n 1024 2>/dev/null || echo "warning: could not lower file descriptor limit from $current_limit to 1024" >&2
+  fi
+  "$PYTHON_BIN" -m pytest -q
+}
+
 if [[ -n "$DIFF_CHECK_RANGE" ]]; then
   run_gate "git diff check ($DIFF_CHECK_RANGE)" git diff --check "$DIFF_CHECK_RANGE"
   if [[ "$DIFF_CHECK_RANGE" != "HEAD" ]]; then
@@ -186,8 +204,13 @@ run_gate "stress smoke" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUT
 
 if [[ "$MODE" == "full" ]]; then
   run_gate "pytest full" "$PYTHON_BIN" -m pytest -q
-  run_gate "pytest low fd" bash -c 'ulimit -n 1024 && "$1" -m pytest -q' _ "$PYTHON_BIN"
+  run_gate "pytest low fd" run_low_fd_pytest
   run_gate "stress release" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUTPUT_DIR/stress-release" --tier release --json
+fi
+
+dirty_end="$(git status --short 2>/dev/null || true)"
+if [[ "${dirty_end:-}" != "${dirty_start:-}" ]]; then
+  FAILURES+=("validation changed git status; inspect start/end status in $CHECKLIST")
 fi
 
 cat >> "$CHECKLIST" <<'EOF'
@@ -203,7 +226,15 @@ cat >> "$CHECKLIST" <<'EOF'
 
 ```text
 EOF
-printf '%s\n' "${dirty:-clean}" >> "$CHECKLIST"
+printf '%s\n' "${dirty_start:-clean}" >> "$CHECKLIST"
+cat >> "$CHECKLIST" <<'EOF'
+```
+
+## Git status after validation
+
+```text
+EOF
+printf '%s\n' "${dirty_end:-clean}" >> "$CHECKLIST"
 cat >> "$CHECKLIST" <<'EOF'
 ```
 EOF

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODE="smoke"
+OUTPUT_DIR=""
+KEEP_GOING=0
+PYTHON_BIN="${PYTHON:-python}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validate_release.sh [--full] [--output DIR] [--keep-going]
+
+Runs offline local release-validation gates and writes a reusable validation
+checklist plus command logs under a fresh output directory.
+
+Options:
+  --full        Run full pytest, low-fd pytest, and release stress tier.
+  --output DIR  Write artifacts to DIR. DIR must not already exist.
+  --keep-going  Run all gates and report failures instead of stopping at first failure.
+  -h, --help    Show this help.
+
+Environment:
+  PYTHON=/path/to/python  Python interpreter to use for all Python gates.
+                          It must have pytest available.
+EOF
+}
+
+fail_prereq() {
+  cat >&2 <<EOF
+Release validation prerequisite failed: $1
+
+Using Python: $PYTHON_BIN
+
+Fix:
+  - activate a Python environment with pytest installed, or
+  - run with PYTHON=/path/to/python $0 [--full]
+
+Examples:
+  python -m pip install pytest
+  PYTHON=/path/to/venv/bin/python scripts/validate_release.sh --full
+EOF
+  exit 2
+}
+
+require_python_module() {
+  local module="$1"
+  local purpose="$2"
+  if ! "$PYTHON_BIN" - "$module" <<'PY' >/dev/null 2>&1
+import importlib.util
+import sys
+module = sys.argv[1]
+raise SystemExit(0 if importlib.util.find_spec(module) is not None else 1)
+PY
+  then
+    fail_prereq "Python module '$module' is required for $purpose."
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full)
+      MODE="full"
+      shift
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "--output requires a directory" >&2
+        exit 2
+      fi
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --keep-going)
+      KEEP_GOING=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  fail_prereq "Python interpreter not found."
+fi
+require_python_module "pytest" "pytest validation gates"
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="/tmp/hermes-lcm-release-validation-$(date -u +%Y%m%d-%H%M%S)"
+fi
+
+if [[ -e "$OUTPUT_DIR" ]]; then
+  echo "Refusing to reuse existing output directory: $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR/logs"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+CHECKLIST="$OUTPUT_DIR/validation-checklist.md"
+FAILURES=()
+
+cd "$REPO_ROOT"
+
+branch="$(git branch --show-current 2>/dev/null || true)"
+commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
+dirty="$(git status --short 2>/dev/null || true)"
+
+cat > "$CHECKLIST" <<EOF
+# hermes-lcm release validation
+
+- generated_at_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- mode: $MODE
+- repo: ${branch:-detached}@${commit:-unknown}
+- output_dir: $OUTPUT_DIR
+- provider_network_side_effects: none expected
+- live_profile_mutations: none expected
+
+## Gates
+EOF
+
+run_gate() {
+  local name="$1"
+  shift
+  local log_name
+  log_name="$(printf '%s' "$name" | tr '[:upper:] /' '[:lower:]--' | tr -cd '[:alnum:]_.-')"
+  local log_path="$OUTPUT_DIR/logs/${log_name}.log"
+
+  local command_display
+  printf -v command_display '%q ' "$@"
+  command_display="${command_display% }"
+
+  printf '==> %s\n' "$name"
+  printf '\n### %s\n\nCommand:\n\n```bash\n%s\n```\n\n' "$name" "$command_display" >> "$CHECKLIST"
+
+  set +e
+  "$@" > "$log_path" 2>&1
+  local status=$?
+  set -e
+
+  if [[ $status -eq 0 ]]; then
+    printf -- '- [x] %s -> pass (`%s`)\n' "$name" "$log_path" >> "$CHECKLIST"
+  else
+    printf -- '- [ ] %s -> fail exit %s (`%s`)\n' "$name" "$status" "$log_path" >> "$CHECKLIST"
+    FAILURES+=("$name exit $status; log=$log_path")
+    if [[ "$KEEP_GOING" -ne 1 ]]; then
+      printf '\n## Result\n\nFAILED: %s (exit %s)\n' "$name" "$status" >> "$CHECKLIST"
+      echo "FAILED: $name (exit $status); see $log_path" >&2
+      echo "Checklist: $CHECKLIST" >&2
+      exit "$status"
+    fi
+  fi
+}
+
+run_gate "git diff check" git diff --check
+run_gate "python compileall" "$PYTHON_BIN" -m compileall -q .
+run_gate "script py_compile" "$PYTHON_BIN" -m py_compile scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py
+run_gate "shell syntax" bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh
+run_gate "focused pytest" "$PYTHON_BIN" -m pytest tests/test_lcm_core.py tests/test_lcm_command.py tests/test_packaging_install.py tests/test_benchmarking_cli.py tests/test_stress_release_check.py -q
+run_gate "benchmark smoke" "$PYTHON_BIN" scripts/lcm_benchmark.py --synthetic-fixture release_validation_smoke:2:1:3 --policy benchmarks/policies/pressure_smoke.yaml --output "$OUTPUT_DIR/benchmark-smoke" --allow-external-output --json
+run_gate "stress smoke" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUTPUT_DIR/stress-smoke" --tier smoke --json
+
+if [[ "$MODE" == "full" ]]; then
+  run_gate "pytest full" "$PYTHON_BIN" -m pytest -q
+  run_gate "pytest low fd" bash -c 'ulimit -n 1024 && "$1" -m pytest -q' _ "$PYTHON_BIN"
+  run_gate "stress release" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUTPUT_DIR/stress-release" --tier release --json
+fi
+
+cat >> "$CHECKLIST" <<'EOF'
+
+## Doctor triage checklist
+
+- [ ] safe/ignore warnings reviewed and intentionally left alone
+- [ ] inspect warnings reviewed with source rows/session IDs before mutation
+- [ ] backup-first cleanup warnings used preview commands before any apply command
+- [ ] warning-only classes were not auto-cleaned: summary_quality, lifecycle_fragmentation, payload_storage suspicion, context_pressure
+
+## Git status at validation start
+
+```text
+EOF
+printf '%s\n' "${dirty:-clean}" >> "$CHECKLIST"
+cat >> "$CHECKLIST" <<'EOF'
+```
+EOF
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  {
+    printf '\n## Result\n\nFAILED with %s gate failure(s):\n' "${#FAILURES[@]}"
+    for failure in "${FAILURES[@]}"; do
+      printf -- '- %s\n' "$failure"
+    done
+  } >> "$CHECKLIST"
+  echo "Release validation failed; checklist: $CHECKLIST" >&2
+  exit 1
+fi
+
+cat >> "$CHECKLIST" <<'EOF'
+
+## Result
+
+PASS: all selected release-validation gates passed.
+
+Recommended next release-confidence step: review the generated checklist and scrubbed benchmark/stress artifacts, then run `scripts/validate_release.sh --full` before tagging if this was a smoke run.
+EOF
+
+printf 'PASS: release validation %s\nChecklist: %s\n' "$MODE" "$CHECKLIST"

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -175,6 +175,16 @@ run_gate() {
   fi
 }
 
+run_pytest() {
+  "$PYTHON_BIN" - "$@" <<'PY'
+import sys
+from benchmarking.standalone import ensure_agent_context_engine_importable
+ensure_agent_context_engine_importable()
+import pytest
+raise SystemExit(pytest.main(sys.argv[1:]))
+PY
+}
+
 run_low_fd_pytest() {
   local current_limit
   current_limit="$(ulimit -n 2>/dev/null || true)"
@@ -183,7 +193,7 @@ run_low_fd_pytest() {
   elif [[ "$current_limit" =~ ^[0-9]+$ ]] && (( current_limit > 1024 )); then
     ulimit -n 1024 2>/dev/null || echo "warning: could not lower file descriptor limit from $current_limit to 1024" >&2
   fi
-  "$PYTHON_BIN" -m pytest -q
+  run_pytest -q
 }
 
 if [[ -n "$DIFF_CHECK_RANGE" ]]; then
@@ -198,12 +208,12 @@ fi
 run_gate "python compileall" "$PYTHON_BIN" -m compileall -q .
 run_gate "script py_compile" "$PYTHON_BIN" -m py_compile scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py
 run_gate "shell syntax" bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh
-run_gate "focused pytest" "$PYTHON_BIN" -m pytest tests/test_lcm_core.py tests/test_lcm_command.py tests/test_packaging_install.py tests/test_benchmarking_cli.py tests/test_stress_release_check.py -q
+run_gate "focused pytest" run_pytest tests/test_lcm_core.py tests/test_lcm_command.py tests/test_packaging_install.py tests/test_benchmarking_cli.py tests/test_stress_release_check.py -q
 run_gate "benchmark smoke" "$PYTHON_BIN" scripts/lcm_benchmark.py --synthetic-fixture release_validation_smoke:2:1:3 --policy benchmarks/policies/pressure_smoke.yaml --output "$OUTPUT_DIR/benchmark-smoke" --allow-external-output --json
 run_gate "stress smoke" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUTPUT_DIR/stress-smoke" --tier smoke --json
 
 if [[ "$MODE" == "full" ]]; then
-  run_gate "pytest full" "$PYTHON_BIN" -m pytest -q
+  run_gate "pytest full" run_pytest -q
   run_gate "pytest low fd" run_low_fd_pytest
   run_gate "stress release" "$PYTHON_BIN" scripts/lcm_stress_check.py --output "$OUTPUT_DIR/stress-release" --tier release --json
 fi

--- a/scripts/validate_release.sh
+++ b/scripts/validate_release.sh
@@ -123,8 +123,8 @@ DIFF_CHECK_RANGE="${LCM_RELEASE_DIFF_BASE:-}"
 if [[ -z "$DIFF_CHECK_RANGE" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if git rev-parse --verify origin/main >/dev/null 2>&1 && ! git diff --quiet origin/main...HEAD -- .; then
     DIFF_CHECK_RANGE="origin/main...HEAD"
-  else
-    DIFF_CHECK_RANGE="HEAD"
+  elif git rev-parse --verify 'HEAD^' >/dev/null 2>&1; then
+    DIFF_CHECK_RANGE="HEAD^...HEAD"
   fi
 fi
 

--- a/tests/test_benchmarking_cli.py
+++ b/tests/test_benchmarking_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+import importlib
 import importlib.util
 import json
 import sys
@@ -18,6 +20,49 @@ def _load_benchmark_cli():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _block_agent_imports(monkeypatch):
+    for name in list(sys.modules):
+        if name == "agent" or name.startswith("agent.") or name == "hermes_lcm" or name.startswith("hermes_lcm."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+    real_import_module = importlib.import_module
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and (name == "agent" or name.startswith("agent.")) and name not in sys.modules:
+            missing = "agent.context_engine" if name.startswith("agent.") else "agent"
+            raise ModuleNotFoundError(f"No module named {missing!r}", name=missing)
+        return real_import(name, globals, locals, fromlist, level)
+
+    def blocked_import_module(name, package=None):
+        if name == "agent.context_engine" and name not in sys.modules:
+            raise ModuleNotFoundError("No module named 'agent.context_engine'", name=name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    monkeypatch.setattr(importlib, "import_module", blocked_import_module)
+
+
+def test_cli_synthetic_fixture_runs_without_hermes_agent_importable(tmp_path, monkeypatch):
+    cli = _load_benchmark_cli()
+    _block_agent_imports(monkeypatch)
+
+    result = cli.main([
+        "--synthetic-fixture",
+        "standalone_probe:2:1:3",
+        "--policy",
+        "benchmarks/policies/pressure_smoke.yaml",
+        "--output",
+        str(tmp_path),
+        "--allow-external-output",
+        "--json",
+    ])
+
+    assert result == 0
+    assert (tmp_path / "summary.json").exists()
+    assert not hasattr(sys.modules["agent.context_engine"], "__file__")
 
 
 def test_cli_accepts_synthetic_fixture_specs(tmp_path):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -677,6 +677,20 @@ def test_lcm_doctor_lifecycle_failure_guidance_requires_inspection():
     assert "could not read" in guidance["rationale"]
 
 
+@pytest.mark.parametrize("check_name", ["orphaned_dag_nodes", "summary_quality"])
+def test_lcm_doctor_dag_failure_guidance_requires_inspection(check_name):
+    guidance = doctor_guidance_for_check({
+        "check": check_name,
+        "status": "fail",
+        "detail": "dag read error",
+    })
+
+    assert guidance is not None
+    assert guidance["action"] == "inspect"
+    assert guidance["warning_only"] is False
+    assert "could not read" in guidance["rationale"]
+
+
 def test_lcm_doctor_source_lineage_failure_guidance_requires_inspection():
     guidance = doctor_guidance_for_check({
         "check": "source_lineage_hygiene",

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -745,6 +745,20 @@ def test_lcm_doctor_command_lifecycle_read_error_guidance_is_failure(engine, mon
     assert "lifecycle_fragmentation: inspect warning-only" not in result
 
 
+def test_lcm_doctor_command_payload_read_error_guidance_is_failure(engine, monkeypatch):
+    def fail_payload_scan(*_args, **_kwargs):
+        raise RuntimeError("payload read error")
+
+    monkeypatch.setattr(command_mod, "scan_sqlite_payload_risks", fail_payload_scan)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: issues-found" in result
+    assert "payload_storage_error: payload read error" in result
+    assert "payload_storage: inspect —" in result
+    assert "payload_storage: inspect warning-only" not in result
+
+
 def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):
     engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
     engine._store.append("sess-unknown", {"role": "user", "content": "unknown message"})

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -446,6 +446,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "plugin_version: 0.18.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
+    assert "triage_guidance:\n- none" in result
 
 
 def test_lcm_doctor_reports_heartbeat_noise_rows_without_mutating_or_leaking_content(engine):
@@ -622,6 +623,31 @@ def test_lcm_doctor_distinguishes_observations_from_recommended_actions(tmp_path
     assert "cleanup_candidates" in result
     assert "/lcm doctor clean" in result
     assert "/lcm backup" in result
+    assert "triage_guidance:" in result
+    assert "cleanup_candidates: backup-first cleanup" in result
+
+
+def test_lcm_doctor_tool_guidance_maps_warning_classes_to_operator_actions(engine):
+    engine._store.append("heartbeat-session", {"role": "assistant", "content": "Still working..."}, token_estimate=2)
+    engine._dag.add_node(
+        SummaryNode(
+            session_id="test-session",
+            depth=0,
+            summary="tiny",
+            token_count=1,
+            source_token_count=500,
+            source_ids=[],
+            source_type="messages",
+            created_at=0,
+        )
+    )
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    guidance = {item["check"]: item for item in doctor["guidance"]}
+
+    assert guidance["payload_storage"]["action"] == "safe/ignore"
+    assert guidance["summary_quality"]["action"] == "inspect"
+    assert guidance["summary_quality"]["warning_only"] is True
 
 
 def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -13,6 +13,7 @@ import hermes_lcm.command as command_mod
 from hermes_lcm.command import _fmt_size, handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
+from hermes_lcm.diagnostics import doctor_guidance_for_check
 from hermes_lcm.engine import LCMEngine
 
 
@@ -648,6 +649,47 @@ def test_lcm_doctor_tool_guidance_maps_warning_classes_to_operator_actions(engin
     assert guidance["payload_storage"]["action"] == "safe/ignore"
     assert guidance["summary_quality"]["action"] == "inspect"
     assert guidance["summary_quality"]["warning_only"] is True
+
+
+def test_lcm_doctor_source_lineage_failure_guidance_requires_inspection():
+    guidance = doctor_guidance_for_check({
+        "check": "source_lineage_hygiene",
+        "status": "fail",
+        "detail": "sqlite read error",
+    })
+
+    assert guidance is not None
+    assert guidance["action"] == "inspect"
+    assert "safe to ignore" not in guidance["operator_action"]
+    assert "source-lineage" in guidance["operator_action"]
+    assert guidance["warning_only"] is False
+
+
+def test_lcm_doctor_source_lineage_warning_preserves_legacy_blank_source_guidance():
+    guidance = doctor_guidance_for_check({
+        "check": "source_lineage_hygiene",
+        "status": "warn",
+        "detail": {"legacy_blank_source_messages": 2},
+    })
+
+    assert guidance is not None
+    assert guidance["action"] == "safe/ignore"
+    assert "legacy blank-source" in guidance["operator_action"]
+
+
+def test_lcm_doctor_tool_source_lineage_read_error_guidance_requires_inspection(engine, monkeypatch):
+    def fail_source_stats():
+        raise RuntimeError("sqlite read error")
+
+    monkeypatch.setattr(engine._store, "get_source_stats", fail_source_stats)
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    guidance = {item["check"]: item for item in doctor["guidance"]}
+
+    assert doctor["overall"] == "unhealthy"
+    assert guidance["source_lineage_hygiene"]["action"] == "inspect"
+    assert "safe to ignore" not in guidance["source_lineage_hygiene"]["operator_action"]
+    assert "source-lineage" in guidance["source_lineage_hygiene"]["operator_action"]
 
 
 def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -651,6 +651,32 @@ def test_lcm_doctor_tool_guidance_maps_warning_classes_to_operator_actions(engin
     assert guidance["summary_quality"]["warning_only"] is True
 
 
+def test_lcm_doctor_payload_failure_guidance_requires_inspection():
+    guidance = doctor_guidance_for_check({
+        "check": "payload_storage",
+        "status": "fail",
+        "detail": "sqlite read error",
+    })
+
+    assert guidance is not None
+    assert guidance["action"] == "inspect"
+    assert guidance["warning_only"] is False
+    assert "could not read" in guidance["rationale"]
+
+
+def test_lcm_doctor_lifecycle_failure_guidance_requires_inspection():
+    guidance = doctor_guidance_for_check({
+        "check": "lifecycle_fragmentation",
+        "status": "fail",
+        "detail": {"error": "lifecycle read error"},
+    })
+
+    assert guidance is not None
+    assert guidance["action"] == "inspect"
+    assert guidance["warning_only"] is False
+    assert "could not read" in guidance["rationale"]
+
+
 def test_lcm_doctor_source_lineage_failure_guidance_requires_inspection():
     guidance = doctor_guidance_for_check({
         "check": "source_lineage_hygiene",
@@ -690,6 +716,19 @@ def test_lcm_doctor_tool_source_lineage_read_error_guidance_requires_inspection(
     assert guidance["source_lineage_hygiene"]["action"] == "inspect"
     assert "safe to ignore" not in guidance["source_lineage_hygiene"]["operator_action"]
     assert "source-lineage" in guidance["source_lineage_hygiene"]["operator_action"]
+
+
+def test_lcm_doctor_command_lifecycle_read_error_guidance_is_failure(engine, monkeypatch):
+    def fail_lifecycle_stats(*_args, **_kwargs):
+        raise RuntimeError("lifecycle read error")
+
+    monkeypatch.setattr(engine._lifecycle, "get_fragmentation_stats", fail_lifecycle_stats)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: issues-found" in result
+    assert "lifecycle_fragmentation: inspect —" in result
+    assert "lifecycle_fragmentation: inspect warning-only" not in result
 
 
 def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import importlib.util
 import logging
+import os
+import shutil
 import subprocess
 import sys
 
@@ -62,6 +64,49 @@ def test_standalone_install_scripts_exist_and_are_shell_scripts():
     assert install_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
     assert update_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
     assert validate_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
+
+
+def test_validate_release_checks_committed_pr_diff_against_origin_main(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    source_script = repo_root / "scripts" / "validate_release.sh"
+    true_bin = shutil.which("true")
+    assert true_bin is not None
+
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(source_script, scripts_dir / "validate_release.sh")
+
+    def git(*args):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Hermes Test")
+    git("config", "user.email", "hermes-test@example.invalid")
+    (repo / "README.md").write_text("clean\n", encoding="utf-8")
+    git("add", "README.md", "scripts/validate_release.sh")
+    git("commit", "-m", "base")
+    git("update-ref", "refs/remotes/origin/main", "HEAD")
+    git("checkout", "-b", "feature")
+    (repo / "bad.txt").write_text("committed trailing whitespace  \n", encoding="utf-8")
+    git("add", "bad.txt")
+    git("commit", "-m", "add bad whitespace")
+
+    output_dir = tmp_path / "validation-output"
+    result = subprocess.run(
+        ["bash", "scripts/validate_release.sh", "--output", str(output_dir)],
+        cwd=repo,
+        env={**os.environ, "PYTHON": true_bin},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "FAILED: git diff check (origin/main...HEAD)" in result.stderr
+    checklist = output_dir / "validation-checklist.md"
+    assert checklist.exists()
+    assert "diff_check_range: origin/main...HEAD" in checklist.read_text(encoding="utf-8")
 
 
 def test_plugin_manifest_lists_all_registered_tools():

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -75,6 +75,10 @@ def test_validate_release_routes_cache_artifacts_outside_checkout():
     assert "dirty_start=\"$(git status --short" in validate_script
     assert "dirty_end=\"$(git status --short" in validate_script
     assert "validation changed git status" in validate_script
+    assert "run_pytest()" in validate_script
+    assert "ensure_agent_context_engine_importable()" in validate_script
+    assert "run_gate \"focused pytest\" run_pytest" in validate_script
+    assert "run_gate \"pytest full\" run_pytest" in validate_script
     assert "run_low_fd_pytest" in validate_script
     assert "ulimit -n 1024 &&" not in validate_script
 

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -122,6 +122,47 @@ def test_validate_release_checks_committed_pr_diff_against_origin_main(tmp_path)
     assert "diff_check_range: origin/main...HEAD" in checklist.read_text(encoding="utf-8")
 
 
+def test_validate_release_checks_last_commit_when_origin_main_missing(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    source_script = repo_root / "scripts" / "validate_release.sh"
+    true_bin = shutil.which("true")
+    assert true_bin is not None
+
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(source_script, scripts_dir / "validate_release.sh")
+
+    def git(*args):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Hermes Test")
+    git("config", "user.email", "hermes-test@example.invalid")
+    (repo / "README.md").write_text("clean\n", encoding="utf-8")
+    git("add", "README.md", "scripts/validate_release.sh")
+    git("commit", "-m", "base")
+    (repo / "bad.txt").write_text("committed trailing whitespace  \n", encoding="utf-8")
+    git("add", "bad.txt")
+    git("commit", "-m", "add bad whitespace")
+
+    output_dir = tmp_path / "validation-output"
+    result = subprocess.run(
+        ["bash", "scripts/validate_release.sh", "--output", str(output_dir)],
+        cwd=repo,
+        env={**os.environ, "PYTHON": true_bin},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "FAILED: git diff check (HEAD^...HEAD)" in result.stderr
+    checklist = output_dir / "validation-checklist.md"
+    assert checklist.exists()
+    assert "diff_check_range: HEAD^...HEAD" in checklist.read_text(encoding="utf-8")
+
+
 def test_plugin_manifest_lists_all_registered_tools():
     repo_root = Path(__file__).resolve().parent.parent
     manifest = (repo_root / "plugin.yaml").read_text(encoding="utf-8")

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -66,6 +66,19 @@ def test_standalone_install_scripts_exist_and_are_shell_scripts():
     assert validate_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
 
 
+def test_validate_release_routes_cache_artifacts_outside_checkout():
+    repo_root = Path(__file__).resolve().parent.parent
+    validate_script = (repo_root / "scripts" / "validate_release.sh").read_text(encoding="utf-8")
+
+    assert "PYTHONPYCACHEPREFIX=\"$OUTPUT_DIR/pycache\"" in validate_script
+    assert "PYTEST_ADDOPTS=\"-p no:cacheprovider" in validate_script
+    assert "dirty_start=\"$(git status --short" in validate_script
+    assert "dirty_end=\"$(git status --short" in validate_script
+    assert "validation changed git status" in validate_script
+    assert "run_low_fd_pytest" in validate_script
+    assert "ulimit -n 1024 &&" not in validate_script
+
+
 def test_validate_release_checks_committed_pr_diff_against_origin_main(tmp_path):
     repo_root = Path(__file__).resolve().parent.parent
     source_script = repo_root / "scripts" / "validate_release.sh"

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import importlib.util
+import logging
 import subprocess
 import sys
 
@@ -53,11 +54,14 @@ def test_standalone_install_scripts_exist_and_are_shell_scripts():
 
     install_script = repo_root / "scripts" / "install.sh"
     update_script = repo_root / "scripts" / "update.sh"
+    validate_script = repo_root / "scripts" / "validate_release.sh"
 
     assert install_script.exists(), "scripts/install.sh should exist"
     assert update_script.exists(), "scripts/update.sh should exist"
+    assert validate_script.exists(), "scripts/validate_release.sh should exist"
     assert install_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
     assert update_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
+    assert validate_script.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash\n")
 
 
 def test_plugin_manifest_lists_all_registered_tools():
@@ -221,6 +225,34 @@ def test_plugin_entrypoint_skips_registered_lcm_tools_without_message_forwarding
     assert ctx.engine is not None
     assert registered == {}
     assert EXPECTED_LCM_TOOLS.issubset({schema["name"] for schema in ctx.engine.get_tool_schemas()})
+
+
+def test_capability_false_host_log_describes_expected_path_b_fallback(caplog):
+    module = _load_plugin_entrypoint_module("hermes_lcm_packaging_expected_path_b_fallback")
+    registered = []
+
+    class _HermesAgentV016LikeCtx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_tool(self, name, toolset, schema, handler, description="", emoji=""):
+            registered.append(name)
+
+    ctx = _HermesAgentV016LikeCtx()
+    caplog.set_level(logging.INFO)
+
+    module.register(ctx)
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert ctx.engine is not None
+    assert registered == []
+    assert EXPECTED_LCM_TOOLS.issubset({schema["name"] for schema in ctx.engine.get_tool_schemas()})
+    assert "LCM tools are available through context-engine schemas" in messages
+    assert "expected Path B fallback" in messages
+    assert "tool registration skipped because" not in messages
 
 
 def test_register_gracefully_degrades_when_host_lacks_register_tool():

--- a/tests/test_stress_release_check.py
+++ b/tests/test_stress_release_check.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
 import hashlib
+import importlib
 import importlib.util
 import json
 import os
@@ -23,6 +25,29 @@ def _load_stress_cli():
     return module
 
 
+def _block_agent_imports(monkeypatch):
+    for name in list(sys.modules):
+        if name == "agent" or name.startswith("agent.") or name == "hermes_lcm" or name.startswith("hermes_lcm."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+    real_import_module = importlib.import_module
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and (name == "agent" or name.startswith("agent.")) and name not in sys.modules:
+            missing = "agent.context_engine" if name.startswith("agent.") else "agent"
+            raise ModuleNotFoundError(f"No module named {missing!r}", name=missing)
+        return real_import(name, globals, locals, fromlist, level)
+
+    def blocked_import_module(name, package=None):
+        if name == "agent.context_engine" and name not in sys.modules:
+            raise ModuleNotFoundError("No module named 'agent.context_engine'", name=name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    monkeypatch.setattr(importlib, "import_module", blocked_import_module)
+
+
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -36,6 +61,22 @@ def _canonical_results_hash(results: dict) -> str:
 
 def _assert_path_under(path_value: str, root: Path) -> None:
     assert Path(path_value).resolve().is_relative_to(root.resolve())
+
+
+def test_stress_cli_query_fuzz_runs_without_hermes_agent_importable(tmp_path, monkeypatch):
+    cli = _load_stress_cli()
+    _block_agent_imports(monkeypatch)
+
+    assert cli.main([
+        "--output",
+        str(tmp_path / "stress-standalone"),
+        "--tier",
+        "smoke",
+        "--scenario",
+        "query_fuzz_no_crash",
+        "--json",
+    ]) == 0
+    assert not hasattr(sys.modules["agent.context_engine"], "__file__")
 
 
 def test_stress_cli_refuses_non_empty_output_directory(tmp_path):

--- a/tools.py
+++ b/tools.py
@@ -15,7 +15,11 @@ from .externalize import (
     find_externalized_payload_for_message,
     load_externalized_payload,
 )
-from .diagnostics import _has_lifecycle_fragmentation, _state_db_path_for_engine
+from .diagnostics import (
+    _has_lifecycle_fragmentation,
+    _state_db_path_for_engine,
+    doctor_guidance_for_checks,
+)
 from .dag import build_nodes_fts_spec
 from .db_bootstrap import check_external_content_fts_integrity, inspect_lcm_schema_health
 from .extraction import sanitize_pre_compaction_content
@@ -2241,4 +2245,5 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         "overall": overall,
         "runtime_identity": engine.get_runtime_identity(),
         "checks": checks,
+        "guidance": doctor_guidance_for_checks(checks),
     })


### PR DESCRIPTION
## Summary
- clarify expected Path B/context-engine fallback wording for older Hermes hosts so startup logs do not look like broken tool registration
- split operator-heavy README material into dedicated docs and add a repo-root changelog
- add standalone benchmark/stress import fallback, release validation script, doctor triage guidance, and regression coverage

Fixes #271

## Validation
- scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-fix-271
- PASS: git diff check, compileall, script py_compile, shell syntax, focused pytest, benchmark smoke, stress smoke, full pytest, low-fd pytest, release stress

## Notes
- One PR is the smallest sane publishable unit: docs, fallback wording, standalone validation, and doctor guidance were accepted together as the local issue #271 operability stack.
