### PR TITLE
fix: harden doctor diagnostics paths

### DIFF
--- a/command.py
+++ b/command.py
@@ -693,7 +693,10 @@ def _scan_fts_repair(engine) -> dict[str, Any]:
     conn = engine._store._conn
     for label, spec in specs.items():
         try:
-            needs_repair = external_content_fts_needs_repair(conn, spec)
+            structural_needs_repair = external_content_fts_needs_repair(conn, spec)
+            integrity_check = check_external_content_fts_integrity(conn, spec)
+            integrity_status = str(integrity_check.get("status") or "fail")
+            needs_repair = structural_needs_repair or integrity_status == "fail"
             content_count = int(conn.execute(
                 f"SELECT COUNT(*) FROM {spec.content_table}"
             ).fetchone()[0])
@@ -706,6 +709,8 @@ def _scan_fts_repair(engine) -> dict[str, Any]:
                 "needs_repair": needs_repair,
                 "content_rows": content_count,
                 "fts_rows": fts_count,
+                "integrity_status": integrity_status,
+                "integrity_detail": integrity_check.get("detail"),
                 "error": None,
             }
         except Exception as exc:  # pragma: no cover - defensive
@@ -714,6 +719,8 @@ def _scan_fts_repair(engine) -> dict[str, Any]:
                 "needs_repair": True,
                 "content_rows": None,
                 "fts_rows": None,
+                "integrity_status": "error",
+                "integrity_detail": str(exc),
                 "error": str(exc),
             }
     return {
@@ -736,6 +743,7 @@ def _doctor_repair_text(engine) -> str:
         else:
             lines.append(f"{label}_content_rows: {item['content_rows']}")
             lines.append(f"{label}_fts_rows: {item['fts_rows']}")
+            lines.append(f"{label}_integrity_status: {item['integrity_status']}")
     lines.append("note: read-only scan only — no FTS tables were repaired")
     if scan["needs_repair"]:
         lines.append("note: use `/lcm doctor repair apply` to create a backup and repair FTS indexes")

--- a/command.py
+++ b/command.py
@@ -9,6 +9,7 @@ import sqlite3
 from typing import Any
 
 from .db_bootstrap import (
+    check_external_content_fts_integrity,
     external_content_fts_needs_repair,
     inspect_lcm_schema_health,
     repair_external_content_fts,
@@ -914,18 +915,26 @@ def _doctor_text(engine) -> str:
 
     try:
         store_fts_count = int(store_conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
-        store_fts = "ok"
+        store_fts_integrity = check_external_content_fts_integrity(store_conn, build_message_fts_spec())
+        store_fts = "ok" if store_fts_integrity["status"] == "pass" else store_fts_integrity["status"]
+        if store_fts != "ok":
+            issues.append("messages_fts")
     except Exception as exc:  # pragma: no cover - defensive
         store_fts_count = f"error: {exc}"
         store_fts = f"error: {exc}"
+        store_fts_integrity = {"status": "fail", "detail": str(exc)}
         issues.append("messages_fts")
 
     try:
         node_fts_count = int(dag_conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0])
-        node_fts = "ok"
+        node_fts_integrity = check_external_content_fts_integrity(dag_conn, build_nodes_fts_spec())
+        node_fts = "ok" if node_fts_integrity["status"] == "pass" else node_fts_integrity["status"]
+        if node_fts != "ok":
+            issues.append("nodes_fts")
     except Exception as exc:  # pragma: no cover - defensive
         node_fts_count = f"error: {exc}"
         node_fts = f"error: {exc}"
+        node_fts_integrity = {"status": "fail", "detail": str(exc)}
         issues.append("nodes_fts")
 
     total_messages = _safe_count(store_conn, "SELECT COUNT(*) FROM messages", "messages_total")

--- a/command.py
+++ b/command.py
@@ -890,6 +890,7 @@ def _doctor_text(engine) -> str:
     dag_conn = engine._dag._conn
 
     issues: list[str] = []
+    recommended_actions: list[str] = []
     schema_health = inspect_lcm_schema_health(store_conn, database_path=str(db_path))
     schema_missing_raw = schema_health.get("missing_tables")
     schema_missing_tables = [str(name) for name in schema_missing_raw] if isinstance(schema_missing_raw, list) else []
@@ -913,12 +914,18 @@ def _doctor_text(engine) -> str:
         integrity = f"error: {exc}"
         issues.append("sqlite_integrity")
 
+    def _fts_text_status(result: dict[str, Any]) -> str:
+        status = str(result.get("status") or "fail")
+        return "ok" if status == "pass" else status
+
     try:
         store_fts_count = int(store_conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
         store_fts_integrity = check_external_content_fts_integrity(store_conn, build_message_fts_spec())
-        store_fts = "ok" if store_fts_integrity["status"] == "pass" else store_fts_integrity["status"]
-        if store_fts != "ok":
+        store_fts = _fts_text_status(store_fts_integrity)
+        if store_fts == "fail":
             issues.append("messages_fts")
+        elif store_fts == "unchecked":
+            recommended_actions.append("rerun `/lcm doctor` with read-write SQLite access if a deep messages FTS check is needed")
     except Exception as exc:  # pragma: no cover - defensive
         store_fts_count = f"error: {exc}"
         store_fts = f"error: {exc}"
@@ -928,9 +935,11 @@ def _doctor_text(engine) -> str:
     try:
         node_fts_count = int(dag_conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0])
         node_fts_integrity = check_external_content_fts_integrity(dag_conn, build_nodes_fts_spec())
-        node_fts = "ok" if node_fts_integrity["status"] == "pass" else node_fts_integrity["status"]
-        if node_fts != "ok":
+        node_fts = _fts_text_status(node_fts_integrity)
+        if node_fts == "fail":
             issues.append("nodes_fts")
+        elif node_fts == "unchecked":
+            recommended_actions.append("rerun `/lcm doctor` with read-write SQLite access if a deep nodes FTS check is needed")
     except Exception as exc:  # pragma: no cover - defensive
         node_fts_count = f"error: {exc}"
         node_fts = f"error: {exc}"
@@ -1023,7 +1032,6 @@ def _doctor_text(engine) -> str:
             debt_rows = [(f"error: {exc}", "error", 0)]
 
     observations: list[str] = []
-    recommended_actions: list[str] = []
     missing_externalized_refs = int(externalized_integrity.get("externalized_payload_refs_missing", 0) or 0)
     suspicious_payload_rows = sum(
         len(payload_risks.get(key) or [])
@@ -1189,9 +1197,17 @@ def _doctor_text(engine) -> str:
     if schema_health.get("error") or schema_missing_tables:
         triage_checks.append({"check": "schema_core_tables", "status": "fail", "detail": schema_health})
     if store_fts != "ok":
-        triage_checks.append({"check": "messages_fts_integrity", "status": "fail", "detail": store_fts})
+        triage_checks.append({
+            "check": "messages_fts_integrity",
+            "status": "warn" if store_fts == "unchecked" else "fail",
+            "detail": store_fts_integrity,
+        })
     if node_fts != "ok":
-        triage_checks.append({"check": "nodes_fts_integrity", "status": "fail", "detail": node_fts})
+        triage_checks.append({
+            "check": "nodes_fts_integrity",
+            "status": "warn" if node_fts == "unchecked" else "fail",
+            "detail": node_fts_integrity,
+        })
     if clean_scan["candidates"]:
         triage_checks.append({"check": "cleanup_candidates", "status": "warn", "detail": clean_scan})
     if payload_storage_error or missing_externalized_refs or any(payload_risks.get(key) for key in (

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -12,6 +12,20 @@ DOCTOR_ACTION_INSPECT = "inspect"
 DOCTOR_ACTION_BACKUP_FIRST_CLEANUP = "backup-first cleanup"
 
 
+def _enforce_state_db_containment(path: Path, *, description: str) -> Path:
+    resolved = path.expanduser().resolve()
+    env_base = os.environ.get("LCM_HERMES_BASE_DIR")
+    if env_base:
+        allowed_base = Path(env_base).expanduser().resolve()
+        try:
+            resolved.relative_to(allowed_base)
+        except ValueError:
+            raise ValueError(
+                f"{description} resolves to {resolved} which is not within allowed base {allowed_base}"
+            )
+    return resolved
+
+
 def state_db_path_for_engine(engine: Any) -> Path:
     """Return the Hermes state database path for an LCM engine.
 
@@ -20,19 +34,15 @@ def state_db_path_for_engine(engine: Any) -> Path:
     """
     hermes_home = getattr(engine, "_hermes_home", "") or ""
     if hermes_home:
-        resolved = Path(hermes_home).expanduser().resolve() / "state.db"
-        env_base = os.environ.get("LCM_HERMES_BASE_DIR")
-        if env_base:
-            allowed_base = Path(env_base).expanduser().resolve()
-            try:
-                resolved.relative_to(allowed_base)
-            except ValueError:
-                raise ValueError(
-                    f"hermes_home {hermes_home} resolves to {resolved} which is not within allowed base {allowed_base}"
-                )
-        return resolved
+        return _enforce_state_db_containment(
+            Path(hermes_home) / "state.db",
+            description=f"hermes_home {hermes_home}",
+        )
     db_path = Path(getattr(engine._store, "db_path", Path.home() / ".hermes" / "lcm.db"))
-    return db_path.parent / "state.db"
+    return _enforce_state_db_containment(
+        db_path.parent / "state.db",
+        description=f"state database fallback from LCM database {db_path}",
+    )
 
 
 def has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -93,9 +93,15 @@ def doctor_guidance_for_check(check: dict[str, Any]) -> dict[str, Any] | None:
     elif name == "schema_core_tables":
         command = "verify HERMES_HOME/LCM_DATABASE_PATH points at the intended LCM database before repair or restore"
     elif name in {"messages_fts_integrity", "nodes_fts_integrity", "fts_index_sync"}:
-        action = DOCTOR_ACTION_BACKUP_FIRST_CLEANUP
-        command = "run `/lcm doctor repair` first; if it still recommends repair, run `/lcm backup` before `/lcm doctor repair apply`"
-        rationale = "FTS repair is rebuildable, but it still mutates SQLite indexes"
+        if status == "warn" and isinstance(detail, dict) and detail.get("status") == "unchecked":
+            action = DOCTOR_ACTION_INSPECT
+            command = "rerun `/lcm doctor` with read-write SQLite access if a deep FTS integrity result is needed"
+            warning_only = True
+            rationale = "the deep FTS check could not run, but this is not evidence that the index is corrupt"
+        else:
+            action = DOCTOR_ACTION_BACKUP_FIRST_CLEANUP
+            command = "run `/lcm doctor repair` first; if it still recommends repair, run `/lcm backup` before `/lcm doctor repair apply`"
+            rationale = "FTS repair is rebuildable, but it still mutates SQLite indexes"
     elif name == "sqlite_storage":
         command = "inspect journal/quick_check output and database/WAL size; restore from backup if SQLite reports corruption"
     elif name == "payload_storage":

--- a/engine.py
+++ b/engine.py
@@ -22,6 +22,7 @@ from agent.context_engine import ContextEngine
 
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
+from .diagnostics import _enforce_state_db_containment
 from .escalation import (
     SummaryCircuitBreaker,
     _strip_reasoning_blocks,
@@ -1500,19 +1501,15 @@ class LCMEngine(ContextEngine):
         kwargs = kwargs or {}
         hermes_home = str(kwargs.get("hermes_home") or self._hermes_home or "")
         if hermes_home:
-            # Prevent directory traversal by resolving the path
-            path = Path(hermes_home).expanduser().resolve()
-            # Check containment within allowed base only when restriction is active
-            allowed_base = self._get_allowed_hermes_base()
-            if allowed_base is not None:
-                try:
-                    path.relative_to(allowed_base)
-                except ValueError:
-                    raise ValueError(
-                        f"hermes_home {hermes_home} resolves to {path} which is not within allowed base {allowed_base}"
-                    )
-            return path / "state.db"
-        return Path(self._store.db_path).parent / "state.db"
+            return _enforce_state_db_containment(
+                Path(hermes_home) / "state.db",
+                description=f"hermes_home {hermes_home}",
+            )
+        db_path = Path(self._store.db_path)
+        return _enforce_state_db_containment(
+            db_path.parent / "state.db",
+            description=f"state database fallback from LCM database {db_path}",
+        )
 
     def _caller_is_auxiliary_agent_frame(self, caller_self: Any) -> bool:
         if caller_self is None:
@@ -2614,13 +2611,8 @@ class LCMEngine(ContextEngine):
         except Exception as exc:  # pragma: no cover - defensive
             status["source_lineage"] = {"error": str(exc)}
         try:
-            state_db_path = (
-                Path(self._hermes_home).expanduser() / "state.db"
-                if self._hermes_home
-                else Path(self._store.db_path).parent / "state.db"
-            )
             status["lifecycle_fragmentation"] = self._lifecycle.get_fragmentation_stats(
-                state_db_path=state_db_path
+                state_db_path=self._state_db_path()
             )
         except Exception as exc:  # pragma: no cover - defensive
             status["lifecycle_fragmentation"] = {"error": str(exc), "read_only": True}

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -13,8 +13,10 @@ import hermes_lcm.command as command_mod
 from hermes_lcm.command import _fmt_size, handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
+from hermes_lcm.db_bootstrap import check_external_content_fts_integrity
 from hermes_lcm.diagnostics import doctor_guidance_for_check
 from hermes_lcm.engine import LCMEngine
+from hermes_lcm.store import build_message_fts_spec
 
 
 @pytest.fixture
@@ -1028,6 +1030,31 @@ def test_lcm_doctor_clean_rejects_unknown_extra_args(engine):
     assert "/lcm doctor source" in result
     assert "/lcm doctor source apply" in result
     assert "/lcm doctor retention" in result
+
+
+def test_lcm_doctor_text_reports_same_count_stale_message_fts(engine):
+    engine._store.append(
+        "test-session",
+        {"role": "user", "content": "original searchable content"},
+        token_estimate=1,
+    )
+    engine._store._conn.execute("DROP TRIGGER msg_fts_update")
+    engine._store._conn.execute(
+        "UPDATE messages SET content = ? WHERE session_id = ?",
+        ("changed content", "test-session"),
+    )
+    engine._store._conn.commit()
+
+    fts_integrity = check_external_content_fts_integrity(engine._store._conn, build_message_fts_spec())
+    json_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    text_result = handle_lcm_command("doctor", engine)
+
+    assert fts_integrity["status"] == "fail"
+    messages_check = next(check for check in json_result["checks"] if check["check"] == "messages_fts_integrity")
+    assert messages_check["status"] == "fail"
+    assert "status: issues-found" in text_result
+    assert "messages_fts: fail" in text_result
+    assert "/lcm doctor repair" in text_result
 
 
 def test_lcm_doctor_repair_reports_fts_drift_without_mutating(tmp_path):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1057,6 +1057,25 @@ def test_lcm_doctor_text_reports_same_count_stale_message_fts(engine):
     assert "/lcm doctor repair" in text_result
 
 
+def test_lcm_doctor_text_reports_unchecked_message_fts_as_warning(engine, monkeypatch):
+    def fake_fts_integrity(_conn, spec):
+        if spec.table_name == "messages_fts":
+            return {"status": "unchecked", "detail": "attempt to write a readonly database"}
+        return {"status": "pass", "detail": "ok"}
+
+    monkeypatch.setattr(command_mod, "check_external_content_fts_integrity", fake_fts_integrity)
+
+    text_result = handle_lcm_command("doctor", engine)
+
+    assert "status: action-recommended" in text_result
+    assert "messages_fts: unchecked" in text_result
+    assert "nodes_fts: ok" in text_result
+    assert "issues: none" in text_result
+    assert "messages_fts_integrity: inspect warning-only" in text_result
+    assert "read-write SQLite access" in text_result
+    assert "/lcm doctor repair" not in text_result
+
+
 def test_lcm_doctor_repair_reports_fts_drift_without_mutating(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "lcm_repair_drift.db"))
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1076,6 +1076,29 @@ def test_lcm_doctor_text_reports_unchecked_message_fts_as_warning(engine, monkey
     assert "/lcm doctor repair" not in text_result
 
 
+def test_lcm_doctor_json_preserves_unchecked_fts_detail_for_guidance(engine, monkeypatch):
+    def fake_fts_integrity(_conn, spec):
+        if spec.table_name == "messages_fts":
+            return {"status": "unchecked", "detail": "attempt to write a readonly database"}
+        return {"status": "pass", "detail": "ok"}
+
+    monkeypatch.setattr(lcm_tools, "check_external_content_fts_integrity", fake_fts_integrity)
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    messages_check = next(check for check in doctor["checks"] if check["check"] == "messages_fts_integrity")
+    guidance = {item["check"]: item for item in doctor["guidance"]}
+
+    assert messages_check["status"] == "warn"
+    assert messages_check["detail"] == {
+        "status": "unchecked",
+        "detail": "attempt to write a readonly database",
+    }
+    assert guidance["messages_fts_integrity"]["action"] == "inspect"
+    assert guidance["messages_fts_integrity"]["warning_only"] is True
+    assert "read-write SQLite access" in guidance["messages_fts_integrity"]["operator_action"]
+    assert "/lcm doctor repair" not in guidance["messages_fts_integrity"]["operator_action"]
+
+
 def test_lcm_doctor_repair_reports_fts_drift_without_mutating(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "lcm_repair_drift.db"))
     engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
@@ -1111,6 +1134,29 @@ def test_lcm_doctor_repair_reports_fts_drift_without_mutating(tmp_path):
         ).fetchall()
     }
     assert remaining_triggers == set()
+
+
+def test_lcm_doctor_repair_reports_same_count_deep_fts_drift(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_repair_deep_drift.db"))
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    engine._session_id = "live-session"
+    engine._session_platform = "telegram"
+    engine._conversation_id = "live-session"
+    engine._store.append("live-session", {"role": "user", "content": "original searchable content"}, token_estimate=4)
+    engine._store._conn.execute("DROP TRIGGER msg_fts_update")
+    engine._store._conn.execute(
+        "UPDATE messages SET content = ? WHERE session_id = ?",
+        ("changed searchable content", "live-session"),
+    )
+    engine._store._conn.commit()
+
+    result = handle_lcm_command("doctor repair", engine)
+
+    assert "LCM doctor repair" in result
+    assert "status: repair-needed" in result
+    assert "messages_fts: repair-needed" in result
+    assert "messages_fts_integrity_status: fail" in result
+    assert "note: use `/lcm doctor repair apply`" in result
 
 
 def test_lcm_doctor_repair_dry_run_works_with_read_only_database(tmp_path):

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -505,7 +505,7 @@ def test_plugin_entrypoint_registration_is_repeatable_and_returns_lcm_engine():
     assert engine.name == "lcm"
 
 
-def test_register_gracefully_degrades_when_host_lacks_register_tool():
+def test_register_gracefully_degrades_when_legacy_host_lacks_register_tool():
     """Guard regression: register() must not raise when ctx lacks register_tool."""
     repo_root = Path(__file__).resolve().parent.parent
     module = _load_plugin_entrypoint_module("hermes_lcm_no_register_tool")

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -62,3 +62,37 @@ def test_engine_state_db_path_outside_allowed_base(monkeypatch):
         # Should raise ValueError
         with pytest.raises(ValueError, match="not within allowed base"):
             engine._state_db_path()
+
+
+def test_state_db_path_fallback_outside_allowed_base_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("LCM_HERMES_BASE_DIR", str(tmp_path / "allowed"))
+
+    from hermes_lcm.command import _state_db_path_for_engine as command_state_db_path
+    from hermes_lcm.tools import _state_db_path_for_engine as tools_state_db_path
+
+    class MockStore:
+        db_path = str(tmp_path / "outside" / "lcm.db")
+
+    class MockEngine:
+        _hermes_home = ""
+        _store = MockStore()
+
+    for state_db_path_for_engine in (command_state_db_path, tools_state_db_path):
+        with pytest.raises(ValueError, match="not within allowed base"):
+            state_db_path_for_engine(MockEngine())
+
+
+def test_engine_state_db_path_fallback_outside_allowed_base_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("LCM_HERMES_BASE_DIR", str(tmp_path / "allowed"))
+
+    from hermes_lcm.engine import LCMEngine
+
+    class MockStore:
+        db_path = str(tmp_path / "outside" / "lcm.db")
+
+    engine = LCMEngine.__new__(LCMEngine)
+    engine._hermes_home = ""
+    engine._store = MockStore()
+
+    with pytest.raises(ValueError, match="not within allowed base"):
+        engine._state_db_path()

--- a/tools.py
+++ b/tools.py
@@ -2026,7 +2026,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             checks.append({
                 "check": check_name,
                 "status": "warn" if status == "unchecked" else status,
-                "detail": fts_integrity["detail"],
+                "detail": fts_integrity if status == "unchecked" else fts_integrity["detail"],
             })
         except Exception as e:
             checks.append({


### PR DESCRIPTION
## Summary

This PR hardens the doctor diagnostics path in three places:

1. `/lcm doctor` now uses the same deep FTS integrity checks as the JSON `lcm_doctor` tool instead of treating readable FTS row counts as proof of health.
2. Unchecked FTS integrity results stay warnings, matching the JSON tool behavior, instead of becoming hard repair failures.
3. State DB path discovery now enforces `LCM_HERMES_BASE_DIR` containment on fallback paths derived from the LCM DB path, not only when `hermes_home` is set.

It also renames a duplicate packaging test function so pytest collects both tests instead of silently shadowing one.

## Why

Doctor output is a trust boundary for operators. The text command and JSON tool should not disagree on core health classes, especially when same row count FTS drift can leave search stale while still looking superficially healthy.

The repair preview also needs to see the same deep FTS failures that doctor can report, otherwise the command would tell operators to repair a problem that its own preview could not detect.

The state DB fallback is read only here, but it still derives a host file path from runtime state. If an allowed Hermes base is configured, that containment rule should apply consistently to explicit and fallback paths.

## Validation

Validated locally with focused and full checks:

```text
python3 -m pytest tests/test_lcm_command.py tests/test_path_containment.py tests/test_path_security.py tests/test_packaging_install.py -q
scripts/validate_release.sh --full
```

Release validation passed in full after rebasing onto latest main:

```text
PASS: release validation full
Checklist: /tmp/hermes-lcm-release-validation-20260624-220333/validation-checklist.md
```

## Notes

This keeps the repair apply path backup-first. The patch only makes diagnostic and preview status more truthful.
