### PR TITLE
fix: resolve active LCM clone for post hooks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,7 +50,7 @@ def _host_forwards_registered_tool_messages(ctx) -> bool:
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
-    from .engine import LCMEngine
+    from .engine import LCMEngine, resolve_active_lcm_engine
     from .schemas import (
         LCM_GREP,
         LCM_LOAD_SESSION,
@@ -164,7 +164,7 @@ def register(ctx):
                 and getattr(active_engine, "name", None) == "lcm"
                 and hasattr(active_engine, "ingest")
             ):
-                active_engine = engine
+                active_engine = None
 
             session_id = str(kwargs.get("session_id") or "")
             conversation_id = str(
@@ -174,13 +174,20 @@ def register(ctx):
             )
             platform = str(kwargs.get("platform") or "")
 
+            if active_engine is None:
+                active_engine = resolve_active_lcm_engine(
+                    session_id=session_id,
+                    conversation_id=conversation_id,
+                ) or engine
+
             try:
-                if session_id and (
-                    str(getattr(active_engine, "current_session_id", "") or "") != session_id
-                    or (
-                        conversation_id
-                        and str(getattr(active_engine, "current_conversation_id", "") or "") != conversation_id
-                    )
+                # Session identity is authoritative for rebinding. Older hosts
+                # can deliver stale lane metadata alongside the correct active
+                # session id; rebinding a clone on conversation_id mismatch
+                # alone would move it away from the runtime it is serving.
+                if (
+                    session_id
+                    and str(getattr(active_engine, "current_session_id", "") or "") != session_id
                 ):
                     active_engine.on_session_start(
                         session_id,

--- a/engine.py
+++ b/engine.py
@@ -14,6 +14,7 @@ import sqlite3
 import subprocess
 import threading
 import time
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
@@ -79,6 +80,85 @@ from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
 logger = logging.getLogger(__name__)
+
+_ACTIVE_ENGINE_REGISTRY_LOCK = threading.RLock()
+_ACTIVE_ENGINES_BY_SESSION_ID = weakref.WeakValueDictionary()
+_ACTIVE_ENGINES_BY_CONVERSATION_ID = weakref.WeakValueDictionary()
+
+
+def _is_usable_lcm_engine(engine: Any) -> bool:
+    return bool(
+        engine is not None
+        and getattr(engine, "name", None) == "lcm"
+        and hasattr(engine, "ingest")
+    )
+
+
+def _engine_matches_session_binding(engine: Any, session_id: str) -> bool:
+    return bool(
+        _is_usable_lcm_engine(engine)
+        and session_id
+        and str(getattr(engine, "_session_id", "") or "") == session_id
+    )
+
+
+def _engine_matches_conversation_binding(engine: Any, conversation_id: str) -> bool:
+    return bool(
+        _is_usable_lcm_engine(engine)
+        and conversation_id
+        and str(getattr(engine, "_conversation_id", "") or "") == conversation_id
+    )
+
+
+def _remove_registry_entries_for_engine(
+    engine: Any,
+    *,
+    keep_session_id: str = "",
+    keep_conversation_id: str = "",
+) -> None:
+    for registered_session_id, registered_engine in list(_ACTIVE_ENGINES_BY_SESSION_ID.items()):
+        if registered_engine is engine and registered_session_id != keep_session_id:
+            _ACTIVE_ENGINES_BY_SESSION_ID.pop(registered_session_id, None)
+    for registered_conversation_id, registered_engine in list(
+        _ACTIVE_ENGINES_BY_CONVERSATION_ID.items()
+    ):
+        if registered_engine is engine and registered_conversation_id != keep_conversation_id:
+            _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(registered_conversation_id, None)
+
+
+def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -> Any:
+    """Return the LCM runtime clone most recently bound to a session/lane.
+
+    Newer Hermes Agent hosts pass the active per-agent context engine directly
+    to ``post_llm_call`` hooks. Older hosts may only pass session/lane ids. LCM
+    clones register their own session binding when ``on_session_start`` runs so
+    post-turn ingest can still follow the active clone instead of rebinding the
+    process-wide plugin singleton.
+    """
+    session_id = str(session_id or "")
+    conversation_id = str(conversation_id or "")
+    with _ACTIVE_ENGINE_REGISTRY_LOCK:
+        if session_id:
+            engine = _ACTIVE_ENGINES_BY_SESSION_ID.get(session_id)
+            if _engine_matches_session_binding(engine, session_id):
+                return engine
+            if engine is not None:
+                _ACTIVE_ENGINES_BY_SESSION_ID.pop(session_id, None)
+        if conversation_id:
+            engine = _ACTIVE_ENGINES_BY_CONVERSATION_ID.get(conversation_id)
+            conversation_matches = _engine_matches_conversation_binding(
+                engine,
+                conversation_id,
+            )
+            session_matches = not session_id or _engine_matches_session_binding(
+                engine,
+                session_id,
+            )
+            if conversation_matches and session_matches:
+                return engine
+            if engine is not None and not conversation_matches:
+                _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
+    return None
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
@@ -558,6 +638,7 @@ class LCMEngine(ContextEngine):
 
     def _reset_profile_runtime_state(self) -> None:
         """Clear process-local session state that cannot cross profile homes."""
+        self._unregister_active_engine_binding()
         self._session_id = ""
         self._session_platform = ""
         self._foreground_session_id = ""
@@ -1399,6 +1480,7 @@ class LCMEngine(ContextEngine):
         state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
         self._conversation_id = state.conversation_id
         self._last_compacted_store_id = state.current_frontier_store_id
+        self._register_active_engine_binding()
         if not self._session_ignored and not self._session_stateless:
             self._foreground_session_id = session_id
             self._foreground_session_platform = self._session_platform
@@ -1428,6 +1510,25 @@ class LCMEngine(ContextEngine):
                     deleted,
                     self._config.empty_lifecycle_gc_threshold,
                 )
+
+    def _register_active_engine_binding(self) -> None:
+        session_id = str(self._session_id or "")
+        conversation_id = str(self._conversation_id or "")
+        if not session_id:
+            return
+        with _ACTIVE_ENGINE_REGISTRY_LOCK:
+            _remove_registry_entries_for_engine(
+                self,
+                keep_session_id=session_id,
+                keep_conversation_id=conversation_id,
+            )
+            _ACTIVE_ENGINES_BY_SESSION_ID[session_id] = self
+            if conversation_id:
+                _ACTIVE_ENGINES_BY_CONVERSATION_ID[conversation_id] = self
+
+    def _unregister_active_engine_binding(self) -> None:
+        with _ACTIVE_ENGINE_REGISTRY_LOCK:
+            _remove_registry_entries_for_engine(self)
 
     def _persist_frontier_marker(self) -> None:
         if not self._session_id or not self._conversation_id:
@@ -4892,6 +4993,7 @@ class LCMEngine(ContextEngine):
     # -- Lifecycle ---------------------------------------------------------
 
     def shutdown(self):
+        self._unregister_active_engine_binding()
         self._store.close()
         self._dag.close()
         self._lifecycle.close()

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -603,6 +603,133 @@ def test_registered_tool_handler_forwards_messages_to_engine_handle_tool_call(mo
         assert kwargs["messages"] == test_messages, f"{name}: messages content mismatch"
 
 
+def test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor(monkeypatch, tmp_path):
+    module = _load_plugin_entrypoint_module("hermes_lcm_post_hook_registered_clone")
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    class _CtxNoTool:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _CtxNoTool()
+    module.register(ctx)
+    assert ctx.engine is not None
+
+    active_clone = ctx.engine.clone_for_agent()
+    active_clone.on_session_start(
+        "discord-session",
+        platform="discord",
+        conversation_id="agent:main:discord:thread:t:t",
+    )
+    hook = manager._hooks["post_llm_call"][-1]
+    history = [{"role": "user", "content": "registered clone canary"}]
+
+    clone_ingests = []
+    singleton_ingests = []
+
+    def spy_clone_ingest(messages):
+        clone_ingests.append(list(messages))
+
+    def spy_singleton_ingest(messages):
+        singleton_ingests.append(list(messages))
+
+    monkeypatch.setattr(active_clone, "ingest", spy_clone_ingest)
+    monkeypatch.setattr(ctx.engine, "ingest", spy_singleton_ingest)
+
+    hook(
+        session_id="discord-session",
+        conversation_id="agent:main:discord:thread:t:t",
+        platform="discord",
+        conversation_history=history,
+    )
+
+    assert clone_ingests == [history]
+    assert singleton_ingests == []
+    assert active_clone.current_session_id == "discord-session"
+    assert active_clone.current_conversation_id == "agent:main:discord:thread:t:t"
+    assert ctx.engine.current_session_id == ""
+    active_clone.shutdown()
+    ctx.engine.shutdown()
+
+
+def test_post_llm_hook_ignores_stale_registered_clone_after_rebind(monkeypatch, tmp_path):
+    for lookup_mode in ("session", "conversation", "mismatched_conversation"):
+        module = _load_plugin_entrypoint_module(f"hermes_lcm_post_hook_stale_{lookup_mode}")
+        manager = types.SimpleNamespace(_hooks={})
+        fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+        fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+        monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / f"hermes_home_{lookup_mode}"))
+
+        class _CtxNoTool:
+            def __init__(self):
+                self.engine = None
+
+            def register_context_engine(self, engine):
+                self.engine = engine
+
+        ctx = _CtxNoTool()
+        module.register(ctx)
+        active_clone = ctx.engine.clone_for_agent()
+        active_clone.on_session_start(
+            "session-a",
+            platform="discord",
+            conversation_id="agent:main:discord:thread:a:a",
+        )
+        active_clone.on_session_start(
+            "session-b",
+            platform="discord",
+            conversation_id="agent:main:discord:thread:b:b",
+        )
+
+        clone_ingests = []
+        singleton_ingests = []
+        monkeypatch.setattr(active_clone, "ingest", lambda messages: clone_ingests.append(list(messages)))
+        monkeypatch.setattr(ctx.engine, "ingest", lambda messages: singleton_ingests.append(list(messages)))
+
+        history = [{"role": "user", "content": f"old {lookup_mode}"}]
+        kwargs = {
+            "conversation_id": "agent:main:discord:thread:a:a",
+            "platform": "discord",
+            "conversation_history": history,
+        }
+        if lookup_mode == "session":
+            kwargs["session_id"] = "session-a"
+        elif lookup_mode == "mismatched_conversation":
+            kwargs["session_id"] = "session-b"
+
+        manager._hooks["post_llm_call"][-1](**kwargs)
+
+        if lookup_mode == "mismatched_conversation":
+            assert clone_ingests == [history]
+            assert singleton_ingests == []
+        else:
+            assert clone_ingests == []
+            assert singleton_ingests == [history]
+        assert active_clone.current_session_id == "session-b"
+        assert active_clone.current_conversation_id == "agent:main:discord:thread:b:b"
+
+        if lookup_mode == "mismatched_conversation":
+            clone_ingests.clear()
+            manager._hooks["post_llm_call"][-1](
+                session_id="session-b",
+                platform="discord",
+                conversation_history=[{"role": "user", "content": "session only"}],
+            )
+            assert clone_ingests == [[{"role": "user", "content": "session only"}]]
+        active_clone.shutdown()
+        ctx.engine.shutdown()
+
+
 def test_post_llm_hook_prefers_active_lcm_clone(monkeypatch, tmp_path):
     module = _load_plugin_entrypoint_module("hermes_lcm_post_hook_active_clone")
     manager = types.SimpleNamespace(_hooks={})


### PR DESCRIPTION
## Summary
- Add a weak in-process registry for LCM engine clones keyed by `session_id` and `conversation_id` when a clone binds through `on_session_start()`.
- Make the `post_llm_call` hook resolve that registered active clone when older Hermes Agent hosts do not pass `context_compressor`.
- Keep the existing direct `context_compressor` path and legacy singleton fallback intact.

## Why
Newer Hermes Agent hosts can pass the active per-agent context engine into `post_llm_call`, but older/current deployments may only pass session/lane metadata. In that case LCM's post-turn ingest can fall back to the process-wide plugin singleton, which can rebind the wrong runtime in multi-lane gateway use.

LCM clones already know when they become active through `on_session_start()`. Registering that binding inside LCM lets post-turn ingest follow the correct clone without requiring a Hermes Agent host change first. This makes the plugin more defensive while keeping the generic host-contract PR useful rather than blocking.

## Validation
- [x] RED regression first: `python -m pytest tests/test_packaging_install.py::test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor -q -o addopts=` failed before the fix because the hook used the singleton instead of the registered clone.
- [x] Focused hook regression: `python -m pytest tests/test_packaging_install.py::test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor tests/test_packaging_install.py::test_post_llm_hook_prefers_active_lcm_clone tests/test_packaging_install.py::test_post_llm_hook_rebinds_legacy_singleton_between_gateway_lanes -q -o addopts=` -> 3 passed.
- [x] Clone/packaging focus: `python -m pytest tests/test_lcm_core.py::TestLCMEngineCloning tests/test_packaging_install.py::test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor tests/test_packaging_install.py::test_post_llm_hook_prefers_active_lcm_clone tests/test_packaging_install.py::test_post_llm_hook_rebinds_legacy_singleton_between_gateway_lanes tests/test_packaging_install.py::test_plugin_entrypoint_registration_is_repeatable_and_returns_lcm_engine -q -o addopts=` -> 11 passed.
- [x] Affected-area suite: `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` -> 690 passed, 3 dependency deprecation warnings.
- [x] Full suite: `python -m pytest -q -o addopts=` -> 1054 passed, 3 dependency deprecation warnings.
- [x] Production lint/compile checks: `python -m ruff check __init__.py engine.py`, `python -m compileall -q __init__.py engine.py tests/test_packaging_install.py`, `git diff --check` -> passed.
- [x] Release validation on committed PR diff: `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-active-clone-post-hook-final` -> PASS.

## Notes
- The registry uses `weakref.WeakValueDictionary`, so it does not keep cloned engines alive after the host drops them.
- Resolution order is session id first, then conversation id. The direct host-supplied `context_compressor` still wins when available.
- This does not change storage schema, tool schemas, or host APIs.
- Companion Hermes Agent host PR #54452 remains useful because it passes the active engine directly, but this PR makes LCM safer without waiting for that host-side change.
