### PR TITLE
Data-safety fixes: GC tombstone, ingest visibility, ignore-drop count, recall order

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -34,6 +34,7 @@ from .externalize import (
     build_transcript_gc_placeholder,
     extract_externalized_ref,
     find_externalized_payload_for_message,
+    is_externalized_placeholder,
     load_externalized_payload,
     maybe_externalize_tool_output,
 )
@@ -465,6 +466,13 @@ class LCMEngine(ContextEngine):
             self._config.ignore_message_patterns
         )
         self._ignored_message_count: int = 0
+        # Raw messages permanently dropped because they matched
+        # ignore_message_patterns. These are NOT persisted anywhere, so an
+        # over-broad operator pattern silently discards substantive turns from
+        # the "lossless" store. Count + log them so the loss is at least
+        # visible; full lossless retention (store with ignored=1) is a larger
+        # follow-up that touches cursor reconciliation and FTS.
+        self._ignore_pattern_dropped_count: int = 0
 
         # Track which store_ids have been ingested into the DAG
         self._last_compacted_store_id: int = 0
@@ -534,6 +542,16 @@ class LCMEngine(ContextEngine):
         self._last_condensation_suppressed_reason = ""
         self._last_compression_status = "idle"
         self._last_compression_noop_reason = ""
+        # Ingest-failure tracking. The core promise is that nothing is ever
+        # lost, but a swallowed persistence error (disk full, DB locked,
+        # corruption) silently breaks it: the turn continues while messages
+        # exist only in the volatile host list. Surface it instead of hiding
+        # it in a debug log so get_status()/doctor can escalate. Store-scoped,
+        # not session-scoped, so it is not cleared on session reset.
+        self._ingest_failure_count = 0
+        self._consecutive_ingest_failures = 0
+        self._last_ingest_error = ""
+        self._last_ingest_error_time: float = 0
         # Cooldown timestamp to prevent compression cascade after boundary skip.
         # Set when skip-carry-over path is taken in _continue_compression_boundary.
         self._last_boundary_skip_time: float = 0
@@ -931,6 +949,32 @@ class LCMEngine(ContextEngine):
         self._last_boundary_skip_time = 0
         return False
 
+    def _record_ingest_success(self) -> None:
+        self._consecutive_ingest_failures = 0
+
+    def _record_ingest_failure(self, where: str, error: Exception) -> None:
+        """Track a swallowed ingest error so it is operator-visible.
+
+        Escalates to error level once failures are consecutive: a single
+        transient lock is a warning, but a sustained inability to persist
+        means the lossless guarantee is broken and must not stay hidden.
+        """
+        self._ingest_failure_count += 1
+        self._consecutive_ingest_failures += 1
+        self._last_ingest_error = f"{type(error).__name__}: {error}"
+        self._last_ingest_error_time = time.time()
+        message = "LCM ingest failed (%s): %s [consecutive=%d, total=%d]"
+        args = (
+            where,
+            error,
+            self._consecutive_ingest_failures,
+            self._ingest_failure_count,
+        )
+        if self._consecutive_ingest_failures >= 3:
+            logger.error(message, *args)
+        else:
+            logger.warning(message, *args)
+
     def ingest(self, messages: List[Dict[str, Any]]) -> None:
         """Persist messages to the durable store every turn.
 
@@ -949,12 +993,13 @@ class LCMEngine(ContextEngine):
         if self._session_id and messages:
             try:
                 self._ingest_messages(messages)
+                self._record_ingest_success()
                 logger.debug(
                     "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
                     self._session_id, len(messages), self._ingest_cursor,
                 )
             except Exception as e:
-                logger.warning("Ingest during per-turn ingest(): %s", e)
+                self._record_ingest_failure("per-turn ingest()", e)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         if self._session_ignored or self._session_stateless or self._thread_context_stateless():
@@ -995,8 +1040,18 @@ class LCMEngine(ContextEngine):
         if self._session_id and messages:
             try:
                 replay_messages = self._ingest_messages(messages)
+                self._record_ingest_success()
             except Exception as e:
-                logger.warning("Ingest during preflight: %s", e)
+                # Fail closed for NORMAL threshold compaction: the store did not
+                # accept this turn, so do not compact against a store missing the
+                # latest messages - that could rebuild active context without
+                # them. But still honor emergency overflow recovery, whose whole
+                # job is to keep the prompt under the provider limit; it converges
+                # via deterministic L3 truncation without needing the store write.
+                self._record_ingest_failure("preflight", e)
+                if self._should_force_overflow_recovery(observed_tokens=rough):
+                    return True
+                return False
         if replay_messages is not None and replay_messages != messages:
             if self._compression_boundary_cooldown_active():
                 return False
@@ -3104,6 +3159,10 @@ class LCMEngine(ContextEngine):
             "threshold_tokens": self.threshold_tokens,
             "last_compression_status": self._last_compression_status,
             "last_compression_noop_reason": self._last_compression_noop_reason,
+            "ingest_failure_count": self._ingest_failure_count,
+            "consecutive_ingest_failures": self._consecutive_ingest_failures,
+            "last_ingest_error": self._last_ingest_error,
+            "last_ingest_error_time": self._last_ingest_error_time,
             "model": self.model,
             "provider": self.provider,
             "context_length_source": self._context_length_source,
@@ -3164,6 +3223,7 @@ class LCMEngine(ContextEngine):
             status["stateless_session_patterns_source"] = self._config.stateless_session_patterns_source
             status["ignore_message_patterns_source"] = self._config.ignore_message_patterns_source
             status["ignored_message_count"] = self._ignored_message_count
+            status["ignore_pattern_dropped_count"] = self._ignore_pattern_dropped_count
             status["ingest_reconciliation"] = dict(self._last_ingest_reconciliation)
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
@@ -5129,11 +5189,25 @@ class LCMEngine(ContextEngine):
                         active_message["content"] = self._ignored_active_replay_placeholder(original_text)
                         active_replay_messages[absolute_idx] = active_message
                     excerpt = original_text[:80].replace("\n", " ")
-                    logger.debug(
-                        "LCM ignore_message_patterns dropped %s message: %r",
-                        original_msg.get("role", "unknown"),
-                        excerpt,
-                    )
+                    if ignored_original_messages[absolute_idx]:
+                        # A raw message matched ignore_message_patterns and is
+                        # discarded here - never persisted anywhere. Count and
+                        # log it (INFO) so an over-broad pattern silently eating
+                        # substantive turns is at least visible to the operator.
+                        self._ignore_pattern_dropped_count += 1
+                        logger.info(
+                            "LCM ignore_message_patterns dropped %s message "
+                            "(not persisted; total dropped=%d): %r",
+                            original_msg.get("role", "unknown"),
+                            self._ignore_pattern_dropped_count,
+                            excerpt,
+                        )
+                    else:
+                        logger.debug(
+                            "LCM ignore_message_patterns dropped %s message: %r",
+                            original_msg.get("role", "unknown"),
+                            excerpt,
+                        )
                     continue
                 kept.append((absolute_idx, replay_msg))
             messages_to_store_with_index = kept
@@ -5445,7 +5519,13 @@ class LCMEngine(ContextEngine):
             if not content:
                 continue
 
-            ref = extract_externalized_ref(content)
+            # Only take the fast ref-branch when the ENTIRE row is the
+            # externalized placeholder. A ref merely embedded in surrounding
+            # text (e.g. a recall-tool result that quotes a placeholder) must
+            # fall through to the content-equality lookup below, which tombstones
+            # only when the full row content matches the stored payload -
+            # otherwise the surrounding, never-externalized text is lost.
+            ref = extract_externalized_ref(content) if is_externalized_placeholder(content) else None
             if ref:
                 externalized = load_externalized_payload(
                     ref,

--- a/engine.py
+++ b/engine.py
@@ -3063,8 +3063,9 @@ class LCMEngine(ContextEngine):
         ):
             try:
                 self._ingest_messages(messages)
+                self._record_ingest_success()
             except Exception as e:
-                logger.warning("Ingest during tool call failed: %s", e)
+                self._record_ingest_failure("tool-call ingest", e)
 
         handlers = {
             "lcm_grep": lcm_tools.lcm_grep,

--- a/store.py
+++ b/store.py
@@ -1084,7 +1084,7 @@ class MessageStore:
                         WHERE {' AND '.join(where)}
                         {order_by}
                         LIMIT ? OFFSET ?""",
-                    [*base_args, *exact_args, *order_args, batch_limit, offset],
+                    [*base_args, *order_args, *exact_args, batch_limit, offset],
                 ).fetchall()
                 if not rows:
                     break

--- a/store.py
+++ b/store.py
@@ -1002,7 +1002,7 @@ class MessageStore:
                         WHERE {' AND '.join(where)}
                         {order_by}
                         LIMIT ? OFFSET ?""",
-                    [*base_args, *order_args, batch_limit, offset],
+                    [*base_args, *exact_args, *order_args, batch_limit, offset],
                 ).fetchall()
                 scanned_rows += len(rows)
                 add_rows(rows)
@@ -1052,6 +1052,19 @@ class MessageStore:
                     score_exprs.append(expr)
                     order_args.extend(expr_args)
             score_expr = " + ".join(score_exprs) if score_exprs else "0"
+            exact_exprs: list[str] = []
+            exact_args: list[Any] = []
+            for phrase in phrases:
+                phrase_text = (phrase or "").strip()
+                if phrase_text:
+                    exact_exprs.append("CASE WHEN LOWER(content) = LOWER(?) THEN 1 ELSE 0 END")
+                    exact_args.append(phrase_text)
+            for term in terms:
+                term_text = (term or "").strip()
+                if term_text:
+                    exact_exprs.append("CASE WHEN LOWER(content) = LOWER(?) THEN 1 ELSE 0 END")
+                    exact_args.append(term_text)
+            exact_expr = " + ".join(exact_exprs) if exact_exprs else "0"
             directness_expr = "0.0 + 0"
 
             if normalized_sort == "hybrid":
@@ -1063,7 +1076,7 @@ class MessageStore:
                 primary_expr = f"({score_expr})"
 
             order_by = (
-                f"ORDER BY {primary_expr} DESC, ({directness_expr}) DESC, "
+                f"ORDER BY ({exact_expr}) DESC, {primary_expr} DESC, ({directness_expr}) DESC, "
                 f"{role_bias} ASC, timestamp DESC, store_id DESC"
             )
             candidate_cap = compute_search_candidate_cap(limit)

--- a/store.py
+++ b/store.py
@@ -1089,7 +1089,7 @@ class MessageStore:
                         WHERE {' AND '.join(where)}
                         {order_by}
                         LIMIT ? OFFSET ?""",
-                    [*base_args, *order_args, batch_limit, offset],
+                    [*base_args, *exact_args, *order_args, batch_limit, offset],
                 ).fetchall()
                 if not rows:
                     break

--- a/store.py
+++ b/store.py
@@ -1037,14 +1037,28 @@ class MessageStore:
                         offset += len(tie_rows)
                     break
         else:
-            rows = self._conn.execute(
-                f"""SELECT {_MESSAGE_SELECT_COLUMNS}
-                    FROM messages
-                    WHERE {' AND '.join(where)}
-                    LIMIT ?""",
-                [*base_args, fetch_limit],
-            ).fetchall()
-            add_rows(rows)
+            # Deterministic, recent-biased candidate scan for relevance/hybrid.
+            # Without an ORDER BY the LIKE fallback scored an arbitrary
+            # storage-order slice, so the best matches beyond the first page
+            # were never examined (final ranking still happens in Python below).
+            candidate_cap = compute_search_candidate_cap(limit)
+            offset = 0
+            while offset < candidate_cap:
+                batch_limit = min(fetch_limit, candidate_cap - offset)
+                rows = self._conn.execute(
+                    f"""SELECT {_MESSAGE_SELECT_COLUMNS}
+                        FROM messages
+                        WHERE {' AND '.join(where)}
+                        ORDER BY timestamp DESC, store_id DESC
+                        LIMIT ? OFFSET ?""",
+                    [*base_args, batch_limit, offset],
+                ).fetchall()
+                if not rows:
+                    break
+                add_rows(rows)
+                offset += len(rows)
+                if len(rows) < batch_limit:
+                    break
 
         results.sort(key=lambda result: _fallback_result_sort_key(result, sort))
         for result in results:

--- a/store.py
+++ b/store.py
@@ -1002,7 +1002,7 @@ class MessageStore:
                         WHERE {' AND '.join(where)}
                         {order_by}
                         LIMIT ? OFFSET ?""",
-                    [*base_args, *exact_args, *order_args, batch_limit, offset],
+                    [*base_args, *order_args, batch_limit, offset],
                 ).fetchall()
                 scanned_rows += len(rows)
                 add_rows(rows)

--- a/store.py
+++ b/store.py
@@ -903,16 +903,16 @@ class MessageStore:
         collapse_risky_repeats = contains_risky_fts_ascii(query)
         order_by = ""
         order_args: list[Any] = []
+        role_bias = "CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
+
+        def count_expr(term: str) -> tuple[str, list[Any]]:
+            return (
+                "((LENGTH(LOWER(content)) - LENGTH(REPLACE(LOWER(content), LOWER(?), ''))) "
+                "/ NULLIF(LENGTH(?), 0))",
+                [term, term],
+            )
+
         if normalized_sort == "recency":
-            role_bias = "CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
-
-            def count_expr(term: str) -> tuple[str, list[Any]]:
-                return (
-                    "((LENGTH(LOWER(content)) - LENGTH(REPLACE(LOWER(content), LOWER(?), ''))) "
-                    "/ NULLIF(LENGTH(?), 0))",
-                    [term, term],
-                )
-
             score_exprs: list[str] = []
             for term in terms:
                 if collapse_risky_repeats:
@@ -1037,10 +1037,35 @@ class MessageStore:
                         offset += len(tie_rows)
                     break
         else:
-            # Deterministic, recent-biased candidate scan for relevance/hybrid.
-            # Without an ORDER BY the LIKE fallback scored an arbitrary
-            # storage-order slice, so the best matches beyond the first page
-            # were never examined (final ranking still happens in Python below).
+            # Deterministic relevance/hybrid candidate scan for LIKE fallback.
+            # Apply the same coarse score/directness ordering before the hard
+            # candidate cap that Python uses below; otherwise a recent-biased
+            # window can exclude older but materially better relevance matches.
+            score_exprs: list[str] = []
+            order_args = []
+            for term in terms:
+                if collapse_risky_repeats:
+                    score_exprs.append("CASE WHEN content LIKE ? ESCAPE '\\' THEN 1 ELSE 0 END")
+                    order_args.append(f"%{escape_like(term)}%")
+                else:
+                    expr, expr_args = count_expr(term)
+                    score_exprs.append(expr)
+                    order_args.extend(expr_args)
+            score_expr = " + ".join(score_exprs) if score_exprs else "0"
+            directness_expr = "0.0 + 0"
+
+            if normalized_sort == "hybrid":
+                primary_expr = (
+                    f"(({score_expr}) / (1 + (MAX(0.0, "
+                    f"((strftime('%s','now') - timestamp) / 3600.0)) * {AGE_DECAY_RATE})))"
+                )
+            else:
+                primary_expr = f"({score_expr})"
+
+            order_by = (
+                f"ORDER BY {primary_expr} DESC, ({directness_expr}) DESC, "
+                f"{role_bias} ASC, timestamp DESC, store_id DESC"
+            )
             candidate_cap = compute_search_candidate_cap(limit)
             offset = 0
             while offset < candidate_cap:
@@ -1049,9 +1074,9 @@ class MessageStore:
                     f"""SELECT {_MESSAGE_SELECT_COLUMNS}
                         FROM messages
                         WHERE {' AND '.join(where)}
-                        ORDER BY timestamp DESC, store_id DESC
+                        {order_by}
                         LIMIT ? OFFSET ?""",
-                    [*base_args, batch_limit, offset],
+                    [*base_args, *order_args, batch_limit, offset],
                 ).fetchall()
                 if not rows:
                     break

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -3071,6 +3071,28 @@ def test_ignore_message_patterns_scan_only_new_tail_after_cursor(tmp_path):
     assert [row["content"] for row in rows][-2:] == ["old message 49", "new message"]
 
 
+def test_ignore_message_pattern_drop_is_counted_and_surfaced_in_status(tmp_path):
+    engine = _engine(tmp_path)
+    engine._compiled_ignore_message_patterns = [_CountingIgnorePattern()]
+
+    engine._ingest_messages([
+        {"role": "user", "content": "keep this substantive turn"},
+        {"role": "user", "content": "DROP: noisy heartbeat"},
+    ])
+
+    # The matched message is not persisted (unchanged behavior)...
+    rows = engine._store.get_session_messages(engine.current_session_id)
+    assert [row["content"] for row in rows] == ["keep this substantive turn"]
+    # ...but the drop is no longer silent: it is counted and visible in status.
+    assert engine._ignore_pattern_dropped_count == 1
+    status = engine.get_status()
+    assert status["ignore_pattern_dropped_count"] == 1
+
+    doctor = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    drop_check = next(c for c in doctor["checks"] if c["check"] == "ignore_pattern_drops")
+    assert drop_check["status"] == "warn"
+
+
 def test_live_placeholder_text_does_not_match_ignore_pattern_via_payload(tmp_path):
     engine = _engine(tmp_path)
     pattern = _CountingIgnorePattern()

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1274,6 +1274,20 @@ class TestMessageStore:
         assert results, "expected LIKE-fallback matches"
         assert results[0]["store_id"] == needle_id
 
+    @pytest.mark.parametrize("sort", ["relevance", "hybrid"])
+    def test_like_fallback_relevance_sort_binds_order_args_before_exact_match(self, store, monkeypatch, sort):
+        import hermes_lcm.store as store_module
+
+        monkeypatch.setattr(store_module, "compute_search_candidate_cap", lambda _limit: 10)
+        needle_id = store.append("sess1", {"role": "user", "content": "alpha beta older best"})
+        for i in range(20):
+            store.append("sess1", {"role": "user", "content": f"alpha recent filler {i}"})
+
+        results = store.search("alpha-beta", session_id="sess1", limit=5, sort=sort)
+
+        assert [result["store_id"] for result in results][:1] == [needle_id]
+        assert any(result["store_id"] == needle_id for result in results)
+
     def test_like_fallback_relevance_sort_finds_recent_match_beyond_first_page(self, store):
         # Regression: with more matching rows than the candidate fetch limit,
         # the relevance/hybrid LIKE fallback fetched an arbitrary storage-order

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1113,6 +1113,21 @@ class TestMessageStore:
         assert scoped_results == []
         assert {result["session_id"] for result in all_results} == {"sess1", "sess2"}
 
+    def test_like_fallback_relevance_sort_does_not_drop_older_best_match_at_candidate_cap(self, store):
+        # Regression: relevance LIKE fallback must order by relevance before
+        # applying the candidate cap. A recent-first window can miss an older
+        # row with a higher term score.
+        needle_id = store.append(
+            "sess1", {"role": "user", "content": "検索対象 検索対象 検索対象 older best match"}
+        )
+        for i in range(520):
+            store.append("sess1", {"role": "user", "content": f"検索対象 recent filler {i}"})
+
+        results = store.search("検索対象", session_id="sess1", limit=5, sort="relevance")
+
+        assert results, "expected LIKE-fallback matches"
+        assert results[0]["store_id"] == needle_id
+
     def test_like_fallback_relevance_sort_finds_recent_match_beyond_first_page(self, store):
         # Regression: with more matching rows than the candidate fetch limit,
         # the relevance/hybrid LIKE fallback fetched an arbitrary storage-order

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -5150,3 +5150,23 @@ class TestLCMEngineCloning:
             shutdown = getattr(clone, "shutdown", None)
             if callable(shutdown):
                 shutdown()
+
+
+def test_like_fallback_relevance_preserves_exact_match_before_candidate_cap(tmp_path):
+    from hermes_lcm.store import MessageStore
+    import hermes_lcm.store as store_module
+
+    original = store_module.compute_search_candidate_cap
+    store_module.compute_search_candidate_cap = lambda limit: 2
+    try:
+        store = MessageStore(tmp_path / "lcm.db")
+        try:
+            for idx in range(4):
+                store.append("s", {"role": "assistant", "content": f"needle filler filler filler {idx}"})
+            store.append("s", {"role": "assistant", "content": "needle"})
+            results = store.search("needle", session_id="s", limit=1, sort="relevance")
+            assert results[0]["content"] == "needle"
+        finally:
+            store.close()
+    finally:
+        store_module.compute_search_candidate_cap = original

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1113,6 +1113,24 @@ class TestMessageStore:
         assert scoped_results == []
         assert {result["session_id"] for result in all_results} == {"sess1", "sess2"}
 
+    def test_like_fallback_relevance_sort_finds_recent_match_beyond_first_page(self, store):
+        # Regression: with more matching rows than the candidate fetch limit,
+        # the relevance/hybrid LIKE fallback fetched an arbitrary storage-order
+        # (oldest-first) slice with no ORDER BY, so the most relevant recent
+        # match beyond the first page was never scored. It must now scan
+        # recent-first up to the candidate cap. The CJK query forces the LIKE
+        # fallback path (FTS cannot tokenize it).
+        for i in range(60):
+            store.append("sess1", {"role": "user", "content": f"検索対象 background note {i}"})
+        needle_id = store.append(
+            "sess1", {"role": "user", "content": "検索対象 検索対象 検索対象 top match"}
+        )
+
+        results = store.search("検索対象", session_id="sess1", limit=5, sort="relevance")
+
+        assert results, "expected LIKE-fallback matches"
+        assert results[0]["store_id"] == needle_id
+
     def test_source_stored_and_filterable(self, store):
         store.append("sess1", {"role": "user", "content": "docker in cli"}, source="cli")
         store.append("sess2", {"role": "user", "content": "docker in discord"}, source="discord")

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2919,6 +2919,45 @@ class TestEngineABC:
         assert "store_messages" in status
         assert "dag_nodes" in status
 
+    def test_ingest_failure_is_surfaced_in_status_and_not_swallowed(self, engine):
+        def boom(_messages):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        engine._ingest_messages = boom
+        msgs = [{"role": "user", "content": "turn that cannot be persisted"}]
+
+        engine.ingest(msgs)
+        status = engine.get_status()
+        assert status["ingest_failure_count"] == 1
+        assert status["consecutive_ingest_failures"] == 1
+        assert "OperationalError" in status["last_ingest_error"]
+
+        engine.threshold_tokens = 1
+        assert engine.should_compress_preflight(msgs) is False
+        status = engine.get_status()
+        assert status["ingest_failure_count"] == 2
+        assert status["consecutive_ingest_failures"] == 2
+
+        del engine._ingest_messages
+        engine.ingest(msgs)
+        status = engine.get_status()
+        assert status["consecutive_ingest_failures"] == 0
+        assert status["ingest_failure_count"] == 2
+
+    def test_preflight_ingest_failure_still_allows_emergency_overflow_recovery(self, engine):
+        # Fail-closed defers NORMAL compaction on ingest failure, but emergency
+        # overflow recovery (which keeps the prompt under the provider limit and
+        # converges via deterministic L3) must still be requested.
+        def boom(_messages):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        engine._ingest_messages = boom
+        engine._should_force_overflow_recovery = lambda **kwargs: True
+
+        assert engine.should_compress_preflight(
+            [{"role": "user", "content": "over-limit turn"}]
+        ) is True
+
     def test_lcm_grep_ingests_live_history_before_search(self, engine):
         engine.on_session_start("live-search", platform="telegram", context_length=200000)
         messages = [
@@ -18649,6 +18688,45 @@ class TestEngineTools:
         )
 
         assert engine._store.get(tool_store_id)["content"].startswith("[GC'd externalized tool output:")
+
+    def test_gc_does_not_tombstone_row_with_only_embedded_externalized_ref(self, tmp_path):
+        # Regression: a tool row that merely QUOTES an externalized placeholder
+        # inside surrounding text (e.g. a recall-tool result) must not have its
+        # whole content tombstoned - that would discard the surrounding text,
+        # which was never externalized and is unrecoverable.
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_gc_embed.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=200,
+            large_output_transcript_gc_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine._session_id = "test-session"
+
+        big = "RESULT:\n" + ("abcdef" * 2000)
+        engine._ingest_messages([
+            {"role": "tool", "tool_call_id": "call_ext", "content": big},
+        ])
+        placeholder = next(
+            row for row in engine._store.get_range("test-session") if row["role"] == "tool"
+        )["content"]
+        assert placeholder.startswith("[Externalized tool output:")
+        assert "ref=" in placeholder
+
+        embedded = f"Here are the search results:\n{placeholder}\nEnd of results."
+        embed_store_id = engine._store.append(
+            "test-session",
+            {"role": "tool", "tool_call_id": "call_recall", "content": embedded},
+        )
+
+        engine._maybe_gc_compacted_tool_results(
+            [{"role": "tool", "tool_call_id": "call_recall", "content": embedded}],
+            [embed_store_id],
+        )
+
+        preserved = engine._store.get(embed_store_id)["content"]
+        assert preserved == embedded
+        assert not preserved.startswith("[GC'd externalized")
 
     def test_handle_expand_does_not_inline_full_externalized_payload_for_gc_rows(self, tmp_path, monkeypatch):
         config = LCMConfig(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2958,6 +2958,25 @@ class TestEngineABC:
             [{"role": "user", "content": "over-limit turn"}]
         ) is True
 
+    def test_tool_call_ingest_failure_is_surfaced_in_status(self, engine):
+        engine.on_session_start("live-search-failure", platform="telegram", context_length=200000)
+
+        def boom(_messages):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        engine._ingest_messages = boom
+
+        engine.handle_tool_call(
+            "lcm_status",
+            {},
+            messages=[{"role": "user", "content": "turn that cannot be persisted"}],
+        )
+
+        status = engine.get_status()
+        assert status["ingest_failure_count"] == 1
+        assert status["consecutive_ingest_failures"] == 1
+        assert "OperationalError" in status["last_ingest_error"]
+
     def test_lcm_grep_ingests_live_history_before_search(self, engine):
         engine.on_session_start("live-search", platform="telegram", context_length=200000)
         messages = [

--- a/tools.py
+++ b/tools.py
@@ -2002,6 +2002,41 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "detail": str(e),
         })
 
+    # Ingest health: a swallowed persistence error means turns were not
+    # durably stored, silently breaking the lossless guarantee. Surface it.
+    ingest_failures = int(getattr(engine, "_ingest_failure_count", 0) or 0)
+    consecutive_failures = int(getattr(engine, "_consecutive_ingest_failures", 0) or 0)
+    if consecutive_failures > 0:
+        ingest_status = "fail"
+    elif ingest_failures > 0:
+        ingest_status = "warn"
+    else:
+        ingest_status = "pass"
+    checks.append({
+        "check": "ingest_health",
+        "status": ingest_status,
+        "detail": {
+            "total_failures": ingest_failures,
+            "consecutive_failures": consecutive_failures,
+            "last_error": getattr(engine, "_last_ingest_error", "") or "",
+            "last_error_time": getattr(engine, "_last_ingest_error_time", 0) or 0,
+        } if ingest_failures else "no ingest failures recorded",
+    })
+
+    # ignore_message_patterns drops discard raw content that is never persisted.
+    # A non-zero count is worth surfacing so an over-broad pattern is noticed.
+    dropped = int(getattr(engine, "_ignore_pattern_dropped_count", 0) or 0)
+    checks.append({
+        "check": "ignore_pattern_drops",
+        "status": "warn" if dropped else "pass",
+        "detail": (
+            f"{dropped} message(s) dropped by ignore_message_patterns and not "
+            "persisted; verify the pattern is not matching substantive turns"
+            if dropped
+            else "no messages dropped by ignore_message_patterns"
+        ),
+    })
+
     try:
         conn = engine._store._conn
         if conn is None:


### PR DESCRIPTION
## Summary
- Transcript GC only takes the fast externalized-ref branch when the whole row IS the placeholder (`is_externalized_placeholder`); an embedded ref now falls through to the content-equality lookup instead of tombstoning the entire row.
- Per-turn `ingest()` and `should_compress_preflight()` record persistence failures (count, last error) instead of swallowing them at debug; `get_status()` and `lcm_doctor` surface an `ingest_health` check, and failures escalate to error when consecutive.
- Preflight fails closed on ingest failure (does not compact against a store missing the latest turn) but still honors emergency overflow recovery.
- `ignore_message_patterns` drops are counted, logged at info, and surfaced in status/doctor (`ignore_pattern_drops`).
- The relevance/hybrid LIKE search fallback scans deterministically recent-first up to the candidate cap instead of scoring an arbitrary storage-order slice with no `ORDER BY`.

## Why
- The core guarantee is that nothing is ever lost, but a tool row that merely quotes an externalized placeholder (e.g. output of the LCM recall tools) had its surrounding, never-externalized text discarded by GC.
- A failing store (disk full, lock beyond busy-timeout, corruption) previously stopped persisting turns silently, with only a debug log; the loss must be operator-visible and must not let the prompt overflow the provider.
- An over-broad `ignore_message_patterns` silently discarded substantive turns from the "lossless" store; drops should at least be visible.
- Without an `ORDER BY`, relevance/hybrid recall on CJK/degraded-FTS queries never scored the best matches beyond the first storage-order page.

## Validation
- Resolved current-main merge conflicts on branch head `f66c290`.
- Addressed Codex P2 on LIKE fallback ordering: SQL candidate cap now orders by relevance/hybrid primary score before exact whole-query tie-breaks, avoiding single-term exact rows crowding out stronger multi-term matches.
- Focused local validation with host stub: CJK LIKE fallback relevance tests, exact whole-query/multi-term regression tests, sensitive-ingest search regression, and ingest-failure status tests passed.
- CI green on head `f66c290`: workflow-lint and Python 3.11, 3.12, 3.13, 3.14.
