### PR TITLE
Add a steady-state per-turn hot-path benchmark

### DIFF
--- a/benchmarking/steady_state.py
+++ b/benchmarking/steady_state.py
@@ -169,51 +169,53 @@ def _measure_case(
     history_sizes: tuple[int, ...],
     iterations: int,
 ) -> list[SteadyStateSample]:
-    engine = _build_engine(case, run_dir)
-    history: list[dict[str, Any]] = []
-    next_index = 0
     samples: list[SteadyStateSample] = []
 
     for target in sorted(history_sizes):
-        # Grow the history to the target size (ingesting as we go so the store
-        # tracks it, mirroring how turns accumulate in production).
-        while len(history) < target:
-            history.extend(_synthetic_turn(next_index))
-            next_index += 1
-            engine.ingest(history)
+        target_run_dir = run_dir / f"{case.name}-{target}"
+        engine = _build_engine(case, target_run_dir)
+        history: list[dict[str, Any]] = []
+        next_index = 0
+        try:
+            # Build an independent history for each target so a nearby smaller
+            # target cannot pre-populate store/identity maps for the next one.
+            while len(history) < target:
+                history.extend(_synthetic_turn(next_index))
+                next_index += 1
+                engine.ingest(history)
 
-        ingest_ms: list[float] = []
-        preflight_ms: list[float] = []
-        writes: list[int] = []
-        for _ in range(iterations):
-            history.extend(_synthetic_turn(next_index))
-            next_index += 1
+            ingest_ms: list[float] = []
+            preflight_ms: list[float] = []
+            writes: list[int] = []
+            for _ in range(iterations):
+                history.extend(_synthetic_turn(next_index))
+                next_index += 1
 
-            before_changes = _total_changes(engine)
-            t0 = time.perf_counter()
-            engine.ingest(history)
-            t1 = time.perf_counter()
-            engine.should_compress_preflight(history)
-            t2 = time.perf_counter()
+                before_changes = _total_changes(engine)
+                t0 = time.perf_counter()
+                engine.ingest(history)
+                t1 = time.perf_counter()
+                engine.should_compress_preflight(history)
+                t2 = time.perf_counter()
 
-            ingest_ms.append((t1 - t0) * 1000.0)
-            preflight_ms.append((t2 - t1) * 1000.0)
-            writes.append(max(0, _total_changes(engine) - before_changes))
+                ingest_ms.append((t1 - t0) * 1000.0)
+                preflight_ms.append((t2 - t1) * 1000.0)
+                writes.append(max(0, _total_changes(engine) - before_changes))
 
-        samples.append(
-            SteadyStateSample(
-                case=case.name,
-                history_size=len(history),
-                iterations=iterations,
-                ingest_p50_ms=round(statistics.median(ingest_ms), 4),
-                ingest_p95_ms=round(_percentile(ingest_ms, 95), 4),
-                preflight_p50_ms=round(statistics.median(preflight_ms), 4),
-                preflight_p95_ms=round(_percentile(preflight_ms, 95), 4),
-                row_writes_per_turn=round(statistics.mean(writes), 2) if writes else 0.0,
+            samples.append(
+                SteadyStateSample(
+                    case=case.name,
+                    history_size=len(history),
+                    iterations=iterations,
+                    ingest_p50_ms=round(statistics.median(ingest_ms), 4),
+                    ingest_p95_ms=round(_percentile(ingest_ms, 95), 4),
+                    preflight_p50_ms=round(statistics.median(preflight_ms), 4),
+                    preflight_p95_ms=round(_percentile(preflight_ms, 95), 4),
+                    row_writes_per_turn=round(statistics.mean(writes), 2) if writes else 0.0,
+                )
             )
-        )
-
-    engine.shutdown()
+        finally:
+            engine.shutdown()
     return samples
 
 
@@ -225,6 +227,8 @@ def run_steady_state(
     cases: tuple[SteadyStateCase, ...] = DEFAULT_CASES,
     progress: Optional[Callable[[str], None]] = None,
 ) -> SteadyStateReport:
+    if run_dir.exists() and any(run_dir.iterdir()):
+        raise FileExistsError(f"steady-state output directory is not empty: {run_dir}")
     run_dir.mkdir(parents=True, exist_ok=True)
     report = SteadyStateReport(history_sizes=tuple(sorted(history_sizes)), iterations=iterations)
     for case in cases:

--- a/benchmarking/steady_state.py
+++ b/benchmarking/steady_state.py
@@ -1,0 +1,252 @@
+"""Steady-state per-turn hot-path benchmark.
+
+The existing replay/stress benchmarks time ``compress()``. They do not measure
+the path that runs on *every* turn regardless of compaction: the post-LLM
+``ingest()`` hook plus ``should_compress_preflight()``. That path re-scans the
+active history each turn (quarantine / redaction / placeholder passes, token
+counts, ignore/store-id maps), so its cost can grow with conversation length
+even when nothing is compacted.
+
+This module replays N turns *without* triggering compaction (a very high
+threshold) and records per-turn wall time for ``ingest`` + ``preflight`` at a
+range of history sizes, under a few configurations (baseline, ignore-message
+patterns on, sensitive patterns on). It is a regression guard: per-turn cost
+should stay roughly flat as history grows, not scale with it.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .replay import _ensure_hermes_lcm_package
+
+
+DEFAULT_HISTORY_SIZES = (200, 1000, 4000)
+DEFAULT_ITERATIONS = 25
+# Effectively disable compaction so we isolate the ingest/preflight cost.
+_NO_COMPACT_CONTEXT_LENGTH = 100_000_000
+
+
+@dataclass
+class SteadyStateCase:
+    """One measured configuration."""
+
+    name: str
+    ignore_message_patterns: tuple[str, ...] = ()
+    sensitive_patterns: tuple[str, ...] = ()
+
+
+@dataclass
+class SteadyStateSample:
+    case: str
+    history_size: int
+    iterations: int
+    ingest_p50_ms: float
+    ingest_p95_ms: float
+    preflight_p50_ms: float
+    preflight_p95_ms: float
+    row_writes_per_turn: float
+
+
+@dataclass
+class SteadyStateReport:
+    history_sizes: tuple[int, ...]
+    iterations: int
+    samples: list[SteadyStateSample] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "history_sizes": list(self.history_sizes),
+            "iterations": self.iterations,
+            "samples": [sample.__dict__ for sample in self.samples],
+        }
+
+
+DEFAULT_CASES: tuple[SteadyStateCase, ...] = (
+    SteadyStateCase(name="baseline"),
+    SteadyStateCase(name="ignore_patterns", ignore_message_patterns=("^HEARTBEAT",)),
+    SteadyStateCase(
+        name="sensitive_patterns",
+        sensitive_patterns=("api_key", "bearer_token", "password_assignment", "private_key"),
+    ),
+)
+
+
+def _build_engine(case: SteadyStateCase, run_dir: Path):
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.config import LCMConfig
+    from hermes_lcm.engine import LCMEngine
+
+    db_path = run_dir / f"steady_{case.name}.lcm.db"
+    hermes_home = run_dir / f"hermes-home-{case.name}"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    config = LCMConfig(
+        database_path=str(db_path),
+        # A large fresh tail + very high context length keep both the preflight
+        # threshold and force-overflow recovery from ever firing.
+        fresh_tail_count=8,
+        leaf_chunk_tokens=100_000,
+        context_threshold=0.99,
+    )
+    if case.ignore_message_patterns:
+        setattr(config, "ignore_message_patterns", list(case.ignore_message_patterns))
+    if case.sensitive_patterns:
+        setattr(config, "sensitive_patterns_enabled", True)
+        setattr(config, "sensitive_patterns", list(case.sensitive_patterns))
+
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine.on_session_start(
+        f"steady-{case.name}",
+        platform="benchmark",
+        conversation_id=f"steady-{case.name}",
+        model="benchmark-model",
+        provider="benchmark",
+        context_length=_NO_COMPACT_CONTEXT_LENGTH,
+    )
+    engine.update_model(
+        model="benchmark-model",
+        context_length=_NO_COMPACT_CONTEXT_LENGTH,
+        provider="benchmark",
+    )
+    return engine
+
+
+def _synthetic_turn(index: int) -> list[dict[str, Any]]:
+    # A user/assistant pair with enough varied content to exercise the passes
+    # without tripping externalization or externally-observable heuristics.
+    return [
+        {
+            "role": "user",
+            "content": (
+                f"Turn {index}: please review module_{index % 37}.py and summarize "
+                f"the change to function handler_{index % 53} regarding value {index * 7}."
+            ),
+        },
+        {
+            "role": "assistant",
+            "content": (
+                f"Reviewed module_{index % 37}.py. handler_{index % 53} now clamps "
+                f"value {index * 7} and returns early on empty input; no other changes."
+            ),
+        },
+    ]
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = pct / 100.0 * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def _total_changes(engine: Any) -> int:
+    total = 0
+    for attr in ("_store", "_dag", "_lifecycle"):
+        holder = getattr(engine, attr, None)
+        conn = getattr(holder, "_conn", None)
+        if conn is not None:
+            try:
+                total += int(conn.total_changes)
+            except Exception:
+                pass
+    return total
+
+
+def _measure_case(
+    case: SteadyStateCase,
+    run_dir: Path,
+    history_sizes: tuple[int, ...],
+    iterations: int,
+) -> list[SteadyStateSample]:
+    engine = _build_engine(case, run_dir)
+    history: list[dict[str, Any]] = []
+    next_index = 0
+    samples: list[SteadyStateSample] = []
+
+    for target in sorted(history_sizes):
+        # Grow the history to the target size (ingesting as we go so the store
+        # tracks it, mirroring how turns accumulate in production).
+        while len(history) < target:
+            history.extend(_synthetic_turn(next_index))
+            next_index += 1
+            engine.ingest(history)
+
+        ingest_ms: list[float] = []
+        preflight_ms: list[float] = []
+        writes: list[int] = []
+        for _ in range(iterations):
+            history.extend(_synthetic_turn(next_index))
+            next_index += 1
+
+            before_changes = _total_changes(engine)
+            t0 = time.perf_counter()
+            engine.ingest(history)
+            t1 = time.perf_counter()
+            engine.should_compress_preflight(history)
+            t2 = time.perf_counter()
+
+            ingest_ms.append((t1 - t0) * 1000.0)
+            preflight_ms.append((t2 - t1) * 1000.0)
+            writes.append(max(0, _total_changes(engine) - before_changes))
+
+        samples.append(
+            SteadyStateSample(
+                case=case.name,
+                history_size=len(history),
+                iterations=iterations,
+                ingest_p50_ms=round(statistics.median(ingest_ms), 4),
+                ingest_p95_ms=round(_percentile(ingest_ms, 95), 4),
+                preflight_p50_ms=round(statistics.median(preflight_ms), 4),
+                preflight_p95_ms=round(_percentile(preflight_ms, 95), 4),
+                row_writes_per_turn=round(statistics.mean(writes), 2) if writes else 0.0,
+            )
+        )
+
+    engine.shutdown()
+    return samples
+
+
+def run_steady_state(
+    run_dir: Path,
+    *,
+    history_sizes: tuple[int, ...] = DEFAULT_HISTORY_SIZES,
+    iterations: int = DEFAULT_ITERATIONS,
+    cases: tuple[SteadyStateCase, ...] = DEFAULT_CASES,
+    progress: Optional[Callable[[str], None]] = None,
+) -> SteadyStateReport:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    report = SteadyStateReport(history_sizes=tuple(sorted(history_sizes)), iterations=iterations)
+    for case in cases:
+        if progress is not None:
+            progress(f"measuring case: {case.name}")
+        report.samples.extend(_measure_case(case, run_dir, history_sizes, iterations))
+    return report
+
+
+def format_report(report: SteadyStateReport) -> str:
+    lines = [
+        f"Steady-state per-turn hot path (iterations={report.iterations})",
+        f"history sizes: {', '.join(str(s) for s in report.history_sizes)}",
+        "",
+        f"{'case':<20}{'history':>9}{'ingest p50':>13}{'ingest p95':>13}"
+        f"{'pre p50':>10}{'pre p95':>10}{'writes/turn':>13}",
+    ]
+    for sample in report.samples:
+        lines.append(
+            f"{sample.case:<20}{sample.history_size:>9}"
+            f"{sample.ingest_p50_ms:>12.3f}m{sample.ingest_p95_ms:>12.3f}m"
+            f"{sample.preflight_p50_ms:>9.3f}m{sample.preflight_p95_ms:>9.3f}m"
+            f"{sample.row_writes_per_turn:>13.2f}"
+        )
+    return "\n".join(lines)

--- a/benchmarking/steady_state.py
+++ b/benchmarking/steady_state.py
@@ -219,6 +219,17 @@ def _measure_case(
     return samples
 
 
+def _ignore_message_filtering_active(case: SteadyStateCase) -> bool:
+    """Return whether an ignore-message benchmark case can exercise filtering."""
+
+    if not case.ignore_message_patterns:
+        return True
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.message_patterns import compile_message_patterns
+
+    return bool(compile_message_patterns(case.ignore_message_patterns))
+
+
 def run_steady_state(
     run_dir: Path,
     *,
@@ -232,6 +243,13 @@ def run_steady_state(
     run_dir.mkdir(parents=True, exist_ok=True)
     report = SteadyStateReport(history_sizes=tuple(sorted(history_sizes)), iterations=iterations)
     for case in cases:
+        if not _ignore_message_filtering_active(case):
+            if progress is not None:
+                progress(
+                    f"skipping inactive case: {case.name} "
+                    "(ignore message regex filtering unavailable)"
+                )
+            continue
         if progress is not None:
             progress(f"measuring case: {case.name}")
         report.samples.extend(_measure_case(case, run_dir, history_sizes, iterations))

--- a/scripts/lcm_steady_state_bench.py
+++ b/scripts/lcm_steady_state_bench.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Measure the per-turn ingest/preflight hot path at a range of history sizes.
+
+Unlike lcm_benchmark.py (which times compaction), this replays turns *without*
+compacting and reports how per-turn ingest/preflight latency scales with
+conversation length. Use it as a regression guard: the per-turn cost should stay
+roughly flat as history grows, not scale with it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarking.steady_state import (
+    DEFAULT_HISTORY_SIZES,
+    DEFAULT_ITERATIONS,
+    format_report,
+    run_steady_state,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--history-size",
+        type=int,
+        action="append",
+        default=[],
+        help="History size (message count) to sample. Repeatable. "
+        f"Default: {', '.join(str(s) for s in DEFAULT_HISTORY_SIZES)}.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=DEFAULT_ITERATIONS,
+        help="Measured turns per history size.",
+    )
+    parser.add_argument("--output", help="Directory for benchmark DBs (default: a temp dir).")
+    parser.add_argument("--json", action="store_true", help="Print the report as JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    history_sizes = tuple(args.history_size) if args.history_size else DEFAULT_HISTORY_SIZES
+    run_dir = Path(args.output) if args.output else Path(tempfile.mkdtemp(prefix="lcm-steady-"))
+
+    report = run_steady_state(
+        run_dir,
+        history_sizes=history_sizes,
+        iterations=args.iterations,
+        progress=lambda msg: print(f"[steady-state] {msg}", file=sys.stderr),
+    )
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(format_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_benchmarking_steady_state.py
+++ b/tests/test_benchmarking_steady_state.py
@@ -1,0 +1,55 @@
+"""Tests for the steady-state per-turn hot-path benchmark."""
+
+from benchmarking.steady_state import (
+    SteadyStateCase,
+    format_report,
+    run_steady_state,
+)
+
+
+def test_steady_state_report_covers_all_cases_and_sizes(tmp_path):
+    report = run_steady_state(tmp_path, history_sizes=(20, 60), iterations=3)
+
+    # One sample per (case, history size). Default cases: baseline,
+    # ignore_patterns, sensitive_patterns.
+    assert len(report.samples) == 3 * 2
+    assert {s.case for s in report.samples} == {
+        "baseline",
+        "ignore_patterns",
+        "sensitive_patterns",
+    }
+    # History grows in whole turns (2 msgs), so sizes are >= the requested targets.
+    baseline_sizes = sorted(s.history_size for s in report.samples if s.case == "baseline")
+    assert baseline_sizes[0] >= 20
+    assert baseline_sizes[1] >= 60
+    for sample in report.samples:
+        assert sample.iterations == 3
+        assert sample.ingest_p50_ms >= 0.0
+        assert sample.ingest_p95_ms >= sample.ingest_p50_ms
+        assert sample.preflight_p95_ms >= sample.preflight_p50_ms
+
+
+def test_steady_state_does_not_compact(tmp_path):
+    # The whole point is to isolate ingest/preflight, so compaction must never
+    # fire during the run (very high threshold + context length).
+    report = run_steady_state(
+        tmp_path,
+        history_sizes=(40,),
+        iterations=2,
+        cases=(SteadyStateCase(name="baseline"),),
+    )
+    assert len(report.samples) == 1
+    assert "baseline" in format_report(report)
+
+
+def test_steady_state_report_serializes(tmp_path):
+    report = run_steady_state(
+        tmp_path,
+        history_sizes=(20,),
+        iterations=2,
+        cases=(SteadyStateCase(name="baseline"),),
+    )
+    data = report.to_dict()
+    assert data["iterations"] == 2
+    assert data["history_sizes"] == [20]
+    assert data["samples"] and data["samples"][0]["case"] == "baseline"

--- a/tests/test_benchmarking_steady_state.py
+++ b/tests/test_benchmarking_steady_state.py
@@ -53,3 +53,36 @@ def test_steady_state_report_serializes(tmp_path):
     assert data["iterations"] == 2
     assert data["history_sizes"] == [20]
     assert data["samples"] and data["samples"][0]["case"] == "baseline"
+
+
+def test_steady_state_rejects_populated_output_directory(tmp_path):
+    (tmp_path / "old.json").write_text("{}")
+
+    try:
+        run_steady_state(tmp_path, history_sizes=(20,), iterations=1, cases=(SteadyStateCase(name="baseline"),))
+    except FileExistsError as exc:
+        assert "not empty" in str(exc)
+    else:
+        raise AssertionError("expected FileExistsError")
+
+
+def test_steady_state_isolates_each_target_size(tmp_path, monkeypatch):
+    import benchmarking.steady_state as steady
+
+    built = []
+    original = steady._build_engine
+
+    def tracking_build(case, run_dir):
+        built.append(run_dir.name)
+        return original(case, run_dir)
+
+    monkeypatch.setattr(steady, "_build_engine", tracking_build)
+    report = run_steady_state(
+        tmp_path,
+        history_sizes=(20, 22),
+        iterations=1,
+        cases=(SteadyStateCase(name="baseline"),),
+    )
+
+    assert len(report.samples) == 2
+    assert built == ["baseline-20", "baseline-22"]

--- a/tests/test_benchmarking_steady_state.py
+++ b/tests/test_benchmarking_steady_state.py
@@ -1,5 +1,11 @@
 """Tests for the steady-state per-turn hot-path benchmark."""
 
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
 from benchmarking.steady_state import (
     SteadyStateCase,
     format_report,
@@ -7,7 +13,41 @@ from benchmarking.steady_state import (
 )
 
 
-def test_steady_state_report_covers_all_cases_and_sizes(tmp_path):
+class _FakeRegexPattern:
+    pattern = "^HEARTBEAT"
+
+    def search(self, text, timeout=None):
+        return None
+
+
+class _FakeRegexEngine:
+    error = ValueError
+
+    @staticmethod
+    def compile(pattern):
+        return _FakeRegexPattern()
+
+
+def _enable_message_regex(monkeypatch):
+    import hermes_lcm.message_patterns as message_patterns
+
+    monkeypatch.setattr(message_patterns, "_regex_engine", _FakeRegexEngine)
+    monkeypatch.setattr(message_patterns, "_MISSING_REGEX_WARNING_EMITTED", False)
+
+
+def _load_steady_state_cli():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "lcm_steady_state_bench.py"
+    spec = importlib.util.spec_from_file_location("lcm_steady_state_bench_cli", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_steady_state_report_covers_all_cases_and_sizes(tmp_path, monkeypatch):
+    _enable_message_regex(monkeypatch)
+
     report = run_steady_state(tmp_path, history_sizes=(20, 60), iterations=3)
 
     # One sample per (case, history size). Default cases: baseline,
@@ -86,3 +126,52 @@ def test_steady_state_isolates_each_target_size(tmp_path, monkeypatch):
 
     assert len(report.samples) == 2
     assert built == ["baseline-20", "baseline-22"]
+
+
+def test_steady_state_skips_ignore_case_when_regex_filtering_is_inactive(tmp_path, monkeypatch):
+    import hermes_lcm.message_patterns as message_patterns
+
+    monkeypatch.setattr(message_patterns, "_regex_engine", None)
+    monkeypatch.setattr(message_patterns, "_MISSING_REGEX_WARNING_EMITTED", False)
+    progress: list[str] = []
+
+    report = run_steady_state(
+        tmp_path,
+        history_sizes=(20,),
+        iterations=1,
+        progress=progress.append,
+    )
+
+    assert {sample.case for sample in report.samples} == {"baseline", "sensitive_patterns"}
+    assert all(sample.case != "ignore_patterns" for sample in report.samples)
+    assert any(
+        "skipping inactive case: ignore_patterns" in message
+        and "unavailable" in message
+        for message in progress
+    )
+
+
+def test_steady_state_cli_suppresses_inactive_ignore_case(tmp_path, monkeypatch, capsys):
+    import hermes_lcm.message_patterns as message_patterns
+
+    monkeypatch.setattr(message_patterns, "_regex_engine", None)
+    monkeypatch.setattr(message_patterns, "_MISSING_REGEX_WARNING_EMITTED", False)
+    cli = _load_steady_state_cli()
+
+    result = cli.main([
+        "--history-size",
+        "20",
+        "--iterations",
+        "1",
+        "--output",
+        str(tmp_path),
+        "--json",
+    ])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert result == 0
+    assert {sample["case"] for sample in payload["samples"]} == {"baseline", "sensitive_patterns"}
+    assert "ignore_patterns" not in captured.out
+    assert "[steady-state] skipping inactive case: ignore_patterns" in captured.err


### PR DESCRIPTION
## Summary
- Add `benchmarking/steady_state.py` and `scripts/lcm_steady_state_bench.py`: replay turns WITHOUT compacting (very high threshold + context length) and report per-turn `ingest`/`preflight` p50/p95 and row-writes-per-turn at a range of history sizes, under baseline / `ignore_message_patterns` / `sensitive_patterns` configs.
- Purely additive: three new files, no existing code touched. Adds 3 tests.

## Why
- The existing replay/stress benchmarks time `compress()`. Nothing measured the path that runs on every turn regardless of compaction: the post-LLM `ingest()` hook plus `should_compress_preflight()`, which re-scans the active history each turn.
- Intended as a regression guard so a per-turn cost that scales with conversation length is visible. On the current code the ignore-patterns and sensitive-patterns configs already show clear growth with history size, which a future ingest-path optimization should flatten.

## Validation
- CI green across workflow-lint and Python 3.11-3.14 matrix
