### PR TITLE
docs: spike async compaction atomic publish

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,4 +71,5 @@ lightweight ABC stub.
 
 - [Operator guide](operator-guide.md)
 - [Retrieval tools reference](retrieval-tools.md)
+- [Opt-in async/background compaction design](async-background-compaction.md)
 - [Benchmarking and stress checks](../benchmarks/README.md)

--- a/docs/async-background-compaction.md
+++ b/docs/async-background-compaction.md
@@ -1,0 +1,304 @@
+# Opt-in async/background compaction with atomic publish
+
+Design spike for preparing old stable chunks off the turn-critical path while keeping current LCM behavior unchanged unless explicitly enabled.
+
+Refs:
+
+- Lossless Claw #807 — prepare incremental summaries in the background and publish atomically
+- Lossless Claw #942 — live config must beat stale persisted thresholds/debt
+- Lossless Claw #902 — summary failure/backoff must not wedge compaction debt forever
+
+## Problem
+
+Today `LCMEngine.compress()` does the expensive work synchronously: ingest, select the oldest raw backlog outside the fresh tail, call the summarizer, write canonical DAG nodes, optionally condense, then assemble the active context. That preserves the important cache-friendly property: active context changes only at threshold/full-sweep boundaries. The downside is foreground latency, especially with slow local summarizers or serial leaf chains.
+
+The safe target is not “write summaries in another thread and flip a boolean.” The target is a two-phase lifecycle:
+
+1. **Prepare** non-canonical summaries for old, stable raw-message chunks in the background.
+2. **Promote** a complete, still-valid batch atomically when normal foreground compaction would have run.
+
+Until promotion, active context, search, recall, expansion, transcript GC, and doctor integrity checks behave as if the prepared summaries do not exist.
+
+## Non-goals for the first slice
+
+- No default behavior change.
+- No mandatory background thread in normal installs.
+- No prebuilt condensation layers in the first slice. Leaf-only promotion is already useful and is easier to prove atomic.
+- No replacement for foreground compaction. If prepared work is absent, incomplete, stale, or invalid, foreground compaction falls back to today’s path.
+- No persisted threshold override that can win over live config. Persisted metadata is evidence to validate against live policy, not policy itself.
+
+## Proposed flags
+
+Add config fields, all disabled by default:
+
+| Field | Env | Default | Meaning |
+| --- | --- | ---: | --- |
+| `async_background_compaction_enabled` | `LCM_ASYNC_BACKGROUND_COMPACTION_ENABLED` | `false` | Enables the feature surface. |
+| `async_background_compaction_worker_enabled` | `LCM_ASYNC_BACKGROUND_COMPACTION_WORKER_ENABLED` | `false` | Allows automatic background preparation. Tests and hosts may still call one-shot prep manually when the feature is enabled. |
+| `async_background_compaction_max_batches` | `LCM_ASYNC_BACKGROUND_COMPACTION_MAX_BATCHES` | `2` | Backpressure cap per conversation. |
+| `async_background_compaction_retry_backoff_seconds` | `LCM_ASYNC_BACKGROUND_COMPACTION_RETRY_BACKOFF_SECONDS` | `300` | Cooldown after summary failures. |
+
+The enable flag should guard all writes to the new tables and all promotion attempts. Reader filters must still be robust if old pending rows exist after the flag is later disabled.
+
+## Storage model
+
+Add tables separate from canonical `summary_nodes`:
+
+### `compaction_batches`
+
+One row per prepared generation.
+
+Suggested columns:
+
+- `batch_id TEXT PRIMARY KEY`
+- `conversation_id TEXT NOT NULL`
+- `session_id TEXT NOT NULL`
+- `state TEXT NOT NULL` — `pending`, `preparing`, `ready`, `promoting`, `promoted`, `rejected`, `failed`, `superseded`
+- `frontier_start_store_id INTEGER NOT NULL`
+- `frontier_end_store_id INTEGER NOT NULL`
+- `fresh_tail_count INTEGER NOT NULL`
+- `leaf_chunk_tokens INTEGER NOT NULL`
+- `policy_fingerprint TEXT NOT NULL`
+- `summary_route_fingerprint TEXT NOT NULL`
+- `source_coverage_hash TEXT NOT NULL`
+- `expected_leaf_count INTEGER NOT NULL`
+- `prepared_leaf_count INTEGER NOT NULL DEFAULT 0`
+- `failure_count INTEGER NOT NULL DEFAULT 0`
+- `next_retry_at REAL`
+- `last_error TEXT`
+- `created_at REAL NOT NULL`
+- `updated_at REAL NOT NULL`
+- `promoted_at REAL`
+- `rejected_reason TEXT`
+
+Indexes:
+
+- `(conversation_id, state, created_at)`
+- `(session_id, state, created_at)`
+- `(next_retry_at, state)`
+
+### `pending_summary_nodes`
+
+Prepared but non-canonical leaf summaries.
+
+Suggested columns:
+
+- `pending_id TEXT PRIMARY KEY`
+- `batch_id TEXT NOT NULL REFERENCES compaction_batches(batch_id)`
+- `conversation_id TEXT NOT NULL`
+- `session_id TEXT NOT NULL`
+- `depth INTEGER NOT NULL DEFAULT 0`
+- `summary TEXT NOT NULL`
+- `token_count INTEGER NOT NULL`
+- `source_token_count INTEGER NOT NULL`
+- `source_ids TEXT NOT NULL`
+- `source_identity_hashes TEXT NOT NULL`
+- `source_range_start_store_id INTEGER NOT NULL`
+- `source_range_end_store_id INTEGER NOT NULL`
+- `previous_pending_ids TEXT NOT NULL DEFAULT '[]'`
+- `created_at REAL NOT NULL`
+- `earliest_at REAL`
+- `latest_at REAL`
+- `expand_hint TEXT DEFAULT ''`
+
+Indexes:
+
+- `(batch_id, source_range_start_store_id)`
+- `(conversation_id, state)` is intentionally on the batch table; pending nodes should not have independent canonical state.
+
+Do **not** add pending rows to `summary_nodes`. Reusing the canonical table with a lifecycle flag would make every reader, FTS query, and integrity check a footgun. Keeping pending rows in a separate table gives active-only defaults naturally.
+
+## Fingerprints and validation inputs
+
+A prepared batch is valid only for the exact policy and source frontier it was created for.
+
+### Policy fingerprint
+
+Hash a normalized JSON object of compaction policy inputs that affect chunking or active-context semantics:
+
+- schema/protocol version, e.g. `async_compaction_protocol_v1`
+- `fresh_tail_count`
+- `leaf_chunk_tokens`
+- `context_threshold` / effective preflight threshold policy
+- `dynamic_leaf_chunk_enabled`
+- `dynamic_leaf_chunk_max`
+- `ignore_message_patterns` plus their source
+- sensitive-pattern config that changes stored/summarized text
+- large-output externalization settings that change serializer input
+- `custom_instructions`
+- `l2_budget_ratio`, `l3_truncate_tokens`
+- `incremental_max_depth` only if the batch later supports pending condensation
+
+### Summary route fingerprint
+
+Hash the effective summarizer contract:
+
+- `summary_model`
+- `summary_fallback_models`
+- provider/model route after parsing, if available
+- summarizer timeout class only if it changes produced summaries or failure policy
+- plugin version/protocol version
+
+A model/config change should not necessarily delete pending rows immediately, but promotion must reject rows whose fingerprints no longer match live config.
+
+### Source coverage hash
+
+For every source row in the prepared range, hash a canonical tuple:
+
+```text
+store_id | session_id | conversation_id | role | content_sha256 | tool_call_id | tool_calls_sha256 | tool_name | timestamp
+```
+
+Promotion validates both:
+
+- the ordered set of `store_id`s is exactly what the batch claims;
+- the identity hash for every row still matches.
+
+This catches transcript reconciliation, late ingest of missing rows inside the range, externalization/GC rewrites, and accidental ordinal drift.
+
+## Preparation lifecycle
+
+Background preparation should operate only on raw messages that are outside the fresh tail at preparation time.
+
+1. Resolve live config and compute the compactable prefix using the same filtering as foreground compaction.
+2. Choose the oldest chunk(s) up to the current publishable frontier.
+3. Create or resume a `pending`/`preparing` batch for that frontier.
+4. Generate leaf summaries into `pending_summary_nodes`, optionally using previous pending summaries from the same batch as continuity context.
+5. Mark the batch `ready` only when `prepared_leaf_count == expected_leaf_count` and every expected range is covered exactly once.
+
+Preparation must not mutate:
+
+- `summary_nodes`
+- active replay context
+- compaction count
+- frontier markers
+- transcript GC state
+- generated placeholder ordinals
+
+## Atomic promotion
+
+Foreground compaction remains the owner of canonical changes. When `should_compress_preflight()` says compaction is needed, `compress()` may attempt prepared promotion before doing synchronous summarization.
+
+Promotion runs in one SQLite transaction on a single connection, using `BEGIN IMMEDIATE` so foreground/background writers serialize.
+
+The promotion path should not call existing helpers that perform their own commits on separate SQLite connections. Canonical node inserts, lifecycle frontier updates, batch state changes, and superseding older batches must share one transaction boundary. In-process markers such as `_last_compacted_store_id` should update only after the transaction commits.
+
+Validation inside the transaction:
+
+1. Feature flag still enabled.
+2. Batch is `ready` for this `conversation_id` and `session_id`.
+3. Live policy fingerprint equals batch policy fingerprint.
+4. Live summary route fingerprint equals batch summary route fingerprint.
+5. Current lifecycle frontier equals the batch’s expected start frontier.
+6. Fresh-tail boundary still permits promoting the full prepared range. If the boundary moved such that only a prefix is safe, reject the batch for v1 rather than partially publish.
+7. Source rows for the claimed range still exist, are ordered, and match every source identity hash.
+8. Pending nodes cover the full source range without gaps or overlaps.
+9. No canonical `summary_nodes` already cover the same source IDs. This handles a foreground compaction race that won before promotion.
+
+Publish steps in the same transaction:
+
+1. Insert canonical `summary_nodes` copied from pending rows.
+2. Advance lifecycle frontier to the promoted end store id.
+3. Mark the batch `promoted` with `promoted_at`.
+4. Mark older pending/ready batches for the same conversation `superseded`.
+5. Commit.
+
+Only after commit may the engine assemble active context from canonical summaries. If any validation step fails, mark the batch `rejected` with a reason in a transaction that does **not** insert canonical summaries or advance the frontier, then fall back to today’s foreground compaction path.
+
+## Race semantics
+
+### Foreground compaction wins first
+
+If a synchronous foreground pass inserts canonical nodes and advances the frontier while a background batch is pending, later promotion sees either frontier mismatch or canonical source overlap. It rejects/supersedes the stale batch and leaves the foreground result intact.
+
+### Background ready wins first
+
+Foreground promotion takes `BEGIN IMMEDIATE`, validates current source/frontier/fingerprints, publishes, then assembles. A concurrent background preparer trying to write the same batch waits or fails with normal SQLite busy behavior and must reload batch state before continuing.
+
+### Background failure/backoff
+
+Summary failure increments `failure_count`, stores a compact `last_error`, and sets `next_retry_at`. It must not create compaction debt that blocks foreground recovery. Foreground compaction can always ignore failed/pending work and use the current synchronous path.
+
+### Restart
+
+On startup/session bind:
+
+- `promoting` from a crashed transaction should not be visible as canonical unless the transaction committed. If the batch row says `promoting` but no canonical nodes/frontier were advanced, mark it `rejected` or return it to `ready` after validation.
+- `preparing` older than a timeout becomes `pending` for retry, or `failed` if backoff policy says so.
+- `ready` batches are left ready, but promotion still revalidates live config and source coverage.
+- Pending rows are never used by active context during recovery.
+
+SQLite transaction atomicity should mean there is no half-published active state. Recovery still needs explicit cleanup of stale lifecycle labels so status/doctor is trustworthy.
+
+## Reader and diagnostics rules
+
+Active readers default to canonical rows only:
+
+- `lcm_grep` summary search ignores pending rows.
+- `lcm_expand(node_id=...)` cannot expand pending IDs through the canonical node path.
+- `lcm_describe` active DAG overview excludes pending rows.
+- transcript GC eligibility ignores pending rows.
+- doctor active-context integrity checks ignore pending rows unless checking async health specifically.
+
+Add an explicit async section to status/doctor instead:
+
+```json
+"async_compaction": {
+  "enabled": false,
+  "worker_enabled": false,
+  "pending_batches": 0,
+  "preparing_batches": 0,
+  "prepared_batches": 0,
+  "promoted_batches": 0,
+  "rejected_batches": 0,
+  "failed_batches": 0,
+  "superseded_batches": 0,
+  "pending_summaries": 0,
+  "oldest_pending_age_seconds": null,
+  "last_rejected_reason": null,
+  "last_error": null
+}
+```
+
+Doctor should warn, not fail, for normal disabled state. It should warn on:
+
+- stale `preparing` batches beyond recovery timeout;
+- ready batches whose live policy fingerprint no longer matches;
+- failed batches whose backoff has expired but no worker has retried;
+- pending rows whose batch is missing.
+
+## Implementation sequence
+
+1. **Acceptance tests first** for stale rejection, config change rejection, foreground/background race, summary failure/backoff, restart recovery, successful atomic promotion, pending invisibility, and status/doctor counts.
+2. Schema only: create the two tables and reader filters, with feature disabled and no behavior change.
+3. Manual one-shot preparer behind the flag, no automatic worker yet.
+4. Atomic promotion path in `compress()` before foreground summarization, with fallback on any reject.
+5. Status/doctor async counts.
+6. Optional worker loop with backpressure and retry policy.
+7. Later: pending condensed layers, if leaf-only promotion leaves too much foreground work.
+
+## Test matrix
+
+These are mirrored in `tests/test_async_background_compaction_design.py` as xfailed RED spike tests until the implementation exists.
+
+| Test | Proves |
+| --- | --- |
+| `test_pending_summaries_are_invisible_until_atomic_promotion` | Pending rows do not affect active assembly/search/status counters except async diagnostics. |
+| `test_atomic_promotion_rejects_stale_source_identity` | Transcript reconciliation or row rewrite invalidates the batch without canonical mutation. |
+| `test_atomic_promotion_rejects_live_config_change` | Live config/policy wins over persisted prepared metadata. |
+| `test_foreground_compaction_race_supersedes_pending_batch` | Foreground compaction and background promotion cannot double-compact or mix generations. |
+| `test_summary_failure_backoff_does_not_wedge_foreground_compaction` | Failed background prep backs off but foreground synchronous compaction remains available. |
+| `test_restart_recovers_or_discards_pending_batches_safely` | Restart never makes pending rows canonical and cleans stale lifecycle states. |
+| `test_default_disabled_async_compaction_is_inert` | Default-off config performs no background preparation and reports zero async counts. |
+| `test_atomic_promotion_rejects_summary_route_change` | Model/route changes reject stale prepared summaries before canonical mutation. |
+| `test_atomic_promotion_rejects_live_threshold_policy_change` | Live threshold policy changes beat persisted prepared metadata. |
+| `test_successful_atomic_promotion_is_all_or_nothing` | Canonical node insert, frontier advance, and batch promotion commit together. |
+| `test_atomic_promotion_rolls_back_partial_publish_failure` | A mid-promotion failure leaves no canonical node/frontier/batch half-state. |
+| `test_status_and_doctor_report_async_compaction_counts` | Operators see pending/prepared/promoted/rejected/failed counts. |
+
+## Open questions
+
+- Should v1 reject a ready batch when only a prefix is still publishable, or support prefix promotion? Recommendation: reject in v1. Prefix promotion makes continuity and expected leaf counts more complex.
+- Should automatic workers live inside `LCMEngine`, a plugin lifecycle helper, or a host-managed scheduler? Recommendation: start with a manual one-shot preparer and make the automatic worker a later slice.
+- Should route fingerprint include fallback model order? Recommendation: yes. Different fallback order can change output after partial failures.
+- Should summary timeout changes reject prepared work? Recommendation: no unless timeout policy changes the output contract; include route/model/policy version, not operational timing knobs.

--- a/tests/test_async_background_compaction_design.py
+++ b/tests/test_async_background_compaction_design.py
@@ -1,0 +1,333 @@
+"""RED spike tests for opt-in async/background compaction.
+
+These tests intentionally describe the desired public/private contract before
+implementation exists. They stay xfailed on the design branch so the normal
+suite remains green, but strict xfail means each scenario becomes a real gate as
+soon as the feature starts landing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="async/background compaction with atomic publish is design-only; implementation not landed",
+)
+
+
+def _engine(tmp_path, *, session_id="async-session", conversation_id="async-conversation"):
+    config = LCMConfig(
+        database_path=str(tmp_path / f"{session_id}.db"),
+        fresh_tail_count=2,
+        leaf_chunk_tokens=20,
+        context_threshold=0.10,
+    )
+    # Future config fields. They are dynamic here so these RED tests can be
+    # written before the dataclass grows the real fields.
+    config.async_background_compaction_enabled = True
+    config.async_background_compaction_worker_enabled = False
+    engine = LCMEngine(config=config)
+    engine.on_session_start(
+        session_id,
+        conversation_id=conversation_id,
+        platform="test",
+        context_length=1_000,
+    )
+    return engine
+
+
+def _messages(count=10, *, prefix="message"):
+    messages = [{"role": "system", "content": "system prompt"}]
+    for idx in range(count):
+        role = "user" if idx % 2 == 0 else "assistant"
+        messages.append(
+            {
+                "role": role,
+                "content": f"{prefix} {idx} " + ("x " * 12),
+            }
+        )
+    return messages
+
+
+def test_default_disabled_async_compaction_is_inert(tmp_path):
+    """Given default config, background prep is disabled and reports zero async debt."""
+    config = LCMConfig(
+        database_path=str(tmp_path / "disabled.db"),
+        fresh_tail_count=2,
+        leaf_chunk_tokens=20,
+        context_threshold=0.10,
+    )
+    engine = LCMEngine(config=config)
+    engine.on_session_start(
+        "disabled-session",
+        conversation_id="disabled-conversation",
+        platform="test",
+        context_length=1_000,
+    )
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+
+        result = engine.prepare_background_compaction_once(messages)
+
+        assert result is None or result.state == "disabled"
+        status = json.loads(engine.handle_tool_call("lcm_status", {}))
+        assert status["async_compaction"]["enabled"] is False
+        assert status["async_compaction"]["pending_batches"] == 0
+        assert status["async_compaction"]["prepared_batches"] == 0
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+    finally:
+        engine.shutdown()
+
+
+def test_pending_summaries_are_invisible_until_atomic_promotion(tmp_path):
+    """Given prepared pending leaves, active context/readers ignore them until promotion."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+
+        batch = engine.prepare_background_compaction_once(messages)
+
+        assert batch.state == "ready"
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+        status = json.loads(engine.handle_tool_call("lcm_status", {}))
+        assert status["async_compaction"]["prepared_batches"] == 1
+        assert status["dag"]["total_nodes"] == 0
+        grep = json.loads(engine.handle_tool_call("lcm_grep", {"query": "message"}))
+        assert all(result.get("kind") != "pending_summary" for result in grep.get("results", []))
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_rejects_stale_source_identity(tmp_path):
+    """Given source rows changed after prep, promotion rejects without canonical mutation."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        first_source_id = batch.source_ids[0]
+        engine._store._conn.execute(
+            "UPDATE messages SET content = content || ' reconciled late' WHERE store_id = ?",
+            (first_source_id,),
+        )
+        engine._store._conn.commit()
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is False
+        assert result.reason == "source_identity_mismatch"
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+        assert engine.get_async_compaction_status()["rejected_batches"] == 1
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_rejects_live_config_change(tmp_path):
+    """Given live config changes after prep, live policy wins over stale persisted metadata."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        engine._config.fresh_tail_count = 6
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is False
+        assert result.reason == "policy_fingerprint_mismatch"
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_rejects_summary_route_change(tmp_path):
+    """Given summary model changes after prep, promotion rejects stale route output."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        engine._config.summary_model = "different-summary-model"
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is False
+        assert result.reason == "summary_route_fingerprint_mismatch"
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_rejects_live_threshold_policy_change(tmp_path):
+    """Given threshold changes after prep, live config beats persisted batch policy."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        engine._config.context_threshold = 0.75
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is False
+        assert result.reason == "policy_fingerprint_mismatch"
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+    finally:
+        engine.shutdown()
+
+
+def test_foreground_compaction_race_supersedes_pending_batch(tmp_path, monkeypatch):
+    """Given foreground compaction lands first, stale pending work is rejected/superseded."""
+    engine = _engine(tmp_path)
+    try:
+        monkeypatch.setattr(
+            "hermes_lcm.engine.summarize_with_escalation",
+            lambda **kwargs: ("foreground summary", 0),
+        )
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        compacted = engine.compress(messages, current_tokens=engine.threshold_tokens + 1)
+        result = engine.promote_prepared_compaction(batch.batch_id, compacted)
+
+        assert engine._dag.get_session_node_count(engine.current_session_id) >= 1
+        assert result.promoted is False
+        assert result.reason in {"frontier_mismatch", "canonical_source_overlap"}
+        async_status = engine.get_async_compaction_status()
+        assert async_status["superseded_batches"] + async_status["rejected_batches"] >= 1
+    finally:
+        engine.shutdown()
+
+
+def test_summary_failure_backoff_does_not_wedge_foreground_compaction(tmp_path, monkeypatch):
+    """Given background summary failure, backoff is visible but foreground can still compact."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+
+        monkeypatch.setattr(
+            "hermes_lcm.engine.summarize_with_escalation",
+            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("summary spend backoff open")),
+        )
+        batch = engine.prepare_background_compaction_once(messages)
+        assert batch.state == "failed"
+        assert engine.get_async_compaction_status()["failed_batches"] == 1
+
+        monkeypatch.setattr(
+            "hermes_lcm.engine.summarize_with_escalation",
+            lambda **kwargs: ("foreground recovery summary", 0),
+        )
+        compacted = engine.compress(messages, current_tokens=engine.threshold_tokens + 1)
+
+        assert compacted != messages
+        assert engine._last_compression_status == "compacted"
+    finally:
+        engine.shutdown()
+
+
+def test_restart_recovers_or_discards_pending_batches_safely(tmp_path):
+    """Given pending/preparing rows at shutdown, restart never treats them as canonical."""
+    db_path = tmp_path / "restart.db"
+    config = LCMConfig(database_path=str(db_path), fresh_tail_count=2, leaf_chunk_tokens=20)
+    config.async_background_compaction_enabled = True
+
+    engine = LCMEngine(config=config)
+    engine.on_session_start("restart-session", conversation_id="restart-conversation", context_length=1_000)
+    messages = _messages()
+    try:
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages, leave_state="preparing")
+        assert batch.state == "preparing"
+    finally:
+        engine.shutdown()
+
+    restarted = LCMEngine(config=config)
+    try:
+        restarted.on_session_start("restart-session", conversation_id="restart-conversation", context_length=1_000)
+        status = restarted.get_async_compaction_status()
+
+        assert restarted._dag.get_session_node_count(restarted.current_session_id) == 0
+        assert status["preparing_batches"] == 0
+        assert status["pending_batches"] + status["rejected_batches"] + status["failed_batches"] >= 1
+    finally:
+        restarted.shutdown()
+
+
+def test_successful_atomic_promotion_is_all_or_nothing(tmp_path):
+    """Given a valid ready batch, node insert/frontier advance/batch state commit together."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+        old_frontier = engine.get_status()["lifecycle"]["current_frontier_store_id"]
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is True
+        assert engine._dag.get_session_node_count(engine.current_session_id) == batch.expected_leaf_count
+        lifecycle = engine.get_status()["lifecycle"]
+        assert lifecycle["current_frontier_store_id"] > old_frontier
+        assert lifecycle["current_frontier_store_id"] == batch.frontier_end_store_id
+        assert engine.get_async_compaction_status()["promoted_batches"] == 1
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_rolls_back_partial_publish_failure(tmp_path):
+    """Given a mid-promotion failure, no canonical node/frontier/batch half-state remains."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+        old_frontier = engine.get_status()["lifecycle"]["current_frontier_store_id"]
+        engine._async_compaction_publish_failure_hook = "after_canonical_insert"
+
+        with pytest.raises(RuntimeError, match="injected async promotion failure"):
+            engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        lifecycle = engine.get_status()["lifecycle"]
+        assert lifecycle["current_frontier_store_id"] == old_frontier
+        assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+        async_status = engine.get_async_compaction_status()
+        assert async_status["promoted_batches"] == 0
+        assert async_status["prepared_batches"] == 1
+    finally:
+        engine.shutdown()
+
+
+def test_status_and_doctor_report_async_compaction_counts(tmp_path):
+    """Given mixed async states, status and doctor expose pending/prepared/promoted/rejected counts."""
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages()
+        engine.ingest(messages)
+        ready = engine.prepare_background_compaction_once(messages)
+        engine.reject_prepared_compaction(ready.batch_id, reason="policy_fingerprint_mismatch")
+        engine.prepare_background_compaction_once(messages)
+
+        status = json.loads(engine.handle_tool_call("lcm_status", {}))
+        doctor = json.loads(engine.handle_tool_call("lcm_doctor", {}))
+
+        assert status["async_compaction"]["prepared_batches"] == 1
+        assert status["async_compaction"]["rejected_batches"] == 1
+        async_checks = [check for check in doctor["checks"] if check["check"].startswith("async_compaction")]
+        assert async_checks
+        assert any("prepared_batches" in check["detail"] for check in async_checks)
+    finally:
+        engine.shutdown()


### PR DESCRIPTION
## Summary
- Add a design spike for opt-in async/background LCM compaction with atomic publish.
- Define the two-phase lifecycle: prepare non-canonical summaries in the background, then validate/promote a complete batch atomically from foreground compaction.
- Add strict-xfailed RED tests for the intended contract: default-off behavior, pending invisibility, stale/config/model rejection, race safety, restart safety, backoff behavior, rollback, and status/doctor visibility.

## Why
Foreground LCM compaction currently does the expensive summarization work on the turn-critical path. That keeps active context stable and cache-friendly, but it can add latency when the summarizer is slow or when leaf chains grow.

The goal here is not a casual refactor or “background thread writes canonical summaries.” The safe shape is a two-phase model: prepare old stable chunks in the background, keep them non-canonical and invisible, then atomically validate/promote a complete batch only when foreground compaction would have run anyway.

This is also meant to capture the guardrails from Lossless Claw:
- #807: background-prepared summaries are useful only if they stay ignored until a publish boundary
- #942: live config must beat stale persisted thresholds/debt
- #902: summary failure/backoff must not permanently wedge foreground recovery

## Scope
- Add a design doc for opt-in async/background LCM compaction with atomic publish.
- Link the design from `docs/architecture.md`.
- Add strict-xfailed RED spike tests that define the intended contract before implementation.

This PR intentionally does **not** implement the production worker, schema, promotion path, or runtime behavior yet.

## Agreed contract
- Default behavior stays unchanged.
- Feature is behind explicit flags.
- Pending/prepared summaries are ignored by active context, search/grep, describe/expand, transcript GC, and normal doctor integrity checks until promoted.
- Promotion must be atomic: canonical node inserts, lifecycle frontier updates, batch state changes, and superseding older batches share one SQLite transaction boundary.
- Promotion validates source IDs/source identity, lifecycle frontier, live config/policy fingerprint, summary route/model fingerprint, and complete source coverage.
- Live config wins over stale persisted batch metadata, including threshold/preflight policy changes.
- Foreground compaction racing background prep is safe: no double-compaction or mixed generations.
- Restart with pending/preparing/ready work resumes or discards safely without making pending rows canonical.
- Summary failure/backoff is visible but cannot block normal foreground compaction recovery.
- Status/doctor expose async counts such as pending/prepared/promoted/rejected/failed/superseded batches and pending summaries.

## Tests added
The new spike tests are intentionally strict-xfailed until the async compaction API/schema exists:
- default-disabled async compaction is inert
- pending summaries are invisible until atomic promotion
- stale source identity rejects without canonical mutation
- live config/policy changes reject stale prepared batches
- summary route/model changes reject stale prepared batches
- foreground compaction race rejects/supersedes pending work
- background summary failure/backoff does not wedge foreground compaction
- restart recovers/discards pending work safely
- successful atomic promotion commits canonical nodes/frontier/batch state together
- injected partial-publish failure rolls back without half-state
- status/doctor report async compaction counts

## Validation
- `python -m pytest tests/test_async_background_compaction_design.py -q -o addopts=` → `12 xfailed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` → `803 passed`
- `git diff --check` → clean
- Internal Codex xhigh review → PASS, no blockers
- GitHub CI on this PR → all checks passing
