### PR TITLE
fix: avoid brace parsing in focus brief prompts

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -180,12 +180,12 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
         "\n"
         "Demote old / completed topics:\n"
         "If the summary contains tasks, questions, or remaining work that are no longer active in the latest turns,\n"
-        "mark them under one of these historical headings: {markers}.\n"
+        f"mark them under one of these historical headings: {markers}.\n"
         "Frame them as STALE context — the agent must NOT resume that work unless the latest user message\n"
         "explicitly asks for it. If fully resolved, reduce to a one-line bullet or omit.\n"
         "Exception: active blockers or handoff state should NOT be demoted even if they are absent from the\n"
         "latest turns. Keep blockers and pending handoffs outside historical headings so the agent can still act on them.\n"
-    ).format(markers=markers)
+    )
 
 
 def _build_l2_focus_brief(focus_topic: str) -> str:
@@ -205,12 +205,12 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         "Keep other active tasks only when they are current blockers or handoff state.\n"
         "\n"
         "Demote old / completed topics:\n"
-        "Place non-current work under: {markers}.\n"
+        f"Place non-current work under: {markers}.\n"
         "These sections are STALE — the agent must not act on them unless the latest user message explicitly\n"
         "requests it. Reduce resolved topics to one-liners or drop.\n"
         "Exception: active blockers and pending handoff state should NOT be demoted even when absent from recent\n"
         "turns. Keep them outside historical headings so the agent retains awareness of unresolved constraints.\n"
-    ).format(markers=markers)
+    )
 
 
 def _summary_model_chain(primary_model: str = "", fallback_models: list[str] | tuple[str, ...] | None = None) -> list[str]:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3648,6 +3648,18 @@ class TestEscalation:
         assert "Exception: active blockers and pending handoff state should NOT be demoted" in prompt
         assert "Keep them outside historical headings so the agent retains awareness" in prompt
 
+    def test_focus_topic_with_braces_does_not_break_prompts(self):
+        from hermes_lcm.escalation import _build_l1_prompt, _build_l2_prompt
+
+        focus_topic = 'payload {"a": 1} and trailing {brace'
+        l1 = _build_l1_prompt("test content", 500, depth=0, focus_topic=focus_topic)
+        l2 = _build_l2_prompt("test content", 500, focus_topic=focus_topic)
+
+        assert f"Primary focus: {focus_topic}" in l1
+        assert f"Primary focus: {focus_topic}" in l2
+        assert "Demote old / completed topics:" in l1
+        assert "Demote old / completed topics:" in l2
+
     def test_focus_topic_is_normalized_and_bounded_in_prompts(self):
         from hermes_lcm.escalation import _build_l1_prompt
         noisy_focus = "  migration\n\n" + ("very-long-topic " * 40)


### PR DESCRIPTION
## Summary
- replace the trailing `.format(markers=markers)` calls in the L1/L2 focus brief builders with direct f-string interpolation
- prevent `focus_topic` values containing literal braces from breaking prompt construction
- add a regression test covering brace-containing focus topics

## Root cause
`_build_l1_focus_brief()` and `_build_l2_focus_brief()` interpolated `focus_topic` into the prompt and then called `.format(markers=markers)` on the whole string. If `focus_topic` contained literal `{...}` content (for example JSON or unmatched `{`), prompt construction could raise `ValueError` / `KeyError` during formatting.

## Test plan
- added `test_focus_topic_with_braces_does_not_break_prompts`
- locally verified `_build_l1_focus_brief()` and `_build_l2_focus_brief()` with a topic containing `payload {"a": 1} and trailing {brace`
