### PR TITLE
fix: preserve raw tool call integrity refs

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1057,13 +1057,16 @@ def _is_escaped_placeholder_example(text: str, start: int) -> bool:
 
 
 def _is_quoted_placeholder_example(text: str, start: int) -> bool:
-    if not _is_inside_token_quote_span(text, start, '"'):
-        return False
-    quote = text.rfind('"', 0, start)
-    if quote < 0:
-        return False
-    context = text[max(0, quote - 80):quote]
-    return _looks_like_example_quote_context(context)
+    for quote_token in ('"', "'"):
+        if not _is_inside_token_quote_span(text, start, quote_token):
+            continue
+        quote = text.rfind(quote_token, 0, start)
+        if quote < 0:
+            continue
+        context = text[max(0, quote - 80):quote]
+        if _looks_like_example_quote_context(context):
+            return True
+    return False
 
 
 def _looks_like_json_container_string(text: str) -> bool:
@@ -1113,13 +1116,13 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
     if is_externalized_ingest_placeholder(stripped) or is_externalized_placeholder(stripped):
         return extract_all_externalized_payload_refs(stripped)
     if field == "tool_calls":
-        refs: list[str] = []
+        refs = _extract_unescaped_externalized_payload_refs(value, ignore_quoted_spans=True)
         parsed = _maybe_parse_json_string(value)
         if parsed is None:
             return refs
         for argument in _walk_tool_call_argument_values(parsed):
             if isinstance(argument, str):
-                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(argument))
+                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(argument, ignore_quoted_spans=True))
                 parsed_argument = _maybe_parse_json_string(argument)
                 if parsed_argument is not None:
                     for nested in _walk_string_values(parsed_argument):

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2096,6 +2096,90 @@ def test_externalized_payload_integrity_scan_detects_embedded_tool_call_metadata
     assert detail["externalized_payload_files_unreferenced"] == 0
 
 
+def test_externalized_payload_integrity_scan_counts_duplicate_provider_custom_field_placeholder(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    (storage_dir / "present-provider-custom.json").write_text(json.dumps({"content": "payload"}))
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=present-provider-custom.json]"
+    )
+    tool_calls = (
+        '[{"metadata":"'
+        + placeholder
+        + '","metadata":"fallback","function":{"arguments":"{}"}}]'
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["externalized_payload_files_unreferenced"] == 0
+
+
+def test_externalized_payload_integrity_scan_reports_missing_ref_in_malformed_tool_calls(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=missing-malformed-tool-calls.json]"
+    )
+    tool_calls = '[{"function":{"arguments":"{}"},"metadata":"' + placeholder + '"'
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "telegram",
+            "role": "assistant",
+            "field": "tool_calls",
+            "externalized_ref": "missing-malformed-tool-calls.json",
+        }
+    ]
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_tool_call_argument_placeholder_with_duplicate_keys(tmp_path):
     engine = _engine(tmp_path)
     storage_dir = tmp_path / "externalized"
@@ -2341,6 +2425,50 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
         "chars=1; bytes=1; ref=example-missing.json]"
     )
     arguments = json.dumps({"log": f'pytest output: "prefix before placeholder {placeholder}"'})
+    tool_calls = json.dumps(
+        [
+            {
+                "function": {
+                    "name": "inspect_log",
+                    "arguments": arguments,
+                }
+            }
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "telegram",
+            "assistant",
+            "calling tool",
+            None,
+            tool_calls,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(engine._store._conn, engine._config, hermes_home=engine._hermes_home)
+
+    assert detail["externalized_payload_refs_total"] == 0
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["missing_externalized_payload_refs"] == []
+
+
+def test_externalized_payload_integrity_scan_ignores_single_quoted_placeholder_examples_inside_tool_call_json(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized LCM ingest payload: kind=media_payload; field=tool_calls; "
+        "chars=1; bytes=1; ref=example-single-quote.json]"
+    )
+    arguments = json.dumps({"log": f"pytest output: 'prefix before placeholder {placeholder}'"})
     tool_calls = json.dumps(
         [
             {


### PR DESCRIPTION
## Why

The payload integrity scanner currently trusts parsed `tool_calls` too much. That misses real externalized payload refs when old/backfilled rows contain malformed JSON, or when provider-specific fields use duplicate JSON keys that Python's normal `json.loads` collapses.

That breaks the storage-boundary accounting in both directions:

- missing payload files can be missed entirely
- existing payload files can be reported as unreferenced even though a raw tool-call field still references them
- single-quoted pytest/log examples can still be counted as live missing refs

## What changed

- Scan raw `tool_calls` text with the same quote/example suppression before walking parsed JSON.
- Use quote suppression for raw `function.arguments` scans too, including single-quoted example snippets.
- Keep exact generated-looking refs counted even inside log/pytest text; only example-like refs in labeled example contexts are suppressed.
- Add regressions for:
  - single-quoted example placeholders
  - duplicate provider custom fields
  - malformed `tool_calls` with missing refs

## Validation

- `python3 -m pytest tests/test_ingest_protection.py -q`
- `scripts/validate_release.sh --full`

Full validation checklist: `/tmp/hermes-lcm-release-validation-20260625-014349/validation-checklist.md`
