### PR TITLE
fix: avoid payload integrity false positives from log examples

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1022,9 +1022,34 @@ def _walk_tool_call_argument_values(value: Any):
             yield from _walk_tool_call_argument_values(item)
 
 
+def _is_inside_token_quote_span(text: str, start: int, token: str) -> bool:
+    in_span = False
+    i = 0
+    while i < start:
+        if text.startswith(token, i):
+            in_span = not in_span
+            i += len(token)
+        else:
+            i += 1
+    return in_span
+
+
+def _has_escaped_quote_before(text: str, start: int) -> bool:
+    return re.search(r"\\+[\"']", text[:start]) is not None
+
+
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
     prefix = text[max(0, start - 8):start]
-    return '\\"' in prefix or "\\'" in prefix or prefix.endswith("\\")
+    return (
+        '\\"' in prefix
+        or "\\'" in prefix
+        or prefix.endswith("\\")
+        or _has_escaped_quote_before(text, start)
+    )
+
+
+def _is_quoted_placeholder_example(text: str, start: int) -> bool:
+    return _is_inside_token_quote_span(text, start, '"') or _is_inside_token_quote_span(text, start, "'")
 
 
 def _looks_like_json_container_string(text: str) -> bool:
@@ -1032,11 +1057,13 @@ def _looks_like_json_container_string(text: str) -> bool:
     return stripped.startswith("{") or stripped.startswith("[")
 
 
-def _extract_unescaped_externalized_payload_refs(text: str) -> list[str]:
+def _extract_unescaped_externalized_payload_refs(text: str, *, ignore_quoted_spans: bool = False) -> list[str]:
     refs: list[str] = []
     for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
         for match in pattern.finditer(text):
             if _is_escaped_placeholder_example(text, match.start()):
+                continue
+            if ignore_quoted_spans and _is_quoted_placeholder_example(text, match.start()):
                 continue
             ref = match.group(1).strip()
             if _is_basename_ref(ref) and ref not in refs:
@@ -1074,7 +1101,7 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                     if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
                         _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
                     else:
-                        _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
+                        _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True))
         for nested in _walk_string_values(parsed):
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
@@ -1090,8 +1117,8 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                 nested_stripped = nested.strip()
                 if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
                     _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
-                elif _looks_like_json_container_string(nested_stripped):
-                    _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
+                else:
+                    _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True))
         return refs
     return extract_all_externalized_payload_refs(value)
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1034,6 +1034,10 @@ def _is_inside_token_quote_span(text: str, start: int, token: str) -> bool:
     return in_span
 
 
+def _looks_like_example_quote_context(context: str) -> bool:
+    return re.search(r"(?:pytest\s+output|log|example|traceback|failure)\s*:\s*$", context.lower()) is not None
+
+
 def _has_local_escaped_quote_before(text: str, start: int) -> bool:
     boundary = max(text.rfind(delimiter, 0, start) for delimiter in (",", "{", "["))
     segment = text[boundary + 1:start]
@@ -1041,8 +1045,8 @@ def _has_local_escaped_quote_before(text: str, start: int) -> bool:
     if not matches:
         return False
     quote = matches[-1]
-    context = segment[max(0, quote.start() - 80):quote.start()].lower()
-    return any(marker in context for marker in ("pytest", "log", "example", "traceback", "failure"))
+    context = segment[max(0, quote.start() - 80):quote.start()]
+    return _looks_like_example_quote_context(context)
 
 
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
@@ -1056,8 +1060,8 @@ def _is_quoted_placeholder_example(text: str, start: int) -> bool:
     quote = text.rfind('"', 0, start)
     if quote < 0:
         return False
-    context = text[max(0, quote - 80):quote].lower()
-    return any(marker in context for marker in ("pytest", "log", "example", "traceback", "failure"))
+    context = text[max(0, quote - 80):quote]
+    return _looks_like_example_quote_context(context)
 
 
 def _looks_like_json_container_string(text: str) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1050,7 +1050,13 @@ def _is_escaped_placeholder_example(text: str, start: int) -> bool:
 
 
 def _is_quoted_placeholder_example(text: str, start: int) -> bool:
-    return _is_inside_token_quote_span(text, start, '"')
+    if not _is_inside_token_quote_span(text, start, '"'):
+        return False
+    quote = text.rfind('"', 0, start)
+    if quote < 0:
+        return False
+    context = text[max(0, quote - 80):quote].lower()
+    return any(marker in context for marker in ("pytest", "output", "log", "example", "traceback", "failure"))
 
 
 def _looks_like_json_container_string(text: str) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1035,18 +1035,19 @@ def _is_inside_token_quote_span(text: str, start: int, token: str) -> bool:
 
 
 def _has_local_escaped_quote_before(text: str, start: int) -> bool:
-    boundary = max(text.rfind(delimiter, 0, start) for delimiter in (",", "{", "[", ":"))
-    return re.search(r"\\+[\"']", text[boundary + 1:start]) is not None
+    boundary = max(text.rfind(delimiter, 0, start) for delimiter in (",", "{", "["))
+    segment = text[boundary + 1:start]
+    matches = list(re.finditer(r"\\+[\"']", segment))
+    if not matches:
+        return False
+    quote = matches[-1]
+    context = segment[max(0, quote.start() - 80):quote.start()].lower()
+    return any(marker in context for marker in ("pytest", "output", "log", "example", "traceback", "failure"))
 
 
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
     prefix = text[max(0, start - 8):start]
-    return (
-        '\\"' in prefix
-        or "\\'" in prefix
-        or prefix.endswith("\\")
-        or _has_local_escaped_quote_before(text, start)
-    )
+    return prefix.endswith("\\") or _has_local_escaped_quote_before(text, start)
 
 
 def _is_quoted_placeholder_example(text: str, start: int) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1049,7 +1049,7 @@ def _is_escaped_placeholder_example(text: str, start: int) -> bool:
 
 
 def _is_quoted_placeholder_example(text: str, start: int) -> bool:
-    return _is_inside_token_quote_span(text, start, '"') or _is_inside_token_quote_span(text, start, "'")
+    return _is_inside_token_quote_span(text, start, '"')
 
 
 def _looks_like_json_container_string(text: str) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1096,6 +1096,17 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
         for argument in _walk_tool_call_argument_values(parsed):
             if isinstance(argument, str):
                 _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(argument))
+                parsed_argument = _maybe_parse_json_string(argument)
+                if parsed_argument is not None:
+                    for nested in _walk_string_values(parsed_argument):
+                        nested_stripped = nested.strip()
+                        if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
+                            _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
+                        else:
+                            _append_unique_refs(
+                                refs,
+                                _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True),
+                            )
             else:
                 for nested in _walk_string_values(argument):
                     nested_stripped = nested.strip()

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1012,6 +1012,11 @@ def _is_escaped_placeholder_example(text: str, start: int) -> bool:
     return '\\"' in prefix or "\\'" in prefix or prefix.endswith("\\")
 
 
+def _looks_like_json_container_string(text: str) -> bool:
+    stripped = text.lstrip()
+    return stripped.startswith("{") or stripped.startswith("[")
+
+
 def _extract_unescaped_externalized_payload_refs(text: str) -> list[str]:
     refs: list[str] = []
     for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
@@ -1031,8 +1036,8 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
     pytest failures, or docs that mention placeholder examples. Counting those
     as live payload references turns doctor into a false-positive machine. Exact
     placeholders are still counted everywhere; embedded unescaped placeholders
-    are counted for message content and tool-call argument strings so preserved
-    raw/duplicate-key tool arguments do not hide real refs.
+    are counted for message content and raw JSON-container tool-call argument
+    strings so preserved duplicate-key tool arguments do not hide real refs.
     """
     if not isinstance(value, str) or not value:
         return []
@@ -1048,7 +1053,7 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
                 _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
-            else:
+            elif _looks_like_json_container_string(nested_stripped):
                 _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
         return refs
     if role == "tool":

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -621,12 +621,16 @@ def _maybe_parse_json_string(text: str) -> Any | None:
     stripped = text.strip()
     if not stripped or stripped[0] not in "[{":
         return None
-    try:
-        parsed = json.loads(text)
-    except Exception:
-        return None
-    if isinstance(parsed, (dict, list)):
-        return parsed
+    candidates = [text]
+    if '\\"' in stripped:
+        candidates.append(stripped.replace('\\"', '"'))
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except Exception:
+            continue
+        if isinstance(parsed, (dict, list)):
+            return parsed
     return None
 
 
@@ -1057,7 +1061,16 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                 _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
         return refs
     if role == "tool":
-        return _extract_unescaped_externalized_payload_refs(value)
+        refs = _extract_unescaped_externalized_payload_refs(value)
+        parsed = _maybe_parse_json_string(value)
+        if parsed is not None:
+            for nested in _walk_string_values(parsed):
+                nested_stripped = nested.strip()
+                if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
+                    _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
+                elif _looks_like_json_container_string(nested_stripped):
+                    _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
+        return refs
     return extract_all_externalized_payload_refs(value)
 
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -102,6 +102,9 @@ _HEARTBEAT_NOISE_RE = re.compile(
 _HEARTBEAT_NOISE_MAX_CHARS = 256
 _GENERIC_BASE64_MIN_CHARS = 4096
 _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*ref=([^;\]\s]+)\]")
+_EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE = re.compile(
+    r"\[(?:Externalized|GC'd externalized) (?:tool output|payload):.*?;\s*ref=([^;\]\s]+)\]"
+)
 _SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
 _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     "api_key": re.compile(
@@ -991,6 +994,9 @@ def _append_unique_refs(target: list[str], refs: list[str]) -> None:
 def _walk_string_values(value: Any):
     if isinstance(value, str):
         yield value
+        parsed = _maybe_parse_json_string(value)
+        if parsed is not None and not (isinstance(parsed, str) and parsed == value):
+            yield from _walk_string_values(parsed)
     elif isinstance(value, dict):
         for key, nested in value.items():
             if isinstance(key, str):
@@ -999,6 +1005,23 @@ def _walk_string_values(value: Any):
     elif isinstance(value, list):
         for item in value:
             yield from _walk_string_values(item)
+
+
+def _is_escaped_placeholder_example(text: str, start: int) -> bool:
+    prefix = text[max(0, start - 8):start]
+    return '\\"' in prefix or "\\'" in prefix or prefix.endswith("\\")
+
+
+def _extract_unescaped_externalized_payload_refs(text: str) -> list[str]:
+    refs: list[str] = []
+    for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
+        for match in pattern.finditer(text):
+            if _is_escaped_placeholder_example(text, match.start()):
+                continue
+            ref = match.group(1).strip()
+            if _is_basename_ref(ref) and ref not in refs:
+                refs.append(ref)
+    return refs
 
 
 def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) -> list[str]:
@@ -1027,7 +1050,7 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                 _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
         return refs
     if role == "tool":
-        return []
+        return _extract_unescaped_externalized_payload_refs(value)
     return extract_all_externalized_payload_refs(value)
 
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1011,6 +1011,17 @@ def _walk_string_values(value: Any):
             yield from _walk_string_values(item)
 
 
+def _walk_tool_call_argument_strings(value: Any):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == "arguments" and isinstance(nested, str):
+                yield nested
+            yield from _walk_tool_call_argument_strings(nested)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_tool_call_argument_strings(item)
+
+
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
     prefix = text[max(0, start - 8):start]
     return '\\"' in prefix or "\\'" in prefix or prefix.endswith("\\")
@@ -1040,8 +1051,9 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
     pytest failures, or docs that mention placeholder examples. Counting those
     as live payload references turns doctor into a false-positive machine. Exact
     placeholders are still counted everywhere; embedded unescaped placeholders
-    are counted for message content and raw JSON-container tool-call argument
-    strings so preserved duplicate-key tool arguments do not hide real refs.
+    are counted for message content, raw JSON-container tool-call argument
+    strings, and raw free-form tool-call argument strings so ingestion-produced
+    refs do not disappear while quoted examples stay ignored.
     """
     if not isinstance(value, str) or not value:
         return []
@@ -1053,6 +1065,8 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
         parsed = _maybe_parse_json_string(value)
         if parsed is None:
             return refs
+        for arguments in _walk_tool_call_argument_strings(parsed):
+            _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(arguments))
         for nested in _walk_string_values(parsed):
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -108,9 +108,9 @@ _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE = re.compile(
 _SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
 _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     "api_key": re.compile(
-        r"(?P<prefix>\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key|client[_-]?secret)\b\s*[\"']?\s*[:=]\s*[\"']?)"
+        r"(?P<prefix>(?:\\?[\"']?)\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key|client[_-]?secret)\b\s*(?:\\?[\"']?)\s*[:=]\s*(?:\\?[\"']?))"
         r"(?P<secret>[A-Za-z0-9._~+/=-]{12,})"
-        r"(?P<suffix>[\"']?)",
+        r"(?P<suffix>\\?[\"']?)",
         re.IGNORECASE,
     ),
     "bearer_token": re.compile(
@@ -625,6 +625,8 @@ def _maybe_parse_json_string(text: str) -> Any | None:
     if '\\"' in stripped:
         candidates.append(stripped.replace('\\"', '"'))
     for candidate in candidates:
+        if _json_has_duplicate_object_keys(candidate):
+            return None
         try:
             parsed = json.loads(candidate)
         except Exception:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1030,9 +1030,9 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
     Tool outputs and tool-call arguments often contain escaped code snippets,
     pytest failures, or docs that mention placeholder examples. Counting those
     as live payload references turns doctor into a false-positive machine. Exact
-    placeholders are still counted everywhere; embedded placeholders are counted
-    for normal message content, while tool_calls only count exact placeholder
-    string values after JSON traversal.
+    placeholders are still counted everywhere; embedded unescaped placeholders
+    are counted for message content and tool-call argument strings so preserved
+    raw/duplicate-key tool arguments do not hide real refs.
     """
     if not isinstance(value, str) or not value:
         return []
@@ -1048,6 +1048,8 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
                 _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
+            else:
+                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
         return refs
     if role == "tool":
         return _extract_unescaped_externalized_payload_refs(value)

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1129,8 +1129,8 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
                 _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
-            elif _looks_like_json_container_string(nested_stripped):
-                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
+            else:
+                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True))
         return refs
     if role == "tool":
         refs = _extract_unescaped_externalized_payload_refs(value)

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1011,15 +1011,15 @@ def _walk_string_values(value: Any):
             yield from _walk_string_values(item)
 
 
-def _walk_tool_call_argument_strings(value: Any):
+def _walk_tool_call_argument_values(value: Any):
     if isinstance(value, dict):
         for key, nested in value.items():
-            if key == "arguments" and isinstance(nested, str):
+            if key == "arguments":
                 yield nested
-            yield from _walk_tool_call_argument_strings(nested)
+            yield from _walk_tool_call_argument_values(nested)
     elif isinstance(value, list):
         for item in value:
-            yield from _walk_tool_call_argument_strings(item)
+            yield from _walk_tool_call_argument_values(item)
 
 
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
@@ -1065,8 +1065,16 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
         parsed = _maybe_parse_json_string(value)
         if parsed is None:
             return refs
-        for arguments in _walk_tool_call_argument_strings(parsed):
-            _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(arguments))
+        for argument in _walk_tool_call_argument_values(parsed):
+            if isinstance(argument, str):
+                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(argument))
+            else:
+                for nested in _walk_string_values(argument):
+                    nested_stripped = nested.strip()
+                    if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
+                        _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
+                    else:
+                        _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested))
         for nested in _walk_string_values(parsed):
             nested_stripped = nested.strip()
             if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1042,7 +1042,7 @@ def _has_local_escaped_quote_before(text: str, start: int) -> bool:
         return False
     quote = matches[-1]
     context = segment[max(0, quote.start() - 80):quote.start()].lower()
-    return any(marker in context for marker in ("pytest", "output", "log", "example", "traceback", "failure"))
+    return any(marker in context for marker in ("pytest", "log", "example", "traceback", "failure"))
 
 
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
@@ -1057,7 +1057,7 @@ def _is_quoted_placeholder_example(text: str, start: int) -> bool:
     if quote < 0:
         return False
     context = text[max(0, quote - 80):quote].lower()
-    return any(marker in context for marker in ("pytest", "output", "log", "example", "traceback", "failure"))
+    return any(marker in context for marker in ("pytest", "log", "example", "traceback", "failure"))
 
 
 def _looks_like_json_container_string(text: str) -> bool:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1034,8 +1034,9 @@ def _is_inside_token_quote_span(text: str, start: int, token: str) -> bool:
     return in_span
 
 
-def _has_escaped_quote_before(text: str, start: int) -> bool:
-    return re.search(r"\\+[\"']", text[:start]) is not None
+def _has_local_escaped_quote_before(text: str, start: int) -> bool:
+    boundary = max(text.rfind(delimiter, 0, start) for delimiter in (",", "{", "[", ":"))
+    return re.search(r"\\+[\"']", text[boundary + 1:start]) is not None
 
 
 def _is_escaped_placeholder_example(text: str, start: int) -> bool:
@@ -1044,7 +1045,7 @@ def _is_escaped_placeholder_example(text: str, start: int) -> bool:
         '\\"' in prefix
         or "\\'" in prefix
         or prefix.endswith("\\")
-        or _has_escaped_quote_before(text, start)
+        or _has_local_escaped_quote_before(text, start)
     )
 
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -154,7 +154,7 @@ def extract_ingest_externalized_refs(text: str) -> list[str]:
 
 
 def _is_basename_ref(ref: str) -> bool:
-    return bool(ref) and "/" not in ref and "\\" not in ref and Path(ref).name == ref
+    return bool(ref) and ref.endswith(".json") and "/" not in ref and "\\" not in ref and Path(ref).name == ref
 
 
 def extract_all_externalized_payload_refs(text: str) -> list[str]:
@@ -982,6 +982,55 @@ def protect_messages_for_ingest(
     ]
 
 
+def _append_unique_refs(target: list[str], refs: list[str]) -> None:
+    for ref in refs:
+        if ref not in target:
+            target.append(ref)
+
+
+def _walk_string_values(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, nested in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from _walk_string_values(nested)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_string_values(item)
+
+
+def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) -> list[str]:
+    """Return refs that plausibly came from LCM storage-boundary placeholders.
+
+    Tool outputs and tool-call arguments often contain escaped code snippets,
+    pytest failures, or docs that mention placeholder examples. Counting those
+    as live payload references turns doctor into a false-positive machine. Exact
+    placeholders are still counted everywhere; embedded placeholders are counted
+    for normal message content, while tool_calls only count exact placeholder
+    string values after JSON traversal.
+    """
+    if not isinstance(value, str) or not value:
+        return []
+    stripped = value.strip()
+    if is_externalized_ingest_placeholder(stripped) or is_externalized_placeholder(stripped):
+        return extract_all_externalized_payload_refs(stripped)
+    if field == "tool_calls":
+        refs: list[str] = []
+        parsed = _maybe_parse_json_string(value)
+        if parsed is None:
+            return refs
+        for nested in _walk_string_values(parsed):
+            nested_stripped = nested.strip()
+            if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
+                _append_unique_refs(refs, extract_all_externalized_payload_refs(nested_stripped))
+        return refs
+    if role == "tool":
+        return []
+    return extract_all_externalized_payload_refs(value)
+
+
 def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", limit: int = 5) -> dict[str, Any]:
     """Compare externalized payload refs stored in messages with JSON files.
 
@@ -1009,7 +1058,7 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
         for field, value in (("content", content), ("tool_calls", tool_calls)):
             if not isinstance(value, str):
                 continue
-            for ref in extract_all_externalized_payload_refs(value):
+            for ref in _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field):
                 referenced_refs.add(ref)
                 first_location_by_ref.setdefault(
                     ref,

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1069,16 +1069,27 @@ def _looks_like_json_container_string(text: str) -> bool:
     return stripped.startswith("{") or stripped.startswith("[")
 
 
+def _looks_like_example_payload_ref(ref: str) -> bool:
+    name = Path(ref).name.lower()
+    return name.startswith(("example-", "example_", "fake-", "fake_", "dummy-", "dummy_", "placeholder-", "placeholder_"))
+
+
 def _extract_unescaped_externalized_payload_refs(text: str, *, ignore_quoted_spans: bool = False) -> list[str]:
     refs: list[str] = []
     for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
         for match in pattern.finditer(text):
-            if _is_escaped_placeholder_example(text, match.start()):
-                continue
-            if ignore_quoted_spans and _is_quoted_placeholder_example(text, match.start()):
-                continue
             ref = match.group(1).strip()
-            if _is_basename_ref(ref) and ref not in refs:
+            if not _is_basename_ref(ref):
+                continue
+            if _looks_like_example_payload_ref(ref) and _is_escaped_placeholder_example(text, match.start()):
+                continue
+            if (
+                ignore_quoted_spans
+                and _looks_like_example_payload_ref(ref)
+                and _is_quoted_placeholder_example(text, match.start())
+            ):
+                continue
+            if ref not in refs:
                 refs.append(ref)
     return refs
 

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2077,6 +2077,50 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_examples_inside_tool_call_json(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=example-missing.json]"
+    )
+    arguments = json.dumps({"log": f'pytest output: "{placeholder}"'})
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "inspect_log",
+                    "arguments": arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 0
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["missing_externalized_payload_refs"] == []
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_tool_content_placeholder(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2174,6 +2174,53 @@ def test_externalized_payload_integrity_scan_detects_json_tool_call_argument_pla
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_detects_json_tool_call_argument_placeholder_after_unmatched_caption_quote(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-unmatched-caption-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-unmatched-caption-tool-call-media.json]"
+    )
+    arguments = json.dumps({"image": f'caption says "front {placeholder}'})
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_detects_parsed_object_tool_call_argument_placeholder(tmp_path):
     engine = _engine(tmp_path)
     storage_dir = tmp_path / "externalized"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2077,6 +2077,52 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_detects_free_form_tool_call_argument_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-free-form-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-free-form-tool-call-media.json]"
+    )
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": f"prefix {placeholder} suffix",
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_examples_inside_tool_call_json(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2164,6 +2164,77 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_content_place
     ]
 
 
+def test_externalized_payload_integrity_scan_detects_escaped_json_tool_content_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-tool-content-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=content; "
+        "chars=1; bytes=1; ref=present-tool-content-media.json]"
+    )
+    content = '{\\"image\\":\\"' + placeholder + '\\"}'
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "tool",
+            content,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
+def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_examples_inside_tool_content_json(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=content; "
+        "chars=1; bytes=1; ref=example-tool-content.json]"
+    )
+    content = '{\\"log\\":\\"pytest output: \\\\\\\"' + placeholder + '\\\\\\\"\\"}'
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "tool",
+            content,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 0
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["missing_externalized_payload_refs"] == []
+
+
 def test_lcm_doctor_warns_on_missing_externalized_payload_refs_when_inline_payloads_are_clean(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2315,7 +2315,7 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_content_place
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()
     content = (
-        'tool returned \\\"preview\\\" plus '
+        'log returned \\\"preview\\\" plus '
         "[Externalized LCM ingest payload: kind=media_payload; field=content; "
         "chars=1; bytes=1; ref=missing-tool-content-media.json]"
     )

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2176,7 +2176,7 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
         "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
         "chars=1; bytes=1; ref=example-missing.json]"
     )
-    arguments = json.dumps({"log": f'pytest output: "{placeholder}"'})
+    arguments = json.dumps({"log": f'pytest output: "prefix before placeholder {placeholder}"'})
     tool_calls = json.dumps(
         [
             {
@@ -2265,7 +2265,7 @@ def test_externalized_payload_integrity_scan_detects_escaped_json_tool_content_p
         "[Externalized LCM ingest payload: kind=media_payload; field=content; "
         "chars=1; bytes=1; ref=present-tool-content-media.json]"
     )
-    content = '{\\"image\\":\\"' + placeholder + '\\"}'
+    content = '{\\"image\\":\\"x ' + placeholder + '\\"}'
     engine._store._conn.execute(
         """INSERT INTO messages
            (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
@@ -2300,7 +2300,7 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
         "[Externalized LCM ingest payload: kind=media_payload; field=content; "
         "chars=1; bytes=1; ref=example-tool-content.json]"
     )
-    content = '{\\"log\\":\\"pytest output: \\\\\\\"' + placeholder + '\\\\\\\"\\"}'
+    content = '{\\"log\\":\\"pytest output: \\\\\\\"prefix before placeholder ' + placeholder + '\\\\\\\"\\"}'
     engine._store._conn.execute(
         """INSERT INTO messages
            (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1978,6 +1978,101 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
     assert detail["missing_externalized_payload_refs"] == []
 
 
+def test_externalized_payload_integrity_scan_detects_nested_tool_call_argument_json_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=missing-tool-call-media.json]"
+    )
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": json.dumps({"image": placeholder}),
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "telegram",
+            "role": "assistant",
+            "field": "tool_calls",
+            "externalized_ref": "missing-tool-call-media.json",
+        }
+    ]
+
+
+def test_externalized_payload_integrity_scan_detects_embedded_tool_content_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    content = (
+        "tool returned preview text plus "
+        "[Externalized LCM ingest payload: kind=media_payload; field=content; "
+        "chars=1; bytes=1; ref=missing-tool-content-media.json]"
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "tool",
+            content,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "telegram",
+            "role": "tool",
+            "field": "content",
+            "externalized_ref": "missing-tool-content-media.json",
+        }
+    ]
+
+
 def test_lcm_doctor_warns_on_missing_externalized_payload_refs_when_inline_payloads_are_clean(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2127,6 +2127,53 @@ def test_externalized_payload_integrity_scan_detects_free_form_tool_call_argumen
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_detects_json_tool_call_argument_placeholder_after_caption_quotes(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-caption-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-caption-tool-call-media.json]"
+    )
+    arguments = json.dumps({"image": f'caption says "front" {placeholder}'})
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_detects_parsed_object_tool_call_argument_placeholder(tmp_path):
     engine = _engine(tmp_path)
     storage_dir = tmp_path / "externalized"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2315,7 +2315,7 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_content_place
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()
     content = (
-        "tool returned preview text plus "
+        'tool returned \\\"preview\\\" plus '
         "[Externalized LCM ingest payload: kind=media_payload; field=content; "
         "chars=1; bytes=1; ref=missing-tool-content-media.json]"
     )

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2137,7 +2137,7 @@ def test_externalized_payload_integrity_scan_detects_parsed_object_tool_call_arg
             {
                 "function": {
                     "name": "analyze_image",
-                    "arguments": {"image": f"prefix {placeholder} suffix"},
+                    "arguments": {"image": f"user's screenshot {placeholder} suffix"},
                 }
             }
         ]

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2363,7 +2363,7 @@ def test_externalized_payload_integrity_scan_detects_escaped_json_tool_content_p
         "[Externalized LCM ingest payload: kind=media_payload; field=content; "
         "chars=1; bytes=1; ref=present-tool-content-media.json]"
     )
-    content = '{\\"image\\":\\"x ' + placeholder + '\\"}'
+    content = '{\\"output\\":\\"' + placeholder + '\\",\\"output\\":\\"fallback\\"}'
     engine._store._conn.execute(
         """INSERT INTO messages
            (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -336,10 +336,16 @@ def test_sensitive_patterns_cover_client_secret_duplicate_json_and_quoted_passwo
     client_secret = "oauthsupersecret1234567890"
     first_json_secret = "oldoauthclientsecret1234567890"
     second_json_secret = "newoauthclientsecret1234567890"
+    escaped_first_json_secret = "alphaescapedclientsecret1234567890"
+    escaped_second_json_secret = "betaescapedclientsecret1234567890"
     password_phrase = "correct horse battery staple"
     duplicate_key_json = (
         f'{{"client_secret":"{first_json_secret}",'
         f'"client_secret":"{second_json_secret}"}}'
+    )
+    escaped_duplicate_key_json = (
+        f'{{\\"client_secret\\":\\"{escaped_first_json_secret}\\",'
+        f'\\"client_secret\\":\\"{escaped_second_json_secret}\\"}}'
     )
 
     engine._ingest_messages([
@@ -355,7 +361,12 @@ def test_sensitive_patterns_cover_client_secret_duplicate_json_and_quoted_passwo
                     "id": "call_1",
                     "type": "function",
                     "function": {"name": "oauth", "arguments": duplicate_key_json},
-                }
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "oauth", "arguments": escaped_duplicate_key_json},
+                },
             ],
         },
     ])
@@ -364,7 +375,15 @@ def test_sensitive_patterns_cover_client_secret_duplicate_json_and_quoted_passwo
         "SELECT content, COALESCE(tool_calls, '') FROM messages ORDER BY store_id"
     ).fetchall()
     stored_text = "\n".join("\n".join(row) for row in rows)
-    for raw in (client_secret, first_json_secret, second_json_secret, password_phrase, "horse battery staple"):
+    for raw in (
+        client_secret,
+        first_json_secret,
+        second_json_secret,
+        escaped_first_json_secret,
+        escaped_second_json_secret,
+        password_phrase,
+        "horse battery staple",
+    ):
         assert raw not in stored_text
         assert engine._store.search(raw, session_id=engine.current_session_id) == []
     assert "client_secret=" in stored_text

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2030,6 +2030,53 @@ def test_externalized_payload_integrity_scan_detects_nested_tool_call_argument_j
     ]
 
 
+def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument_placeholder_with_duplicate_keys(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-tool-call-media.json]"
+    )
+    duplicate_key_arguments = '{"image":"' + placeholder + '","image":"plain text fallback"}'
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": duplicate_key_arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_tool_content_placeholder(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1950,7 +1950,7 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
     escaped_output = (
         'pytest output: \\\\"[Externalized LCM ingest payload: kind=ingest_payload; '
         'field=content; chars=1; bytes=1; '
-        'ref=20260510_103254_ingest_payload_content_71c66761c2bb_18ae2db8ba71a961.json]\\\\"'
+        'ref=example-log-ref.json]\\\\"'
     )
     engine._store._conn.execute(
         """INSERT INTO messages
@@ -2356,6 +2356,53 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
     assert detail["externalized_payload_refs_total"] == 0
     assert detail["externalized_payload_refs_missing"] == 0
     assert detail["missing_externalized_payload_refs"] == []
+
+
+def test_externalized_payload_integrity_scan_counts_real_refs_inside_tool_call_log_quotes(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "20260625-real-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=20260625-real-tool-call-media.json]"
+    )
+    arguments = json.dumps({"log": f'pytest output: "prefix before placeholder {placeholder}"'})
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "inspect_log",
+                    "arguments": arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
 
 
 def test_externalized_payload_integrity_scan_detects_embedded_tool_content_placeholder(tmp_path):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1944,6 +1944,40 @@ def test_externalized_payload_integrity_scan_detects_embedded_content_placeholde
     ]
 
 
+def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_examples_in_logs(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    escaped_output = (
+        'pytest output: \\\\"[Externalized LCM ingest payload: kind=ingest_payload; '
+        'field=content; chars=1; bytes=1; '
+        'ref=20260510_103254_ingest_payload_content_71c66761c2bb_18ae2db8ba71a961.json]\\\\"'
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "tool",
+            escaped_output,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 0
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["missing_externalized_payload_refs"] == []
+
+
 def test_lcm_doctor_warns_on_missing_externalized_payload_refs_when_inline_payloads_are_clean(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2030,6 +2030,53 @@ def test_externalized_payload_integrity_scan_detects_nested_tool_call_argument_j
     ]
 
 
+def test_externalized_payload_integrity_scan_detects_embedded_tool_call_metadata_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-tool-call-metadata-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-tool-call-metadata-media.json]"
+    )
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": "{}",
+                },
+                "metadata": f"prefix {placeholder} suffix",
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument_placeholder_with_duplicate_keys(tmp_path):
     engine = _engine(tmp_path)
     storage_dir = tmp_path / "externalized"

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2039,7 +2039,11 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument
         "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
         "chars=1; bytes=1; ref=present-tool-call-media.json]"
     )
-    duplicate_key_arguments = '{"image":"' + placeholder + '","image":"plain text fallback"}'
+    duplicate_key_arguments = (
+        '{"note":"said \\\"hi\\\"","image":"'
+        + placeholder
+        + '","image":"plain text fallback"}'
+    )
     tool_calls = json.dumps(
         [
             {

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2123,6 +2123,52 @@ def test_externalized_payload_integrity_scan_detects_free_form_tool_call_argumen
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_detects_parsed_object_tool_call_argument_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-object-tool-call-media.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-object-tool-call-media.json]"
+    )
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "analyze_image",
+                    "arguments": {"image": f"prefix {placeholder} suffix"},
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
 def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_examples_inside_tool_call_json(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()


### PR DESCRIPTION
## Summary

This PR tightens the payload integrity diagnostic so it only counts real LCM externalized payload placeholders as stored references.

The previous scan could pick up placeholder-looking text inside old logs, pytest output, or tool output and report it as missing externalized payload files. That made `/lcm doctor` look like stored payloads were missing when the database only contained diagnostic examples.

The scan now keeps the false-positive guard while still preserving real payload references in nested tool-call arguments, raw duplicate-key tool argument strings, embedded tool content, escaped JSON tool content, free-form tool-call argument strings, and parsed object tool-call arguments. It also preserves escaped and parsed quote context so quoted log examples do not become live refs after JSON unescaping, while real parsed embedded refs still count.

## Why

Payload integrity is an operator trust surface. If doctor reports missing payload files, users may start restoring or cleaning storage that is not actually broken. The scan should flag real durable placeholders, not old text that merely describes placeholder syntax.

## Validation

Validated locally with:

```text
python3 -m pytest tests/test_ingest_protection.py -q
scripts/validate_release.sh --full
```

Release validation passed in full after rebasing onto latest main:

```text
PASS: release validation full
Checklist: /tmp/hermes-lcm-release-validation-20260625-011802/validation-checklist.md
```

## Notes

This does not change the generic parser helpers used for expansion. The stricter behavior is limited to the integrity scan path.
