### PR TITLE
fix: align Codex OAuth effective context windows

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -81,15 +81,62 @@ logger = logging.getLogger(__name__)
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
 _SESSION_END_BUSY_TIMEOUT_MS = 50
-_CODEX_GPT55_CONTEXT_CAP = 272_000
+# ChatGPT Codex OAuth exposes provider-enforced context windows that can be
+# materially lower than the same model slug on direct OpenAI/OpenRouter routes.
+# Hermes Agent resolves these from chatgpt.com/backend-api/codex/models, with
+# this table as its fallback. LCM sees only the host-advertised context_length;
+# when that value was explicitly overridden above the real Codex OAuth window,
+# we still have to budget against the effective provider window or compaction
+# fires too late and provider requests can overflow.
+_CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
+    "gpt-5.1-codex-max": 272_000,
+    "gpt-5.1-codex-mini": 272_000,
+    "gpt-5.3-codex-spark": 128_000,
+    "gpt-5.3-codex": 272_000,
+    "gpt-5.2-codex": 272_000,
+    "gpt-5.4-mini": 272_000,
+    "gpt-5.5": 272_000,
+    "gpt-5.4": 272_000,
+    "gpt-5.2": 272_000,
+    "gpt-5": 272_000,
+}
 _CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
 
 
-def _is_codex_gpt55_route(model: str, provider: str) -> bool:
+def _bare_model_slug(model: str | None) -> str:
+    return (model or "").strip().lower().rsplit("/", 1)[-1]
+
+
+def _is_openai_codex_route(provider: str | None) -> bool:
+    return (provider or "").strip().lower() == "openai-codex"
+
+
+def _codex_oauth_context_cap(model: str | None, provider: str | None) -> int | None:
+    """Return LCM's best-known Codex OAuth effective context cap.
+
+    This intentionally mirrors Hermes Agent's hardcoded fallback policy, not the
+    direct OpenAI model catalog. A host-provided context_length may be a user
+    override or stale cache entry; Codex OAuth still enforces these lower route
+    windows.
+    """
+    if not _is_openai_codex_route(provider):
+        return None
+    bare_model = _bare_model_slug(model)
+    if not bare_model:
+        return None
+    for slug, cap in sorted(
+        _CODEX_OAUTH_CONTEXT_CAPS.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        if slug in bare_model:
+            return cap
+    return None
+
+
+def _is_codex_gpt55_route(model: str | None, provider: str | None) -> bool:
     """Return True for gpt-5.5 on ChatGPT Codex OAuth, mirroring Hermes core."""
-    if (provider or "").strip().lower() != "openai-codex":
+    if not _is_openai_codex_route(provider):
         return False
-    bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
+    bare_model = _bare_model_slug(model)
     return (
         bare_model == "gpt-5.5"
         or bare_model.startswith("gpt-5.5-")
@@ -560,14 +607,12 @@ class LCMEngine(ContextEngine):
     ) -> tuple[int, int | None, str]:
         route_model = self.model if model is None else model
         route_provider = self.provider if provider is None else provider
-        if (
-            raw_context_length > _CODEX_GPT55_CONTEXT_CAP
-            and _is_codex_gpt55_route(route_model, route_provider)
-        ):
+        cap = _codex_oauth_context_cap(route_model, route_provider)
+        if cap is not None and raw_context_length > cap:
             return (
-                _CODEX_GPT55_CONTEXT_CAP,
-                _CODEX_GPT55_CONTEXT_CAP,
-                "codex_gpt55_route_cap",
+                cap,
+                cap,
+                "codex_oauth_context_cap",
             )
         return raw_context_length, None, ""
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -508,6 +508,26 @@ def test_lcm_doctor_context_pressure_uses_runtime_threshold(tmp_path):
         engine.shutdown()
 
 
+def test_lcm_doctor_config_validation_uses_runtime_threshold_for_autoraised_context(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.20,
+        database_path=str(tmp_path / "doctor-runtime-validation.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model("gpt-5.5", 400_000, provider="openai-codex")
+
+        doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+        validation = next(check for check in doctor["checks"] if check["check"] == "config_validation")
+
+        assert engine.context_threshold == 0.85
+        assert validation["status"] == "pass"
+        assert validation["detail"] == "all settings within normal ranges"
+    finally:
+        engine.shutdown()
+
+
 def test_lcm_doctor_text_reports_missing_externalized_payload_refs(engine):
     storage_dir = Path(engine._hermes_home) / "lcm-large-outputs"
     storage_dir.mkdir(parents=True)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -558,6 +558,21 @@ class TestConfig:
 
         assert c.context_threshold == 0.68
 
+    def test_from_env_reads_hermes_codex_gpt55_autoraise_flag(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "compression:\n  threshold: 0.68\n  codex_gpt55_autoraise: false\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        c = LCMConfig.from_env()
+
+        assert c.context_threshold == 0.68
+        assert c.codex_gpt55_autoraise_enabled is False
+        assert c.config_sources["codex_gpt55_autoraise_enabled"] == "config_yaml:compression.codex_gpt55_autoraise"
+
     def test_from_env_reads_hermes_auxiliary_compression_timeout_when_lcm_env_missing(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -261,7 +261,7 @@ def test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold(tmp_path):
         assert engine.raw_context_length == 400_000
         assert engine.context_length == 272_000
         assert engine.effective_context_length_cap == 272_000
-        assert engine.effective_context_length_reason == "codex_gpt55_route_cap"
+        assert engine.effective_context_length_reason == "codex_oauth_context_cap"
         assert engine.context_threshold == 0.85
         assert engine.threshold_tokens == int(272_000 * 0.85)
 
@@ -276,7 +276,7 @@ def test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold(tmp_path):
         engine.shutdown()
 
 
-def test_codex_gpt55_route_cap_keeps_explicit_lcm_threshold(tmp_path):
+def test_codex_oauth_context_cap_keeps_explicit_lcm_threshold(tmp_path):
     config = LCMConfig(
         context_threshold=0.68,
         database_path=str(tmp_path / "codex-explicit-threshold.db"),
@@ -303,7 +303,82 @@ def test_codex_gpt55_route_cap_keeps_explicit_lcm_threshold(tmp_path):
         engine.shutdown()
 
 
-def test_codex_gpt55_route_cap_constrains_reserve_based_assembly_cap(tmp_path):
+def test_codex_oauth_context_cap_keeps_lcm_config_yaml_threshold_override(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.62,
+        database_path=str(tmp_path / "codex-lcm-yaml-threshold.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:lcm.context_threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.context_threshold == 0.62
+        assert engine.threshold_tokens == int(272_000 * 0.62)
+        assert engine._context_threshold_source == "config_yaml:lcm.context_threshold"
+        assert engine._context_threshold_autoraised is None
+    finally:
+        engine.shutdown()
+
+
+def test_codex_gpt55_autoraise_can_be_disabled(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        codex_gpt55_autoraise_enabled=False,
+        database_path=str(tmp_path / "codex-autoraise-disabled.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 272_000
+        assert engine.context_threshold == 0.68
+        assert engine.threshold_tokens == int(272_000 * 0.68)
+        assert engine._context_threshold_source == "config_yaml:compression.threshold"
+        assert engine._context_threshold_autoraised is None
+    finally:
+        engine.shutdown()
+
+
+def test_codex_oauth_context_cap_applies_without_gpt55_threshold_magic(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.68,
+        database_path=str(tmp_path / "codex-spark-cap.db"),
+    )
+    config.config_sources["context_threshold"] = "config_yaml:compression.threshold"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.3-codex-spark",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.raw_context_length == 400_000
+        assert engine.context_length == 128_000
+        assert engine.effective_context_length_cap == 128_000
+        assert engine.effective_context_length_reason == "codex_oauth_context_cap"
+        assert engine.context_threshold == 0.68
+        assert engine.threshold_tokens == int(128_000 * 0.68)
+        assert engine._context_threshold_source == "config_yaml:compression.threshold"
+        assert engine._context_threshold_autoraised is None
+    finally:
+        engine.shutdown()
+
+
+def test_codex_oauth_context_cap_constrains_reserve_based_assembly_cap(tmp_path):
     config = LCMConfig(
         context_threshold=0.85,
         database_path=str(tmp_path / "codex-assembly-cap.db"),
@@ -410,7 +485,7 @@ def test_session_start_only_uses_incoming_route_for_codex_gpt55_cap(tmp_path):
         assert engine.context_length == 272_000
         assert engine.context_threshold == 0.85
         assert engine.threshold_tokens == int(272_000 * 0.85)
-        assert engine.effective_context_length_reason == "codex_gpt55_route_cap"
+        assert engine.effective_context_length_reason == "codex_oauth_context_cap"
 
         engine.on_session_start(
             "telegram:chat-2:session-1",
@@ -451,7 +526,7 @@ def test_lcm_status_surfaces_capped_context_and_effective_threshold(tmp_path):
         assert payload["raw_context_length"] == 400_000
         assert payload["context_length"] == 272_000
         assert payload["effective_context_length_cap"] == 272_000
-        assert payload["effective_context_length_reason"] == "codex_gpt55_route_cap"
+        assert payload["effective_context_length_reason"] == "codex_oauth_context_cap"
         assert payload["configured_context_threshold"] == 0.68
         assert payload["context_threshold"] == 0.85
         assert payload["context_threshold_source"] == "codex_gpt55_autoraise"

--- a/tools.py
+++ b/tools.py
@@ -2175,10 +2175,11 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     c = engine._config
     if c.fresh_tail_count < 2:
         config_warnings.append("fresh_tail_count < 2 may cause aggressive compaction")
-    if c.context_threshold > 0.95:
-        config_warnings.append("context_threshold > 0.95 leaves very little headroom")
-    if c.context_threshold < 0.3:
-        config_warnings.append("context_threshold < 0.3 triggers compaction very early")
+    runtime_context_threshold = float(getattr(engine, "context_threshold", c.context_threshold))
+    if runtime_context_threshold > 0.95:
+        config_warnings.append("runtime context_threshold > 0.95 leaves very little headroom")
+    if runtime_context_threshold < 0.3:
+        config_warnings.append("runtime context_threshold < 0.3 triggers compaction very early")
     if c.condensation_fanin < 2:
         config_warnings.append("condensation_fanin < 2 creates excessive depth growth")
     if c.incremental_max_depth == 0:


### PR DESCRIPTION
## Why

PR #274 fixed the immediate gpt-5.5/Codex OAuth issue, but the underlying problem is broader: LCM receives a host-advertised `context_length`, and that value can be an explicit user override or stale value that is larger than the provider-enforced Codex OAuth window.

Hermes Agent resolves Codex OAuth context windows through the Codex `/models` route with a fallback table. LCM does not receive that full provenance. If LCM budgets against the raw advertised value, it can delay compaction until too close to the real backend limit.

This follow-up makes LCM treat context sizing as explicit runtime state:

- `raw_context_length`: what the host handed to LCM
- `context_length`: the effective budget LCM should use
- `effective_context_length_cap` / `effective_context_length_reason`: why the budget was capped
- configured vs runtime compaction threshold diagnostics

## What changed

- Generalizes the Codex OAuth cap handling from just `gpt-5.5` to the same known Codex OAuth fallback windows Hermes Agent uses for Codex slugs.
- Keeps the gpt-5.5-specific `0.85` threshold auto-raise scoped exactly to the Hermes Agent core route behavior.
- Preserves explicit LCM threshold overrides from both:
  - `LCM_CONTEXT_THRESHOLD`
  - `lcm.context_threshold`
- Honors `compression.codex_gpt55_autoraise: false` so operators can opt out of the gpt-5.5 threshold raise.
- Updates doctor/config validation to reason from the runtime threshold, not only the configured value.
- Adds regression tests for Codex Spark-style 128K caps, explicit override precedence, opt-out behavior, and diagnostics.

## Verification

```bash
python -m pytest tests/test_lcm_engine.py::test_codex_oauth_context_cap_applies_without_gpt55_threshold_magic tests/test_lcm_engine.py::test_codex_oauth_context_cap_keeps_lcm_config_yaml_threshold_override tests/test_lcm_engine.py::test_codex_gpt55_autoraise_can_be_disabled tests/test_lcm_core.py::TestConfig::test_from_env_reads_hermes_codex_gpt55_autoraise_flag tests/test_lcm_command.py::test_lcm_doctor_config_validation_uses_runtime_threshold_for_autoraised_context -q
# 5 passed

python -m pytest tests/test_lcm_engine.py tests/test_lcm_command.py tests/test_lcm_core.py tests/test_lcm_preset_command.py tests/test_benchmarking_types.py -q
# 746 passed, 3 warnings

python -m pytest tests/ -q
# 1015 passed, 3 warnings
```

Warnings are dependency deprecations from `discord.player audioop`, `lark_oapi`, and `websockets.legacy`.

Local read-only Codex audit also found no blocking issues after the follow-up changes.