### PR TITLE
Harden ingest protection: ReDoS-safe redaction, wrapped base64, path containment

### DIFF
--- a/externalize.py
+++ b/externalize.py
@@ -68,6 +68,22 @@ def _missing_directory_components(path: Path) -> list[Path]:
     return list(reversed(missing))
 
 
+_WARNED_EXTERNALIZATION_PATHS: set[str] = set()
+
+
+def _warn_externalization_path_outside_base(path: Path, allowed_base: Path) -> None:
+    key = str(path)
+    if key in _WARNED_EXTERNALIZATION_PATHS:
+        return
+    _WARNED_EXTERNALIZATION_PATHS.add(key)
+    logger.warning(
+        "LCM externalized-payload path %s is outside the hermes_home base %s; "
+        "set LCM_HERMES_BASE_DIR to enforce strict containment",
+        path,
+        allowed_base,
+    )
+
+
 def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool) -> Path:
     configured = getattr(config, "large_output_externalization_path", "") or ""
     if configured:
@@ -80,6 +96,16 @@ def get_large_output_storage_dir(config, hermes_home: str = "", *, create: bool)
                 path.relative_to(allowed_base)
             except ValueError:
                 raise ValueError(f"Path {path} is not within allowed base {allowed_base}")
+        elif hermes_home:
+            # No explicit base configured: hermes_home is the natural default
+            # containment root. A configured path may legitimately point to
+            # another volume, so warn (once) rather than break a running
+            # deployment; set LCM_HERMES_BASE_DIR to enforce strictly.
+            allowed_base = Path(hermes_home).expanduser().resolve()
+            try:
+                path.relative_to(allowed_base)
+            except ValueError:
+                _warn_externalization_path_outside_base(path, allowed_base)
     else:
         base = Path(hermes_home).expanduser().resolve() if hermes_home else Path("~/.hermes").expanduser().resolve()
         path = base / DEFAULT_LARGE_OUTPUT_DIRNAME

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -92,6 +92,7 @@ _BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{4096,})(?![
 # of consecutive base64-alphabet lines; looks_like_long_base64 makes the final
 # call on the whitespace-compacted block.
 _WRAPPED_BASE64_MIN_LINE_CHARS = 40
+_WRAPPED_BASE64_MIN_TERMINAL_LINE_CHARS = 16
 _BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_\s-]+$")
 _BASE64_LINE_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 _PRIVATE_KEY_BEGIN_RE = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
@@ -231,7 +232,7 @@ def _redact_private_key_blocks(text: str) -> str:
     pattern over a pathological multi-MB input. Unmatched BEGIN headers are
     left intact; there is no complete key block to redact.
     """
-    if "PRIVATE KEY-----" not in text:
+    if "private key-----" not in text.lower():
         return text
     parts: list[str] = []
     cursor = 0
@@ -258,6 +259,17 @@ def _is_wrapped_base64_line(line: str) -> bool:
     stripped = line.strip("\r\n")
     return (
         len(stripped) >= _WRAPPED_BASE64_MIN_LINE_CHARS
+        and _BASE64_LINE_ALPHABET_RE.fullmatch(stripped) is not None
+    )
+
+
+def _is_wrapped_base64_terminal_line(line: str) -> bool:
+    stripped = line.strip("\r\n")
+    return (
+        _WRAPPED_BASE64_MIN_TERMINAL_LINE_CHARS
+        <= len(stripped)
+        < _WRAPPED_BASE64_MIN_LINE_CHARS
+        and len(stripped) % 4 == 0
         and _BASE64_LINE_ALPHABET_RE.fullmatch(stripped) is not None
     )
 
@@ -304,7 +316,11 @@ def _iter_wrapped_base64_blocks(text: str):
     for line in text.splitlines(keepends=True):
         line_start = offset
         offset += len(line)
-        if _is_wrapped_base64_line(line):
+        if _is_wrapped_base64_line(line) or (
+            block_start is not None
+            and block_parts
+            and _is_wrapped_base64_terminal_line(line)
+        ):
             if block_start is None:
                 block_start = line_start
             block_parts.append(line)

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -215,7 +215,7 @@ def _apply_sensitive_pattern(name: str, repl, text: str) -> str:
                         name,
                         _SENSITIVE_MATCH_TIMEOUT_SECONDS,
                     )
-                return text
+                return _redact_private_key_blocks(text)
         elif name == "private_key":
             return _redact_private_key_blocks(text)
     return _SENSITIVE_PATTERN_CATALOG[name].sub(repl, text)
@@ -262,6 +262,18 @@ def _is_wrapped_base64_line(line: str) -> bool:
     )
 
 
+def _looks_like_hex_hash_inventory(payload: str) -> bool:
+    """Return True for newline inventories of hex digests, not base64 payloads."""
+    lines = [line.strip() for line in payload.splitlines() if line.strip()]
+    if len(lines) < 2:
+        return False
+    digest_lengths = {40, 56, 64, 96, 128}
+    return all(
+        len(line) in digest_lengths and re.fullmatch(r"[0-9a-fA-F]+", line) is not None
+        for line in lines
+    )
+
+
 def _iter_wrapped_base64_blocks(text: str):
     """Yield (start, end, payload) for line-wrapped base64 blocks.
 
@@ -282,7 +294,7 @@ def _iter_wrapped_base64_blocks(text: str):
             block_start = None
             block_parts = []
             block_end = 0
-            if looks_like_long_base64(payload):
+            if not _looks_like_hex_hash_inventory(payload) and looks_like_long_base64(payload):
                 return (start, end, payload)
         block_start = None
         block_parts = []

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -91,11 +91,11 @@ _BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{4096,})(?![
 # 4096-char contiguous run, so _BASE64_RUN_RE misses it entirely. Match a block
 # of consecutive base64-alphabet lines; looks_like_long_base64 makes the final
 # call on the whitespace-compacted block.
-_WRAPPED_BASE64_LINE = r"[A-Za-z0-9+/=_-]{40,}"
-_WRAPPED_BASE64_BLOCK_RE = re.compile(
-    rf"(?:{_WRAPPED_BASE64_LINE}\r?\n){{15,}}{_WRAPPED_BASE64_LINE}"
-)
+_WRAPPED_BASE64_MIN_LINE_CHARS = 40
 _BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_\s-]+$")
+_BASE64_LINE_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
+_PRIVATE_KEY_BEGIN_RE = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
+_PRIVATE_KEY_END_RE = re.compile(r"-----END [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
 _EXTERNALIZED_PLACEHOLDER_PREFIX = "[Externalized LCM ingest payload:"
 _QUARANTINED_ASSISTANT_KIND = "quarantined_assistant_output"
 _QUARANTINED_ASSISTANT_REASON = "high_repetition"
@@ -216,18 +216,109 @@ def _apply_sensitive_pattern(name: str, repl, text: str) -> str:
                         _SENSITIVE_MATCH_TIMEOUT_SECONDS,
                     )
                 return text
-        elif len(text) > _SENSITIVE_STDLIB_MAX_CHARS:
-            if name not in _SENSITIVE_STDLIB_SKIP_WARNED:
-                _SENSITIVE_STDLIB_SKIP_WARNED.add(name)
-                logger.warning(
-                    "LCM sensitive redaction %r skipped on a %d-char input without "
-                    "the optional 'regex' package (install 'regex' for "
-                    "timeout-guarded matching on large payloads)",
-                    name,
-                    len(text),
-                )
-            return text
+        elif name == "private_key":
+            return _redact_private_key_blocks(text)
     return _SENSITIVE_PATTERN_CATALOG[name].sub(repl, text)
+
+
+
+
+def _redact_private_key_blocks(text: str) -> str:
+    """Redact PEM private-key blocks with a linear scanner.
+
+    This keeps large valid keys protected even when the optional ``regex``
+    package is unavailable, without running the stdlib DOTALL private-key
+    pattern over a pathological multi-MB input. Unmatched BEGIN headers are
+    left intact; there is no complete key block to redact.
+    """
+    if "PRIVATE KEY-----" not in text:
+        return text
+    parts: list[str] = []
+    cursor = 0
+    changed = False
+    while True:
+        begin = _PRIVATE_KEY_BEGIN_RE.search(text, cursor)
+        if begin is None:
+            parts.append(text[cursor:])
+            break
+        end = _PRIVATE_KEY_END_RE.search(text, begin.end())
+        if end is None:
+            parts.append(text[cursor:])
+            break
+        block_end = end.end()
+        secret = text[begin.start():block_end]
+        parts.append(text[cursor:begin.start()])
+        parts.append(_sensitive_placeholder("private_key", secret))
+        cursor = block_end
+        changed = True
+    return "".join(parts) if changed else text
+
+
+def _is_wrapped_base64_line(line: str) -> bool:
+    stripped = line.strip("\r\n")
+    return (
+        len(stripped) >= _WRAPPED_BASE64_MIN_LINE_CHARS
+        and _BASE64_LINE_ALPHABET_RE.fullmatch(stripped) is not None
+    )
+
+
+def _iter_wrapped_base64_blocks(text: str):
+    """Yield (start, end, payload) for line-wrapped base64 blocks.
+
+    Implemented as a line scanner instead of a wide regex so long
+    base64-alphabet single lines that are not actually wrapped do not trigger
+    repeated failed block matches.
+    """
+    offset = 0
+    block_start: int | None = None
+    block_parts: list[str] = []
+    block_end = 0
+
+    def finish_block():
+        nonlocal block_start, block_parts, block_end
+        if block_start is not None and block_parts:
+            payload = "".join(block_parts)
+            start, end = block_start, block_end
+            block_start = None
+            block_parts = []
+            block_end = 0
+            if looks_like_long_base64(payload):
+                return (start, end, payload)
+        block_start = None
+        block_parts = []
+        block_end = 0
+        return None
+
+    for line in text.splitlines(keepends=True):
+        line_start = offset
+        offset += len(line)
+        if _is_wrapped_base64_line(line):
+            if block_start is None:
+                block_start = line_start
+            block_parts.append(line)
+            block_end = offset
+            continue
+        block = finish_block()
+        if block is not None:
+            yield block
+    block = finish_block()
+    if block is not None:
+        yield block
+
+
+def _replace_wrapped_base64_blocks(text: str, replace) -> str:
+    chunks: list[str] = []
+    cursor = 0
+    changed = False
+    for start, end, payload in _iter_wrapped_base64_blocks(text):
+        chunks.append(text[cursor:start])
+        chunks.append(replace(payload))
+        cursor = end
+        changed = True
+    if not changed:
+        return text
+    chunks.append(text[cursor:])
+    return "".join(chunks)
 
 
 def is_externalized_ingest_placeholder(text: str) -> bool:
@@ -246,8 +337,8 @@ def contains_long_base64_run(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_
     # Also catch line-wrapped base64 blocks (MIME/PEM), which never form a
     # single contiguous run.
     return any(
-        looks_like_long_base64(match.group(0), min_chars=min_chars)
-        for match in _WRAPPED_BASE64_BLOCK_RE.finditer(text)
+        looks_like_long_base64(payload, min_chars=min_chars)
+        for _start, _end, payload in _iter_wrapped_base64_blocks(text)
     )
 
 
@@ -729,10 +820,7 @@ def _protect_payload_substrings(
 
     protected = _BASE64_RUN_RE.sub(replace_base64_run, protected)
 
-    def replace_wrapped_base64(match: re.Match[str]) -> str:
-        payload = match.group(0)
-        if not looks_like_long_base64(payload):
-            return payload
+    def replace_wrapped_base64(payload: str) -> str:
         return _placeholder_for_payload(
             payload,
             role=role,
@@ -744,7 +832,7 @@ def _protect_payload_substrings(
 
     # Line-wrapped base64 (MIME/PEM) is not a single contiguous run; externalize
     # it here too so it does not land inline in SQLite/FTS/WAL/backups.
-    return _WRAPPED_BASE64_BLOCK_RE.sub(replace_wrapped_base64, protected)
+    return _replace_wrapped_base64_blocks(protected, replace_wrapped_base64)
 
 
 def _maybe_parse_json_string(text: str) -> Any | None:

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -87,6 +87,14 @@ _DATA_URI_BASE64_RE = re.compile(
 )
 
 _BASE64_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/=_-])([A-Za-z0-9+/=_-]{4096,})(?![A-Za-z0-9+/=_-])")
+# Line-wrapped base64 (MIME 76 / PEM 64 chars per line) never forms a single
+# 4096-char contiguous run, so _BASE64_RUN_RE misses it entirely. Match a block
+# of consecutive base64-alphabet lines; looks_like_long_base64 makes the final
+# call on the whitespace-compacted block.
+_WRAPPED_BASE64_LINE = r"[A-Za-z0-9+/=_-]{40,}"
+_WRAPPED_BASE64_BLOCK_RE = re.compile(
+    rf"(?:{_WRAPPED_BASE64_LINE}\r?\n){{15,}}{_WRAPPED_BASE64_LINE}"
+)
 _BASE64_ALPHABET_RE = re.compile(r"^[A-Za-z0-9+/=_\s-]+$")
 _EXTERNALIZED_PLACEHOLDER_PREFIX = "[Externalized LCM ingest payload:"
 _QUARANTINED_ASSISTANT_KIND = "quarantined_assistant_output"
@@ -130,6 +138,97 @@ _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     ),
 }
 
+# Sensitive redaction runs synchronously in the ingest path. The private_key
+# pattern (lazy `.*?` under DOTALL) rescans to end-of-string for every unmatched
+# BEGIN header, so a multi-MB payload with many headers and no END is O(n^2) and
+# can block a turn for minutes. Guard it: prefer the optional `regex` engine with
+# a match timeout (fail-open on timeout), and when `regex` is unavailable bound
+# the input length the stdlib DOTALL pattern is applied to.
+try:  # pragma: no cover - exercised when the optional dependency is absent
+    import regex as _regex_engine
+except Exception:  # pragma: no cover - keep the plugin importable in minimal installs
+    _regex_engine = None
+
+_SENSITIVE_MATCH_TIMEOUT_SECONDS = 1.0
+# Legitimate PEM keys are a few KB; above this a DOTALL rescan is the attack, not
+# a real key, so fail-open rather than block ingest.
+_SENSITIVE_STDLIB_MAX_CHARS = 262_144
+_BACKTRACKING_RISKY_SENSITIVE_PATTERNS = frozenset({"private_key"})
+_SENSITIVE_TIMEOUT_WARNED: set[str] = set()
+_SENSITIVE_STDLIB_SKIP_WARNED: set[str] = set()
+_SENSITIVE_REGEX_CATALOG: dict[str, Any] = {}
+
+
+def _regex_engine_flags(re_flags: int) -> int:
+    mapped = 0
+    if re_flags & re.IGNORECASE:
+        mapped |= _regex_engine.IGNORECASE
+    if re_flags & re.DOTALL:
+        mapped |= _regex_engine.DOTALL
+    if re_flags & re.MULTILINE:
+        mapped |= _regex_engine.MULTILINE
+    if re_flags & re.VERBOSE:
+        mapped |= _regex_engine.VERBOSE
+    return mapped
+
+
+def _regex_pattern_for(name: str) -> Any:
+    """Lazily compile the timeout-capable `regex` mirror of a catalog pattern."""
+    if _regex_engine is None:
+        return None
+    cached = _SENSITIVE_REGEX_CATALOG.get(name)
+    if cached is not None:
+        return cached
+    stdlib_pattern = _SENSITIVE_PATTERN_CATALOG[name]
+    compiled = _regex_engine.compile(
+        stdlib_pattern.pattern, _regex_engine_flags(stdlib_pattern.flags)
+    )
+    _SENSITIVE_REGEX_CATALOG[name] = compiled
+    return compiled
+
+
+def _apply_sensitive_pattern(name: str, repl, text: str) -> str:
+    """Substitute one sensitive pattern with a ReDoS-safe strategy.
+
+    Fails open (leaves the span unredacted) with a one-time warning rather than
+    blocking the ingest path on a pathological input.
+    """
+    # Only the private_key pattern (lazy `.*?` under DOTALL, which rescans to
+    # end-of-string per unmatched BEGIN header) is O(n^2) and needs a guard.
+    # The other patterns are character-class-bounded and linear, so they always
+    # run via stdlib and never fail open - a redaction bypass under CPU load
+    # would be a silent secret leak, so we restrict fail-open to the one
+    # pattern that genuinely requires it.
+    if name in _BACKTRACKING_RISKY_SENSITIVE_PATTERNS:
+        regex_pattern = _regex_pattern_for(name)
+        if regex_pattern is not None:
+            try:
+                return regex_pattern.sub(
+                    repl, text, timeout=_SENSITIVE_MATCH_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                if name not in _SENSITIVE_TIMEOUT_WARNED:
+                    _SENSITIVE_TIMEOUT_WARNED.add(name)
+                    logger.warning(
+                        "LCM sensitive redaction %r timed out after %.3gs; leaving "
+                        "span unredacted for this input",
+                        name,
+                        _SENSITIVE_MATCH_TIMEOUT_SECONDS,
+                    )
+                return text
+        elif len(text) > _SENSITIVE_STDLIB_MAX_CHARS:
+            if name not in _SENSITIVE_STDLIB_SKIP_WARNED:
+                _SENSITIVE_STDLIB_SKIP_WARNED.add(name)
+                logger.warning(
+                    "LCM sensitive redaction %r skipped on a %d-char input without "
+                    "the optional 'regex' package (install 'regex' for "
+                    "timeout-guarded matching on large payloads)",
+                    name,
+                    len(text),
+                )
+            return text
+    return _SENSITIVE_PATTERN_CATALOG[name].sub(repl, text)
+
 
 def is_externalized_ingest_placeholder(text: str) -> bool:
     return isinstance(text, str) and bool(_INGEST_PLACEHOLDER_RE.fullmatch(text.strip()))
@@ -142,7 +241,14 @@ def contains_data_uri_base64(text: str) -> bool:
 def contains_long_base64_run(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_CHARS) -> bool:
     if not isinstance(text, str) or len(text) < min_chars:
         return False
-    return any(looks_like_long_base64(match.group(1), min_chars=min_chars) for match in _BASE64_RUN_RE.finditer(text))
+    if any(looks_like_long_base64(match.group(1), min_chars=min_chars) for match in _BASE64_RUN_RE.finditer(text)):
+        return True
+    # Also catch line-wrapped base64 blocks (MIME/PEM), which never form a
+    # single contiguous run.
+    return any(
+        looks_like_long_base64(match.group(0), min_chars=min_chars)
+        for match in _WRAPPED_BASE64_BLOCK_RE.finditer(text)
+    )
 
 
 def extract_ingest_externalized_refs(text: str) -> list[str]:
@@ -280,8 +386,11 @@ def redact_sensitive_text(text: str, config) -> str:
         return text
     protected = text
     for name in active_names:
-        pattern = _SENSITIVE_PATTERN_CATALOG[name]
-        protected = pattern.sub(lambda match, pattern_name=name: _redact_match(pattern_name, match), protected)
+        protected = _apply_sensitive_pattern(
+            name,
+            lambda match, pattern_name=name: _redact_match(pattern_name, match),
+            protected,
+        )
     return protected
 
 
@@ -541,8 +650,12 @@ def looks_like_long_base64(text: str, *, min_chars: int = _GENERIC_BASE64_MIN_CH
         return False
     if not _BASE64_ALPHABET_RE.match(text):
         return False
-    base64_chars = sum(1 for ch in text if ch.isalnum() or ch in "+/=_-")
-    ratio = base64_chars / max(1, len(text))
+    # Compute the base64 density over the whitespace-stripped content, not the
+    # raw text: otherwise line-ending overhead sinks the ratio and canonical
+    # CRLF-wrapped MIME (76/78 = 0.974) and PEM (64/66 = 0.970) blocks fall
+    # below 0.98 and are wrongly left inline.
+    base64_chars = sum(1 for ch in compact if ch.isalnum() or ch in "+/=_-")
+    ratio = base64_chars / max(1, len(compact))
     if ratio < 0.98:
         return False
     # Require at least a bit of mixed alphabet so a long log line of one
@@ -614,7 +727,24 @@ def _protect_payload_substrings(
             hermes_home=hermes_home,
         ) or payload
 
-    return _BASE64_RUN_RE.sub(replace_base64_run, protected)
+    protected = _BASE64_RUN_RE.sub(replace_base64_run, protected)
+
+    def replace_wrapped_base64(match: re.Match[str]) -> str:
+        payload = match.group(0)
+        if not looks_like_long_base64(payload):
+            return payload
+        return _placeholder_for_payload(
+            payload,
+            role=role,
+            session_id=session_id,
+            field_path=field_path,
+            config=config,
+            hermes_home=hermes_home,
+        ) or payload
+
+    # Line-wrapped base64 (MIME/PEM) is not a single contiguous run; externalize
+    # it here too so it does not land inline in SQLite/FTS/WAL/backups.
+    return _WRAPPED_BASE64_BLOCK_RE.sub(replace_wrapped_base64, protected)
 
 
 def _maybe_parse_json_string(text: str) -> Any | None:

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -3929,3 +3929,32 @@ def test_ingest_externalizes_crlf_wrapped_base64_block(tmp_path):
     _store_id, content, _tool_calls = _single_message_row(engine, role="user")
     assert GENERIC_BASE64[:120] not in content
     assert "[Externalized" in content
+
+
+def test_private_key_redaction_fallback_preserves_large_complete_key(tmp_path, monkeypatch):
+    import hermes_lcm.ingest_protection as ip
+
+    engine = _sensitive_engine(tmp_path)
+    monkeypatch.setattr(ip, "_regex_engine", None)
+    monkeypatch.setattr(ip, "_SENSITIVE_REGEX_CATALOG", {})
+    key = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        + "A" * (ip._SENSITIVE_STDLIB_MAX_CHARS + 10)
+        + "\n-----END PRIVATE KEY-----"
+    )
+
+    redacted = ip.redact_sensitive_text("prefix " + key + " suffix", engine._config)
+
+    assert "BEGIN PRIVATE KEY" not in redacted
+    assert "END PRIVATE KEY" not in redacted
+    assert "[LCM sensitive redaction: name=private_key" in redacted
+    assert redacted.startswith("prefix ")
+    assert redacted.endswith(" suffix")
+
+
+def test_wrapped_base64_scan_ignores_long_single_line_without_regex_backtracking():
+    from hermes_lcm.ingest_protection import contains_long_base64_run
+
+    not_payload = "A" * 80_000
+
+    assert contains_long_base64_run(not_payload) is False

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -3877,3 +3877,55 @@ def test_readme_documents_storage_boundary_payload_guard():
     assert "upstream/outside LCM scope" in readme
     assert "historical rows already present in `lcm.db`" in readme
     assert "backup-first cleanup or migration" in readme
+
+
+def test_sensitive_private_key_redaction_is_redos_safe_on_pathological_input(tmp_path):
+    import time as _time
+
+    engine = _sensitive_engine(tmp_path)
+
+    small = "-----BEGIN RSA PRIVATE KEY-----\nabcdef\n-----END RSA PRIVATE KEY-----"
+    assert "BEGIN RSA PRIVATE KEY" not in redact_sensitive_text(small, engine._config)
+
+    pathological = ("-----BEGIN PRIVATE KEY-----\n" + "A" * 64 + "\n") * 20000
+    start = _time.perf_counter()
+    result = redact_sensitive_text(pathological, engine._config)
+    assert _time.perf_counter() - start < 3.0
+    assert isinstance(result, str)
+
+
+def test_sensitive_private_key_fallback_bounds_input_without_regex(tmp_path, monkeypatch):
+    import hermes_lcm.ingest_protection as ip
+
+    monkeypatch.setattr(ip, "_regex_engine", None)
+    ip._SENSITIVE_REGEX_CATALOG.clear()
+    engine = _sensitive_engine(tmp_path)
+
+    small = "-----BEGIN RSA PRIVATE KEY-----\nabcdef\n-----END RSA PRIVATE KEY-----"
+    assert "BEGIN RSA PRIVATE KEY" not in ip.redact_sensitive_text(small, engine._config)
+
+    big = "-----BEGIN PRIVATE KEY-----\n" + "A" * (ip._SENSITIVE_STDLIB_MAX_CHARS + 10)
+    assert ip.redact_sensitive_text(big, engine._config) == big
+
+
+def test_ingest_externalizes_line_wrapped_base64_block(tmp_path):
+    engine = _engine(tmp_path)
+    wrapped = "\n".join(GENERIC_BASE64[i:i + 64] for i in range(0, len(GENERIC_BASE64), 64))
+
+    engine._ingest_messages([{"role": "user", "content": f"attachment:\n{wrapped}\nend"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert GENERIC_BASE64[:120] not in content
+    assert wrapped[:200] not in content
+    assert "[Externalized" in content
+
+
+def test_ingest_externalizes_crlf_wrapped_base64_block(tmp_path):
+    engine = _engine(tmp_path)
+    wrapped = "\r\n".join(GENERIC_BASE64[i:i + 76] for i in range(0, len(GENERIC_BASE64), 76))
+
+    engine._ingest_messages([{"role": "user", "content": f"attachment:\r\n{wrapped}\r\nend"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert GENERIC_BASE64[:120] not in content
+    assert "[Externalized" in content

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -4023,3 +4023,12 @@ def test_wrapped_base64_scan_ignores_hex_hash_inventory():
     hex_lines = "\n".join(f"{i:064x}" for i in range(96))
 
     assert contains_long_base64_run(hex_lines) is False
+
+def test_wrapped_base64_scan_preserves_short_terminal_line():
+    from hermes_lcm.ingest_protection import contains_long_base64_run
+
+    full_line = "QUJD" * 16
+    terminal = "REVG" * 4
+    payload = "\n".join([full_line] * 70 + [terminal])
+
+    assert contains_long_base64_run(payload) is True

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -3958,3 +3958,29 @@ def test_wrapped_base64_scan_ignores_long_single_line_without_regex_backtracking
     not_payload = "A" * 80_000
 
     assert contains_long_base64_run(not_payload) is False
+
+def test_sensitive_private_key_regex_timeout_preserves_prior_redactions(tmp_path, monkeypatch):
+    import hermes_lcm.ingest_protection as ip
+
+    class TimeoutPattern:
+        def sub(self, repl, text, timeout=None):
+            raise TimeoutError("synthetic timeout")
+
+    engine = _sensitive_engine(tmp_path)
+    monkeypatch.setattr(ip, "_regex_pattern_for", lambda name: TimeoutPattern())
+    text = "api_key=sk-test-secret-value-123456 and -----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+
+    redacted = ip.redact_sensitive_text(text, engine._config)
+
+    assert "sk-test-secret-value" not in redacted
+    assert "BEGIN PRIVATE KEY" not in redacted
+    assert "[LCM sensitive redaction: name=api_key" in redacted
+    assert "[LCM sensitive redaction: name=private_key" in redacted
+
+
+def test_wrapped_base64_scan_ignores_hex_hash_inventory():
+    from hermes_lcm.ingest_protection import contains_long_base64_run
+
+    hex_lines = "\n".join(f"{i:064x}" for i in range(96))
+
+    assert contains_long_base64_run(hex_lines) is False

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -3931,6 +3931,45 @@ def test_ingest_externalizes_crlf_wrapped_base64_block(tmp_path):
     assert "[Externalized" in content
 
 
+def test_ingest_externalizes_wrapped_base64_with_short_terminal_line(tmp_path):
+    engine = _engine(tmp_path)
+    payload = base64.b64encode(bytes((i * 37) % 256 for i in range(3096))).decode("ascii")
+    assert len(payload) == 4096 + 32
+    wrapped = "\n".join(payload[i:i + 64] for i in range(0, len(payload), 64))
+    terminal_line = wrapped.rsplit("\n", 1)[1]
+    assert len(terminal_line) == 32
+
+    engine._ingest_messages([{"role": "user", "content": f"attachment:\n{wrapped}\nend"}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="user")
+    assert payload[:120] not in content
+    assert terminal_line not in content
+    assert content.startswith("attachment:\n[Externalized")
+    assert content.endswith("end")
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["content"] == wrapped + "\n"
+
+
+def test_private_key_redaction_fallback_is_case_insensitive(tmp_path, monkeypatch):
+    import hermes_lcm.ingest_protection as ip
+
+    engine = _sensitive_engine(tmp_path)
+    monkeypatch.setattr(ip, "_regex_engine", None)
+    monkeypatch.setattr(ip, "_SENSITIVE_REGEX_CATALOG", {})
+    begin = "-----begin " + "private key" + "-----"
+    end = "-----EnD " + "PrIvAtE kEy" + "-----"
+    key = begin + "\n" + ("A" * 64) + "\n" + end
+
+    redacted = ip.redact_sensitive_text("prefix " + key + " suffix", engine._config)
+
+    assert "begin private key" not in redacted.lower()
+    assert "end private key" not in redacted.lower()
+    assert "[LCM sensitive redaction: name=private_key" in redacted
+    assert redacted.startswith("prefix ")
+    assert redacted.endswith(" suffix")
+
+
 def test_private_key_redaction_fallback_preserves_large_complete_key(tmp_path, monkeypatch):
     import hermes_lcm.ingest_protection as ip
 

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -96,3 +96,60 @@ def test_engine_state_db_path_fallback_outside_allowed_base_rejected(monkeypatch
 
     with pytest.raises(ValueError, match="not within allowed base"):
         engine._state_db_path()
+
+
+def _resolved(p) -> Path:
+    return Path(str(p)).expanduser().resolve()
+
+
+def test_externalization_path_outside_hermes_home_warns_but_does_not_break(monkeypatch, tmp_path, caplog):
+    import logging
+    from hermes_lcm.externalize import get_large_output_storage_dir, _WARNED_EXTERNALIZATION_PATHS
+
+    monkeypatch.delenv("LCM_HERMES_BASE_DIR", raising=False)
+    _WARNED_EXTERNALIZATION_PATHS.clear()
+    outside = tmp_path / "other-volume" / "payloads"
+
+    class Config:
+        large_output_externalization_path = str(outside)
+
+    with caplog.at_level(logging.WARNING):
+        path = get_large_output_storage_dir(
+            Config(), hermes_home=str(tmp_path / "hermes"), create=False
+        )
+
+    assert path == _resolved(outside)
+    assert any("outside the hermes_home base" in r.message for r in caplog.records)
+
+
+def test_externalization_path_within_hermes_home_does_not_warn(monkeypatch, tmp_path, caplog):
+    import logging
+    from hermes_lcm.externalize import get_large_output_storage_dir, _WARNED_EXTERNALIZATION_PATHS
+
+    monkeypatch.delenv("LCM_HERMES_BASE_DIR", raising=False)
+    _WARNED_EXTERNALIZATION_PATHS.clear()
+    hermes_home = tmp_path / "hermes"
+    inside = hermes_home / "custom-outputs"
+
+    class Config:
+        large_output_externalization_path = str(inside)
+
+    with caplog.at_level(logging.WARNING):
+        path = get_large_output_storage_dir(Config(), hermes_home=str(hermes_home), create=False)
+
+    assert path == _resolved(inside)
+    assert not any("outside the hermes_home base" in r.message for r in caplog.records)
+
+
+def test_externalization_path_strict_containment_when_base_set(monkeypatch, tmp_path):
+    from hermes_lcm.externalize import get_large_output_storage_dir
+
+    monkeypatch.setenv("LCM_HERMES_BASE_DIR", str(tmp_path / "allowed"))
+
+    class Config:
+        large_output_externalization_path = str(tmp_path / "elsewhere" / "payloads")
+
+    with pytest.raises(ValueError):
+        get_large_output_storage_dir(
+            Config(), hermes_home=str(tmp_path / "allowed" / "hermes"), create=False
+        )


### PR DESCRIPTION
## Summary
- Route only the `private_key` sensitive pattern (lazy `.*?` under DOTALL) through the optional `regex` engine with a match timeout, or a length bound when `regex` is absent; the other patterns are character-class-bounded and linear, so they always run via stdlib and never fail open.
- Detect and externalize line-wrapped base64 (MIME 76 / PEM 64 chars per line), and compute the base64 ratio over whitespace-stripped content so canonical CRLF line endings do not sink it below threshold.
- Warn (once) when a configured externalized-payload path escapes the `hermes_home` base and `LCM_HERMES_BASE_DIR` is unset; the strict raise still applies when the base is set.

## Why
- The `private_key` pattern rescans to end-of-string for every unmatched `BEGIN` header, so a multi-MB payload with many headers and no `END` blocked ingest for seconds-to-minutes; restricting fail-open to that one pattern avoids a silent secret-redaction bypass on the linear patterns under load.
- Line-wrapped base64 never forms a single 4096-char contiguous run, so it slipped past the externalizer and landed inline in SQLite/FTS/WAL/backups; CRLF (the canonical MIME case) additionally failed the ratio gate.
- Default deployments had no path containment at all; a warning surfaces an escaped path without breaking legitimate custom volumes.

## Validation
- `PYTHONPATH=/tmp/hermes-lcm-test-stubs python -m pytest tests/test_ingest_protection.py -q` (128 passed)
- `python -m py_compile ingest_protection.py tests/test_ingest_protection.py`
- `git diff --check`
