### PR TITLE
fix: preserve Discord lane metadata in LCM

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -156,11 +156,40 @@ def register(ctx):
 
         def _on_post_llm_call(**kwargs):
             history = kwargs.get("conversation_history")
-            if history:
-                try:
-                    engine.ingest(history)
-                except Exception as exc:
-                    logger.debug("LCM post_llm_call ingest error: %s", exc)
+            if not history:
+                return
+            active_engine = kwargs.get("context_compressor")
+            if not (
+                active_engine is not None
+                and getattr(active_engine, "name", None) == "lcm"
+                and hasattr(active_engine, "ingest")
+            ):
+                active_engine = engine
+
+            session_id = str(kwargs.get("session_id") or "")
+            conversation_id = str(
+                kwargs.get("conversation_id")
+                or kwargs.get("gateway_session_key")
+                or ""
+            )
+            platform = str(kwargs.get("platform") or "")
+
+            try:
+                if session_id and (
+                    str(getattr(active_engine, "current_session_id", "") or "") != session_id
+                    or (
+                        conversation_id
+                        and str(getattr(active_engine, "current_conversation_id", "") or "") != conversation_id
+                    )
+                ):
+                    active_engine.on_session_start(
+                        session_id,
+                        platform=platform,
+                        conversation_id=conversation_id or None,
+                    )
+                active_engine.ingest(history)
+            except Exception as exc:
+                logger.debug("LCM post_llm_call ingest error: %s", exc)
 
         _mgr._hooks.setdefault("post_llm_call", []).append(_on_post_llm_call)
         logger.debug("LCM registered post_llm_call hook for per-turn ingest")

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -17,7 +17,7 @@ from typing import Iterable, Sequence
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 SQLITE_BUSY_TIMEOUT_MS = 30_000
 _MIN_DISK_SPACE_BYTES = 50 * 1024 * 1024
 REQUIRED_CORE_TABLES = (
@@ -173,6 +173,22 @@ def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_rollover_at REAL")
     if "last_reset_at" not in columns:
         conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_reset_at REAL")
+
+
+def ensure_message_origin_columns(conn: sqlite3.Connection) -> None:
+    table_row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='messages'"
+    ).fetchone()
+    if not table_row:
+        return
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()
+    }
+    if "conversation_id" not in columns:
+        conn.execute("ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_msg_conversation_session ON messages(conversation_id, session_id, store_id)"
+    )
 
 
 def mark_migration_step_complete(conn: sqlite3.Connection, step_name: str) -> None:
@@ -597,5 +613,10 @@ def run_versioned_migrations(conn: sqlite3.Connection) -> None:
     if current_version < 4:
         mark_migration_step_complete(conn, "v4_lifecycle_debt_columns")
         current_version = 4
+
+    ensure_message_origin_columns(conn)
+    if current_version < 5:
+        mark_migration_step_complete(conn, "v5_message_conversation_id")
+        current_version = 5
 
     set_schema_version(conn, current_version)

--- a/engine.py
+++ b/engine.py
@@ -3585,6 +3585,7 @@ class LCMEngine(ContextEngine):
             protected_messages,
             estimates,
             source=self._session_platform,
+            conversation_id=self._conversation_id,
         )
         self._ingest_cursor = n
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))

--- a/schemas.py
+++ b/schemas.py
@@ -67,6 +67,13 @@ LCM_GREP = {
                     "Use 'unknown' for explicit unknown-source content."
                 ),
             },
+            "conversation_id": {
+                "type": "string",
+                "description": (
+                    "Optional gateway conversation/session key filter for lane-scoped retrieval. "
+                    "Use this to restrict Discord searches to one channel/thread/forum topic lane when rows carry metadata."
+                ),
+            },
             "role": {
                 "type": "string",
                 "enum": ["system", "user", "assistant", "tool", "unknown"],

--- a/store.py
+++ b/store.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 _MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
 _MESSAGE_SELECT_COLUMNS = (
     "store_id, session_id, source, role, content, tool_call_id, "
-    "tool_calls, tool_name, timestamp, token_estimate, pinned"
+    "tool_calls, tool_name, timestamp, token_estimate, pinned, conversation_id"
 )
 _UNKNOWN_SOURCE = "unknown"
 
@@ -71,12 +71,23 @@ def _normalize_source_value(source: str | None) -> str:
     return normalized or _UNKNOWN_SOURCE
 
 
+def _normalize_conversation_id_value(conversation_id: str | None) -> str:
+    return (conversation_id or "").strip()
+
+
 def _source_filter_clause(column: str, source: str | None) -> tuple[str | None, list[str]]:
     normalized = _normalize_source_value(source) if source is not None else ""
     if not normalized:
         return None, []
     if normalized == _UNKNOWN_SOURCE:
         return f"({column} = ? OR {_legacy_blank_source_clause(column)})", [_UNKNOWN_SOURCE]
+    return f"{column} = ?", [normalized]
+
+
+def _conversation_filter_clause(column: str, conversation_id: str | None) -> tuple[str | None, list[str]]:
+    normalized = _normalize_conversation_id_value(conversation_id)
+    if not normalized:
+        return None, []
     return f"{column} = ?", [normalized]
 
 
@@ -240,6 +251,7 @@ class MessageStore:
                 store_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL,
                 source TEXT DEFAULT '',
+                conversation_id TEXT DEFAULT '',
                 role TEXT NOT NULL,
                 content TEXT,
                 tool_call_id TEXT,
@@ -265,6 +277,7 @@ class MessageStore:
         )
         run_versioned_migrations(self._conn)
         self._ensure_source_column()
+        self._ensure_conversation_id_column()
         self._conn.commit()
 
     def _ensure_source_column(self) -> None:
@@ -277,10 +290,21 @@ class MessageStore:
             "CREATE INDEX IF NOT EXISTS idx_msg_source_session ON messages(source, session_id, store_id)"
         )
 
+    def _ensure_conversation_id_column(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "conversation_id" not in columns:
+            self._conn.execute("ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_msg_conversation_session ON messages(conversation_id, session_id, store_id)"
+        )
+
     # -- Write operations ---------------------------------------------------
 
     def append(self, session_id: str, msg: Dict[str, Any],
-               token_estimate: int = 0, source: str = "") -> int:
+               token_estimate: int = 0, source: str = "",
+               conversation_id: str = "") -> int:
         """Persist a message and return its store_id."""
         msg = protect_message_for_ingest(
             msg,
@@ -294,12 +318,13 @@ class MessageStore:
         with self._write_lock:
             cur = self._conn.execute(
                 """INSERT INTO messages
-                   (session_id, source, role, content, tool_call_id, tool_calls,
+                   (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,
                     tool_name, timestamp, token_estimate, pinned)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     _normalize_source_value(source),
+                    _normalize_conversation_id_value(conversation_id),
                     msg.get("role", "unknown"),
                     _normalize_content_value(msg.get("content")),
                     msg.get("tool_call_id"),
@@ -316,7 +341,8 @@ class MessageStore:
     def append_batch(self, session_id: str,
                      messages: List[Dict[str, Any]],
                      token_estimates: List[int] | None = None,
-                     source: str = "") -> List[int]:
+                     source: str = "",
+                     conversation_id: str = "") -> List[int]:
         """Persist multiple messages in one transaction. Returns store_ids."""
         protected_messages = protect_messages_for_ingest(
             messages,
@@ -329,12 +355,14 @@ class MessageStore:
             protected_messages,
             token_estimates,
             source=source,
+            conversation_id=conversation_id,
         )
 
     def _append_protected_batch(self, session_id: str,
                                 messages: List[Dict[str, Any]],
                                 token_estimates: List[int] | None = None,
-                                source: str = "") -> List[int]:
+                                source: str = "",
+                                conversation_id: str = "") -> List[int]:
         """Persist messages that already passed ingest protection.
 
         This is an internal fast path for callers that need the protected form
@@ -353,12 +381,13 @@ class MessageStore:
                 ts = time.time()
                 cur = self._conn.execute(
                     """INSERT INTO messages
-                       (session_id, source, role, content, tool_call_id, tool_calls,
+                       (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,
                         tool_name, timestamp, token_estimate, pinned)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         _normalize_source_value(source),
+                        _normalize_conversation_id_value(conversation_id),
                         msg.get("role", "unknown"),
                         _normalize_content_value(msg.get("content")),
                         msg.get("tool_call_id"),
@@ -700,6 +729,7 @@ class MessageStore:
     def search(self, query: str, session_id: str | None = None,
                limit: int = 20, sort: str | None = None,
                source: str | None = None,
+               conversation_id: str | None = None,
                role: str | None = None,
                time_from: float | None = None,
                time_to: float | None = None) -> List[Dict[str, Any]]:
@@ -712,6 +742,7 @@ class MessageStore:
         - ``source`` limits which raw rows inside those sessions are eligible
         - ``source='unknown'`` means the explicit unknown-source bucket, with
           legacy blank-source rows treated as equivalent for back-compat
+        - ``conversation_id`` limits rows to one gateway conversation/session key
         """
         safe_query = sanitize_fts5_query(query)
         terms = extract_search_terms(safe_query)
@@ -723,6 +754,7 @@ class MessageStore:
                 limit=limit,
                 sort=sort,
                 source=source,
+                conversation_id=conversation_id,
                 role=role,
                 time_from=time_from,
                 time_to=time_to,
@@ -738,6 +770,7 @@ class MessageStore:
         apply_directness_adjustment = should_apply_directness_rank_adjustment(terms, phrases)
         max_rank_bonus = compute_directness_rank_bonus_upper_bound(terms, phrases) * 3e-7
         source_clause, source_args = _source_filter_clause("m.source", source)
+        conversation_clause, conversation_args = _conversation_filter_clause("m.conversation_id", conversation_id)
         offset = 0
         scanned_rows = 0
         results: list[Dict[str, Any]] = []
@@ -751,6 +784,9 @@ class MessageStore:
                 if source_clause:
                     where.append(source_clause)
                     args.extend(source_args)
+                if conversation_clause:
+                    where.append(conversation_clause)
+                    args.extend(conversation_args)
                 if role is not None:
                     where.append("m.role = ?")
                     args.append(role)
@@ -763,7 +799,7 @@ class MessageStore:
                 args.extend([fetch_limit, offset])
                 rows = self._conn.execute(
                     f"""SELECT m.store_id, m.session_id, m.source, m.role, m.content, m.tool_call_id,
-                              m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned,
+                              m.tool_calls, m.tool_name, m.timestamp, m.token_estimate, m.pinned, m.conversation_id,
                               rank as search_rank,
                               snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
                        FROM messages_fts fts
@@ -781,6 +817,7 @@ class MessageStore:
                     limit=limit,
                     sort=sort,
                     source=source,
+                    conversation_id=conversation_id,
                     role=role,
                     time_from=time_from,
                     time_to=time_to,
@@ -789,7 +826,7 @@ class MessageStore:
             raw_primary_values: list[float] = []
             for r in rows:
                 d = self._row_to_dict(r)
-                base_columns = 11
+                base_columns = 12
                 d["search_rank"] = r[base_columns] if len(r) > base_columns else None
                 d["snippet"] = r[base_columns + 1] if len(r) > (base_columns + 1) else ""
                 d["_directness_score"] = _message_directness_score(d.get("role"), d.get("content"), terms, phrases)
@@ -821,6 +858,7 @@ class MessageStore:
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,
                      source: str | None = None,
+                     conversation_id: str | None = None,
                      role: str | None = None,
                      time_from: float | None = None,
                      time_to: float | None = None) -> List[Dict[str, Any]]:
@@ -840,6 +878,10 @@ class MessageStore:
         if source_clause:
             where.append(source_clause)
             args.extend(source_args)
+        conversation_clause, conversation_args = _conversation_filter_clause("conversation_id", conversation_id)
+        if conversation_clause:
+            where.append(conversation_clause)
+            args.extend(conversation_args)
         if role is not None:
             where.append("role = ?")
             args.append(role)
@@ -1017,10 +1059,11 @@ class MessageStore:
             return {}
         cols = [
             "store_id", "session_id", "source", "role", "content", "tool_call_id",
-            "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned",
+            "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned", "conversation_id",
         ]
         d = dict(zip(cols, row[:len(cols)]))
         d["source"] = _normalize_source_value(d.get("source"))
+        d["conversation_id"] = _normalize_conversation_id_value(d.get("conversation_id"))
         # Deserialize tool_calls JSON
         if d.get("tool_calls"):
             try:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1128,6 +1128,59 @@ class TestMessageStore:
         assert discord_results[0]["source"] == "discord"
         assert discord_results[0]["session_id"] == "sess2"
 
+    def test_conversation_id_stored_and_filterable_for_discord_lanes(self, store):
+        main_id = store.append(
+            "sess-main",
+            {"role": "user", "content": "docker in discord main lane"},
+            source="discord",
+            conversation_id="agent:main:discord:group:main:user",
+        )
+        thread_id = store.append(
+            "sess-thread",
+            {"role": "user", "content": "docker in discord forum topic"},
+            source="discord",
+            conversation_id="agent:main:discord:thread:topic:topic",
+        )
+
+        main_results = store.search(
+            "docker",
+            source="discord",
+            conversation_id="agent:main:discord:group:main:user",
+        )
+        thread_results = store.search(
+            "docker",
+            source="discord",
+            conversation_id="agent:main:discord:thread:topic:topic",
+        )
+
+        assert [result["store_id"] for result in main_results] == [main_id]
+        assert main_results[0]["conversation_id"] == "agent:main:discord:group:main:user"
+        assert [result["store_id"] for result in thread_results] == [thread_id]
+        assert thread_results[0]["conversation_id"] == "agent:main:discord:thread:topic:topic"
+        assert store.get(main_id)["conversation_id"] == "agent:main:discord:group:main:user"
+
+    def test_like_fallback_filters_by_conversation_id(self, store):
+        store.append(
+            "sess-main",
+            {"role": "user", "content": "foo bar lane main"},
+            source="discord",
+            conversation_id="agent:main:discord:group:main:user",
+        )
+        thread_id = store.append(
+            "sess-thread",
+            {"role": "user", "content": "foo bar lane topic"},
+            source="discord",
+            conversation_id="agent:main:discord:thread:topic:topic",
+        )
+
+        results = store.search(
+            'foo"bar',
+            source="discord",
+            conversation_id="agent:main:discord:thread:topic:topic",
+        )
+
+        assert [result["store_id"] for result in results] == [thread_id]
+
     def test_missing_source_is_normalized_to_unknown_and_filterable(self, store):
         store_id = store.append("sess-unknown", {"role": "user", "content": "docker with unknown source"})
 
@@ -1337,7 +1390,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("4",)
+        assert version == ("5",)
 
         results = store.search("docker", session_id="sess1")
         assert len(results) == 1
@@ -1386,7 +1439,7 @@ class TestMessageStore:
         version = store._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("4",)
+        assert version == ("5",)
 
         migration_state = store._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"
@@ -2295,7 +2348,7 @@ class TestLifecycleStateStore:
         version = state._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()[0]
-        assert version == "4"
+        assert version == "5"
 
         tables = {
             row[0]
@@ -2875,7 +2928,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("4",)
+        assert version == ("5",)
 
         results = dag.search("docker", session_id="s1")
         assert len(results) == 1
@@ -2927,7 +2980,7 @@ class TestSummaryDAG:
         version = dag._conn.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("4",)
+        assert version == ("5",)
 
         migration_state = dag._conn.execute(
             "SELECT step_name FROM lcm_migration_state ORDER BY step_name"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -45,6 +45,36 @@ def test_shutdown_closes_lifecycle_store(tmp_path):
     assert engine._lifecycle._conn is None
 
 
+def test_discord_short_turn_ingest_preserves_conversation_id(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "discord-lanes.db"))
+    engine = LCMEngine(config=config)
+    try:
+        conversation_id = "agent:main:discord:thread:1520890589762031776:1520890589762031776"
+        engine.on_session_start(
+            "discord-session-1",
+            platform="discord",
+            conversation_id=conversation_id,
+            context_length=200_000,
+        )
+
+        engine.ingest([
+            {"role": "user", "content": "needle from discord topic"},
+            {"role": "assistant", "content": "topic answer"},
+        ])
+
+        rows = engine._store.search(
+            "needle",
+            source="discord",
+            conversation_id=conversation_id,
+        )
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "discord-session-1"
+        assert rows[0]["source"] == "discord"
+        assert rows[0]["conversation_id"] == conversation_id
+    finally:
+        engine.shutdown()
+
+
 def test_engine_deallocation_releases_sqlite_fds_without_gc(tmp_path):
     fd_dir = Path("/proc/self/fd")
     if not fd_dir.exists():
@@ -1299,6 +1329,8 @@ class TestEngineABC:
         assert "source" in grep_props
         assert "descendant source lineage" in grep_props["source"]["description"]
         assert "unknown" in grep_props["source"]["description"]
+        assert "conversation_id" in grep_props
+        assert "Discord" in grep_props["conversation_id"]["description"]
         # The default scope still steers callers to the active session.
         description_lower = grep_schema["description"].lower()
         assert (
@@ -2866,6 +2898,46 @@ class TestEngineABC:
 
         assert result["total_results"] >= 1
         assert any("needle phrase" in item["snippet"] for item in result["results"])
+
+    def test_lcm_grep_filters_live_discord_history_by_conversation_id(self, engine):
+        target_conversation = "agent:main:discord:thread:topic-a:topic-a"
+        other_conversation = "agent:main:discord:thread:topic-b:topic-b"
+        engine.on_session_start(
+            "discord-topic-a",
+            platform="discord",
+            conversation_id=target_conversation,
+            context_length=200000,
+        )
+        engine.ingest([
+            {"role": "user", "content": "multichannel canary from topic a"},
+        ])
+        engine.on_session_start(
+            "discord-topic-b",
+            platform="discord",
+            conversation_id=other_conversation,
+            context_length=200000,
+        )
+        engine.ingest([
+            {"role": "user", "content": "multichannel canary from topic b"},
+        ])
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_grep",
+                {
+                    "query": "multichannel canary",
+                    "session_scope": "all",
+                    "source": "discord",
+                    "conversation_id": target_conversation,
+                    "limit": 5,
+                },
+            )
+        )
+
+        assert result["conversation_id"] == target_conversation
+        assert result["summary_results_omitted"] is True
+        assert [item["conversation_id"] for item in result["results"]] == [target_conversation]
+        assert "topic a" in result["results"][0]["snippet"]
 
     def test_compress_accepts_focus_topic(self, engine, monkeypatch):
         import importlib

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import types
 
 
 EXPECTED_LCM_TOOLS = {
@@ -600,3 +601,130 @@ def test_registered_tool_handler_forwards_messages_to_engine_handle_tool_call(mo
         assert "messages" in kwargs, f"{name}: messages kwarg not forwarded"
         # Depending on whether engine passes it through, at minimum verify it arrived
         assert kwargs["messages"] == test_messages, f"{name}: messages content mismatch"
+
+
+def test_post_llm_hook_prefers_active_lcm_clone(monkeypatch, tmp_path):
+    module = _load_plugin_entrypoint_module("hermes_lcm_post_hook_active_clone")
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    class _CtxNoTool:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _CtxNoTool()
+    module.register(ctx)
+    assert ctx.engine is not None
+
+    class _ActiveClone:
+        name = "lcm"
+
+        def __init__(self):
+            self.current_session_id = ""
+            self.current_conversation_id = ""
+            self.starts = []
+            self.ingested = []
+
+        def on_session_start(self, session_id, **kwargs):
+            self.current_session_id = session_id
+            self.current_conversation_id = kwargs.get("conversation_id") or session_id
+            self.starts.append((session_id, kwargs))
+
+        def ingest(self, history):
+            self.ingested.append(list(history))
+
+    active = _ActiveClone()
+    hook = manager._hooks["post_llm_call"][-1]
+    history = [{"role": "user", "content": "discord lane canary"}]
+
+    hook(
+        context_compressor=active,
+        session_id="discord-session",
+        conversation_id="agent:main:discord:thread:t:t",
+        platform="discord",
+        conversation_history=history,
+    )
+
+    assert active.starts == [
+        (
+            "discord-session",
+            {
+                "platform": "discord",
+                "conversation_id": "agent:main:discord:thread:t:t",
+            },
+        )
+    ]
+    assert active.ingested == [history]
+    assert ctx.engine.current_session_id == ""
+    ctx.engine.shutdown()
+
+
+def test_post_llm_hook_rebinds_legacy_singleton_between_gateway_lanes(monkeypatch, tmp_path):
+    module = _load_plugin_entrypoint_module("hermes_lcm_post_hook_singleton_rebind")
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    class _CtxNoTool:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _CtxNoTool()
+    module.register(ctx)
+    assert ctx.engine is not None
+    hook = manager._hooks["post_llm_call"][-1]
+
+    ingests = []
+
+    def spy_ingest(history):
+        ingests.append(
+            (
+                ctx.engine.current_session_id,
+                ctx.engine.current_conversation_id,
+                ctx.engine.current_session_platform,
+                list(history),
+            )
+        )
+
+    monkeypatch.setattr(ctx.engine, "ingest", spy_ingest)
+    hook(
+        session_id="discord-topic-a",
+        conversation_id="agent:main:discord:thread:a:a",
+        platform="discord",
+        conversation_history=[{"role": "user", "content": "topic a"}],
+    )
+    hook(
+        session_id="telegram-dm",
+        conversation_id="agent:main:telegram:private:1782862480",
+        platform="telegram",
+        conversation_history=[{"role": "user", "content": "telegram dm"}],
+    )
+
+    assert ingests == [
+        (
+            "discord-topic-a",
+            "agent:main:discord:thread:a:a",
+            "discord",
+            [{"role": "user", "content": "topic a"}],
+        ),
+        (
+            "telegram-dm",
+            "agent:main:telegram:private:1782862480",
+            "telegram",
+            [{"role": "user", "content": "telegram dm"}],
+        ),
+    ]
+    ctx.engine.shutdown()

--- a/tools.py
+++ b/tools.py
@@ -1067,6 +1067,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         str(raw_session_id_arg).strip() if raw_session_id_arg is not None else ""
     )
     source = str(args.get("source") or "").strip() or None
+    conversation_id = str(args.get("conversation_id") or "").strip() or None
     role, role_error = _parse_grep_role(args.get("role"))
     if role_error:
         return json.dumps({"error": role_error})
@@ -1078,7 +1079,12 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         return json.dumps({"error": time_to_error})
     if time_from is not None and time_to is not None and time_to < time_from:
         return json.dumps({"error": "time_to must be greater than or equal to time_from"})
-    raw_message_filter_active = role is not None or time_from is not None or time_to is not None
+    raw_message_filter_active = (
+        role is not None
+        or time_from is not None
+        or time_to is not None
+        or conversation_id is not None
+    )
 
     if requested_session_scope == "current":
         if explicit_session_id:
@@ -1130,6 +1136,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
             limit=source_limit,
             sort=sort,
             source=source,
+            conversation_id=conversation_id,
             role=role,
             time_from=time_from,
             time_to=time_to,
@@ -1143,6 +1150,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
                     "store_id": hit["store_id"],
                     "session_id": hit["session_id"],
                     "source": hit.get("source") or "",
+                    "conversation_id": hit.get("conversation_id") or "",
                     "role": hit["role"],
                     "timestamp": timestamp_value,
                     "snippet": hit.get("snippet", hit.get("content", "")[:200]),
@@ -1211,6 +1219,7 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
         "sort": sort,
         "session_scope": session_scope,
         "source": source,
+        "conversation_id": conversation_id,
         "limit": limit,
         "total_results": len(results),
         "results": results[:limit],
@@ -1392,6 +1401,7 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             "source_type": "raw_message",
             "session_id": stored_session_id,
             "source": stored.get("source") or "",
+            "conversation_id": stored.get("conversation_id") or "",
             "role": stored.get("role"),
             "timestamp": stored.get("timestamp", 0),
             "tool_call_id": stored.get("tool_call_id") or "",


### PR DESCRIPTION
## Summary
- Persist the Hermes gateway `conversation_id` on raw LCM messages so Discord channel/thread/forum-topic lanes can be attributed and filtered.
- Add a `conversation_id` filter to raw-message search and `lcm_grep`, alongside the existing `source`, `session_id`, role, and time filters.
- Make post-turn ingest prefer the active LCM context-engine clone when the host passes it, while preserving the legacy singleton fallback path for older Hermes Agent hosts.

## Why
Hermes Agent already routes Discord conversations with lane-specific gateway session keys, but LCM raw message rows only carried coarse `source=discord` metadata. That makes multi-channel retrieval and debugging too broad: different Discord channels, threads, and forum topics become hard to distinguish after ingest.

This keeps the existing `source` behavior intact and adds `conversation_id` as a narrower optional attribution/filter. Existing rows remain valid with `conversation_id=''`.

Newer Hermes Agent hosts clone context engines per agent/session. For short turns that never trigger compression, the post-turn ingest hook should follow the active LCM clone when available instead of assuming the plugin singleton is the live session engine.

## Validation
- [x] Focused validation: `python -m pytest tests/test_packaging_install.py::test_post_llm_hook_prefers_active_lcm_clone tests/test_packaging_install.py::test_post_llm_hook_rebinds_legacy_singleton_between_gateway_lanes tests/test_lcm_engine.py::test_discord_short_turn_ingest_preserves_conversation_id tests/test_lcm_engine.py::TestEngineABC::test_lcm_grep_filters_live_discord_history_by_conversation_id tests/test_lcm_core.py::TestMessageStore::test_conversation_id_stored_and_filterable_for_discord_lanes tests/test_lcm_core.py::TestMessageStore::test_like_fallback_filters_by_conversation_id -q -o addopts=` -> 6 passed.
- [x] Default validation:
  - [x] `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` -> 688 passed, 3 dependency deprecation warnings.
  - [x] `python -m pytest tests -q -o addopts=` -> 1053 passed, 3 dependency deprecation warnings.
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> 1053 passed, 3 dependency deprecation warnings.
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] CI validation on PR head `97add7b`:
  - [x] `workflow-lint`
  - [x] `test (3.11)`
  - [x] `test (3.12)`
  - [x] `test (3.13)`
  - [x] `test (3.14)`
- [x] Duplicate check: searched open/closed PRs and issues for `conversation_id lcm_grep discord lane metadata`; no matching existing PR/issue found.
- [x] Workflow validation: not applicable; no workflow files changed.

## Notes
- Companion Hermes Agent host PR: https://github.com/NousResearch/hermes-agent/pull/54452. That PR passes the active context engine and gateway lane metadata into `post_llm_call` hooks. This LCM PR consumes that metadata when available and remains backward-compatible when the host does not pass it.
- Telegram/backward compatibility is preserved. Existing rows get `conversation_id=''`, source filters keep their old behavior, and the legacy singleton path explicitly rebinds between lanes such as Discord topics and Telegram DMs.
- This PR does not vendor LCM into Hermes Agent and does not change Hermes Agent core. The host-side change stays in the companion PR as generic plugin-hook metadata.
- No issue number yet.
