### PR TITLE
Perf: memoize token counts and skip unchanged metadata commits

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3575,7 +3575,16 @@ class LCMEngine(ContextEngine):
                 return
             serialized = json.dumps(payload, sort_keys=True)
             with self._store._write_lock:
+                wrote = False
                 for key in count_keys:
+                    # Skip the write (and its fsync commit under synchronous=FULL)
+                    # when the stored value already matches. This runs on every
+                    # ingest and was previously an unconditional UPSERT+commit.
+                    existing = conn.execute(
+                        "SELECT value FROM metadata WHERE key = ?", (key,)
+                    ).fetchone()
+                    if existing is not None and existing[0] == serialized:
+                        continue
                     conn.execute(
                         """
                         INSERT INTO metadata(key, value)
@@ -3584,7 +3593,9 @@ class LCMEngine(ContextEngine):
                         """,
                         (key, serialized),
                     )
-                conn.commit()
+                    wrote = True
+                if wrote:
+                    conn.commit()
         except Exception:
             logger.debug("LCM ignored placeholder count metadata write failed", exc_info=True)
 
@@ -3653,7 +3664,15 @@ class LCMEngine(ContextEngine):
                 return
             serialized = json.dumps(payload, sort_keys=True)
             with self._store._write_lock:
+                wrote = False
                 for key in ordinal_keys:
+                    # Skip the write (and its fsync commit) when unchanged; see
+                    # the counts writer above for rationale.
+                    existing = conn.execute(
+                        "SELECT value FROM metadata WHERE key = ?", (key,)
+                    ).fetchone()
+                    if existing is not None and existing[0] == serialized:
+                        continue
                     conn.execute(
                         """
                         INSERT INTO metadata(key, value)
@@ -3662,7 +3681,9 @@ class LCMEngine(ContextEngine):
                         """,
                         (key, serialized),
                     )
-                conn.commit()
+                    wrote = True
+                if wrote:
+                    conn.commit()
         except Exception:
             logger.debug("LCM ignored placeholder ordinal metadata write failed", exc_info=True)
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1025,6 +1025,13 @@ class TestTokens:
         after = _count_tokens_cached.cache_info()
         assert after.hits >= before.hits + 5
 
+    def test_fallback_token_estimate_ascii_fast_path_skips_character_scan(self):
+        from hermes_lcm.tokens import _fallback_token_estimate
+
+        text = "a" * 80_000
+
+        assert _fallback_token_estimate(text) == len(text) // 4 + 1
+
     def test_fallback_token_estimate_scales_up_for_cjk(self):
         from hermes_lcm.tokens import _fallback_token_estimate
 
@@ -1032,6 +1039,19 @@ class TestTokens:
         cjk = "検索対象データ処理" * 20
         assert _fallback_token_estimate(latin) == len(latin) // 4 + 1
         assert _fallback_token_estimate(cjk) > len(cjk) // 4 + 1
+
+    def test_count_tokens_does_not_cache_large_strings(self):
+        from hermes_lcm import tokens as token_module
+
+        token_module._count_tokens_cached.cache_clear()
+        oversized = "x" * (token_module._MAX_CACHEABLE_TOKEN_TEXT_CHARS + 1)
+        first = token_module.count_tokens(oversized)
+        before = token_module._count_tokens_cached.cache_info()
+        assert token_module.count_tokens(oversized) == first
+        after = token_module._count_tokens_cached.cache_info()
+
+        assert after.currsize == before.currsize == 0
+        assert after.hits == before.hits == 0
 
     def test_count_tokens_tolerates_non_string_unhashable_input(self):
         assert count_tokens({"api_key": 1}) >= 0

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1014,6 +1014,36 @@ class TestTokens:
         assert count_message_tokens(msg) == count_message_tokens(normalized_msg)
         assert count_message_tokens(msg) > 100
 
+    def test_count_tokens_is_memoized(self):
+        from hermes_lcm.tokens import _count_tokens_cached
+
+        text = "a repeated content string used across a turn " * 20
+        first = count_tokens(text)
+        before = _count_tokens_cached.cache_info()
+        for _ in range(5):
+            assert count_tokens(text) == first
+        after = _count_tokens_cached.cache_info()
+        assert after.hits >= before.hits + 5
+
+    def test_fallback_token_estimate_scales_up_for_cjk(self):
+        from hermes_lcm.tokens import _fallback_token_estimate
+
+        latin = "the quick brown fox " * 20
+        cjk = "検索対象データ処理" * 20
+        assert _fallback_token_estimate(latin) == len(latin) // 4 + 1
+        assert _fallback_token_estimate(cjk) > len(cjk) // 4 + 1
+
+    def test_count_tokens_tolerates_non_string_unhashable_input(self):
+        assert count_tokens({"api_key": 1}) >= 0
+        msg = {
+            "role": "assistant",
+            "content": "calling",
+            "tool_calls": [
+                {"function": {"name": "lookup", "arguments": {"api_key": 1}}}
+            ],
+        }
+        assert count_message_tokens(msg) > 0
+
     def test_count_messages_tokens(self):
         msgs = [
             {"role": "user", "content": "hello"},

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1040,18 +1040,31 @@ class TestTokens:
         assert _fallback_token_estimate(latin) == len(latin) // 4 + 1
         assert _fallback_token_estimate(cjk) > len(cjk) // 4 + 1
 
-    def test_count_tokens_does_not_cache_large_strings(self):
+    def test_count_tokens_cache_boundary_is_literal_32_kib(self, monkeypatch):
         from hermes_lcm import tokens as token_module
 
-        token_module._count_tokens_cached.cache_clear()
-        oversized = "x" * (token_module._MAX_CACHEABLE_TOKEN_TEXT_CHARS + 1)
-        first = token_module.count_tokens(oversized)
-        before = token_module._count_tokens_cached.cache_info()
-        assert token_module.count_tokens(oversized) == first
-        after = token_module._count_tokens_cached.cache_info()
+        assert token_module._MAX_CACHEABLE_TOKEN_TEXT_CHARS == 32_768
 
-        assert after.currsize == before.currsize == 0
-        assert after.hits == before.hits == 0
+        monkeypatch.setattr(token_module, "_get_encoder", lambda: None)
+        token_module._count_tokens_cached.cache_clear()
+
+        boundary = "x" * 32_768
+        first = token_module.count_tokens(boundary)
+        before = token_module._count_tokens_cached.cache_info()
+        assert before.currsize == 1
+        assert token_module.count_tokens(boundary) == first
+        after_boundary = token_module._count_tokens_cached.cache_info()
+        assert after_boundary.currsize == 1
+        assert after_boundary.hits == before.hits + 1
+
+        oversized = "x" * 32_769
+        assert token_module.count_tokens(oversized) > 0
+        before_oversized_repeat = token_module._count_tokens_cached.cache_info()
+        assert token_module.count_tokens(oversized) > 0
+        after_oversized_repeat = token_module._count_tokens_cached.cache_info()
+
+        assert after_oversized_repeat.currsize == before_oversized_repeat.currsize == 1
+        assert after_oversized_repeat.hits == before_oversized_repeat.hits
 
     def test_count_tokens_tolerates_non_string_unhashable_input(self):
         assert count_tokens({"api_key": 1}) >= 0
@@ -5171,9 +5184,11 @@ class TestLCMEngineCloning:
 def test_count_tokens_skips_lru_for_large_strings(monkeypatch):
     import hermes_lcm.tokens as tokens
 
+    assert tokens._MAX_CACHEABLE_TOKEN_TEXT_CHARS == 32_768
+
     tokens._count_tokens_cached.cache_clear()
     monkeypatch.setattr(tokens, "_get_encoder", lambda: None)
-    large = "x" * (tokens._MAX_CACHEABLE_TOKEN_TEXT_CHARS + 1)
+    large = "x" * 32_769
 
     first = tokens.count_tokens(large)
     second = tokens.count_tokens(large)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -5167,3 +5167,16 @@ class TestLCMEngineCloning:
             shutdown = getattr(clone, "shutdown", None)
             if callable(shutdown):
                 shutdown()
+
+def test_count_tokens_skips_lru_for_large_strings(monkeypatch):
+    import hermes_lcm.tokens as tokens
+
+    tokens._count_tokens_cached.cache_clear()
+    monkeypatch.setattr(tokens, "_get_encoder", lambda: None)
+    large = "x" * (tokens._MAX_CACHEABLE_TOKEN_TEXT_CHARS + 1)
+
+    first = tokens.count_tokens(large)
+    second = tokens.count_tokens(large)
+
+    assert first == second
+    assert tokens._count_tokens_cached.cache_info().currsize == 0

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2919,6 +2919,23 @@ class TestEngineABC:
         assert "store_messages" in status
         assert "dag_nodes" in status
 
+    def test_placeholder_metadata_write_skips_when_unchanged(self, engine):
+        conn = engine._store._conn
+        if not engine._ignored_placeholder_count_metadata_keys():
+            pytest.skip("no placeholder metadata keys bound for this session")
+
+        engine._write_generated_ignored_placeholder_hash_counts({"a" * 16: 2})
+        changes_after_first = conn.total_changes
+
+        # Identical payload: no UPSERT executed, so no fsync commit either.
+        engine._write_generated_ignored_placeholder_hash_counts({"a" * 16: 2})
+        assert conn.total_changes == changes_after_first
+
+        # A changed payload still writes.
+        engine._write_generated_ignored_placeholder_hash_counts({"a" * 16: 3})
+        assert conn.total_changes > changes_after_first
+        assert engine._load_generated_ignored_placeholder_hash_counts().get("a" * 16) == 3
+
     def test_lcm_grep_ingests_live_history_before_search(self, engine):
         engine.on_session_start("live-search", platform="telegram", context_length=200000)
         messages = [

--- a/tokens.py
+++ b/tokens.py
@@ -4,6 +4,7 @@ Uses tiktoken when available, falls back to char-based estimate.
 """
 
 import logging
+from functools import lru_cache
 from typing import Any, Dict, List
 
 from .message_content import normalize_content_value
@@ -29,17 +30,62 @@ def _get_encoder():
     return _encoder
 
 
-def count_tokens(text: str) -> int:
-    """Count tokens in a string."""
-    if not text:
+def _fallback_token_estimate(text: str) -> int:
+    # Latin text is ~4 chars/token, but CJK and other non-Latin scripts
+    # tokenize far denser (~1-2 tokens/char). A flat len//4 undercounts them
+    # ~3-4x, so preflight under-triggers and assembly can overflow the real
+    # budget. Scale the divisor down as the non-ASCII share rises.
+    length = len(text)
+    if length == 0:
         return 0
+    non_ascii = sum(1 for ch in text if ord(ch) > 127)
+    ratio = non_ascii / length
+    if ratio >= 0.5:
+        divisor = 1.5
+    elif ratio >= 0.2:
+        divisor = 2.5
+    else:
+        divisor = _CHARS_PER_TOKEN
+    return int(length / divisor) + 1
+
+
+def _count_tokens_core(text) -> int:
     enc = _get_encoder()
     if enc is not None:
         try:
             return len(enc.encode(text))
         except Exception:
             pass
+    if isinstance(text, str):
+        return _fallback_token_estimate(text)
     return len(text) // _CHARS_PER_TOKEN + 1
+
+
+@lru_cache(maxsize=8192)
+def _count_tokens_cached(text: str) -> int:
+    # tiktoken encoding is the dominant per-turn cost: assembly and preflight
+    # re-count the same content many times per turn. The encoder is decided
+    # once per process (see _get_encoder), so a content-keyed cache is stable.
+    return _count_tokens_core(text)
+
+
+# Cap what the LRU may retain by reference. Very large strings are the ones
+# least likely to recur identically, and caching them would let the 8192-entry
+# LRU pin hundreds of MB; count those uncached (cost is proportional to size
+# either way).
+_MAX_CACHEABLE_TOKEN_TEXT_CHARS = 32_768
+
+
+def count_tokens(text) -> int:
+    """Count tokens in a string."""
+    if not text:
+        return 0
+    # Only strings are memoized. Callers may pass non-string, unhashable values
+    # (e.g. tool_call arguments as a dict); preserve the legacy tolerance by
+    # counting those uncached rather than feeding them to the LRU.
+    if isinstance(text, str) and len(text) <= _MAX_CACHEABLE_TOKEN_TEXT_CHARS:
+        return _count_tokens_cached(text)
+    return _count_tokens_core(text)
 
 
 def count_message_tokens(msg: Dict[str, Any]) -> int:

--- a/tokens.py
+++ b/tokens.py
@@ -76,7 +76,7 @@ def _count_tokens_cached(text: str) -> int:
 # least likely to recur identically, and caching them would still let the
 # bounded LRU pin unnecessary memory; count those uncached (cost is
 # proportional to size either way).
-_MAX_CACHEABLE_TOKEN_TEXT_CHARS=4096_768
+_MAX_CACHEABLE_TOKEN_TEXT_CHARS = 32_768
 
 
 def count_tokens(text) -> int:

--- a/tokens.py
+++ b/tokens.py
@@ -34,10 +34,13 @@ def _fallback_token_estimate(text: str) -> int:
     # Latin text is ~4 chars/token, but CJK and other non-Latin scripts
     # tokenize far denser (~1-2 tokens/char). A flat len//4 undercounts them
     # ~3-4x, so preflight under-triggers and assembly can overflow the real
-    # budget. Scale the divisor down as the non-ASCII share rises.
+    # budget. ASCII-only text is overwhelmingly common and can use the cheap
+    # legacy estimate without scanning every character.
     length = len(text)
     if length == 0:
         return 0
+    if text.isascii():
+        return length // _CHARS_PER_TOKEN + 1
     non_ascii = sum(1 for ch in text if ord(ch) > 127)
     ratio = non_ascii / length
     if ratio >= 0.5:
@@ -61,7 +64,7 @@ def _count_tokens_core(text) -> int:
     return len(text) // _CHARS_PER_TOKEN + 1
 
 
-@lru_cache(maxsize=8192)
+@lru_cache(maxsize=2048)
 def _count_tokens_cached(text: str) -> int:
     # tiktoken encoding is the dominant per-turn cost: assembly and preflight
     # re-count the same content many times per turn. The encoder is decided
@@ -70,10 +73,10 @@ def _count_tokens_cached(text: str) -> int:
 
 
 # Cap what the LRU may retain by reference. Very large strings are the ones
-# least likely to recur identically, and caching them would let the 8192-entry
-# LRU pin hundreds of MB; count those uncached (cost is proportional to size
-# either way).
-_MAX_CACHEABLE_TOKEN_TEXT_CHARS = 32_768
+# least likely to recur identically, and caching them would still let the
+# bounded LRU pin unnecessary memory; count those uncached (cost is
+# proportional to size either way).
+_MAX_CACHEABLE_TOKEN_TEXT_CHARS=4096_768
 
 
 def count_tokens(text) -> int:


### PR DESCRIPTION
## Summary
- Add an LRU cache to `count_tokens`, keyed on the string; non-string/unhashable inputs (e.g. `tool_call` arguments passed as a dict) are counted uncached to preserve the existing tolerance, and strings over 32KB bypass the cache to bound its memory.
- Make the char-based token fallback (used when `tiktoken` is absent) non-ASCII-aware so CJK/other dense scripts are not undercounted ~3-4x.
- Read-before-write the generated-ignored placeholder count/ordinal metadata: skip the UPSERT (and its fsync commit under `synchronous=FULL`) when the stored value already matches.

## Why
- Assembly and preflight re-count the same message content many times per turn, and the assembler re-measures candidates while packing to budget (~O(n^2) on tool-heavy transcripts); the encoder is decided once per process, so a content-keyed cache is stable and behavior-preserving.
- An undercounted CJK context makes preflight under-trigger and assembly overflow the real budget.
- The placeholder metadata was UPSERT+committed unconditionally on every ingest, i.e. up to two fsync commits per turn even when nothing changed.

## Validation
- CI green after fix commit `bb0e016` across workflow-lint and Python 3.11-3.14 matrix
