### PR TITLE
fix: keep retained lifecycle drift from warning doctor

### DIFF
--- a/command.py
+++ b/command.py
@@ -1142,6 +1142,7 @@ def _doctor_text(engine) -> str:
         observations.append(
             "lifecycle_fragmentation: "
             f"lifecycle_rows={lifecycle_stats['lifecycle_rows']} "
+            f"empty_lifecycle_rows={lifecycle_stats.get('empty_lifecycle_rows', 0)} "
             f"message_sessions={lifecycle_stats['distinct_message_sessions']} "
             f"node_sessions={lifecycle_stats['distinct_node_sessions']} "
             f"current_missing_in_lcm_any={lifecycle_stats['lifecycle_current_missing_in_lcm_any']} "

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -46,27 +46,17 @@ def state_db_path_for_engine(engine: Any) -> Path:
 
 
 def has_lifecycle_fragmentation(stats: dict[str, Any]) -> bool:
-    """Return whether lifecycle diagnostics should be treated as warning evidence."""
-    direct_mismatch_keys = (
-        "lifecycle_current_missing_in_lcm_any",
-        "lifecycle_last_finalized_missing_in_lcm_any",
-        "lifecycle_current_missing_in_state",
-        "lifecycle_last_finalized_missing_in_state",
-        "lcm_message_sessions_missing_in_state",
-        "lcm_node_sessions_missing_in_state",
-    )
-    lifecycle_rows = int(stats.get("lifecycle_rows", 0) or 0)
-    missing_lifecycle_reference_keys = (
-        "message_sessions_without_lifecycle_reference",
-        "node_sessions_without_lifecycle_reference",
-    )
-    return (
-        any(int(stats.get(key, 0) or 0) > 0 for key in direct_mismatch_keys)
-        or (
-            lifecycle_rows > 0
-            and any(int(stats.get(key, 0) or 0) > 0 for key in missing_lifecycle_reference_keys)
-        )
-        or (bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error")))
+    """Return whether lifecycle diagnostics should be treated as warning evidence.
+
+    Retained-history drift is intentionally read-only diagnostic context. Keep the
+    doctor warning for concrete operator action (empty lifecycle rows that the
+    explicit backup-first cleanup path can prune) or diagnostic unreadability, but
+    do not make overall health unhealthy solely because historical LCM/state
+    indexes no longer agree.
+    """
+    empty_lifecycle_rows = int(stats.get("empty_lifecycle_rows", 0) or 0)
+    return empty_lifecycle_rows > 0 or (
+        bool(stats.get("state_db_checked")) and bool(stats.get("state_db_error"))
     )
 
 

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -342,6 +342,7 @@ class LifecycleStateStore:
         Hermes host state. Repair/cleanup flows must stay explicit and separate.
         """
         conn = self._conn
+        assert conn is not None
 
         def _count(query: str, params: tuple[Any, ...] = ()) -> int:
             row = conn.execute(query, params).fetchone()
@@ -367,9 +368,25 @@ class LifecycleStateStore:
         )
         lifecycle_referenced_sessions = lifecycle_current_sessions | lifecycle_last_finalized_sessions
 
+        empty_lifecycle_rows = 0
+        for row in conn.execute(
+            """
+            SELECT current_session_id, last_finalized_session_id
+            FROM lcm_lifecycle_state
+            """
+        ).fetchall():
+            refs = {
+                str(value)
+                for value in (row["current_session_id"], row["last_finalized_session_id"])
+                if value
+            }
+            if not refs or refs.isdisjoint(lcm_any_sessions):
+                empty_lifecycle_rows += 1
+
         stats: dict[str, Any] = {
             "read_only": True,
             "lifecycle_rows": _count("SELECT COUNT(*) FROM lcm_lifecycle_state"),
+            "empty_lifecycle_rows": empty_lifecycle_rows,
             "messages_total": _count("SELECT COUNT(*) FROM messages"),
             "summary_nodes_total": _count("SELECT COUNT(*) FROM summary_nodes"),
             "distinct_message_sessions": len(message_sessions),

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -947,6 +947,7 @@ def test_lcm_doctor_reports_lifecycle_fragmentation_as_read_only_observation(eng
     assert "status: action-recommended" in result
     assert "lifecycle_fragmentation:" in result
     assert "lifecycle_rows=2" in result
+    assert "empty_lifecycle_rows=1" in result
     assert "current_missing_in_lcm_any=1" in result
     assert "current_missing_in_state=1" in result
     assert "node_sessions_missing_in_state=1" in result
@@ -961,7 +962,7 @@ def test_lcm_doctor_reports_lifecycle_fragmentation_as_read_only_observation(eng
     assert engine._lifecycle.row_count() == 2
 
 
-def test_lcm_doctor_warns_on_lcm_sessions_without_lifecycle_references(engine):
+def test_lcm_doctor_reports_lcm_sessions_without_lifecycle_references_as_observations(engine):
     engine.on_session_start("current-session", platform="cli", context_length=200000)
     engine._store.append("current-session", {"role": "user", "content": "covered"}, source="cli")
     engine._store.append("message-only-session", {"role": "user", "content": "missing lifecycle"}, source="cli")
@@ -978,11 +979,14 @@ def test_lcm_doctor_warns_on_lcm_sessions_without_lifecycle_references(engine):
 
     result = handle_lcm_command("doctor", engine)
 
-    assert "status: action-recommended" in result
+    assert "status: ok" in result
+    assert "lifecycle_fragmentation: lifecycle_rows=1" in result
+    assert "empty_lifecycle_rows=0" in result
     assert "message_sessions_without_lifecycle_current=1" in result
     assert "message_sessions_without_lifecycle_reference=1" in result
     assert "node_sessions_without_lifecycle_reference=1" in result
-    assert "inspect lifecycle fragmentation before any cleanup/repair behavior mutates state" in result
+    assert "lifecycle_fragmentation_classification: notice; 2 categories need review" in result
+    assert "triage_guidance:\n- none" in result
 
 
 def test_lcm_doctor_does_not_warn_on_last_finalized_message_session(engine):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -14637,12 +14637,78 @@ class TestEngineTools:
         lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
         assert lifecycle_check["status"] == "warn"
         assert lifecycle_check["detail"]["lifecycle_rows"] == 2
+        assert lifecycle_check["detail"]["empty_lifecycle_rows"] == 1
         assert lifecycle_check["detail"]["lifecycle_current_missing_in_lcm_any"] == 1
         assert lifecycle_check["detail"]["lifecycle_current_missing_in_state"] == 1
         assert lifecycle_check["detail"]["lcm_node_sessions_missing_in_state"] == 1
         assert lifecycle_check["detail"]["state_sessions_missing_in_lcm_any"] == 1
         assert lifecycle_check["detail"]["read_only"] is True
         assert engine._lifecycle.row_count() == 2
+
+    def test_handle_doctor_keeps_retained_history_lifecycle_drift_healthy(self, engine, tmp_path):
+        engine._hermes_home = str(tmp_path / "hermes_home")
+        state_db = tmp_path / "hermes_home" / "state.db"
+        state_db.parent.mkdir(parents=True, exist_ok=True)
+        state_conn = sqlite3.connect(state_db)
+        state_conn.executescript(
+            """
+            CREATE TABLE sessions (id TEXT PRIMARY KEY);
+            INSERT INTO sessions(id) VALUES ('state-only');
+            """
+        )
+        state_conn.commit()
+        state_conn.close()
+        engine._store.append("live-current", {"role": "user", "content": "covered"}, source="cli")
+        engine._store.append("live-finalized", {"role": "user", "content": "covered finalized"}, source="cli")
+        engine._store.append("message-history", {"role": "user", "content": "retained"}, source="cli")
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="node-history",
+                depth=0,
+                summary="retained summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[],
+                source_type="messages",
+                created_at=1.0,
+            )
+        )
+        engine._lifecycle._conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-retained", "live-current", "stale-finalized", 0, 0, 1.0),
+        )
+        engine._lifecycle._conn.execute(
+            """INSERT INTO lcm_lifecycle_state
+               (conversation_id, current_session_id, last_finalized_session_id, current_frontier_store_id, last_finalized_frontier_store_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("conv-retained-current", "stale-current", "live-finalized", 0, 0, 1.0),
+        )
+        engine._lifecycle._conn.commit()
+
+        result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert result["overall"] == "healthy"
+        lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
+        assert lifecycle_check["status"] == "pass"
+        detail = lifecycle_check["detail"]
+        assert detail["empty_lifecycle_rows"] == 0
+        assert detail["lifecycle_current_missing_in_lcm_any"] == 1
+        assert detail["lifecycle_last_finalized_missing_in_lcm_any"] == 1
+        assert detail["lcm_message_sessions_missing_in_state"] == 3
+        assert detail["lcm_node_sessions_missing_in_state"] == 1
+        assert detail["state_sessions_missing_in_lcm_any"] == 1
+        assert detail["classification"]["status"] == "warn"
+        assert any(
+            item["name"] == "stale_lifecycle_current" and item["severity"] == "warn"
+            for item in detail["classification"]["categories"]
+        )
+        assert any(
+            item["name"] == "stale_lifecycle_finalized" and item["severity"] == "warn"
+            for item in detail["classification"]["categories"]
+        )
+        assert not result["guidance"]
 
     def test_handle_doctor_warns_when_existing_state_db_is_unreadable(self, engine, tmp_path):
         engine._hermes_home = str(tmp_path / "hermes_home")
@@ -14666,11 +14732,12 @@ class TestEngineTools:
 
         result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
-        assert result["overall"] == "warnings"
+        assert result["overall"] == "healthy"
         lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
-        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["status"] == "pass"
         assert lifecycle_check["detail"]["message_sessions_without_lifecycle_current"] == 1
         assert lifecycle_check["detail"]["message_sessions_without_lifecycle_reference"] == 1
+        assert lifecycle_check["detail"]["empty_lifecycle_rows"] == 0
         assert lifecycle_check["detail"]["read_only"] is True
 
     def test_handle_doctor_does_not_warn_on_last_finalized_message_session(self, engine):
@@ -14715,10 +14782,11 @@ class TestEngineTools:
 
         result = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
-        assert result["overall"] == "warnings"
+        assert result["overall"] == "healthy"
         lifecycle_check = next(c for c in result["checks"] if c["check"] == "lifecycle_fragmentation")
-        assert lifecycle_check["status"] == "warn"
+        assert lifecycle_check["status"] == "pass"
         assert lifecycle_check["detail"]["node_sessions_without_lifecycle_reference"] == 1
+        assert lifecycle_check["detail"]["empty_lifecycle_rows"] == 0
         assert lifecycle_check["detail"]["read_only"] is True
 
     def test_handle_doctor_warns_on_bad_config(self, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #290.

`lcm_doctor` previously reported overall `warnings` whenever lifecycle fragmentation contained warning-level historical/state drift, even when there were no empty lifecycle rows left for the explicit backup-first cleanup path to prune.

This keeps lifecycle diagnostics conservative while avoiding a false unhealthy doctor result for retained history:

- adds `empty_lifecycle_rows` to lifecycle fragmentation stats
- treats lifecycle fragmentation as doctor warning evidence only when there are empty lifecycle rows or the state DB diagnostic is unreadable
- keeps the existing detailed lifecycle classification in the payload/text output for operator review
- keeps empty lifecycle rows warning/actionable
- downgrades message/node lifecycle-reference drift and retained-history stale lifecycle refs from overall doctor warning evidence

## Why

After empty lifecycle rows are pruned, retained-history lifecycle drift can remain as read-only diagnostic detail. Reporting that retained history as an overall doctor warning makes `lcm_doctor` look unhealthy even though there is no remaining empty lifecycle cleanup action for the operator.

The change preserves conservative diagnostics for actual actionable or unsafe cases: empty lifecycle rows still warn, and unreadable state DB diagnostics still warn.

## Validation

- [x] Focused validation: `python -m pytest tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_reports_lifecycle_fragmentation_without_mutating tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_keeps_retained_history_lifecycle_drift_healthy tests/test_lcm_engine.py::TestEngineTools::test_handle_doctor_warns_when_existing_state_db_is_unreadable tests/test_lcm_command.py::test_lcm_doctor_reports_lifecycle_fragmentation_as_read_only_observation tests/test_lcm_command.py::test_lcm_doctor_reports_lcm_sessions_without_lifecycle_references_as_observations -q` -> `5 passed in 0.19s`
- [x] Broader focused validation: `python -m pytest tests/test_lcm_command.py tests/test_lcm_core.py -q` -> `296 passed in 10.11s`
- [ ] Default validation:
  - [ ] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `1 failed, 681 passed, 1 skipped, 1 warning in 15.78s`; failure is `tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_returns_quickly_under_real_sqlite_writer_lock` timing threshold on this macOS host.
  - [ ] `python -m pytest -q` -> `3 failed, 1043 passed, 1 skipped, 1 warning in 21.84s`; failures are the same session-end timing test plus two macOS `/var` vs `/private/var` tempfile path assertions.
  - [ ] `ulimit -n 1024; python -m pytest -q` -> `3 failed, 1043 passed, 1 skipped, 1 warning in 21.94s`; same failures.
  - [x] `python -m compileall -q .` -> passed.
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed.
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed.
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check` -> passed.
  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-doctor-lifecycle-woz-audit-20260628` -> failed only the full-pytest and low-fd-pytest gates with the same three failures; diff, compile, script syntax, focused pytest, benchmark smoke, stress smoke, and stress release gates passed. Checklist: `/tmp/hermes-lcm-release-validation-doctor-lifecycle-woz-audit-20260628/validation-checklist.md`.
- [ ] Workflow validation, if workflows changed: `actionlint` was not run because this PR does not change workflows.

## Notes

The three default-suite failures were checked against unmodified `upstream/main` (`f468f5b`) in a separate worktree on the same host:

- `tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_returns_quickly_under_real_sqlite_writer_lock` is a pre-existing/flaky macOS timing threshold; repeated upstream-main runs failed with elapsed `0.366s` to `0.449s` against a `< 0.3s` assertion.
- `tests/test_path_containment.py::test_path_containment_within_allowed_base` fails on upstream main due macOS resolving temp paths from `/var/...` to `/private/var/...`.
- `tests/test_path_security.py::test_configured_externalization_path_inside_allowed_base_accepted` fails on upstream main for the same `/var` vs `/private/var` tempfile path assertion.

`python -m pytest -q --deselect tests/test_lcm_engine.py::TestSessionRollover::test_on_session_end_returns_quickly_under_real_sqlite_writer_lock --deselect tests/test_path_containment.py::test_path_containment_within_allowed_base --deselect tests/test_path_security.py::test_configured_externalization_path_inside_allowed_base_accepted` -> `1043 passed, 1 skipped, 3 deselected, 1 warning in 21.05s`.

Refs #290
