### PR TITLE
fix: surface payload warnings in doctor status

### DIFF
--- a/command.py
+++ b/command.py
@@ -1011,6 +1011,15 @@ def _doctor_text(engine) -> str:
     observations: list[str] = []
     recommended_actions: list[str] = []
     missing_externalized_refs = int(externalized_integrity.get("externalized_payload_refs_missing", 0) or 0)
+    suspicious_payload_rows = sum(
+        len(payload_risks.get(key) or [])
+        for key in (
+            "suspicious_data_uri_content_rows",
+            "suspicious_data_uri_tool_calls_rows",
+            "suspicious_base64_like_rows",
+            "suspicious_repetitive_assistant_rows",
+        )
+    )
 
     if schema_health.get("error"):
         observations.append(f"schema_core_tables: error: {schema_health['error']}")
@@ -1054,6 +1063,13 @@ def _doctor_text(engine) -> str:
         )
         recommended_actions.append(
             "inspect missing externalized payload refs and restore from backups if needed"
+        )
+    if suspicious_payload_rows:
+        observations.append(
+            f"payload_storage: {suspicious_payload_rows} suspicious inline/base64 payload row(s) need review"
+        )
+        recommended_actions.append(
+            "inspect suspicious payload rows before cleanup; restore payload files from backup before deleting or rewriting anything"
         )
     if payload_storage_error:
         observations.append(f"payload_storage_error: {payload_storage_error}")

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -759,6 +759,28 @@ def test_lcm_doctor_command_payload_read_error_guidance_is_failure(engine, monke
     assert "payload_storage: inspect warning-only" not in result
 
 
+def test_lcm_doctor_command_payload_warning_drives_action_recommended(engine, monkeypatch):
+    def payload_warning(*_args, **_kwargs):
+        return {
+            "largest_content_rows": [],
+            "largest_tool_calls_rows": [],
+            "suspicious_data_uri_content_rows": [],
+            "suspicious_data_uri_tool_calls_rows": [],
+            "suspicious_base64_like_rows": [{"store_id": 1, "chars": 24000}],
+            "quarantined_assistant_rows": [],
+            "suspicious_repetitive_assistant_rows": [],
+            "heartbeat_noise_rows": [],
+        }
+
+    monkeypatch.setattr(command_mod, "scan_sqlite_payload_risks", payload_warning)
+
+    result = handle_lcm_command("doctor", engine)
+
+    assert "status: action-recommended" in result
+    assert "payload_storage: 1 suspicious inline/base64 payload row(s) need review" in result
+    assert "payload_storage: inspect warning-only" in result
+
+
 def test_lcm_doctor_reports_legacy_blank_source_as_observation_without_warning(engine):
     engine._store.append("sess-known", {"role": "user", "content": "cli message"}, source="cli")
     engine._store.append("sess-unknown", {"role": "user", "content": "unknown message"})


### PR DESCRIPTION
## Summary
- Make `/lcm doctor` surface non-heartbeat suspicious payload-storage warnings in the top-level slash-command status/recommended-action path.
- Keep heartbeat-only payload observations as safe-ignore triage, but make inline/base64 payload warnings drive `action-recommended` instead of printing `status: ok` beside `payload_storage: inspect warning-only`.
- Add regression coverage for the slash-command status/triage mismatch.

## Why
Codex caught this after #272 merged. The JSON `lcm_doctor` path reports suspicious payload rows as `warn`, but the slash-command path could still print `status: ok` when suspicious payload rows existed without missing refs or read errors. Status-based operator checks could miss the warning even though `triage_guidance` showed payload inspection guidance.

This keeps the #272 operator-readiness direction intact: warnings stay non-mutating, but the command status no longer under-reports storage warnings that need review.

## Validation
- [x] `python3 -m pytest tests/test_lcm_command.py::test_lcm_doctor_command_payload_warning_drives_action_recommended tests/test_lcm_command.py::test_lcm_doctor_command_payload_read_error_guidance_is_failure -q` -> `2 passed`
- [x] `python3 -m pytest tests/test_lcm_command.py -q` -> `69 passed`
- [x] `PYTHON=python3 scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-payload-warning-followup` -> passed
- [x] Full pytest from release validation -> `1001 passed, 3 warnings`
- [x] Low-fd pytest from release validation -> `1001 passed, 3 warnings`
- [x] Focused release lane -> `322 passed`
- [x] Git status before/after validation -> clean

Refs #271
Follow-up to #272.