### PR TITLE
docs: document Codex OAuth effective context budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ For a live session check, send one normal Hermes message after restart, then run
 
 If startup logs say LCM tools are available through `context-engine schemas` or mention the `Path B fallback`, that is expected on older Hermes hosts such as Hermes Agent v0.16. The seven `lcm_*` tools remain available through the context-engine path; standalone plugin-registry registration is not required there.
 
+## Runtime context budgets
+
+LCM budgets compaction against the effective context window it can safely use, not blindly against every raw value the host reports. `lcm_status` exposes both sides when they differ:
+
+- `raw_context_length`: the context length Hermes handed to LCM
+- `context_length`: the effective context length LCM budgets against
+- `effective_context_length_cap` and `effective_context_length_reason`: any provider-route cap LCM applied
+- `configured_context_threshold` and `context_threshold`: configured vs runtime compaction threshold
+
+This matters for provider routes whose enforced window is smaller than the same model on another route. For example, ChatGPT Codex OAuth exposes lower effective windows for Codex-family models than the direct OpenAI API. When Hermes hands LCM a larger raw value because of a config override or stale metadata, LCM caps the effective budget for known Codex OAuth slugs and reports the reason in status.
+
+Codex gpt-5.5 keeps Hermes Agent's route-specific behavior: when LCM is inheriting Hermes `compression.threshold`, the runtime threshold can auto-raise to `0.85` so compaction starts around 85% of the 272k Codex OAuth window instead of wasting half the usable context. Explicit LCM overrides still win: set `LCM_CONTEXT_THRESHOLD` or `lcm.context_threshold` if you want a different LCM threshold. Operators can also opt out of the gpt-5.5 inherited-threshold auto-raise with `compression.codex_gpt55_autoraise: false` in Hermes config.
+
 ## Update
 
 If you cloned directly into the plugin directory:

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -213,10 +213,24 @@ state / cache-break signals.
 
 ### Threshold ownership
 
-When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
-threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
-compressor. Hermes core `compression.enabled` is still the global gate that
-allows compaction, so leave it enabled when using LCM.
+When `context.engine: lcm` is active, LCM's runtime threshold is the value shown
+by `lcm_status` as `context_threshold`. Hermes core `compression.enabled` is
+still the global gate that allows compaction, so leave it enabled when using LCM.
+
+Precedence is:
+
+1. `LCM_CONTEXT_THRESHOLD`
+2. `lcm.context_threshold` in Hermes `config.yaml`
+3. inherited Hermes `compression.threshold`
+4. LCM default
+
+Some provider routes may adjust the runtime threshold after config resolution.
+For example, Codex gpt-5.5 on the ChatGPT Codex OAuth route can auto-raise an
+inherited Hermes threshold to `0.85`, matching Hermes Agent's built-in compressor
+behavior for that route. Explicit LCM overrides (`LCM_CONTEXT_THRESHOLD` or
+`lcm.context_threshold`) remain authoritative and are not auto-raised. To opt out
+of the Codex gpt-5.5 inherited-threshold raise, set
+`compression.codex_gpt55_autoraise: false` in Hermes config.
 
 If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the
@@ -280,13 +294,13 @@ around that budget.
 The basic calculation is:
 
 ```text
-compaction trigger = effective context window * LCM_CONTEXT_THRESHOLD
+compaction trigger = effective context window * runtime context_threshold
 ```
 
 Or, working backwards:
 
 ```text
-LCM_CONTEXT_THRESHOLD = desired compaction trigger / effective context window
+runtime context_threshold = desired compaction trigger / effective context window
 ```
 
 Examples, as math rather than universal recommendations:


### PR DESCRIPTION
## Summary

- Documents the Codex OAuth effective context budget behavior introduced in #276.
- Explains `raw_context_length` vs effective `context_length`, provider-route caps, and runtime threshold diagnostics.
- Updates threshold ownership docs so operators understand explicit LCM overrides, inherited Hermes `compression.threshold`, and the Codex gpt-5.5 `0.85` auto-raise/opt-out.

## Why

This docs PR depends on #276. It should not be accepted or merged until #276 has been merged first.

Keeping this separate keeps the implementation PR focused while still giving operators the README/operator-guide explanation once the behavior exists on `main`.

## Validation

- [x] `git diff --check`
- [x] Scope check: docs-only (`README.md`, `docs/operator-guide.md`)

Refs #276
