### PR TITLE
fix: make context engine deepcopy clone-safe

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -485,6 +485,20 @@ class LCMEngine(ContextEngine):
             hermes_home=self._hermes_home,
         )
 
+    def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
+        """Copy the plugin runtime without pickling SQLite-backed helpers.
+
+        Hermes core may deepcopy plugin context engines while creating isolated
+        AIAgent instances. A default object deepcopy walks into MessageStore,
+        SummaryDAG, and LifecycleStateStore sqlite3.Connection handles, which
+        cannot be pickled. LCM already exposes clone_for_agent() as the safe
+        boundary: share durable configuration/database path, but allocate fresh
+        per-agent runtime/storage helper objects.
+        """
+        clone = self.clone_for_agent()
+        memo[id(self)] = clone
+        return clone
+
     def _resolve_db_path(self, hermes_home: str = "") -> Path:
         """Resolve the SQLite path for the active Hermes profile/home."""
         if self._config.database_path:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1,5 +1,6 @@
 """Tests for LCM core components: store, DAG, tokens, config, escalation."""
 
+import copy
 import json
 import re
 import sqlite3
@@ -4745,3 +4746,24 @@ class TestLCMEngineCloning:
             lifecycle.close()
             for engine in (prototype, first_agent, second_agent):
                 engine.shutdown()
+
+    def test_deepcopy_uses_clone_for_agent_without_copying_sqlite_handles(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-deepcopy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            clone = copy.deepcopy(prototype)
+
+            assert clone is not prototype
+            assert isinstance(clone, LCMEngine)
+            assert clone._store is not prototype._store
+            assert clone._dag is not prototype._dag
+            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._config.database_path == prototype._config.database_path
+            assert clone._hermes_home == prototype._hermes_home
+        finally:
+            prototype.shutdown()
+            if clone is not None:
+                clone.shutdown()


### PR DESCRIPTION
## Summary

Hermes Agent v0.17.0 can isolate plugin context engines by calling `copy.deepcopy()` during agent initialization. `LCMEngine` owns SQLite-backed helpers, so the default deepcopy path walks into `sqlite3.Connection` objects and raises `TypeError: cannot pickle 'sqlite3.Connection' object`.

This adds `LCMEngine.__deepcopy__()` and routes it through the existing `clone_for_agent()` boundary. The copied engine keeps the same durable config and database path, but gets fresh runtime storage helpers instead of trying to pickle live SQLite handles.

## Why

LCM already has the right per-agent cloning contract. Without exposing that through Python's deepcopy protocol, compatible Hermes hosts can still fall back to the built-in compressor during agent init even though LCM registered successfully.

Keeping the fix in LCM means hosts that use either `clone_for_agent()` directly or generic `copy.deepcopy()` isolation get the same safe runtime shape.

## Validation

`python3 -m pytest tests/test_lcm_core.py::TestLCMEngineCloning -q`

`python3 -m pytest tests/test_lcm_core.py -q`

`scripts/validate_release.sh --full`

Full validation passed at `/tmp/hermes-lcm-release-validation-20260625-052035/validation-checklist.md`.
