### PR TITLE
fix: preserve context metadata in LCM engine clones

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -478,13 +478,39 @@ class LCMEngine(ContextEngine):
         rebind another conversation's raw-message ingest and lifecycle state.
 
         The clone shares the same durable SQLite database path/configuration,
-        but gets independent session/cursor/lifecycle runtime state. Hermes core
-        calls update_model() on the returned engine before on_session_start().
+        but gets independent session/cursor/lifecycle runtime state. Runtime
+        model and context-window metadata is copied so the clone is immediately
+        budget-aware even before a compatible Hermes host calls update_model().
         """
-        return type(self)(
+        clone = type(self)(
             config=copy.deepcopy(self._config),
             hermes_home=self._hermes_home,
         )
+        clone.model = self.model
+        clone.base_url = self.base_url
+        clone.api_key = self.api_key
+        clone.provider = self.provider
+        clone.api_mode = self.api_mode
+        if self._context_length_source:
+            clone._set_context_length(
+                self.raw_context_length,
+                source=self._context_length_source,
+                model=self.model,
+                provider=self.provider,
+            )
+        elif self.raw_context_length or self.context_length:
+            clone._set_context_length(
+                self.raw_context_length or self.context_length,
+                source="clone_for_agent",
+                model=self.model,
+                provider=self.provider,
+            )
+        # ``update_model()`` authority is a per-runtime lifecycle edge, not
+        # durable metadata.  Compatible hosts call update_model() on the clone
+        # before binding it; hosts that bind only through on_session_start()
+        # must still be able to replace the copied prototype route.
+        clone._update_model_pending_session_start = False
+        return clone
 
     def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
         """Copy the plugin runtime without pickling SQLite-backed helpers.
@@ -2028,9 +2054,21 @@ class LCMEngine(ContextEngine):
             return
         if "model" in kwargs:
             self.model = str(kwargs.get("model") or "")
+        route_affects_context = "model" in kwargs or "provider" in kwargs
         for key in ("base_url", "api_key", "provider", "api_mode"):
             if key in kwargs:
                 setattr(self, key, str(kwargs.get(key) or ""))
+        if (
+            "context_length" not in kwargs
+            and route_affects_context
+            and (self.raw_context_length or self.context_length)
+        ):
+            self._set_context_length(
+                self.raw_context_length or self.context_length,
+                source=self._context_length_source or "session_start",
+                model=self.model,
+                provider=self.provider,
+            )
         self._update_model_pending_session_start = False
 
     def _continue_compression_boundary(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4779,3 +4779,275 @@ class TestLCMEngineCloning:
             prototype.shutdown()
             if clone is not None:
                 clone.shutdown()
+
+    def test_deepcopy_matches_hermes_host_copy_contract_without_fallback(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        def host_selects_context_engine(candidate):
+            try:
+                return copy.deepcopy(candidate)
+            except Exception:
+                return "built-in-compressor-fallback"
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-host-copy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            prototype.update_model(
+                model="gpt-5.5",
+                context_length=400_000,
+                provider="openai-codex",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="responses",
+            )
+            prototype.on_session_start(
+                "parent-session",
+                platform="telegram",
+                conversation_id="agent:main:telegram:dm:1",
+            )
+
+            clone = host_selects_context_engine(prototype)
+
+            assert clone != "built-in-compressor-fallback"
+            assert isinstance(clone, LCMEngine)
+            assert clone.name == "lcm"
+            assert clone is not prototype
+            assert clone._store is not prototype._store
+            assert clone._dag is not prototype._dag
+            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._session_id == ""
+            assert clone._conversation_id == ""
+            assert clone.model == prototype.model
+            assert clone.provider == prototype.provider
+            assert clone.base_url == prototype.base_url
+            assert clone.api_key == prototype.api_key
+            assert clone.api_mode == prototype.api_mode
+            assert clone.raw_context_length == prototype.raw_context_length
+            assert clone.context_length == prototype.context_length
+            assert clone.effective_context_length_cap == prototype.effective_context_length_cap
+            assert clone.effective_context_length_reason == prototype.effective_context_length_reason
+            assert clone._context_length_source == prototype._context_length_source
+            assert clone._context_threshold_source == prototype._context_threshold_source
+            assert clone._context_threshold_autoraised == prototype._context_threshold_autoraised
+            assert clone.threshold_percent == prototype.threshold_percent
+            assert clone.threshold_tokens == prototype.threshold_tokens
+        finally:
+            prototype.shutdown()
+            shutdown = getattr(clone, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+
+    def test_deepcopy_before_session_start_copies_budget_without_pending_authority(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-pre-session-copy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            prototype.update_model(
+                model="gpt-5.5",
+                context_length=400_000,
+                provider="openai-codex",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="responses",
+            )
+
+            clone = copy.deepcopy(prototype)
+
+            assert clone._session_id == ""
+            assert clone._conversation_id == ""
+            assert clone._update_model_pending_session_start is False
+            assert clone.model == "gpt-5.5"
+            assert clone.provider == "openai-codex"
+            assert clone.api_key == "test-secret"
+            assert clone.raw_context_length == 400_000
+            assert clone.context_length == 272_000
+            assert clone.effective_context_length_cap == 272_000
+            assert clone.effective_context_length_reason == "codex_oauth_context_cap"
+            assert clone.context_threshold == 0.85
+            assert clone.threshold_tokens == int(272_000 * 0.85)
+
+            clone.on_session_start(
+                "child-session",
+                platform="telegram",
+                conversation_id="agent:main:telegram:dm:2",
+                model="other-model",
+                provider="custom",
+                base_url="https://other.example.invalid/v1",
+                api_key="other-secret",
+                api_mode="chat",
+                context_length=128_000,
+            )
+
+            assert clone._session_id == "child-session"
+            assert clone._conversation_id == "agent:main:telegram:dm:2"
+            assert clone._update_model_pending_session_start is False
+            assert clone.model == "other-model"
+            assert clone.provider == "custom"
+            assert clone.base_url == "https://other.example.invalid/v1"
+            assert clone.api_key == "other-secret"
+            assert clone.api_mode == "chat"
+            assert clone.raw_context_length == 128_000
+            assert clone.context_length == 128_000
+            assert clone.effective_context_length_cap is None
+            assert clone.effective_context_length_reason == ""
+            assert clone._context_length_source == "session_start"
+            assert clone.threshold_tokens == int(128_000 * clone.context_threshold)
+        finally:
+            prototype.shutdown()
+            shutdown = getattr(clone, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+
+    def test_deepcopy_recomputes_copied_window_when_session_route_changes(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-route-recompute-copy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            prototype.update_model(
+                model="large-custom-model",
+                context_length=1_000_000,
+                provider="custom",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="chat",
+            )
+
+            clone = copy.deepcopy(prototype)
+            assert clone._update_model_pending_session_start is False
+            assert clone.raw_context_length == 1_000_000
+            assert clone.context_length == 1_000_000
+            assert clone.effective_context_length_cap is None
+
+            clone.on_session_start(
+                "codex-session",
+                platform="telegram",
+                conversation_id="agent:main:telegram:dm:4",
+                model="gpt-5.5",
+                provider="openai-codex",
+                base_url="https://codex.example.invalid/v1",
+                api_key="codex-secret",
+                api_mode="responses",
+            )
+
+            assert clone._session_id == "codex-session"
+            assert clone._conversation_id == "agent:main:telegram:dm:4"
+            assert clone.model == "gpt-5.5"
+            assert clone.provider == "openai-codex"
+            assert clone.raw_context_length == 1_000_000
+            assert clone.context_length == 272_000
+            assert clone.effective_context_length_cap == 272_000
+            assert clone.effective_context_length_reason == "codex_oauth_context_cap"
+            assert clone.context_threshold == 0.85
+            assert clone.threshold_tokens == int(272_000 * 0.85)
+        finally:
+            prototype.shutdown()
+            shutdown = getattr(clone, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+
+    def test_deepcopy_recomputes_copied_cap_away_when_session_route_changes(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-route-uncap-copy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            prototype.update_model(
+                model="gpt-5.5",
+                context_length=400_000,
+                provider="openai-codex",
+                base_url="https://codex.example.invalid/v1",
+                api_key="codex-secret",
+                api_mode="responses",
+            )
+
+            clone = copy.deepcopy(prototype)
+            assert clone._update_model_pending_session_start is False
+            assert clone.raw_context_length == 400_000
+            assert clone.context_length == 272_000
+            assert clone.effective_context_length_cap == 272_000
+            assert clone.context_threshold == 0.85
+
+            clone.on_session_start(
+                "custom-session",
+                platform="telegram",
+                conversation_id="agent:main:telegram:dm:5",
+                model="large-custom-model",
+                provider="custom",
+                base_url="https://custom.example.invalid/v1",
+                api_key="custom-secret",
+                api_mode="chat",
+            )
+
+            assert clone._session_id == "custom-session"
+            assert clone._conversation_id == "agent:main:telegram:dm:5"
+            assert clone.model == "large-custom-model"
+            assert clone.provider == "custom"
+            assert clone.raw_context_length == 400_000
+            assert clone.context_length == 400_000
+            assert clone.effective_context_length_cap is None
+            assert clone.effective_context_length_reason == ""
+            assert clone.context_threshold == clone._config.context_threshold
+            assert clone.threshold_tokens == int(400_000 * clone._config.context_threshold)
+        finally:
+            prototype.shutdown()
+            shutdown = getattr(clone, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+
+    def test_deepcopy_preserves_zero_context_metadata_without_pending_authority(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-zero-context-copy.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        try:
+            prototype.update_model(
+                model="unknown-model",
+                context_length=0,
+                provider="custom",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="chat",
+            )
+
+            clone = copy.deepcopy(prototype)
+
+            assert clone._update_model_pending_session_start is False
+            assert clone._context_length_source == "update_model"
+            assert clone.raw_context_length == 0
+            assert clone.context_length == 0
+            assert clone.threshold_tokens == 0
+
+            clone.on_session_start(
+                "zero-window-session",
+                platform="telegram",
+                conversation_id="agent:main:telegram:dm:3",
+                model="resolved-model",
+                provider="custom",
+                base_url="https://resolved.example.invalid/v1",
+                api_key="resolved-secret",
+                api_mode="chat",
+                context_length=400_000,
+            )
+
+            assert clone._session_id == "zero-window-session"
+            assert clone._conversation_id == "agent:main:telegram:dm:3"
+            assert clone._update_model_pending_session_start is False
+            assert clone.model == "resolved-model"
+            assert clone.base_url == "https://resolved.example.invalid/v1"
+            assert clone.api_key == "resolved-secret"
+            assert clone.raw_context_length == 400_000
+            assert clone.context_length == 400_000
+            assert clone._context_length_source == "session_start"
+            assert clone.threshold_tokens == int(400_000 * clone.context_threshold)
+        finally:
+            prototype.shutdown()
+            shutdown = getattr(clone, "shutdown", None)
+            if callable(shutdown):
+                shutdown()


### PR DESCRIPTION
## Summary
- Preserves model route and context-window metadata when `LCMEngine.clone_for_agent()` creates an isolated engine clone.
- Adds host-contract regressions that mimic Hermes Agent selecting a plugin context engine with `copy.deepcopy()` and verify it stays on LCM instead of falling back.
- Covers copy-after-session-start, copy-between-`update_model()`-and-session-start, zero-context-window metadata, pending-authority reset, and route changes that need copied raw windows recapped or uncapped.

## Why
Hermes Agent isolates plugin context engines by copying the registered engine before binding it to a new agent. PR #285 made that safe for SQLite-backed LCM helpers, but the clone only carried storage configuration and relied on the host to call `update_model()` immediately afterward. This makes the copy boundary more complete: cloned engines still get fresh SQLite helpers and fresh session state, while also retaining the model/provider/context budget metadata needed to behave correctly before or after host rebinding.

The pending `update_model()` flag is intentionally reset on clones because that flag is a per-runtime lifecycle edge, not durable route metadata. Compatible hosts call `update_model()` on the clone before session binding; hosts that bind through `on_session_start()` metadata must still be able to replace a copied prototype route. When that session metadata changes model/provider without a new `context_length`, LCM now recomputes the copied raw window under the new route so provider caps are applied or removed correctly.

## Validation
- [x] `python3 -m pytest tests/test_lcm_core.py::TestLCMEngineCloning -q` -> `7 passed`
- [x] `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `682 passed, 3 warnings`
- [x] `python3 -m pytest -q` -> `1046 passed, 3 warnings`
- [x] Temp `HERMES_HOME` host-style smoke with Hermes Agent plugin discovery and `AIAgent(...)` init -> selected `hermes_plugins.hermes_lcm.engine.LCMEngine`, engine name `lcm`, no built-in compressor fallback
- [x] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-deepcopy-host-contract-v6` -> `PASS: release validation full`
- [x] Read-only local Codex audit on the updated diff -> `NO BLOCKERS`
- [x] `git diff --check origin/main...HEAD && git diff --check`

## Notes
This intentionally does not share session binding, ingest cursor, lifecycle runtime state, SQLite helper instances, or pending `update_model()` authority across clones. It only carries the budget/model metadata that is safe and useful for copied engine runtimes.

Refs #285
