### PR TITLE
Serialize lifecycle/DAG writes and keep the frontier monotonic

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -239,23 +239,25 @@ class SummaryDAG:
         Returns the number of deleted nodes. Used during session reset
         to retain only high-level summaries across sessions.
         """
-        cur = self._conn.execute(
-            """DELETE FROM summary_nodes
-               WHERE session_id = ? AND depth < ?""",
-            (session_id, min_depth),
-        )
-        deleted = cur.rowcount
-        self._conn.commit()
+        with self._db_lock:
+            cur = self._conn.execute(
+                """DELETE FROM summary_nodes
+                   WHERE session_id = ? AND depth < ?""",
+                (session_id, min_depth),
+            )
+            deleted = cur.rowcount
+            self._conn.commit()
         return deleted
 
     def delete_session_nodes(self, session_id: str) -> int:
         """Delete all nodes for a session. Returns count deleted."""
-        cur = self._conn.execute(
-            "DELETE FROM summary_nodes WHERE session_id = ?",
-            (session_id,),
-        )
-        deleted = cur.rowcount
-        self._conn.commit()
+        with self._db_lock:
+            cur = self._conn.execute(
+                "DELETE FROM summary_nodes WHERE session_id = ?",
+                (session_id,),
+            )
+            deleted = cur.rowcount
+            self._conn.commit()
         return deleted
 
     def reassign_session_nodes(self, old_session_id: str, new_session_id: str) -> int:
@@ -264,12 +266,13 @@ class SummaryDAG:
         Used for /new carry-over where retained summaries should become part of
         the fresh session while preserving node IDs and node-to-node links.
         """
-        cur = self._conn.execute(
-            "UPDATE summary_nodes SET session_id = ? WHERE session_id = ?",
-            (new_session_id, old_session_id),
-        )
-        moved = cur.rowcount
-        self._conn.commit()
+        with self._db_lock:
+            cur = self._conn.execute(
+                "UPDATE summary_nodes SET session_id = ? WHERE session_id = ?",
+                (new_session_id, old_session_id),
+            )
+            moved = cur.rowcount
+            self._conn.commit()
         return moved
 
     # -- Read ---------------------------------------------------------------

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -846,18 +846,22 @@ class LifecycleStateStore:
             if state is None or state.current_session_id != session_id:
                 return state
             now = time.time()
+            conn = self._conn
+            assert conn is not None
             # MAX() in SQL keeps the advance monotonic even if a concurrent
             # writer bumped the frontier between the read above and this write.
             # A Python-side max() over the stale read could otherwise regress
             # the checkpoint and force the same range to be compacted twice.
-            self._conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE lcm_lifecycle_state
                 SET current_frontier_store_id = MAX(current_frontier_store_id, ?),
                     updated_at = ?
-                WHERE conversation_id = ?
+                WHERE conversation_id = ? AND current_session_id = ?
                 """,
-                (int(frontier_store_id or 0), now, conversation_id),
+                (int(frontier_store_id or 0), now, conversation_id, session_id),
             )
-            self._conn.commit()
+            if cursor.rowcount == 0:
+                return self.get_by_conversation(conversation_id)
+            conn.commit()
             return self.get_by_conversation(conversation_id)

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -10,13 +10,29 @@ This is the smallest viable substrate for cross-turn/session lifecycle state:
 
 from __future__ import annotations
 
+import functools
 import sqlite3
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
 from .db_bootstrap import configure_connection, run_versioned_migrations
+
+
+def _synchronized(method):
+    """Serialize a read-modify-write method on the store's reentrant lock.
+
+    The lifecycle connection is shared across threads (check_same_thread=False,
+    autocommit). Without serialization, two callers reading state and then
+    writing can interleave and clobber each other's update.
+    """
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            return method(self, *args, **kwargs)
+    return wrapper
 
 
 @dataclass
@@ -42,6 +58,11 @@ class LifecycleStateStore:
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn: Optional[sqlite3.Connection] = None
+        # The connection is opened check_same_thread=False in autocommit mode
+        # and is shared across the gateway thread, dispatcher, and sub-agents.
+        # Serialize read-modify-write flows so concurrent binds/frontier
+        # advances cannot interleave and regress the checkpoint.
+        self._lock = threading.RLock()
         self._init_db()
 
     def _init_db(self) -> None:
@@ -120,6 +141,7 @@ class LifecycleStateStore:
         ).fetchone()
         return self._row_to_state(row)
 
+    @_synchronized
     def bind_session(
         self,
         session_id: str,
@@ -226,6 +248,7 @@ class LifecycleStateStore:
         assert state is not None
         return state
 
+    @_synchronized
     def finalize_session(
         self,
         conversation_id: str | None,
@@ -271,6 +294,7 @@ class LifecycleStateStore:
         self._conn.commit()
         return self.get_by_conversation(state.conversation_id)
 
+    @_synchronized
     def record_rollover(
         self,
         conversation_id: str,
@@ -563,6 +587,7 @@ class LifecycleStateStore:
             "categories": categories,
         }
 
+    @_synchronized
     def record_debt(
         self,
         conversation_id: str | None,
@@ -611,6 +636,7 @@ class LifecycleStateStore:
         self._conn.commit()
         return self.get_by_conversation(conversation_id)
 
+    @_synchronized
     def record_maintenance_attempt(self, conversation_id: str | None) -> LifecycleState | None:
         if not conversation_id:
             return None
@@ -630,6 +656,7 @@ class LifecycleStateStore:
         self._conn.commit()
         return self.get_by_conversation(conversation_id)
 
+    @_synchronized
     def record_reset(self, conversation_id: str | None) -> LifecycleState | None:
         if not conversation_id:
             return None
@@ -652,6 +679,7 @@ class LifecycleStateStore:
         self._conn.commit()
         return self.get_by_conversation(conversation_id)
 
+    @_synchronized
     def prune_empty_sessions(
         self,
         *,
@@ -813,19 +841,23 @@ class LifecycleStateStore:
     ) -> LifecycleState | None:
         if not conversation_id:
             return None
-        state = self.get_by_conversation(conversation_id)
-        if state is None or state.current_session_id != session_id:
-            return state
-        frontier = max(int(frontier_store_id or 0), state.current_frontier_store_id)
-        now = time.time()
-        self._conn.execute(
-            """
-            UPDATE lcm_lifecycle_state
-            SET current_frontier_store_id = ?,
-                updated_at = ?
-            WHERE conversation_id = ?
-            """,
-            (frontier, now, conversation_id),
-        )
-        self._conn.commit()
-        return self.get_by_conversation(conversation_id)
+        with self._lock:
+            state = self.get_by_conversation(conversation_id)
+            if state is None or state.current_session_id != session_id:
+                return state
+            now = time.time()
+            # MAX() in SQL keeps the advance monotonic even if a concurrent
+            # writer bumped the frontier between the read above and this write.
+            # A Python-side max() over the stale read could otherwise regress
+            # the checkpoint and force the same range to be compacted twice.
+            self._conn.execute(
+                """
+                UPDATE lcm_lifecycle_state
+                SET current_frontier_store_id = MAX(current_frontier_store_id, ?),
+                    updated_at = ?
+                WHERE conversation_id = ?
+                """,
+                (int(frontier_store_id or 0), now, conversation_id),
+            )
+            self._conn.commit()
+            return self.get_by_conversation(conversation_id)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2354,6 +2354,39 @@ class TestLifecycleStateStore:
         finally:
             store.close()
 
+    def test_advance_frontier_refuses_stale_session_after_rebind(self, tmp_path):
+        db_path = tmp_path / "lifecycle-frontier-rebind.db"
+        store = LifecycleStateStore(db_path)
+        racer = LifecycleStateStore(db_path)
+        try:
+            store.bind_session("s1", conversation_id="c1")
+            original_get = store.get_by_conversation
+            state_seen_before_rebind = []
+
+            def get_and_rebind_once(conversation_id):
+                state = original_get(conversation_id)
+                if not state_seen_before_rebind:
+                    state_seen_before_rebind.append(state.current_session_id)
+                    racer.bind_session("s2", conversation_id="c1")
+                return state
+
+            store.get_by_conversation = get_and_rebind_once
+            try:
+                returned = store.advance_frontier("c1", "s1", 123)
+            finally:
+                del store.get_by_conversation
+
+            final = store.get_by_conversation("c1")
+            assert state_seen_before_rebind == ["s1"]
+            assert returned is not None
+            assert returned.current_session_id == "s2"
+            assert returned.current_frontier_store_id == 0
+            assert final.current_session_id == "s2"
+            assert final.current_frontier_store_id == 0
+        finally:
+            store.close()
+            racer.close()
+
     def test_init_upgrades_legacy_db_and_keeps_missing_state_safe(self, tmp_path):
         db_path = tmp_path / "legacy-lifecycle.db"
         conn = sqlite3.connect(db_path)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2328,6 +2328,32 @@ class TestLifecycleStateStore:
 
         state.close()
 
+    def test_advance_frontier_is_monotonic_under_stale_read(self, tmp_path):
+        import dataclasses
+
+        store = LifecycleStateStore(tmp_path / "lifecycle-frontier.db")
+        try:
+            store.bind_session("s1", conversation_id="c1")
+            store.advance_frontier("c1", "s1", 10)
+            assert store.get_by_conversation("c1").current_frontier_store_id == 10
+
+            # Simulate a racing caller whose read predates the advance to 10:
+            # it sees a stale frontier of 0 and tries to advance to a lower
+            # value. SQL-side MAX must keep the checkpoint monotonic instead of
+            # regressing it (which would force the same range to compact twice).
+            stale = dataclasses.replace(
+                store.get_by_conversation("c1"), current_frontier_store_id=0
+            )
+            store.get_by_conversation = lambda cid: stale
+            try:
+                store.advance_frontier("c1", "s1", 5)
+            finally:
+                del store.get_by_conversation
+
+            assert store.get_by_conversation("c1").current_frontier_store_id == 10
+        finally:
+            store.close()
+
     def test_init_upgrades_legacy_db_and_keeps_missing_state_safe(self, tmp_path):
         db_path = tmp_path / "legacy-lifecycle.db"
         conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Summary
- Add a reentrant lock and a `@_synchronized` decorator over the lifecycle store's read-modify-write methods (`bind_session`, `finalize_session`, `record_rollover`, `record_debt`, `record_maintenance_attempt`, `record_reset`, `prune_empty_sessions`).
- `advance_frontier` computes the new value with SQL `MAX(current_frontier_store_id, ?)` so it stays monotonic even against a stale read.
- `SummaryDAG.delete_below_depth` / `delete_session_nodes` / `reassign_session_nodes` now take `_db_lock` like the other DAG mutators.

## Why
- The lifecycle connection is opened `check_same_thread=False` in autocommit mode and shared across the gateway thread, dispatcher, and sub-agents, but its read-modify-write methods held no lock.
- Two callers advancing the checkpoint frontier could interleave (T1 reads 10 -> writes 15 while T2 reads 10 -> writes 12), regressing the frontier and forcing the same raw range to be compacted again (duplicate summary nodes / GC passes).
- The three DAG mutators executed + committed on the shared connection without the lock the other mutators already hold.

## Validation
- [x] Focused validation: `PYTHONPATH=. python3 -m pytest tests/test_lcm_core.py::TestLifecycleStateStore tests/test_lcm_core.py::TestSummaryDAG -q` -> `54 passed, 24 warnings` (includes the new `test_advance_frontier_is_monotonic_under_stale_read`, which fails on `origin/main`).
- [x] Default validation:
  - [x] `PYTHONPATH=. python3 -m pytest tests -q` -> `1180 passed, 81 warnings`
  - [x] `python3 -m compileall -q .`
  - [x] `python3 -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD`
- [x] Workflow validation, if workflows changed: not applicable; no workflows changed.
- [x] Added-line private/secret hygiene scan -> `0` hits.

## Notes
- Validation used a minimal local `agent.context_engine` stub because this plugin repository is tested standalone outside the Hermes host package.
- The lock is reentrant; the decorated methods only call the undecorated read helpers, so there is no re-entrancy or lock-ordering hazard.
- Part of a set of focused PRs from a larger review of this plugin.

Refs #
