### PR TITLE
fix: cap Codex gpt-5.5 effective context

### DIFF
--- a/command.py
+++ b/command.py
@@ -137,9 +137,14 @@ def _status_text(engine) -> str:
         f"last_compression_status: {status.get('last_compression_status', 'idle')}",
         f"last_compression_noop_reason: {status.get('last_compression_noop_reason', '') or '(none)'}",
         f"context_length: {engine.context_length if session_bound else '(uninitialized)'}",
+        f"raw_context_length: {status.get('raw_context_length', 0) if session_bound else '(uninitialized)'}",
+        f"effective_context_length_cap: {status.get('effective_context_length_cap') or '(none)'}",
+        f"effective_context_length_reason: {status.get('effective_context_length_reason') or '(none)'}",
         f"context_length_source: {context_length_source}",
-        f"context_threshold: {engine._config.context_threshold}",
-        f"context_threshold_source: {config_sources.get('context_threshold', 'manual_or_default')}",
+        f"configured_context_threshold: {status.get('configured_context_threshold', engine._config.context_threshold)}",
+        f"context_threshold: {status.get('context_threshold', engine._config.context_threshold)}",
+        f"context_threshold_source: {status.get('context_threshold_source', config_sources.get('context_threshold', 'manual_or_default'))}",
+        f"context_threshold_autoraised: {status.get('context_threshold_autoraised') or '(none)'}",
         f"threshold_tokens: {engine.threshold_tokens if session_bound else '(uninitialized)'}",
         f"cache_metrics_available: {_fmt_bool(status.get('cache_metrics_available'))}",
         f"last_input_tokens: {status.get('last_input_tokens', 0)}",
@@ -1714,7 +1719,12 @@ def _preset_suggest_text(engine) -> str:
         f"invalid_overrides: {invalid_text}",
         "preview:",
     ])
-    for item in preset_env_diff(preset, engine._config):
+    for item in preset_env_diff(
+        preset,
+        engine._config,
+        runtime_context_threshold=getattr(engine, "context_threshold", None),
+        runtime_context_threshold_source=getattr(engine, "_context_threshold_source", ""),
+    ):
         lines.append(f"- {item}")
     lines.extend([
         f"unsupported_runtime_fields: {unsupported_runtime_fields_text(preset)}",
@@ -1748,7 +1758,12 @@ def _preset_apply_text(tokens: list[str], engine) -> str:
         f"preset: {preset.name}",
         "would_set:",
     ]
-    for item in preset_env_diff(preset, engine._config):
+    for item in preset_env_diff(
+        preset,
+        engine._config,
+        runtime_context_threshold=getattr(engine, "context_threshold", None),
+        runtime_context_threshold_source=getattr(engine, "_context_threshold_source", ""),
+    ):
         lines.append(f"- {item}")
     lines.extend([
         f"unsupported_runtime_fields: {unsupported_runtime_fields_text(preset)}",

--- a/config.py
+++ b/config.py
@@ -223,6 +223,20 @@ def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[
         return default, "default"
 
 
+def _hermes_codex_gpt55_autoraise_with_source(default: bool) -> tuple[bool, str]:
+    cfg = _load_hermes_config_yaml()
+    try:
+        compression = cfg.get("compression") or {}
+        if not isinstance(compression, dict):
+            return default, "default"
+        value = compression.get("codex_gpt55_autoraise")
+        if value is None:
+            return default, "default"
+        return (not _config_bool_disabled(value)), "config_yaml:compression.codex_gpt55_autoraise"
+    except Exception:
+        return default, "default"
+
+
 @dataclass
 class LCMConfig:
     """All tunables for the LCM engine."""
@@ -235,6 +249,10 @@ class LCMConfig:
     leaf_chunk_tokens: int = 20_000
     # Fraction of context window that triggers compaction (0.0–1.0)
     context_threshold: float = 0.35
+    # Mirror Hermes Agent's Codex gpt-5.5 route-specific threshold auto-raise
+    # when LCM is inheriting the host compression threshold. Explicit LCM
+    # threshold overrides remain authoritative.
+    codex_gpt55_autoraise_enabled: bool = True
     # Max condensation depth (-1 = unlimited, 0 = leaf only)
     incremental_max_depth: int = 3
     # How many same-depth summaries trigger condensation
@@ -398,6 +416,10 @@ class LCMConfig:
             default_source=context_source,
         )
         _record("context_threshold", source, warning)
+        c.codex_gpt55_autoraise_enabled, source = _hermes_codex_gpt55_autoraise_with_source(
+            c.codex_gpt55_autoraise_enabled
+        )
+        _record("codex_gpt55_autoraise_enabled", source)
         c.incremental_max_depth = _int("LCM_INCREMENTAL_MAX_DEPTH", c.incremental_max_depth)
         c.condensation_fanin = _int("LCM_CONDENSATION_FANIN", c.condensation_fanin)
         c.dynamic_leaf_chunk_enabled = _parse_bool_env(

--- a/engine.py
+++ b/engine.py
@@ -81,6 +81,20 @@ logger = logging.getLogger(__name__)
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
 _SESSION_END_BUSY_TIMEOUT_MS = 50
+_CODEX_GPT55_CONTEXT_CAP = 272_000
+_CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
+
+
+def _is_codex_gpt55_route(model: str, provider: str) -> bool:
+    """Return True for gpt-5.5 on ChatGPT Codex OAuth, mirroring Hermes core."""
+    if (provider or "").strip().lower() != "openai-codex":
+        return False
+    bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return (
+        bare_model == "gpt-5.5"
+        or bare_model.startswith("gpt-5.5-")
+        or bare_model.startswith("gpt-5.5.")
+    )
 
 # Auto-focus topic derivation: infer a compact focus hint from the most recent
 # real user turns so that summarization can prioritise current user intent.
@@ -344,11 +358,21 @@ class LCMEngine(ContextEngine):
         self.api_key = ""
         self.provider = ""
         self.api_mode = ""
+        self.raw_context_length = 0
         self.context_length = 0
+        self.effective_context_length_cap: int | None = None
+        self.effective_context_length_reason = ""
         self._context_length_source = ""
         self._update_model_pending_session_start = False
         self.threshold_tokens = 0
-        self.threshold_percent = self._config.context_threshold
+        self.context_threshold = self._config.context_threshold
+        self.threshold_percent = self.context_threshold
+        self._context_threshold_source = (
+            self._config.config_sources.get("context_threshold", "manual_or_default")
+            if getattr(self._config, "config_sources", None)
+            else "manual_or_default"
+        )
+        self._context_threshold_autoraised: dict[str, float] | None = None
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
         self.last_total_tokens = 0
@@ -496,7 +520,65 @@ class LCMEngine(ContextEngine):
         logger.info("LCM rebound storage for Hermes home %s", hermes_home)
         return True
 
-    def _set_context_length(self, context_length: Any, *, source: str) -> bool:
+    def _runtime_context_threshold(
+        self,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+    ) -> tuple[float, str, dict[str, float] | None]:
+        configured = float(self._config.context_threshold)
+        source = (
+            self._config.config_sources.get("context_threshold", "manual_or_default")
+            if getattr(self._config, "config_sources", None)
+            else "manual_or_default"
+        )
+        explicit_lcm_override = source in {
+            "env:LCM_CONTEXT_THRESHOLD",
+            "config_yaml:lcm.context_threshold",
+        }
+        route_model = self.model if model is None else model
+        route_provider = self.provider if provider is None else provider
+        if (
+            _is_codex_gpt55_route(route_model, route_provider)
+            and self._config.codex_gpt55_autoraise_enabled
+            and not explicit_lcm_override
+            and configured < _CODEX_GPT55_COMPACTION_THRESHOLD
+        ):
+            return (
+                _CODEX_GPT55_COMPACTION_THRESHOLD,
+                "codex_gpt55_autoraise",
+                {"from": configured, "to": _CODEX_GPT55_COMPACTION_THRESHOLD},
+            )
+        return configured, source, None
+
+    def _effective_context_length(
+        self,
+        raw_context_length: int,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+    ) -> tuple[int, int | None, str]:
+        route_model = self.model if model is None else model
+        route_provider = self.provider if provider is None else provider
+        if (
+            raw_context_length > _CODEX_GPT55_CONTEXT_CAP
+            and _is_codex_gpt55_route(route_model, route_provider)
+        ):
+            return (
+                _CODEX_GPT55_CONTEXT_CAP,
+                _CODEX_GPT55_CONTEXT_CAP,
+                "codex_gpt55_route_cap",
+            )
+        return raw_context_length, None, ""
+
+    def _set_context_length(
+        self,
+        context_length: Any,
+        *,
+        source: str,
+        model: str | None = None,
+        provider: str | None = None,
+    ) -> bool:
         try:
             parsed_context_length = int(context_length)
         except (TypeError, ValueError):
@@ -508,14 +590,33 @@ class LCMEngine(ContextEngine):
                 source,
                 context_length,
             )
+            self.raw_context_length = 0
             self.context_length = 0
+            self.effective_context_length_cap = None
+            self.effective_context_length_reason = ""
             self._context_length_source = source
             self.threshold_tokens = 0
+            self.context_threshold, self._context_threshold_source, self._context_threshold_autoraised = (
+                self._runtime_context_threshold(model=model, provider=provider)
+            )
+            self.threshold_percent = self.context_threshold
             return True
-        self.context_length = parsed_context_length
+        self.raw_context_length = parsed_context_length
+        effective_context_length, cap, reason = self._effective_context_length(
+            parsed_context_length,
+            model=model,
+            provider=provider,
+        )
+        self.context_length = effective_context_length
+        self.effective_context_length_cap = cap
+        self.effective_context_length_reason = reason
         self._context_length_source = source
+        self.context_threshold, self._context_threshold_source, self._context_threshold_autoraised = (
+            self._runtime_context_threshold(model=model, provider=provider)
+        )
+        self.threshold_percent = self.context_threshold
         self.threshold_tokens = int(
-            parsed_context_length * self._config.context_threshold
+            effective_context_length * self.context_threshold
         )
         return True
 
@@ -1830,12 +1931,13 @@ class LCMEngine(ContextEngine):
             else:
                 if (
                     update_model_is_authoritative
-                    and parsed_context_length != self.context_length
+                    and parsed_context_length not in {self.context_length, self.raw_context_length}
                 ):
                     logger.warning(
-                        "LCM ignored stale session-start context_length=%s for model=%s; active update_model context_length=%s",
+                        "LCM ignored stale session-start context_length=%s for model=%s; active update_model raw_context_length=%s effective_context_length=%s",
                         parsed_context_length,
                         self.model or str(kwargs.get("model") or ""),
+                        self.raw_context_length,
                         self.context_length,
                     )
                     self._update_model_pending_session_start = False
@@ -1850,7 +1952,12 @@ class LCMEngine(ContextEngine):
                         self._update_model_pending_session_start = False
                         return
                 else:
-                    self._set_context_length(parsed_context_length, source="session_start")
+                    self._set_context_length(
+                        parsed_context_length,
+                        source="session_start",
+                        model=str(kwargs.get("model") or self.model),
+                        provider=str(kwargs.get("provider") or self.provider),
+                    )
                     update_model_is_authoritative = False
         if (
             update_model_is_authoritative
@@ -2433,14 +2540,20 @@ class LCMEngine(ContextEngine):
             "last_reasoning_tokens": self.last_reasoning_tokens,
             "cache_metrics_available": self.cache_metrics_available,
             "cache_read_ratio": round(self.cache_read_ratio, 4),
+            "raw_context_length": self.raw_context_length,
             "context_length": self.context_length,
+            "effective_context_length_cap": self.effective_context_length_cap,
+            "effective_context_length_reason": self.effective_context_length_reason,
             "threshold_tokens": self.threshold_tokens,
             "last_compression_status": self._last_compression_status,
             "last_compression_noop_reason": self._last_compression_noop_reason,
             "model": self.model,
             "provider": self.provider,
             "context_length_source": self._context_length_source,
-            "context_threshold": self._config.context_threshold,
+            "configured_context_threshold": self._config.context_threshold,
+            "context_threshold": self.context_threshold,
+            "context_threshold_source": self._context_threshold_source,
+            "context_threshold_autoraised": self._context_threshold_autoraised,
             "config_sources": dict(getattr(self._config, "config_sources", {}) or {}),
             "config_source_warnings": list(getattr(self._config, "config_source_warnings", []) or []),
             "ignored_config_yaml_lcm_keys": list(getattr(self._config, "ignored_config_yaml_lcm_keys", []) or []),

--- a/presets.py
+++ b/presets.py
@@ -183,6 +183,8 @@ def preset_env_diff(
     config: Any,
     *,
     environ: Mapping[str, str] | None = None,
+    runtime_context_threshold: float | None = None,
+    runtime_context_threshold_source: str = "",
 ) -> list[str]:
     """Render env-var changes a preset would suggest without applying them."""
 
@@ -202,6 +204,16 @@ def preset_env_diff(
                 f"{env_var}={value} "
                 f"(invalid current value {raw} ignored by runtime; runtime value {current})"
             )
+        elif (
+            field == "context_threshold"
+            and runtime_context_threshold_source == "codex_gpt55_autoraise"
+            and runtime_context_threshold is not None
+            and float(runtime_context_threshold) >= float(value)
+        ):
+            lines.append(
+                f"{env_var}: keep runtime auto-raised value {runtime_context_threshold:g} "
+                f"(preset {value})"
+            )
         else:
             lines.append(f"{env_var}={value}")
     return lines
@@ -212,6 +224,8 @@ def _preset_dry_run_delta(
     config: Any,
     *,
     environ: Mapping[str, str] | None = None,
+    runtime_context_threshold: float | None = None,
+    runtime_context_threshold_source: str = "",
 ) -> list[dict[str, Any]]:
     """Return structured preset dry-run actions without mutating runtime state."""
 
@@ -237,6 +251,19 @@ def _preset_dry_run_delta(
                 "action": "replace_invalid",
                 "invalid_value": env.get(env_var, ""),
                 "current_value": current,
+                "preset_value": preset_value,
+            })
+        elif (
+            field == "context_threshold"
+            and runtime_context_threshold_source == "codex_gpt55_autoraise"
+            and runtime_context_threshold is not None
+            and float(runtime_context_threshold) >= float(preset_value)
+        ):
+            delta.append({
+                "field": field,
+                "env": env_var,
+                "action": "keep_runtime_autoraised",
+                "current_value": runtime_context_threshold,
                 "preset_value": preset_value,
             })
         else:
@@ -309,7 +336,13 @@ def preset_status_payload(
         "notes": preset.notes,
     }
     payload["provenance"] = dict(preset.provenance)
-    payload["dry_run_delta"] = _preset_dry_run_delta(preset, config, environ=env)
+    payload["dry_run_delta"] = _preset_dry_run_delta(
+        preset,
+        config,
+        environ=env,
+        runtime_context_threshold=getattr(engine, "context_threshold", None),
+        runtime_context_threshold_source=getattr(engine, "_context_threshold_source", ""),
+    )
     return payload
 
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -488,6 +488,26 @@ def test_lcm_doctor_tool_reports_heartbeat_noise_as_read_only_payload_detail(eng
     assert "Still working" not in json.dumps(payload)
 
 
+def test_lcm_doctor_context_pressure_uses_runtime_threshold(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "doctor-runtime-threshold.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model("gpt-5.5", 400_000, provider="openai-codex")
+        engine.last_prompt_tokens = 225_000
+
+        doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+        pressure = next(check for check in doctor["checks"] if check["check"] == "context_pressure")
+
+        assert pressure["status"] == "pass"
+        assert pressure["detail"] == "82.7% used, compaction triggers at 85.0%"
+    finally:
+        engine.shutdown()
+
+
 def test_lcm_doctor_text_reports_missing_externalized_payload_refs(engine):
     storage_dir = Path(engine._hermes_home) / "lcm-large-outputs"
     storage_dir.mkdir(parents=True)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -244,6 +244,99 @@ def test_update_model_updates_runtime_metadata_and_context_window(engine):
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
 
 
+def test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-gpt55.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.effective_context_length_cap == 272_000
+        assert engine.effective_context_length_reason == "codex_gpt55_route_cap"
+        assert engine.context_threshold == 0.85
+        assert engine.threshold_tokens == int(272_000 * 0.85)
+
+        status = engine.get_status()
+        assert status["raw_context_length"] == 400_000
+        assert status["context_length"] == 272_000
+        assert status["configured_context_threshold"] == 0.68
+        assert status["context_threshold"] == 0.85
+        assert status["context_threshold_source"] == "codex_gpt55_autoraise"
+        assert status["context_threshold_autoraised"] == {"from": 0.68, "to": 0.85}
+    finally:
+        engine.shutdown()
+
+
+def test_codex_gpt55_route_cap_keeps_explicit_lcm_threshold(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-explicit-threshold.db"),
+    )
+    config.config_sources["context_threshold"] = "env:LCM_CONTEXT_THRESHOLD"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5-2026-04-23",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.context_threshold == 0.68
+        assert engine.threshold_tokens == int(272_000 * 0.68)
+        assert engine._effective_assembly_token_cap() is None
+
+        status = engine.get_status()
+        assert status["context_threshold_source"] == "env:LCM_CONTEXT_THRESHOLD"
+        assert status["context_threshold_autoraised"] is None
+    finally:
+        engine.shutdown()
+
+
+def test_codex_gpt55_route_cap_constrains_reserve_based_assembly_cap(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.85,
+        database_path=str(tmp_path / "codex-assembly-cap.db"),
+        max_assembly_tokens=700_000,
+        reserve_tokens_floor=24_000,
+    )
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5-pro",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.context_length == 272_000
+        assert engine._effective_assembly_token_cap() == 248_000
+    finally:
+        engine.shutdown()
+
+
+def test_non_codex_gpt55_keeps_host_context_window(engine):
+    engine.update_model(
+        model="gpt-5.5",
+        provider="openai",
+        context_length=400_000,
+    )
+
+    assert engine.raw_context_length == 400_000
+    assert engine.context_length == 400_000
+    assert engine.effective_context_length_cap is None
+    assert engine.threshold_tokens == int(400_000 * engine._config.context_threshold)
+
+
 def test_session_start_does_not_overwrite_update_model_context_length_with_stale_metadata(engine):
     engine.update_model(
         model="deepseek-v4-flash",
@@ -262,6 +355,109 @@ def test_session_start_does_not_overwrite_update_model_context_length_with_stale
     assert engine.model == "deepseek-v4-flash"
     assert engine.context_length == 1_000_000
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
+
+
+def test_session_start_accepts_raw_context_length_for_capped_codex_runtime(tmp_path, caplog):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-session-start.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        caplog.set_level(logging.WARNING)
+        engine.on_session_start(
+            "telegram:chat-1:session-2",
+            platform="telegram",
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+            conversation_id="telegram:chat-1",
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.threshold_tokens == int(272_000 * 0.85)
+        assert "ignored stale session-start context_length" not in caplog.text
+    finally:
+        engine.shutdown()
+
+
+def test_session_start_only_uses_incoming_route_for_codex_gpt55_cap(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-session-start-only.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.on_session_start(
+            "telegram:chat-1:session-1",
+            platform="telegram",
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+            conversation_id="telegram:chat-1",
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.context_threshold == 0.85
+        assert engine.threshold_tokens == int(272_000 * 0.85)
+        assert engine.effective_context_length_reason == "codex_gpt55_route_cap"
+
+        engine.on_session_start(
+            "telegram:chat-2:session-1",
+            platform="telegram",
+            model="gpt-5.5",
+            provider="openai",
+            context_length=400_000,
+            conversation_id="telegram:chat-2",
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 400_000
+        assert engine.context_threshold == 0.68
+        assert engine.threshold_tokens == int(400_000 * 0.68)
+        assert engine.effective_context_length_cap is None
+        assert engine.effective_context_length_reason == ""
+    finally:
+        engine.shutdown()
+
+
+def test_lcm_status_surfaces_capped_context_and_effective_threshold(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-status.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine._session_id = "codex-status-session"
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        payload = json.loads(lcm_tools.lcm_status({}, engine=engine))
+
+        assert payload["raw_context_length"] == 400_000
+        assert payload["context_length"] == 272_000
+        assert payload["effective_context_length_cap"] == 272_000
+        assert payload["effective_context_length_reason"] == "codex_gpt55_route_cap"
+        assert payload["configured_context_threshold"] == 0.68
+        assert payload["context_threshold"] == 0.85
+        assert payload["context_threshold_source"] == "codex_gpt55_autoraise"
+        assert payload["context_threshold_autoraised"] == {"from": 0.68, "to": 0.85}
+    finally:
+        engine.shutdown()
 
 
 def test_session_start_does_not_overwrite_update_model_with_stale_runtime_identity(engine):

--- a/tests/test_lcm_preset_command.py
+++ b/tests/test_lcm_preset_command.py
@@ -3,6 +3,7 @@
 from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
+from hermes_lcm.presets import preset_status_payload
 
 
 _PRESET_ENV_VARS = (
@@ -97,6 +98,33 @@ def test_lcm_preset_suggest_reports_explicit_operator_config_precedence(tmp_path
     assert "explicit_overrides: LCM_FRESH_TAIL_COUNT" in result
     assert "LCM_FRESH_TAIL_COUNT: keep explicit value 99 (preset 24)" in result
     assert "note: suggestion only; no live config was changed" in result
+
+
+def test_lcm_preset_suggest_does_not_lower_codex_gpt55_autoraised_threshold(tmp_path, monkeypatch):
+    _clear_preset_env(monkeypatch)
+    engine = _engine(tmp_path, context_length=400_000)
+    engine._config.context_threshold = 0.68
+    engine._config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine.update_model(
+        model="gpt-5.5",
+        provider="openai-codex",
+        context_length=400_000,
+    )
+
+    result = handle_lcm_command("preset suggest", engine)
+    payload = preset_status_payload(engine, environ={})
+
+    assert "LCM_CONTEXT_THRESHOLD: keep runtime auto-raised value 0.85 (preset 0.75)" in result
+    assert "LCM_FRESH_TAIL_COUNT=24" in result
+    assert "LCM_LEAF_CHUNK_TOKENS=8000" in result
+    context_delta = next(item for item in payload["dry_run_delta"] if item["field"] == "context_threshold")
+    assert context_delta == {
+        "field": "context_threshold",
+        "env": "LCM_CONTEXT_THRESHOLD",
+        "action": "keep_runtime_autoraised",
+        "current_value": 0.85,
+        "preset_value": 0.75,
+    }
 
 
 def test_lcm_preset_suggest_reports_spark_for_128k_context_window(tmp_path, monkeypatch):

--- a/tools.py
+++ b/tools.py
@@ -1887,9 +1887,15 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         "last_compression_noop_reason": full_status.get("last_compression_noop_reason", ""),
         "model": full_status.get("model", ""),
         "provider": full_status.get("provider", ""),
+        "raw_context_length": full_status.get("raw_context_length", engine.context_length),
         "context_length": engine.context_length,
+        "effective_context_length_cap": full_status.get("effective_context_length_cap"),
+        "effective_context_length_reason": full_status.get("effective_context_length_reason", ""),
         "context_length_source": full_status.get("context_length_source", ""),
+        "configured_context_threshold": full_status.get("configured_context_threshold", engine._config.context_threshold),
         "context_threshold": full_status.get("context_threshold", engine._config.context_threshold),
+        "context_threshold_source": full_status.get("context_threshold_source", ""),
+        "context_threshold_autoraised": full_status.get("context_threshold_autoraised"),
         "threshold_tokens": engine.threshold_tokens,
         "last_prompt_tokens": engine.last_prompt_tokens,
         "last_input_tokens": engine.last_input_tokens,
@@ -2228,7 +2234,8 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     # 7. Context pressure
     if engine.context_length > 0:
         usage_pct = round(engine.last_prompt_tokens / engine.context_length * 100, 1) if engine.context_length else 0
-        threshold_pct = round(c.context_threshold * 100, 1)
+        runtime_threshold = float(getattr(engine, "context_threshold", c.context_threshold))
+        threshold_pct = round(runtime_threshold * 100, 1)
         checks.append({
             "check": "context_pressure",
             "status": "pass" if usage_pct < threshold_pct else "warn",


### PR DESCRIPTION
## Summary
- Cap `openai-codex` `gpt-5.5` to a 272000 token effective context window when the host reports a larger raw window.
- Mirror Hermes Agent's 0.85 Codex gpt-5.5 auto-compaction threshold when LCM is inheriting the host compression threshold.
- Keep explicit LCM threshold overrides authoritative, and show raw/effective context plus configured/runtime thresholds in status, tools, doctor, and preset previews.

## Why
Hermes Agent treats the Codex OAuth route for gpt-5.5 as a 272K backend window and raises the trigger threshold to 85 percent, which gives a trigger around 231K tokens.

LCM was inheriting the host threshold but still using the host-reported 400K context window. With a 0.68 threshold that made the trigger 272K tokens, which is the effective Codex cap itself rather than a safe pre-cap compaction point.

This keeps LCM aligned with the host route behavior without changing Hermes Agent core and without taking control away from explicit LCM operator overrides.

## Validation
- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py tests/test_lcm_command.py tests/test_lcm_preset_command.py tests/test_benchmarking_types.py -q` -> `527 passed, 3 warnings`
- [x] Default validation: `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `669 passed, 3 warnings`
- [x] Default validation: `python -m pytest -q` -> `1010 passed, 3 warnings`
- [x] Release validation: `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-codex-gpt55-effective-context` -> `PASS: release validation full`
- [x] Diff checks: `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check` -> passed
- [x] Local runtime probe: `openai-codex/gpt-5.5` raw 400000 -> effective 272000, configured threshold 0.68 -> runtime threshold 0.85, threshold tokens 231200
- [x] Local read-only Codex audit -> no blocking findings after the session-start and doctor-threshold fixes

## Notes
- No Hermes Agent core files are changed.
- `LCM_CONTEXT_THRESHOLD` and `lcm.context_threshold` remain explicit operator overrides and are not auto-raised.
- Non-Codex providers and non-gpt-5.5 model families keep the host-reported context window.
