### PR TITLE
fix: add CREATE_NO_WINDOW to _git() subprocess call on Windows

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -13,6 +13,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import threading
 import time
 import weakref
@@ -295,12 +296,17 @@ def _git_runtime_identity(root: Path) -> dict[str, Any]:
 
     def _git(*args: str) -> str | None:
         try:
+            popen_kwargs = {
+                "check": False,
+                "capture_output": True,
+                "text": True,
+                "timeout": 1,
+            }
+            if sys.platform == "win32":
+                popen_kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
             result = subprocess.run(
                 ["git", "-C", str(root), *args],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=1,
+                **popen_kwargs,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             logger.debug("LCM git identity probe failed at %s: %s", root, exc)


### PR DESCRIPTION
## Problem

When the Hermes gateway runs under `pythonw.exe` (GUI subsystem, no console), the `subprocess.run()` call to `git` in `_git()` (engine.py) allocates a visible `conhost.exe` window.

## Root Cause

`pythonw.exe` is a GUI-subsystem process with no console. When it spawns a console-mode child (like `git.exe`), the child allocates its own console — which appears as a visible window. The `CREATE_NO_WINDOW` flag (`0x08000000`) suppresses this.

## Fix

Add `creationflags=0x08000000` (`CREATE_NO_WINDOW`) to the `subprocess.run()` call in `_git()` on Windows. No-op on POSIX.

```python
if sys.platform == "win32":
    popen_kwargs["creationflags"] = 0x08000000  # CREATE_NO_WINDOW
```

## Testing

- Verified on Windows 10 with Hermes gateway running as `pythonw.exe`
- `git` calls from LCM engine no longer pop up console windows
- POSIX behavior unchanged