### PR TITLE
docs: add community health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our pledge
+
+We want `hermes-lcm` to be a focused, useful, and respectful technical project.
+Contributors, maintainers, and users are expected to keep discussion constructive,
+specific, and safe for people with different backgrounds and experience levels.
+
+## Expected behavior
+
+- Be respectful and direct.
+- Critique ideas, code, tests, and tradeoffs; do not attack people.
+- Assume good intent, but accept corrections when impact differs from intent.
+- Keep reports actionable: include context, evidence, and reproduction details when relevant.
+- Respect boundaries around private information, credentials, logs, and user data.
+
+## Unacceptable behavior
+
+- Harassment, threats, stalking, or intimidation.
+- Personal attacks, insults, slurs, or demeaning language.
+- Publishing private information without explicit permission.
+- Sexualized language or imagery in project spaces.
+- Repeated off-topic disruption after maintainers ask for focus.
+- Attempts to pressure maintainers into unsafe releases, disclosure, or access changes.
+
+## Scope
+
+This code applies in project spaces, including GitHub issues, pull requests,
+discussions, reviews, and any other public or maintainer-run project channel.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments; lock threads; reject issues or pull
+requests; block participants; or take other proportionate action to protect the
+project and its contributors.
+
+If you need to report conduct concerns, contact the maintainer through GitHub.
+Do not include secrets, private logs, or sensitive personal information in a public
+issue. If the concern is security-sensitive, follow the security policy instead.
+
+## Attribution
+
+This policy is adapted from common open source community conduct guidelines and is
+kept intentionally short for a small maintainer-led project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Schoettler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ for changelogs.
 
 ## License
 
-MIT
+[MIT](LICENSE)
 
 ## Star history
 

--- a/README.md
+++ b/README.md
@@ -648,6 +648,8 @@ exposes retrieval tools that can drill back into exact stored sources.
 - [Standard compression diagram](docs/standard_compression.png)
 - [LCM compression diagram](docs/lcm_compression.png)
 - [Contributing guide](CONTRIBUTING.md)
+- [Code of conduct](CODE_OF_CONDUCT.md)
+- [Security policy](SECURITY.md)
 - [Releases](https://github.com/stephenschoettler/hermes-lcm/releases)
 
 ## Development
@@ -683,6 +685,8 @@ Issues and PRs welcome. Bug fixes and correctness improvements are highest
 priority. New features should be scoped, backwards-compatible, and tested.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, validation, and PR guidance.
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for project conduct expectations
+and [SECURITY.md](SECURITY.md) for vulnerability reporting.
 See the [releases page](https://github.com/stephenschoettler/hermes-lcm/releases)
 for changelogs.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the current `main` branch and the latest GitHub release.
+Older releases may receive guidance or a patch release when the issue is severe and
+a safe backport is practical.
+
+## Reporting a vulnerability
+
+Please do not publish exploitable details in a public issue first.
+
+Preferred reporting path:
+
+1. Use GitHub's private vulnerability reporting / Security Advisory flow for this
+   repository when available.
+2. If private reporting is not available, open a minimal public issue that says you
+   have a security report and asks the maintainer for a private contact path. Do
+   not include secrets, tokens, database dumps, private transcripts, or exploit
+   details in that public issue.
+
+Useful report details:
+
+- affected version or commit
+- operating system and Python version
+- configuration relevant to the issue
+- minimal reproduction steps or proof of concept
+- expected impact
+- whether sensitive data, credentials, transcripts, or externalized payloads are involved
+
+## What to avoid sending publicly
+
+- API keys, bearer tokens, OAuth tokens, passwords, private keys, cookies, or session IDs
+- private conversation transcripts or user data
+- full `lcm.db` files unless explicitly requested through a private channel
+- exploit steps that would let others reproduce harm before a fix exists
+
+## Response expectations
+
+The maintainer will triage reports as time permits. Confirmed vulnerabilities will
+be fixed in the smallest safe change, with tests when practical. Release notes will
+credit reporters when they want credit and when doing so does not increase risk.


### PR DESCRIPTION
## Summary
- add an explicit MIT `LICENSE` file
- add root community health docs: `CODE_OF_CONDUCT.md` and `SECURITY.md`
- link README docs/contributing sections to the license, conduct, and security files

## Why
- issue #270 correctly noted that the README says MIT but the repository did not include a license file
- the GitHub community checklist also showed missing code-of-conduct and security-policy files
- clearer community/legal/security surfaces make reuse and standalone/MCP proposals safer to evaluate

## Validation
- [x] Focused validation: ad-hoc `/tmp/hermes-verify-*` script -> passed
- [x] `git diff --check HEAD^..HEAD`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-<topic>`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- Docs/community-health-only change; no runtime code or workflow files changed.

Refs #270
