### PR TITLE
fix: bound ignored session context fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ it.
 pattern sources, whether the current session is ignored/stateless, and a
 process-lifetime `ignored_message_count`.
 
+Ignored/stateless sessions are a storage ownership boundary, not a context-window
+opt-out. LCM does not ingest raw messages or create DAG nodes for sessions that
+match `LCM_IGNORE_SESSION_PATTERNS`, `LCM_STATELESS_SESSION_PATTERNS`, or the
+in-process auxiliary/thread stateless marker. If those sessions cross the normal
+context threshold, LCM delegates the compaction call to Hermes' native
+`ContextCompressor` so the active request is still bounded before model overflow.
+If the native compressor is unavailable, LCM falls back to a deterministic
+head/tail trim as a last-resort safety net, still without writing the bypassed
+session to `lcm.db`.
+
 ### Large tool-output handling
 
 Storage-boundary payload guard contract: LCM prevents media-ish inline payloads from being written into plugin-local SQLite rows at the storage boundary.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -431,6 +431,16 @@ their `*_source` fields (`default` or `env`), the current session's `ignored` an
 can confirm their patterns are loaded and watch how often message filters fire.
 The counter resets on engine restart.
 
+Ignored/stateless sessions are a storage ownership boundary, not a context-window
+opt-out. LCM does not ingest raw messages or create DAG nodes for sessions that
+match `LCM_IGNORE_SESSION_PATTERNS`, `LCM_STATELESS_SESSION_PATTERNS`, or the
+in-process auxiliary/thread stateless marker. If those sessions cross the normal
+context threshold, LCM delegates the compaction call to Hermes' native
+`ContextCompressor` so the active request is still bounded before model overflow.
+If the native compressor is unavailable, LCM falls back to a deterministic
+head/tail trim as a last-resort safety net, still without writing the bypassed
+session to `lcm.db`.
+
 ### Large tool-output handling
 
 Externalization for ordinary large tool output is opt-in. When enabled,

--- a/engine.py
+++ b/engine.py
@@ -3869,26 +3869,18 @@ class LCMEngine(ContextEngine):
                 conversation_id=off_current_normal_conversation_id,
             )
         off_current_prefix_count = None
-        off_current_store_prefix_positive = (
-            off_current_store_prefix_count is not None
-            and off_current_store_prefix_count > 0
-        )
-        off_current_strongest_normal_prefix_count = max(
-            off_current_recorded_prefix_count,
-            off_current_store_prefix_count if off_current_store_prefix_positive else 0,
-        )
+        off_current_store_positive_count = 0
+        if off_current_store_prefix_count is not None and off_current_store_prefix_count > 0:
+            off_current_store_positive_count = off_current_store_prefix_count
+        off_current_store_prefix_positive = off_current_store_positive_count > 0
         if (
-            off_current_strongest_normal_prefix_count > 0
+            off_current_store_prefix_positive
             and (
                 off_current_bypass_prefix_count <= 0
-                or off_current_strongest_normal_prefix_count > off_current_bypass_prefix_count
+                or off_current_store_positive_count > off_current_bypass_prefix_count
             )
         ):
-            off_current_prefix_count = (
-                off_current_store_prefix_count
-                if off_current_store_prefix_positive
-                else off_current_recorded_prefix_count
-            )
+            off_current_prefix_count = off_current_store_positive_count
         if (
             off_current_lineage
             and off_current_normal_conversation_id

--- a/engine.py
+++ b/engine.py
@@ -379,6 +379,7 @@ _SYNTHETIC_ASSISTANT_NOISE = {
 
 _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
 _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+_LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
 
 
 def _tool_call_id(tool_call: Any) -> str:
@@ -584,7 +585,9 @@ class LCMEngine(ContextEngine):
         self._lcm_session_last_bypassed: dict[str, bool] = {}
         self._lcm_session_last_conversation_id: dict[str, str] = {}
         self._lcm_session_last_normal_conversation_id: dict[str, str] = {}
-        self._lcm_bypass_message_prefix_fingerprints: dict[str, list[list[str]]] = {}
+        self._lcm_bypass_message_prefix_fingerprints: dict[
+            str, list[tuple[list[str], bool]]
+        ] = {}
         self._lcm_normal_message_prefix_fingerprints: dict[tuple[str, str], list[str]] = {}
         self._lcm_current_start_allows_bypass_lineage = False
         self._auxiliary_session_lock = threading.RLock()
@@ -3640,11 +3643,21 @@ class LCMEngine(ContextEngine):
     ) -> None:
         if not session_id or not messages:
             return
-        fingerprints = [self._lcm_bypass_message_fingerprint(msg) for msg in messages[:8]]
+        fingerprints = [
+            self._lcm_bypass_message_fingerprint(msg)
+            for msg in messages[:_LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT]
+        ]
         if fingerprints:
             remembered = self._lcm_bypass_message_prefix_fingerprints.setdefault(session_id, [])
-            remembered[:] = [existing for existing in remembered if existing != fingerprints]
-            remembered.append(fingerprints)
+            truncated = len(messages) > _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT
+            retained: list[tuple[list[str], bool]] = []
+            for existing_fingerprints, existing_truncated in remembered:
+                if existing_fingerprints == fingerprints:
+                    truncated = truncated or bool(existing_truncated)
+                    continue
+                retained.append((existing_fingerprints, existing_truncated))
+            retained.append((fingerprints, truncated))
+            remembered[:] = retained
 
     def _remember_lcm_normal_message_prefix(
         self,
@@ -3655,7 +3668,10 @@ class LCMEngine(ContextEngine):
     ) -> None:
         if not session_id or not messages:
             return
-        fingerprints = [self._lcm_bypass_message_fingerprint(msg) for msg in messages[:8]]
+        fingerprints = [
+            self._lcm_bypass_message_fingerprint(msg)
+            for msg in messages[:_LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT]
+        ]
         if fingerprints:
             self._lcm_normal_message_prefix_fingerprints[
                 self._lcm_normal_prefix_key(session_id, conversation_id=conversation_id)
@@ -3710,13 +3726,25 @@ class LCMEngine(ContextEngine):
         session_id: str,
         messages: List[Dict[str, Any]],
     ) -> int:
-        return max(
-            (
-                self._matching_fingerprint_prefix_count(fingerprints, messages)
-                for fingerprints in self._lcm_bypass_message_prefix_fingerprints.get(session_id, [])
-            ),
-            default=0,
-        )
+        count, _truncated = self._matching_lcm_bypass_prefix_evidence(session_id, messages)
+        return count
+
+    def _matching_lcm_bypass_prefix_evidence(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> tuple[int, bool]:
+        best_count = 0
+        best_truncated = False
+        for fingerprints, truncated in self._lcm_bypass_message_prefix_fingerprints.get(session_id, []):
+            count = self._matching_fingerprint_prefix_count(fingerprints, messages)
+            count_truncated = bool(truncated and count > 0 and count == len(fingerprints))
+            if count > best_count:
+                best_count = count
+                best_truncated = count_truncated
+            elif count == best_count:
+                best_truncated = best_truncated or count_truncated
+        return best_count, best_truncated
 
     def _messages_match_lcm_normal_prefix(
         self,
@@ -3808,16 +3836,17 @@ class LCMEngine(ContextEngine):
         same_id_normal_prefix_count = None
         same_id_recorded_normal_prefix_count = 0
         same_id_bypass_prefix_count = 0
+        same_id_bypass_prefix_truncated = False
         if same_id_has_bypass_lineage:
             same_id_conversation_id = (
                 self._conversation_id
                 or self._lcm_session_last_normal_conversation_id.get(session_id)
                 or None
             )
-            same_id_bypass_prefix_count = self._matching_lcm_bypass_prefix_count(
-                session_id,
-                messages,
-            )
+            (
+                same_id_bypass_prefix_count,
+                same_id_bypass_prefix_truncated,
+            ) = self._matching_lcm_bypass_prefix_evidence(session_id, messages)
             same_id_normal_prefix_count = self._session_end_store_prefix_count(
                 session_id,
                 messages,
@@ -3836,8 +3865,15 @@ class LCMEngine(ContextEngine):
             same_id_recorded_normal_prefix_count,
             same_id_normal_prefix_count if same_id_store_prefix_positive else 0,
         )
+        same_id_truncated_bypass_prefix_ambiguous = (
+            same_id_bypass_prefix_truncated
+            and same_id_bypass_prefix_count > 0
+            and same_id_strongest_normal_prefix_count >= same_id_bypass_prefix_count
+            and len(messages) > same_id_bypass_prefix_count
+        )
         same_id_matches_stronger_normal_prefix = (
             same_id_strongest_normal_prefix_count > 0
+            and not same_id_truncated_bypass_prefix_ambiguous
             and (
                 same_id_bypass_prefix_count <= 0
                 or same_id_strongest_normal_prefix_count >= same_id_bypass_prefix_count
@@ -3852,11 +3888,12 @@ class LCMEngine(ContextEngine):
         off_current_store_prefix_count = None
         off_current_recorded_prefix_count = 0
         off_current_bypass_prefix_count = 0
+        off_current_bypass_prefix_truncated = False
         if off_current_lineage:
-            off_current_bypass_prefix_count = self._matching_lcm_bypass_prefix_count(
-                session_id,
-                messages,
-            )
+            (
+                off_current_bypass_prefix_count,
+                off_current_bypass_prefix_truncated,
+            ) = self._matching_lcm_bypass_prefix_evidence(session_id, messages)
         if off_current_lineage and off_current_normal_conversation_id:
             off_current_store_prefix_count = self._session_end_store_prefix_count(
                 session_id,
@@ -3869,23 +3906,30 @@ class LCMEngine(ContextEngine):
                 conversation_id=off_current_normal_conversation_id,
             )
         off_current_prefix_count = None
-        off_current_store_positive_count = 0
-        if off_current_store_prefix_count is not None and off_current_store_prefix_count > 0:
-            off_current_store_positive_count = off_current_store_prefix_count
-        off_current_store_prefix_positive = off_current_store_positive_count > 0
+        off_current_store_prefix_positive = (
+            off_current_store_prefix_count is not None
+            and off_current_store_prefix_count > 0
+        )
+        off_current_store_prefix_for_append = int(off_current_store_prefix_count or 0)
+        off_current_truncated_bypass_prefix_ambiguous = (
+            off_current_bypass_prefix_truncated
+            and off_current_bypass_prefix_count > 0
+            and off_current_store_prefix_for_append >= off_current_bypass_prefix_count
+            and len(messages) > off_current_bypass_prefix_count
+        )
         if (
             off_current_store_prefix_positive
+            and not off_current_truncated_bypass_prefix_ambiguous
             and (
                 off_current_bypass_prefix_count <= 0
-                or off_current_store_positive_count > off_current_bypass_prefix_count
+                or off_current_store_prefix_for_append > off_current_bypass_prefix_count
             )
         ):
-            off_current_prefix_count = off_current_store_positive_count
+            off_current_prefix_count = off_current_store_prefix_for_append
         if (
             off_current_lineage
             and off_current_normal_conversation_id
             and off_current_store_prefix_count == 0
-            and off_current_recorded_prefix_count == 0
             and off_current_bypass_prefix_count <= 0
             and self._lcm_session_last_bypassed.get(session_id) is False
         ):

--- a/engine.py
+++ b/engine.py
@@ -3565,6 +3565,8 @@ class LCMEngine(ContextEngine):
             self._config,
             parse_json_strings=True,
         )
+        if tool_calls is None or tool_calls == [] or tool_calls == {}:
+            tool_calls = None
         return json.dumps(
             tool_calls,
             ensure_ascii=False,
@@ -3627,11 +3629,14 @@ class LCMEngine(ContextEngine):
 
     @staticmethod
     def _lcm_bypass_message_fingerprint(message: Dict[str, Any]) -> str:
+        tool_calls = message.get("tool_calls")
+        if tool_calls is None or tool_calls == [] or tool_calls == {}:
+            tool_calls = None
         payload = {
             "role": message.get("role"),
             "content": normalize_content_value(message.get("content")),
             "tool_call_id": message.get("tool_call_id"),
-            "tool_calls": message.get("tool_calls"),
+            "tool_calls": tool_calls,
         }
         encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
         return hashlib.sha256(encoded.encode("utf-8", errors="replace")).hexdigest()
@@ -3911,10 +3916,27 @@ class LCMEngine(ContextEngine):
             and off_current_store_prefix_count > 0
         )
         off_current_store_prefix_for_append = int(off_current_store_prefix_count or 0)
+        off_current_recorded_prefix_for_append = 0
+        if off_current_recorded_prefix_count > 0 and off_current_normal_conversation_id:
+            try:
+                stored_normal_rows = self._store.get_range(
+                    session_id,
+                    limit=off_current_recorded_prefix_count + 1,
+                    conversation_id=off_current_normal_conversation_id,
+                )
+            except Exception:
+                logger.debug("LCM off-current recorded-prefix row-count probe failed", exc_info=True)
+                stored_normal_rows = []
+            if len(stored_normal_rows) == off_current_recorded_prefix_count:
+                off_current_recorded_prefix_for_append = off_current_recorded_prefix_count
+        off_current_strongest_normal_prefix_count = max(
+            off_current_store_prefix_for_append if off_current_store_prefix_positive else 0,
+            off_current_recorded_prefix_for_append,
+        )
         off_current_truncated_bypass_prefix_ambiguous = (
             off_current_bypass_prefix_truncated
             and off_current_bypass_prefix_count > 0
-            and off_current_store_prefix_for_append >= off_current_bypass_prefix_count
+            and off_current_strongest_normal_prefix_count >= off_current_bypass_prefix_count
             and len(messages) > off_current_bypass_prefix_count
         )
         if (
@@ -3926,6 +3948,15 @@ class LCMEngine(ContextEngine):
             )
         ):
             off_current_prefix_count = off_current_store_prefix_for_append
+        elif (
+            off_current_recorded_prefix_for_append > 0
+            and not off_current_truncated_bypass_prefix_ambiguous
+            and (
+                off_current_bypass_prefix_count <= 0
+                or off_current_recorded_prefix_for_append > off_current_bypass_prefix_count
+            )
+        ):
+            off_current_prefix_count = off_current_recorded_prefix_for_append
         if (
             off_current_lineage
             and off_current_normal_conversation_id

--- a/engine.py
+++ b/engine.py
@@ -7,6 +7,7 @@ with a DAG-based summarization system that preserves every message.
 import copy
 import hashlib
 import inspect
+import importlib
 import json
 import logging
 import os
@@ -36,6 +37,7 @@ from .externalize import (
     extract_externalized_ref,
     find_externalized_payload_for_message,
     find_externalized_tool_result_content_for_call,
+    is_externalized_placeholder,
     load_externalized_payload,
     maybe_externalize_tool_output,
 )
@@ -574,7 +576,21 @@ class LCMEngine(ContextEngine):
         self._thread_context = threading.local()
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
+        self._lcm_bypass_lineage_session_ids: set[str] = set()
+        self._lcm_bypass_lineage_platforms: dict[str, set[str]] = {}
+        self._lcm_non_bypass_platforms: dict[str, set[str]] = {}
+        self._lcm_session_last_platform: dict[str, str] = {}
+        self._lcm_session_last_normal_platform: dict[str, str] = {}
+        self._lcm_session_last_bypassed: dict[str, bool] = {}
+        self._lcm_session_last_conversation_id: dict[str, str] = {}
+        self._lcm_session_last_normal_conversation_id: dict[str, str] = {}
+        self._lcm_bypass_message_prefix_fingerprints: dict[str, list[list[str]]] = {}
+        self._lcm_normal_message_prefix_fingerprints: dict[tuple[str, str], list[str]] = {}
+        self._lcm_current_start_allows_bypass_lineage = False
         self._auxiliary_session_lock = threading.RLock()
+        self._host_fallback_compressor: Any = None
+        self._host_fallback_session_id = ""
+        self._host_fallback_import_warning_logged = False
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -619,6 +635,7 @@ class LCMEngine(ContextEngine):
         # before binding it; hosts that bind only through on_session_start()
         # must still be able to replace the copied prototype route.
         clone._update_model_pending_session_start = False
+        clone._lcm_current_start_allows_bypass_lineage = False
         return clone
 
     def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
@@ -684,6 +701,20 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.clear()
             self._auxiliary_lineage_session_ids.clear()
+            self._lcm_bypass_lineage_session_ids.clear()
+            self._lcm_bypass_lineage_platforms.clear()
+            self._lcm_non_bypass_platforms.clear()
+            self._lcm_session_last_platform.clear()
+            self._lcm_session_last_normal_platform.clear()
+            self._lcm_session_last_bypassed.clear()
+            self._lcm_session_last_conversation_id.clear()
+            self._lcm_session_last_normal_conversation_id.clear()
+            self._lcm_bypass_message_prefix_fingerprints.clear()
+            self._lcm_normal_message_prefix_fingerprints.clear()
+        self._lcm_current_start_allows_bypass_lineage = False
+        self._host_fallback_compressor = None
+        self._host_fallback_session_id = ""
+        self._host_fallback_import_warning_logged = False
         self._clear_thread_context_stateless()
         self._reset_session_scoped_runtime_state()
 
@@ -948,6 +979,482 @@ class LCMEngine(ContextEngine):
         self._last_boundary_skip_time = 0
         return False
 
+    def _bypasses_lcm_context_management(self) -> bool:
+        """Return True when this binding must not write/manage LCM state.
+
+        Ignored, stateless, and in-process auxiliary sessions are excluded from
+        LCM storage. They still need context-size protection because Hermes has
+        exactly one active context engine; returning a pure no-op here would
+        disable every compaction layer for the session.
+        """
+        return bool(
+            self._session_ignored
+            or self._session_stateless
+            or self._thread_context_stateless()
+        )
+
+    def _bypass_lcm_reason(self) -> str:
+        if self._thread_context_stateless():
+            return "auxiliary thread context"
+        if self._session_ignored:
+            return "ignored session"
+        if self._session_stateless:
+            return "stateless session"
+        return "active session"
+
+    def _bypass_lcm_session_id(self) -> str:
+        return self._thread_context_session_id() or self._session_id or "(unknown)"
+
+    def _session_id_matches_lcm_bypass_filters(
+        self,
+        session_id: str,
+        *,
+        platform: str = "",
+    ) -> bool:
+        if not session_id:
+            return False
+        match_keys = build_session_match_keys(session_id, platform=platform)
+        if matches_session_pattern(match_keys, self._compiled_ignore_session_patterns):
+            return True
+        return matches_session_pattern(match_keys, self._compiled_stateless_session_patterns)
+
+    def _ended_session_directly_bypasses_lcm(self, session_id: str) -> bool:
+        """Classify a session-end callback by the ended id, not the active binding."""
+        if not session_id:
+            return False
+        if session_id == self._thread_context_session_id():
+            return True
+        return self._session_id_matches_lcm_bypass_filters(session_id)
+
+    def _end_host_fallback_compressor_for_session(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        current_session_bypasses: bool,
+    ) -> None:
+        if self._host_fallback_compressor is not None and (
+            current_session_bypasses
+            or not self._host_fallback_session_id
+            or self._host_fallback_session_id == session_id
+        ):
+            compressor = self._host_fallback_compressor
+            fallback_session_id = self._host_fallback_session_id or session_id
+            on_session_end = getattr(compressor, "on_session_end", None)
+            if callable(on_session_end) and fallback_session_id:
+                try:
+                    on_session_end(fallback_session_id, messages)
+                except Exception:
+                    logger.debug("LCM host fallback compressor session-end reset failed", exc_info=True)
+            on_session_reset = getattr(compressor, "on_session_reset", None)
+            if callable(on_session_reset):
+                try:
+                    on_session_reset()
+                except Exception:
+                    logger.debug("LCM host fallback compressor reset failed", exc_info=True)
+            self._host_fallback_compressor = None
+            self._host_fallback_session_id = ""
+
+    def _get_host_fallback_compressor(self) -> Any:
+        """Return Hermes' native compressor for LCM-bypassed sessions if available."""
+        session_id = self._bypass_lcm_session_id()
+        if self._host_fallback_compressor is not None:
+            if session_id == self._host_fallback_session_id:
+                return self._host_fallback_compressor
+            previous = self._host_fallback_compressor
+            on_session_end = getattr(previous, "on_session_end", None)
+            if callable(on_session_end) and self._host_fallback_session_id:
+                try:
+                    on_session_end(self._host_fallback_session_id, [])
+                except Exception:
+                    logger.debug("LCM host fallback compressor session-end reset failed", exc_info=True)
+            on_session_reset = getattr(previous, "on_session_reset", None)
+            if callable(on_session_reset):
+                try:
+                    on_session_reset()
+                except Exception:
+                    logger.debug("LCM host fallback compressor reset failed", exc_info=True)
+            self._host_fallback_compressor = None
+            self._host_fallback_session_id = ""
+        try:
+            ContextCompressor = getattr(
+                importlib.import_module("agent.context_compressor"),
+                "ContextCompressor",
+            )
+        except Exception as exc:  # pragma: no cover - only hit on non-Hermes hosts
+            if not self._host_fallback_import_warning_logged:
+                logger.warning(
+                    "LCM could not load Hermes native ContextCompressor for bypassed session fallback: %s",
+                    exc,
+                )
+                self._host_fallback_import_warning_logged = True
+            return None
+
+        kwargs = {
+            "model": self.model or "unknown",
+            "threshold_percent": self.context_threshold or self.threshold_percent or 0.50,
+            "protect_first_n": self.protect_first_n,
+            "protect_last_n": self.protect_last_n,
+            "quiet_mode": True,
+            "summary_model_override": self._config.summary_model or None,
+            "base_url": self.base_url,
+            "api_key": self.api_key,
+            "config_context_length": self.context_length or self.raw_context_length or None,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
+        }
+        try:
+            compressor = ContextCompressor(**kwargs)
+        except TypeError:
+            # Older Hermes hosts may not expose all constructor kwargs. Keep the
+            # fallback deliberately conservative rather than failing open to an
+            # unbounded ignored/stateless transcript.
+            try:
+                compressor = ContextCompressor(
+                    self.model or "unknown",
+                    threshold_percent=self.context_threshold or self.threshold_percent or 0.50,
+                    protect_first_n=self.protect_first_n,
+                    protect_last_n=self.protect_last_n,
+                    quiet_mode=True,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "LCM could not initialize Hermes native ContextCompressor for bypassed session fallback; using deterministic trim: %s",
+                    exc,
+                )
+                return None
+        except Exception as exc:
+            logger.warning(
+                "LCM could not initialize Hermes native ContextCompressor for bypassed session fallback; using deterministic trim: %s",
+                exc,
+            )
+            return None
+        self._host_fallback_compressor = compressor
+        self._host_fallback_session_id = session_id
+        self._sync_host_fallback_compressor(compressor)
+        return compressor
+
+    def _sync_host_fallback_compressor(self, compressor: Any) -> None:
+        """Keep the delegated native compressor aligned with LCM runtime metadata."""
+        update_model = getattr(compressor, "update_model", None)
+        context_length = self.context_length or self.raw_context_length
+        if callable(update_model) and context_length > 0:
+            try:
+                update_model(
+                    model=self.model or "unknown",
+                    context_length=context_length,
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    provider=self.provider,
+                    api_mode=self.api_mode,
+                )
+            except TypeError:
+                try:
+                    update_model(self.model or "unknown", context_length, self.base_url, self.api_key)
+                except TypeError:
+                    pass
+                except Exception:
+                    logger.debug("LCM host fallback compressor model sync failed", exc_info=True)
+            except Exception:
+                logger.debug("LCM host fallback compressor model sync failed", exc_info=True)
+        for attr, value in (
+            ("threshold_percent", self.context_threshold or self.threshold_percent),
+            ("protect_first_n", self.protect_first_n),
+            ("protect_last_n", self.protect_last_n),
+        ):
+            try:
+                setattr(compressor, attr, value)
+            except Exception:
+                pass
+        on_session_start = getattr(compressor, "on_session_start", None)
+        session_id = self._bypass_lcm_session_id()
+        if callable(on_session_start) and session_id:
+            try:
+                on_session_start(
+                    session_id,
+                    platform=self._session_platform,
+                    model=self.model,
+                    provider=self.provider,
+                    context_length=context_length,
+                )
+            except Exception:
+                logger.debug("LCM host fallback compressor session bind failed", exc_info=True)
+
+    def _mirror_host_fallback_state(self, compressor: Any) -> None:
+        for attr in (
+            "_last_compress_aborted",
+            "_last_summary_error",
+            "_last_summary_auth_failure",
+            "_last_summary_network_failure",
+            "_last_summary_dropped_count",
+            "_last_summary_fallback_used",
+            "_last_aux_model_failure_error",
+            "_last_aux_model_failure_model",
+        ):
+            if hasattr(compressor, attr):
+                setattr(self, attr, getattr(compressor, attr))
+
+    def _bypass_compaction_target_tokens(
+        self,
+        *,
+        observed_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[int]:
+        caps: list[int] = []
+        assembly_cap = self._overflow_recovery_assembly_cap(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
+        if assembly_cap is not None:
+            caps.append(assembly_cap)
+        if self.threshold_tokens > 0:
+            caps.append(self.threshold_tokens)
+        elif self.context_length > 0:
+            caps.append(self.context_length)
+        return min(caps) if caps else None
+
+    @staticmethod
+    def _truncate_bypass_content_value(content: Any, char_budget: int, *, suffix: str = "") -> Any:
+        if char_budget < 0:
+            char_budget = 0
+        if isinstance(content, str):
+            if len(content) <= char_budget:
+                return content
+            return content[:char_budget] + (suffix if char_budget > 0 else "")
+        if isinstance(content, list):
+            truncated_parts: list[Any] = []
+            changed = False
+            for part in content:
+                if isinstance(part, str):
+                    next_part = part if len(part) <= char_budget else part[:char_budget] + (suffix if char_budget > 0 else "")
+                    changed = changed or next_part != part
+                    truncated_parts.append(next_part)
+                    continue
+                if isinstance(part, dict):
+                    next_part = dict(part)
+                    for key in ("text", "content"):
+                        value = next_part.get(key)
+                        if isinstance(value, str) and len(value) > char_budget:
+                            next_part[key] = value[:char_budget] + (suffix if char_budget > 0 else "")
+                            changed = True
+                        elif isinstance(value, dict):
+                            nested = dict(value)
+                            for nested_key in ("value", "content"):
+                                nested_value = nested.get(nested_key)
+                                if isinstance(nested_value, str) and len(nested_value) > char_budget:
+                                    nested[nested_key] = nested_value[:char_budget] + (suffix if char_budget > 0 else "")
+                                    changed = True
+                            next_part[key] = nested
+                    truncated_parts.append(next_part)
+                    continue
+                truncated_parts.append(part)
+            if changed:
+                return truncated_parts
+        normalized = normalize_content_value(content)
+        if isinstance(normalized, str) and len(normalized) > char_budget:
+            return normalized[:char_budget] + (suffix if char_budget > 0 else "")
+        return content
+
+    def _trim_bypass_compacted_to_cap(
+        self,
+        messages: List[Dict[str, Any]],
+        target_tokens: Optional[int],
+    ) -> List[Dict[str, Any]]:
+        compacted = self._sanitize_active_context_messages(messages)
+        if target_tokens is None or target_tokens <= 0:
+            return compacted
+
+        while len(compacted) > 2 and count_messages_tokens(compacted) > target_tokens:
+            remove_indices: list[int] = []
+            for idx, msg in enumerate(compacted):
+                if idx == 0:
+                    continue
+                if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+                    continue
+                call_ids = _assistant_tool_call_ids([msg])
+                remove_indices = [idx]
+                remove_indices.extend(
+                    follow_idx
+                    for follow_idx in range(idx + 1, len(compacted))
+                    if compacted[follow_idx].get("role") == "tool"
+                    and str(compacted[follow_idx].get("tool_call_id") or "") in call_ids
+                )
+                break
+            if not remove_indices:
+                remove_index = 1
+                if (
+                    compacted[1].get("role") == "tool"
+                    and compacted[0].get("role") == "assistant"
+                    and compacted[0].get("tool_calls")
+                ):
+                    remove_index = 0
+                remove_indices = [remove_index]
+            before_shape = [
+                (msg.get("role"), msg.get("tool_call_id"), bool(msg.get("tool_calls")))
+                for msg in compacted
+            ]
+            before_tokens = count_messages_tokens(compacted)
+            for remove_index in sorted(set(remove_indices), reverse=True):
+                if 0 <= remove_index < len(compacted):
+                    del compacted[remove_index]
+            compacted = self._sanitize_active_context_messages(compacted)
+            after_shape = [
+                (msg.get("role"), msg.get("tool_call_id"), bool(msg.get("tool_calls")))
+                for msg in compacted
+            ]
+            if after_shape == before_shape and count_messages_tokens(compacted) >= before_tokens:
+                break
+
+        if count_messages_tokens(compacted) <= target_tokens:
+            return compacted
+
+        char_budget = max(0, min(500, target_tokens * 4 // max(1, len(compacted))))
+        truncated = compacted
+        previous_budget = -1
+        for _ in range(12):
+            next_messages: list[Dict[str, Any]] = []
+            for msg in compacted:
+                next_msg = dict(msg)
+                content = next_msg.get("content")
+                next_msg["content"] = self._truncate_bypass_content_value(content, char_budget, suffix="…")
+                next_messages.append(next_msg)
+            truncated = self._sanitize_active_context_messages(next_messages)
+            token_count = count_messages_tokens(truncated)
+            if token_count <= target_tokens:
+                return truncated
+            if char_budget == 0 or char_budget == previous_budget:
+                break
+            previous_budget = char_budget
+            ratio = target_tokens / max(1, token_count)
+            char_budget = max(0, min(char_budget - 1, int(char_budget * max(0.25, ratio * 0.8))))
+
+        compacted = truncated
+        while len(compacted) > 1 and count_messages_tokens(compacted) > target_tokens:
+            compacted = self._sanitize_active_context_messages(compacted[1:])
+
+        char_budget = max(0, min(80, target_tokens * 4))
+        previous_budget = -1
+        while count_messages_tokens(compacted) > target_tokens and char_budget != previous_budget:
+            previous_budget = char_budget
+            shrunk: list[Dict[str, Any]] = []
+            for msg in compacted:
+                next_msg = dict(msg)
+                content = next_msg.get("content")
+                next_msg["content"] = self._truncate_bypass_content_value(content, char_budget)
+                shrunk.append(next_msg)
+            compacted = self._sanitize_active_context_messages(shrunk)
+            char_budget = max(0, char_budget // 2)
+
+        return compacted
+
+    def _fallback_tail_compaction(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        target_tokens: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Last-resort size guard when Hermes' native compressor is unavailable."""
+        if len(messages) <= 2:
+            return self._trim_bypass_compacted_to_cap(messages, target_tokens)
+        head_count = max(1, min(self.protect_first_n, len(messages)))
+        tail_count = max(1, min(self.protect_last_n, len(messages) - head_count))
+        marker = {
+            "role": "user",
+            "content": (
+                "[Context omitted: this session is ignored/stateless for LCM, "
+                "and Hermes native compression was unavailable. Older messages "
+                "were dropped to keep the request within the model context window.]"
+            ),
+        }
+        compacted = list(messages[:head_count]) + [marker] + list(messages[-tail_count:])
+        return self._trim_bypass_compacted_to_cap(compacted, target_tokens)
+
+    def _compress_lcm_bypassed_session(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        current_tokens: int | None = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Delegate ignored/stateless context bounding without writing to LCM."""
+        reason = self._bypass_lcm_reason()
+        session_id = self._bypass_lcm_session_id()
+        self._remember_lcm_bypass_message_prefix(session_id, messages)
+        observed_tokens = current_tokens if current_tokens and current_tokens > 0 else count_messages_tokens(messages)
+        force_overflow = self._should_force_overflow_recovery(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
+        if not force and not force_overflow and self.threshold_tokens > 0 and observed_tokens < self.threshold_tokens:
+            logger.debug(
+                "LCM compaction bypass no-op for %s %s below threshold (%s < %s)",
+                reason,
+                session_id,
+                observed_tokens,
+                self.threshold_tokens,
+            )
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = f"LCM bypassed below threshold: {reason}"
+            return self._redact_active_replay_messages(messages)
+
+        logger.debug("LCM delegating compaction for bypassed %s %s", reason, session_id)
+        self._last_compression_status = "host_fallback"
+        self._last_compression_noop_reason = f"LCM bypassed: {reason}"
+        safe_messages = self._redact_active_replay_messages(messages)
+        target_tokens = self._bypass_compaction_target_tokens(
+            observed_tokens=observed_tokens,
+            messages=safe_messages,
+        )
+
+        compressor = self._get_host_fallback_compressor()
+        if compressor is None:
+            compacted = self._fallback_tail_compaction(safe_messages, target_tokens=target_tokens)
+            if compacted != messages:
+                self.compression_count += 1
+            return compacted
+
+        self._sync_host_fallback_compressor(compressor)
+        before_count = int(getattr(compressor, "compression_count", 0) or 0)
+        try:
+            try:
+                compacted = compressor.compress(
+                    safe_messages,
+                    current_tokens=current_tokens,
+                    focus_topic=focus_topic,
+                    force=force,
+                )
+            except TypeError:
+                compacted = compressor.compress(
+                    safe_messages,
+                    current_tokens=current_tokens,
+                    focus_topic=focus_topic,
+                )
+        except Exception as exc:
+            self._mirror_host_fallback_state(compressor)
+            logger.warning(
+                "LCM Hermes native ContextCompressor failed for bypassed %s %s; using deterministic trim: %s",
+                reason,
+                session_id,
+                exc,
+            )
+            self._host_fallback_compressor = None
+            self._host_fallback_session_id = ""
+            compacted = self._fallback_tail_compaction(safe_messages, target_tokens=target_tokens)
+            if compacted != safe_messages:
+                self.compression_count += 1
+                self._last_compress_aborted = False
+            return compacted
+        self._mirror_host_fallback_state(compressor)
+        after_count = int(getattr(compressor, "compression_count", before_count) or before_count)
+        self.compression_count += max(1, after_count - before_count)
+        compacted = self._sanitize_active_context_messages(compacted)
+        if target_tokens is not None and count_messages_tokens(compacted) > target_tokens:
+            compacted = self._fallback_tail_compaction(safe_messages, target_tokens=target_tokens)
+            if compacted != safe_messages:
+                self._last_compress_aborted = False
+        return compacted
+
     def ingest(self, messages: List[Dict[str, Any]]) -> None:
         """Persist messages to the durable store every turn.
 
@@ -961,10 +1468,16 @@ class LCMEngine(ContextEngine):
         compression runs later the same turn, already-ingested messages
         are skipped (no duplicates).
         """
-        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
+        if self._bypasses_lcm_context_management():
+            self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
             return
         if self._session_id and messages:
             try:
+                self._remember_lcm_normal_message_prefix(
+                    self._session_id,
+                    messages,
+                    conversation_id=self._conversation_id,
+                )
                 self._ingest_messages(messages)
                 logger.debug(
                     "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
@@ -974,8 +1487,15 @@ class LCMEngine(ContextEngine):
                 logger.warning("Ingest during per-turn ingest(): %s", e)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
-        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
-            return False
+        if self._bypasses_lcm_context_management():
+            if self._compression_boundary_cooldown_active():
+                return False
+            tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+            if self._should_force_overflow_recovery(observed_tokens=tokens):
+                return True
+            if self.threshold_tokens <= 0:
+                return False
+            return tokens >= self.threshold_tokens
         if self._compression_boundary_cooldown_active():
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
@@ -987,9 +1507,14 @@ class LCMEngine(ContextEngine):
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
-        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
-            return False
-        from .tokens import count_messages_tokens
+        if self._bypasses_lcm_context_management():
+            self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
+            rough = count_messages_tokens(messages)
+            if self._compression_boundary_cooldown_active():
+                return False
+            if self._should_force_overflow_recovery(observed_tokens=rough, messages=messages):
+                return True
+            return self.threshold_tokens > 0 and rough >= self.threshold_tokens
         rough = count_messages_tokens(messages)
         pre_ingest_placeholder_ambiguous_noop = False
         pre_ingest_noop_reason = ""
@@ -1316,7 +1841,8 @@ class LCMEngine(ContextEngine):
 
     def compress(self, messages: List[Dict[str, Any]],
                  current_tokens: int = None,
-                 focus_topic: Optional[str] = None) -> List[Dict[str, Any]]:
+                 focus_topic: Optional[str] = None,
+                 force: bool = False) -> List[Dict[str, Any]]:
         """Main compaction entry point.
 
         1. Ingest any new messages into the store
@@ -1333,22 +1859,13 @@ class LCMEngine(ContextEngine):
         self._last_compression_status = "running"
         self._last_compression_noop_reason = ""
 
-        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
-            reason = (
-                "auxiliary thread context"
-                if self._thread_context_stateless()
-                else "ignored session"
-                if self._session_ignored
-                else "stateless session"
+        if self._bypasses_lcm_context_management():
+            return self._compress_lcm_bypassed_session(
+                messages,
+                current_tokens=current_tokens,
+                focus_topic=focus_topic,
+                force=force,
             )
-            logger.debug(
-                "LCM compress bypassed for %s session %s",
-                "auxiliary" if self._thread_context_stateless() else "ignored" if self._session_ignored else "stateless",
-                self._thread_context_session_id() or self._session_id or "(unknown)",
-            )
-            self._last_compression_status = "noop"
-            self._last_compression_noop_reason = f"bypassed: {reason}"
-            return self._redact_active_replay_messages(messages)
 
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
         force_overflow = self._should_force_overflow_recovery(
@@ -1802,9 +2319,11 @@ class LCMEngine(ContextEngine):
     ) -> None:
         state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
         self._conversation_id = state.conversation_id
+        self._lcm_session_last_conversation_id[session_id] = state.conversation_id
         self._last_compacted_store_id = state.current_frontier_store_id
         self._register_active_engine_binding()
         if not self._session_ignored and not self._session_stateless:
+            self._lcm_session_last_normal_conversation_id[session_id] = state.conversation_id
             self._foreground_session_id = session_id
             self._foreground_session_platform = self._session_platform
             self._foreground_conversation_id = state.conversation_id
@@ -1901,6 +2420,67 @@ class LCMEngine(ContextEngine):
     def _has_auxiliary_lineage_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_lineage_session_ids
+
+    def _has_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> bool:
+        with self._auxiliary_session_lock:
+            if session_id not in self._lcm_bypass_lineage_session_ids:
+                return False
+            if platform is None:
+                return True
+            platforms = self._lcm_bypass_lineage_platforms.get(session_id) or set()
+            return not platforms or platform in platforms
+
+    def _mark_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> None:
+        if not session_id:
+            return
+        platform = self._session_platform if platform is None else str(platform or "")
+        with self._auxiliary_session_lock:
+            self._lcm_bypass_lineage_session_ids.add(session_id)
+            self._lcm_bypass_lineage_platforms.setdefault(session_id, set()).add(platform)
+            self._lcm_session_last_platform[session_id] = platform
+            self._lcm_session_last_bypassed[session_id] = True
+
+    def _unmark_lcm_bypass_lineage_session(self, session_id: str) -> None:
+        if not session_id:
+            return
+        with self._auxiliary_session_lock:
+            self._lcm_bypass_lineage_session_ids.discard(session_id)
+            self._lcm_bypass_lineage_platforms.pop(session_id, None)
+
+    def _handoff_lcm_bypass_lineage(
+        self,
+        old_session_id: str,
+        new_session_id: str,
+        *,
+        new_platform: str = "",
+    ) -> None:
+        with self._auxiliary_session_lock:
+            if old_session_id:
+                self._lcm_bypass_lineage_session_ids.add(old_session_id)
+            if new_session_id:
+                new_platform = str(new_platform or "")
+                self._lcm_bypass_lineage_session_ids.add(new_session_id)
+                self._lcm_bypass_lineage_platforms.setdefault(new_session_id, set()).add(new_platform)
+                self._lcm_session_last_platform[new_session_id] = new_platform
+                self._lcm_session_last_bypassed[new_session_id] = True
+
+    def _compression_boundary_from_lcm_bypassed_session(self, old_session_id: str) -> bool:
+        if not old_session_id:
+            return False
+        if old_session_id in self._lcm_session_last_bypassed:
+            return bool(self._lcm_session_last_bypassed.get(old_session_id))
+        if old_session_id == self._session_id:
+            return bool(
+                self._bypasses_lcm_context_management()
+                or self._session_id_matches_lcm_bypass_filters(
+                    old_session_id,
+                    platform=self._session_platform,
+                )
+            )
+        return bool(
+            self._has_lcm_bypass_lineage_session(old_session_id)
+            or self._session_id_matches_lcm_bypass_filters(old_session_id)
+        )
 
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
@@ -2794,6 +3374,27 @@ class LCMEngine(ContextEngine):
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id
+        self._lcm_current_start_allows_bypass_lineage = False
+        requested_platform = str(kwargs.get("platform") or self._session_platform or "")
+        if self._host_fallback_compressor is not None and (
+            self._host_fallback_session_id != session_id or requested_platform != self._session_platform
+        ):
+            compressor = self._host_fallback_compressor
+            fallback_session_id = self._host_fallback_session_id or previous_session_id
+            on_session_end = getattr(compressor, "on_session_end", None)
+            if callable(on_session_end) and fallback_session_id:
+                try:
+                    on_session_end(fallback_session_id, [])
+                except Exception:
+                    logger.debug("LCM host fallback compressor session-start reset failed", exc_info=True)
+            on_session_reset = getattr(compressor, "on_session_reset", None)
+            if callable(on_session_reset):
+                try:
+                    on_session_reset()
+                except Exception:
+                    logger.debug("LCM host fallback compressor reset failed", exc_info=True)
+            self._host_fallback_compressor = None
+            self._host_fallback_session_id = ""
         if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
             if (
                 self._has_auxiliary_lineage_session(old_session_id)
@@ -2802,6 +3403,36 @@ class LCMEngine(ContextEngine):
                 self._handoff_auxiliary_session(old_session_id, session_id)
                 logger.info(
                     "LCM auxiliary session %s compressed to %s — keeping boundary stateless",
+                    old_session_id,
+                    session_id,
+                )
+                return
+            if self._compression_boundary_from_lcm_bypassed_session(old_session_id):
+                self._handoff_lcm_bypass_lineage(
+                    old_session_id,
+                    session_id,
+                    new_platform=str(kwargs.get("platform") or ""),
+                )
+                self._clear_thread_context_stateless()
+                if previous_session_id and previous_session_id != session_id:
+                    self._finalize_pending_reset_boundary(previous_session_id)
+                    self._reset_session_scoped_runtime_state()
+                else:
+                    self._clear_pending_reset_boundary()
+                    self._ingest_cursor = 0
+                    self._last_compacted_store_id = 0
+                    self._last_overflow_recovery_failed = False
+                    self._last_condensation_suppressed_reason = ""
+                self._lcm_current_start_allows_bypass_lineage = True
+                self._apply_session_start_metadata(session_id, kwargs)
+                self._bind_lifecycle_state(
+                    session_id,
+                    conversation_id=kwargs.get("conversation_id"),
+                )
+                self._schedule_ingest_cursor_reconciliation()
+                self._log_session_filter_diagnostics()
+                logger.info(
+                    "LCM compression boundary %s -> %s stayed stateless because the source session bypasses LCM storage",
                     old_session_id,
                     session_id,
                 )
@@ -2837,6 +3468,321 @@ class LCMEngine(ContextEngine):
         self._schedule_ingest_cursor_reconciliation()
         self._log_session_filter_diagnostics()
 
+    def _session_end_matches_current_store_prefix(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> bool:
+        prefix_count = self._session_end_store_prefix_count(session_id, messages)
+        return prefix_count is not None and prefix_count > 0
+
+    def _session_end_prefix_compare_value(self, value: Any, *, session_id: str) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: self._session_end_prefix_compare_value(child, session_id=session_id)
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                self._session_end_prefix_compare_value(child, session_id=session_id)
+                for child in value
+            ]
+        if not isinstance(value, str):
+            return value
+
+        text = restore_ingest_payload_placeholders(
+            value,
+            config=self._config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
+        stripped = text.strip()
+        ingest_refs = extract_ingest_externalized_refs(stripped)
+        if (
+            len(ingest_refs) == 1
+            and stripped.startswith("[Externalized LCM ingest payload:")
+            and stripped.endswith("]")
+        ):
+            payload = load_externalized_payload(
+                ingest_refs[0],
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            if payload is not None:
+                payload_session_id = str(payload.get("session_id") or "")
+                if not session_id or not payload_session_id or payload_session_id == session_id:
+                    content = payload.get("content")
+                    if isinstance(content, str):
+                        return content
+
+        if is_externalized_placeholder(stripped):
+            ref = extract_externalized_ref(stripped)
+            payload = load_externalized_payload(
+                ref or "",
+                config=self._config,
+                hermes_home=self._hermes_home,
+            )
+            if payload is not None:
+                payload_session_id = str(payload.get("session_id") or "")
+                if not session_id or not payload_session_id or payload_session_id == session_id:
+                    content = payload.get("content")
+                    if isinstance(content, str):
+                        return content
+        return text
+
+    def _session_end_prefix_compare_content(
+        self,
+        message: Dict[str, Any],
+        *,
+        session_id: str,
+    ) -> str:
+        content = self._session_end_prefix_compare_value(
+            (message or {}).get("content"),
+            session_id=session_id,
+        )
+        content = redact_sensitive_value(
+            content,
+            self._config,
+            parse_json_strings=False,
+        )
+        return normalize_content_value(content)
+
+    def _session_end_prefix_compare_tool_calls(
+        self,
+        message: Dict[str, Any],
+        *,
+        session_id: str,
+    ) -> str:
+        tool_calls = self._session_end_prefix_compare_value(
+            (message or {}).get("tool_calls"),
+            session_id=session_id,
+        )
+        tool_calls = redact_sensitive_value(
+            tool_calls,
+            self._config,
+            parse_json_strings=True,
+        )
+        return json.dumps(
+            tool_calls,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+
+    def _session_end_prefix_compare_identity(
+        self,
+        message: Dict[str, Any],
+        *,
+        session_id: str,
+    ) -> tuple[str, str, str, str, str]:
+        return (
+            str((message or {}).get("role") or ""),
+            self._session_end_prefix_compare_content(message, session_id=session_id),
+            str((message or {}).get("tool_call_id") or ""),
+            str((message or {}).get("tool_name") or ""),
+            self._session_end_prefix_compare_tool_calls(message, session_id=session_id),
+        )
+
+    def _session_end_store_prefix_count(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        conversation_id: str | None = None,
+    ) -> Optional[int]:
+        try:
+            stored_messages = self._store.get_range(
+                session_id,
+                limit=max(1, len(messages)),
+                conversation_id=conversation_id,
+            )
+        except Exception:
+            logger.debug("LCM session-end prefix check failed", exc_info=True)
+            return None
+        if not stored_messages:
+            return 0
+        if len(messages) < len(stored_messages):
+            return None
+        for idx, stored_msg in enumerate(stored_messages):
+            msg = messages[idx]
+            try:
+                message_identity = self._session_end_prefix_compare_identity(
+                    msg,
+                    session_id=session_id,
+                )
+                stored_identity = self._session_end_prefix_compare_identity(
+                    stored_msg,
+                    session_id=session_id,
+                )
+            except Exception:
+                logger.debug("LCM session-end prefix compare normalization failed", exc_info=True)
+                return None
+            if message_identity != stored_identity:
+                return None
+        return len(stored_messages)
+
+    @staticmethod
+    def _lcm_bypass_message_fingerprint(message: Dict[str, Any]) -> str:
+        payload = {
+            "role": message.get("role"),
+            "content": normalize_content_value(message.get("content")),
+            "tool_call_id": message.get("tool_call_id"),
+            "tool_calls": message.get("tool_calls"),
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+        return hashlib.sha256(encoded.encode("utf-8", errors="replace")).hexdigest()
+
+    def _remember_lcm_bypass_message_prefix(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        if not session_id or not messages:
+            return
+        fingerprints = [self._lcm_bypass_message_fingerprint(msg) for msg in messages[:8]]
+        if fingerprints:
+            remembered = self._lcm_bypass_message_prefix_fingerprints.setdefault(session_id, [])
+            remembered[:] = [existing for existing in remembered if existing != fingerprints]
+            remembered.append(fingerprints)
+
+    def _remember_lcm_normal_message_prefix(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        conversation_id: str | None = None,
+    ) -> None:
+        if not session_id or not messages:
+            return
+        fingerprints = [self._lcm_bypass_message_fingerprint(msg) for msg in messages[:8]]
+        if fingerprints:
+            self._lcm_normal_message_prefix_fingerprints[
+                self._lcm_normal_prefix_key(session_id, conversation_id=conversation_id)
+            ] = fingerprints
+
+    def _lcm_normal_prefix_key(
+        self,
+        session_id: str,
+        *,
+        conversation_id: str | None = None,
+    ) -> tuple[str, str]:
+        return (
+            session_id,
+            str(
+                conversation_id
+                or self._lcm_session_last_normal_conversation_id.get(session_id)
+                or ""
+            ),
+        )
+
+    def _messages_match_fingerprint_prefix(
+        self,
+        fingerprints: list[str],
+        messages: List[Dict[str, Any]],
+    ) -> bool:
+        return self._matching_fingerprint_prefix_count(fingerprints, messages) > 0
+
+    def _matching_fingerprint_prefix_count(
+        self,
+        fingerprints: list[str],
+        messages: List[Dict[str, Any]],
+    ) -> int:
+        if not fingerprints or not messages:
+            return 0
+        compare_count = min(len(fingerprints), len(messages))
+        if compare_count <= 0:
+            return 0
+        candidate = [self._lcm_bypass_message_fingerprint(msg) for msg in messages[:compare_count]]
+        if candidate == fingerprints[:compare_count]:
+            return compare_count
+        return 0
+
+    def _messages_match_lcm_bypass_prefix(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> bool:
+        return self._matching_lcm_bypass_prefix_count(session_id, messages) > 0
+
+    def _matching_lcm_bypass_prefix_count(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> int:
+        return max(
+            (
+                self._matching_fingerprint_prefix_count(fingerprints, messages)
+                for fingerprints in self._lcm_bypass_message_prefix_fingerprints.get(session_id, [])
+            ),
+            default=0,
+        )
+
+    def _messages_match_lcm_normal_prefix(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        conversation_id: str | None = None,
+    ) -> bool:
+        return self._matching_lcm_normal_prefix_count(
+            session_id,
+            messages,
+            conversation_id=conversation_id,
+        ) > 0
+
+    def _matching_lcm_normal_prefix_count(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        conversation_id: str | None = None,
+    ) -> int:
+        return self._matching_fingerprint_prefix_count(
+            self._lcm_normal_message_prefix_fingerprints.get(
+                self._lcm_normal_prefix_key(session_id, conversation_id=conversation_id)
+            ) or [],
+            messages,
+        )
+
+    def _append_off_current_session_end_suffix(
+        self,
+        session_id: str,
+        suffix: List[Dict[str, Any]],
+        *,
+        source: str,
+        conversation_id: str,
+    ) -> list[int]:
+        if not session_id or not suffix:
+            return []
+        kept: list[Dict[str, Any]] = []
+        for msg in suffix:
+            if self._matches_ignore_message_patterns(msg):
+                self._ignored_message_count += 1
+                excerpt = (text_content_for_pattern_matching(msg.get("content")) or "")[:80].replace("\n", " ")
+                logger.debug(
+                    "LCM ignore_message_patterns dropped late session-end %s message: %r",
+                    msg.get("role", "unknown"),
+                    excerpt,
+                )
+                continue
+            kept.append(msg)
+        if not kept:
+            return []
+        protected_messages = protect_messages_for_ingest(
+            kept,
+            session_id=session_id,
+            config=self._config,
+            hermes_home=self._hermes_home,
+        )
+        return self._store._append_protected_batch(
+            session_id,
+            protected_messages,
+            [count_message_tokens(msg) for msg in protected_messages],
+            source=source,
+            conversation_id=conversation_id,
+        )
+
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         if self._has_auxiliary_lineage_session(session_id) and session_id != self._session_id:
             current_thread_session_id = self._thread_context_session_id()
@@ -2844,6 +3790,168 @@ class LCMEngine(ContextEngine):
                 self._auxiliary_session_ids.discard(session_id)
             if current_thread_session_id == session_id:
                 self._clear_thread_context_stateless(session_id)
+            return
+        current_session_bypasses = session_id == self._session_id and self._bypasses_lcm_context_management()
+        ended_session_directly_bypasses = self._ended_session_directly_bypasses_lcm(session_id)
+        if ended_session_directly_bypasses:
+            self._end_host_fallback_compressor_for_session(
+                session_id,
+                messages,
+                current_session_bypasses=current_session_bypasses,
+            )
+            return
+        same_id_has_bypass_lineage = (
+            session_id == self._session_id
+            and not current_session_bypasses
+            and self._has_lcm_bypass_lineage_session(session_id)
+        )
+        same_id_normal_prefix_count = None
+        same_id_recorded_normal_prefix_count = 0
+        same_id_bypass_prefix_count = 0
+        if same_id_has_bypass_lineage:
+            same_id_conversation_id = (
+                self._conversation_id
+                or self._lcm_session_last_normal_conversation_id.get(session_id)
+                or None
+            )
+            same_id_bypass_prefix_count = self._matching_lcm_bypass_prefix_count(
+                session_id,
+                messages,
+            )
+            same_id_normal_prefix_count = self._session_end_store_prefix_count(
+                session_id,
+                messages,
+                conversation_id=same_id_conversation_id,
+            )
+            same_id_recorded_normal_prefix_count = self._matching_lcm_normal_prefix_count(
+                session_id,
+                messages,
+                conversation_id=same_id_conversation_id,
+            )
+        same_id_store_prefix_positive = (
+            same_id_normal_prefix_count is not None
+            and same_id_normal_prefix_count > 0
+        )
+        same_id_strongest_normal_prefix_count = max(
+            same_id_recorded_normal_prefix_count,
+            same_id_normal_prefix_count if same_id_store_prefix_positive else 0,
+        )
+        same_id_matches_stronger_normal_prefix = (
+            same_id_strongest_normal_prefix_count > 0
+            and (
+                same_id_bypass_prefix_count <= 0
+                or same_id_strongest_normal_prefix_count >= same_id_bypass_prefix_count
+            )
+        )
+        off_current_lineage = session_id != self._session_id and self._has_lcm_bypass_lineage_session(session_id)
+        off_current_normal_conversation_id = (
+            self._lcm_session_last_normal_conversation_id.get(session_id)
+            if off_current_lineage
+            else ""
+        )
+        off_current_store_prefix_count = None
+        off_current_recorded_prefix_count = 0
+        off_current_bypass_prefix_count = 0
+        if off_current_lineage:
+            off_current_bypass_prefix_count = self._matching_lcm_bypass_prefix_count(
+                session_id,
+                messages,
+            )
+        if off_current_lineage and off_current_normal_conversation_id:
+            off_current_store_prefix_count = self._session_end_store_prefix_count(
+                session_id,
+                messages,
+                conversation_id=off_current_normal_conversation_id,
+            )
+            off_current_recorded_prefix_count = self._matching_lcm_normal_prefix_count(
+                session_id,
+                messages,
+                conversation_id=off_current_normal_conversation_id,
+            )
+        off_current_prefix_count = None
+        off_current_store_prefix_positive = (
+            off_current_store_prefix_count is not None
+            and off_current_store_prefix_count > 0
+        )
+        off_current_strongest_normal_prefix_count = max(
+            off_current_recorded_prefix_count,
+            off_current_store_prefix_count if off_current_store_prefix_positive else 0,
+        )
+        if (
+            off_current_strongest_normal_prefix_count > 0
+            and (
+                off_current_bypass_prefix_count <= 0
+                or off_current_strongest_normal_prefix_count > off_current_bypass_prefix_count
+            )
+        ):
+            off_current_prefix_count = (
+                off_current_store_prefix_count
+                if off_current_store_prefix_positive
+                else off_current_recorded_prefix_count
+            )
+        if (
+            off_current_lineage
+            and off_current_normal_conversation_id
+            and off_current_store_prefix_count == 0
+            and off_current_recorded_prefix_count == 0
+            and off_current_bypass_prefix_count <= 0
+            and self._lcm_session_last_bypassed.get(session_id) is False
+        ):
+            off_current_prefix_count = 0
+        same_id_should_bypass = (
+            same_id_has_bypass_lineage
+            and same_id_bypass_prefix_count > 0
+            and not same_id_matches_stronger_normal_prefix
+        )
+        off_current_matches_bypass_prefix = (
+            session_id != self._session_id
+            and self._has_lcm_bypass_lineage_session(session_id)
+            and off_current_bypass_prefix_count > 0
+            and off_current_prefix_count is None
+        )
+        ended_lineage_bypasses = (
+            session_id != self._session_id
+            and self._has_lcm_bypass_lineage_session(session_id)
+            and bool(self._lcm_session_last_bypassed.get(session_id))
+            and not self._session_end_matches_current_store_prefix(session_id, messages)
+        )
+        off_current_should_bypass = off_current_lineage and off_current_prefix_count is None
+        if off_current_prefix_count is not None:
+            prefix_count = off_current_prefix_count
+            suffix = messages[prefix_count:]
+            if suffix:
+                self._append_off_current_session_end_suffix(
+                    session_id,
+                    suffix,
+                    source=(
+                        self._lcm_session_last_normal_platform.get(session_id)
+                        or self._lcm_session_last_platform.get(session_id, self._session_platform)
+                    ),
+                    conversation_id=off_current_normal_conversation_id,
+                )
+            try:
+                state = self._lifecycle.get_by_conversation(off_current_normal_conversation_id)
+                frontier_store_id = state.current_frontier_store_id if state is not None else 0
+                self._lifecycle.finalize_session(
+                    off_current_normal_conversation_id,
+                    session_id,
+                    frontier_store_id=frontier_store_id,
+                )
+            except Exception:
+                logger.debug("LCM off-current session-end lifecycle finalization failed", exc_info=True)
+            return
+        if (
+            current_session_bypasses
+            or same_id_should_bypass
+            or off_current_should_bypass
+            or off_current_matches_bypass_prefix
+            or ended_lineage_bypasses
+        ):
+            self._end_host_fallback_compressor_for_session(
+                session_id,
+                messages,
+                current_session_bypasses=current_session_bypasses,
+            )
             return
         try:
             with _temporary_sqlite_busy_timeout(
@@ -2908,6 +4016,16 @@ class LCMEngine(ContextEngine):
             raise
 
     def on_session_reset(self) -> None:
+        if self._host_fallback_compressor is not None:
+            compressor = self._host_fallback_compressor
+            on_session_reset = getattr(compressor, "on_session_reset", None)
+            if callable(on_session_reset):
+                try:
+                    on_session_reset()
+                except Exception:
+                    logger.debug("LCM host fallback compressor reset failed", exc_info=True)
+            self._host_fallback_compressor = None
+            self._host_fallback_session_id = ""
         self._pending_reset_session_id = self._session_id
         self._pending_reset_conversation_id = self._conversation_id
         self._pending_reset_frontier_store_id = self._last_compacted_store_id
@@ -3243,11 +4361,25 @@ class LCMEngine(ContextEngine):
         )
         self._session_stateless = (
             not self._session_ignored
-            and matches_session_pattern(
-                self._session_match_keys,
-                self._compiled_stateless_session_patterns,
+            and (
+                (
+                    self._lcm_current_start_allows_bypass_lineage
+                    and self._has_lcm_bypass_lineage_session(self._session_id, platform=self._session_platform)
+                )
+                or matches_session_pattern(
+                    self._session_match_keys,
+                    self._compiled_stateless_session_patterns,
+                )
             )
         )
+        if self._session_id:
+            self._lcm_session_last_platform[self._session_id] = self._session_platform
+            self._lcm_session_last_bypassed[self._session_id] = bool(self._session_ignored or self._session_stateless)
+            if not self._session_ignored and not self._session_stateless:
+                self._lcm_non_bypass_platforms.setdefault(self._session_id, set()).add(self._session_platform)
+                self._lcm_session_last_normal_platform[self._session_id] = self._session_platform
+        if self._session_ignored or self._session_stateless:
+            self._mark_lcm_bypass_lineage_session(self._session_id, platform=self._session_platform)
 
     def _log_session_filter_diagnostics(self) -> None:
         if not self._logged_filter_config:

--- a/store.py
+++ b/store.py
@@ -493,22 +493,25 @@ class MessageStore:
 
     def get_range(self, session_id: str, start_id: int = 0,
                   end_id: int | None = None,
-                  limit: int = 1000) -> List[Dict[str, Any]]:
+                  limit: int = 1000,
+                  conversation_id: str | None = None) -> List[Dict[str, Any]]:
         """Get messages in a store_id range for a session."""
+        where = ["session_id = ?", "store_id >= ?"]
+        args: list[Any] = [session_id, start_id]
+        conversation_clause, conversation_args = _conversation_filter_clause("conversation_id", conversation_id)
+        if conversation_clause:
+            where.append(conversation_clause)
+            args.extend(conversation_args)
         if end_id is not None:
-            rows = self._conn.execute(
-                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
-                   WHERE session_id = ? AND store_id >= ? AND store_id <= ?
-                   ORDER BY store_id LIMIT ?""",
-                (session_id, start_id, end_id, limit),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
-                   WHERE session_id = ? AND store_id >= ?
-                   ORDER BY store_id LIMIT ?""",
-                (session_id, start_id, limit),
-            ).fetchall()
+            where.append("store_id <= ?")
+            args.append(end_id)
+        args.append(limit)
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+               WHERE {' AND '.join(where)}
+               ORDER BY store_id LIMIT ?""",
+            args,
+        ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
     def _session_load_where(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1133,6 +1133,36 @@ class TestMessageStore:
         result = store.get_range("sess1", start_id=ids[3], end_id=ids[7])
         assert len(result) == 5
 
+    def test_get_range_can_filter_by_conversation_id(self, store):
+        first = store.append(
+            "sess1",
+            {"role": "user", "content": "conv a first"},
+            conversation_id="conv-a",
+        )
+        store.append(
+            "sess1",
+            {"role": "user", "content": "conv b"},
+            conversation_id="conv-b",
+        )
+        last = store.append(
+            "sess1",
+            {"role": "assistant", "content": "conv a second"},
+            conversation_id="conv-a",
+        )
+
+        unfiltered = store.get_range("sess1", start_id=first, end_id=last)
+        filtered = store.get_range("sess1", start_id=first, end_id=last, conversation_id="conv-a")
+
+        assert [row["content"] for row in unfiltered] == [
+            "conv a first",
+            "conv b",
+            "conv a second",
+        ]
+        assert [row["content"] for row in filtered] == [
+            "conv a first",
+            "conv a second",
+        ]
+
     def test_session_count(self, store):
         store.append("sess1", {"role": "user", "content": "a"})
         store.append("sess1", {"role": "assistant", "content": "b"})
@@ -5886,6 +5916,47 @@ class TestLCMEngineCloning:
             lifecycle.close()
             for engine in (prototype, first_agent, second_agent):
                 engine.shutdown()
+
+    def test_clone_for_agent_does_not_copy_bypass_lineage_into_normal_session(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm-clone-bypass-lineage.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = None
+        shared_prefix = [{"role": "user", "content": "shared opener"}]
+        try:
+            prototype.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            prototype.ingest(shared_prefix)
+
+            clone = prototype.clone_for_agent()
+            clone.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            clone.on_session_end(
+                "shared-session",
+                shared_prefix + [{"role": "assistant", "content": "normal final"}],
+            )
+
+            rows = clone._store.get_session_messages("shared-session")
+            assert [(row["conversation_id"], row["role"], row["content"]) for row in rows] == [
+                ("normal-conversation", "user", "shared opener"),
+                ("normal-conversation", "assistant", "normal final"),
+            ]
+        finally:
+            prototype.shutdown()
+            if clone is not None:
+                clone.shutdown()
 
     def test_deepcopy_uses_clone_for_agent_without_copying_sqlite_handles(self, tmp_path):
         from hermes_lcm.engine import LCMEngine

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12993,6 +12993,177 @@ class TestSessionRollover:
         finally:
             engine.shutdown()
 
+    def test_off_current_recorded_prefix_appends_when_store_normalizes_equivalent_row(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_recorded_prefix_normalized.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            normalized_prefix = {
+                "role": "assistant",
+                "content": "stored row normalizes empty tool_calls",
+                "tool_calls": [],
+            }
+            normal_suffix = {"role": "user", "content": "normal suffix must append"}
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest([normalized_prefix])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            engine.on_session_end("shared-session", [normalized_prefix, normal_suffix])
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                "stored row normalizes empty tool_calls",
+                "normal suffix must append",
+            ]
+            assert all(row["conversation_id"] != "bypass-conversation" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_off_current_store_prefix_appends_normalized_empty_tool_calls_beyond_recorded_limit(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_long_normalized_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            normal_prefix = [
+                {
+                    "role": "assistant",
+                    "content": "long prefix stores empty tool_calls as NULL",
+                    "tool_calls": [],
+                },
+                *(
+                    {"role": "user", "content": f"long normalized prefix {idx}"}
+                    for idx in range(8)
+                ),
+            ]
+            normal_suffix = {"role": "assistant", "content": "long normalized suffix must append"}
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(normal_prefix)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            engine.on_session_end("shared-session", [*normal_prefix, normal_suffix])
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                "long prefix stores empty tool_calls as NULL",
+                *(f"long normalized prefix {idx}" for idx in range(8)),
+                "long normalized suffix must append",
+            ]
+            assert normal_rows[0]["tool_calls"] is None
+            assert all(row["conversation_id"] != "bypass-conversation" for row in rows)
+        finally:
+            engine.shutdown()
+
+    @pytest.mark.parametrize("bypass_tool_calls", [[], {}])
+    def test_off_current_empty_tool_calls_bypass_tie_does_not_append_suffix(
+        self,
+        tmp_path,
+        bypass_tool_calls,
+    ):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_empty_tool_calls_bypass_tie.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            bypass_prefix = {
+                "role": "assistant",
+                "content": "shared empty tool_calls opener",
+                "tool_calls": bypass_tool_calls,
+            }
+            normal_prefix = {
+                "role": "assistant",
+                "content": "shared empty tool_calls opener",
+            }
+            late_bypass_end = [
+                {
+                    "role": "assistant",
+                    "content": "shared empty tool_calls opener",
+                },
+                {
+                    "role": "assistant",
+                    "content": "empty tool_calls bypass suffix must not append",
+                },
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([bypass_prefix])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest([normal_prefix])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == ["shared empty tool_calls opener"]
+            assert normal_rows[0]["tool_calls"] is None
+            assert bypass_rows == []
+            assert all(
+                row["content"] != "empty tool_calls bypass suffix must not append"
+                for row in rows
+            )
+        finally:
+            engine.shutdown()
+
     def test_off_current_truncated_bypass_prefix_does_not_append_ambiguous_suffix(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_off_current_truncated_bypass_prefix.db"),

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12944,6 +12944,179 @@ class TestSessionRollover:
         finally:
             engine.shutdown()
 
+    def test_off_current_store_mismatch_does_not_append_from_recorded_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_store_mismatch.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            normal_messages = [
+                {"role": "user", "content": f"A{i}"}
+                for i in range(9)
+            ]
+            divergent_end = [
+                *normal_messages[:8],
+                {"role": "assistant", "content": "B8 must not append"},
+                {"role": "assistant", "content": "new divergent suffix must not append"},
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(normal_messages)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+
+            engine.on_session_end("shared-session", divergent_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == [f"A{i}" for i in range(9)]
+            assert all(row["content"] != "B8 must not append" for row in rows)
+            assert all(row["content"] != "new divergent suffix must not append" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_off_current_truncated_bypass_prefix_does_not_append_ambiguous_suffix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_truncated_bypass_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_prefix = [
+                {"role": "user", "content": f"shared prefix {i}"}
+                for i in range(9)
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared_prefix)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared_prefix)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_bypass_end = [
+                *shared_prefix,
+                {"role": "assistant", "content": "truncated bypass suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                f"shared prefix {i}"
+                for i in range(9)
+            ]
+            assert bypass_rows == []
+            assert all(row["content"] != "truncated bypass suffix must not append" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_off_current_duplicate_short_bypass_snapshot_keeps_truncated_ambiguity(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_duplicate_short_bypass_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared8 = [
+                {"role": "user", "content": f"duplicate shared prefix {i}"}
+                for i in range(8)
+            ]
+            shared9 = [
+                *shared8,
+                {"role": "assistant", "content": "duplicate shared ninth"},
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="long-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared9)
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="short-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared8)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared9)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_bypass_end = [
+                *shared9,
+                {"role": "assistant", "content": "duplicate truncated bypass suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [
+                row
+                for row in rows
+                if row["conversation_id"] in {"long-bypass-conversation", "short-bypass-conversation"}
+            ]
+            assert [row["content"] for row in normal_rows] == [
+                *(f"duplicate shared prefix {i}" for i in range(8)),
+                "duplicate shared ninth",
+            ]
+            assert bypass_rows == []
+            assert all(
+                row["content"] != "duplicate truncated bypass suffix must not append"
+                for row in rows
+            )
+        finally:
+            engine.shutdown()
+
     @pytest.mark.parametrize("bypass_probe", ["preflight", "compress"])
     def test_shared_opener_bypass_probe_ambiguity_does_not_append_bypass_suffix(self, tmp_path, bypass_probe):
         config = LCMConfig(
@@ -13038,6 +13211,118 @@ class TestSessionRollover:
             assert normal_state is not None
             assert normal_state.current_session_id is None
             assert normal_state.last_finalized_session_id == "shared-session"
+        finally:
+            engine.shutdown()
+
+    def test_current_normal_reuse_with_truncated_bypass_prefix_does_not_append_ambiguous_suffix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_current_normal_truncated_bypass_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_prefix = [
+                {"role": "user", "content": f"current shared prefix {i}"}
+                for i in range(9)
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared_prefix)
+            engine.on_session_end("shared-session", shared_prefix)
+            assert engine._store.get_session_count("shared-session") == 0
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared_prefix)
+
+            late_bypass_end = [
+                *shared_prefix,
+                {"role": "assistant", "content": "current truncated bypass suffix must not persist"},
+            ]
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                f"current shared prefix {i}"
+                for i in range(9)
+            ]
+            assert bypass_rows == []
+            assert all(row["content"] != "current truncated bypass suffix must not persist" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_current_duplicate_short_bypass_snapshot_keeps_truncated_ambiguity(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_current_duplicate_short_bypass_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared8 = [
+                {"role": "user", "content": f"current duplicate shared prefix {i}"}
+                for i in range(8)
+            ]
+            long_bypass = [
+                *shared8,
+                {"role": "assistant", "content": "current duplicate long bypass ninth"},
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="long-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(long_bypass)
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="short-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared8)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(shared8)
+
+            late_bypass_end = [
+                *shared8,
+                {"role": "assistant", "content": "current duplicate truncated suffix must not persist"},
+            ]
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [
+                row
+                for row in rows
+                if row["conversation_id"] in {"long-bypass-conversation", "short-bypass-conversation"}
+            ]
+            assert [row["content"] for row in normal_rows] == [
+                f"current duplicate shared prefix {i}"
+                for i in range(8)
+            ]
+            assert bypass_rows == []
+            assert all(
+                row["content"] != "current duplicate truncated suffix must not persist"
+                for row in rows
+            )
         finally:
             engine.shutdown()
 
@@ -13156,57 +13441,6 @@ class TestSessionRollover:
             assert len(final_rows) == 1
             assert final_rows[0]["source"] == "cli"
             assert stateless_rows == []
-        finally:
-            engine.shutdown()
-
-    def test_off_current_divergent_normal_end_does_not_append_from_recorded_prefix(self, tmp_path):
-        config = LCMConfig(
-            database_path=str(tmp_path / "lcm_off_current_divergent_normal_end.db"),
-            stateless_session_patterns=["stateless"],
-        )
-        engine = LCMEngine(config=config)
-        try:
-            engine.on_session_start(
-                "shared-session",
-                platform="stateless",
-                conversation_id="bypass-conversation",
-                context_length=200000,
-            )
-            engine.ingest([{"role": "user", "content": "unrelated bypass opener"}])
-
-            engine.on_session_start(
-                "shared-session",
-                platform="cli",
-                conversation_id="normal-conversation",
-                context_length=200000,
-            )
-            normal_messages = [
-                {"role": "user", "content": f"normal prefix {idx}"}
-                for idx in range(9)
-            ]
-            engine.ingest(normal_messages)
-
-            engine.on_session_start(
-                "foreground-session",
-                platform="cli",
-                conversation_id="foreground-conversation",
-                context_length=200000,
-            )
-            divergent_end = normal_messages[:8] + [
-                {"role": "user", "content": "divergent ninth message"},
-                {"role": "assistant", "content": "corrupt suffix must not append"},
-            ]
-
-            engine.on_session_end("shared-session", divergent_end)
-
-            rows = engine._store.get_session_messages("shared-session")
-            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
-            assert [row["content"] for row in normal_rows] == [
-                msg["content"] for msg in normal_messages
-            ]
-            assert all(row["content"] != "divergent ninth message" for row in rows)
-            assert all(row["content"] != "corrupt suffix must not append" for row in rows)
-            assert engine._store.get_session_count("foreground-session") == 0
         finally:
             engine.shutdown()
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -13159,6 +13159,57 @@ class TestSessionRollover:
         finally:
             engine.shutdown()
 
+    def test_off_current_divergent_normal_end_does_not_append_from_recorded_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_off_current_divergent_normal_end.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "unrelated bypass opener"}])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_messages = [
+                {"role": "user", "content": f"normal prefix {idx}"}
+                for idx in range(9)
+            ]
+            engine.ingest(normal_messages)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            divergent_end = normal_messages[:8] + [
+                {"role": "user", "content": "divergent ninth message"},
+                {"role": "assistant", "content": "corrupt suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", divergent_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                msg["content"] for msg in normal_messages
+            ]
+            assert all(row["content"] != "divergent ninth message" for row in rows)
+            assert all(row["content"] != "corrupt suffix must not append" for row in rows)
+            assert engine._store.get_session_count("foreground-session") == 0
+        finally:
+            engine.shutdown()
+
     def test_reused_normal_session_id_scopes_off_current_dedupe_to_current_conversation(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_reused_normal_id_current_conversation.db"),

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5,9 +5,11 @@ import json
 import logging
 import re
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -1535,6 +1537,1549 @@ class TestEngineABC:
         try:
             assert count_messages_tokens(messages) >= instance.threshold_tokens
             assert instance.should_compress_preflight(messages)
+        finally:
+            instance.shutdown()
+
+    @staticmethod
+    def _oversized_bypass_messages():
+        return [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old bypass backlog " + "x" * 400},
+            {"role": "assistant", "content": "old bypass answer " + "y" * 400},
+            {"role": "user", "content": "fresh bypass tail " + "z" * 400},
+        ]
+
+    @pytest.mark.parametrize(
+        ("session_id", "config_kwargs"),
+        [
+            ("ignored:session", {"ignore_session_patterns": ["ignored:*"]}),
+            ("stateless:session", {"stateless_session_patterns": ["stateless:*"]}),
+        ],
+    )
+    def test_bypassed_sessions_request_host_compaction_without_lcm_writes(
+        self,
+        tmp_path,
+        session_id,
+        config_kwargs,
+    ):
+        config = LCMConfig(
+            database_path=str(tmp_path / f"{session_id.replace(':', '-')}.db"),
+            **config_kwargs,
+        )
+        instance = LCMEngine(config=config)
+        messages = self._oversized_bypass_messages()
+        try:
+            instance.on_session_start(session_id, platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+
+            assert count_messages_tokens(messages) >= instance.threshold_tokens
+            instance.ingest(messages)
+            instance.on_session_end(session_id, messages)
+
+            assert instance._store.get_session_count(session_id) == 0
+            assert instance._dag.get_session_node_count(session_id) == 0
+            assert instance.should_compress_preflight(messages)
+            assert instance.should_compress(instance.threshold_tokens + 1)
+        finally:
+            instance.shutdown()
+
+    @pytest.mark.parametrize(
+        ("session_id", "config_kwargs"),
+        [
+            ("ignored:session", {"ignore_session_patterns": ["ignored:*"]}),
+            ("stateless:session", {"stateless_session_patterns": ["stateless:*"]}),
+        ],
+    )
+    def test_bypassed_compression_boundary_child_stays_out_of_lcm_storage(
+        self,
+        tmp_path,
+        session_id,
+        config_kwargs,
+    ):
+        child_session_id = "compressed-child"
+        grandchild_session_id = "compressed-grandchild"
+        config = LCMConfig(
+            database_path=str(tmp_path / f"boundary-{session_id.replace(':', '-')}.db"),
+            **config_kwargs,
+        )
+        instance = LCMEngine(config=config)
+        messages = self._oversized_bypass_messages()
+        child_messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "child turn " + "x" * 400},
+        ]
+        try:
+            instance.on_session_start(session_id, platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            assert instance.should_compress_preflight(messages)
+
+            instance.on_session_start(
+                child_session_id,
+                boundary_reason="compression",
+                old_session_id=session_id,
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.ingest(child_messages)
+            instance.on_session_end(child_session_id, child_messages)
+            instance.threshold_tokens = 20
+
+            assert instance._store.get_session_count(session_id) == 0
+            assert instance._store.get_session_count(child_session_id) == 0
+            assert instance._dag.get_session_node_count(session_id) == 0
+            assert instance._dag.get_session_node_count(child_session_id) == 0
+            assert instance.should_compress_preflight(child_messages)
+
+            instance.on_session_start(
+                grandchild_session_id,
+                boundary_reason="compression",
+                old_session_id=child_session_id,
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.ingest(child_messages)
+            instance.threshold_tokens = 20
+
+            assert instance._store.get_session_count(grandchild_session_id) == 0
+            assert instance._dag.get_session_node_count(grandchild_session_id) == 0
+            assert instance.should_compress_preflight(child_messages)
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_compression_boundary_child_without_platform_keeps_lineage(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "boundary-missing-platform.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        child_messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "child without platform must stay bypassed"},
+        ]
+        try:
+            instance.on_session_start("ignored-source", platform="cron", context_length=1_000)
+            assert instance._bypasses_lcm_context_management()
+
+            instance.on_session_start(
+                "compressed-child",
+                boundary_reason="compression",
+                old_session_id="ignored-source",
+                context_length=1_000,
+            )
+
+            assert instance._session_id == "compressed-child"
+            assert instance._session_platform == ""
+            assert not instance._session_ignored
+            assert instance._session_stateless
+            assert instance._bypasses_lcm_context_management()
+            assert instance._has_lcm_bypass_lineage_session("compressed-child", platform="")
+
+            instance.ingest(child_messages)
+            instance.on_session_end("compressed-child", child_messages)
+
+            assert instance._store.get_session_count("ignored-source") == 0
+            assert instance._store.get_session_count("compressed-child") == 0
+            assert instance._dag.get_session_node_count("ignored-source") == 0
+            assert instance._dag.get_session_node_count("compressed-child") == 0
+        finally:
+            instance.shutdown()
+
+    @pytest.mark.parametrize(
+        ("session_id", "config_kwargs"),
+        [
+            ("ignored:session", {"ignore_session_patterns": ["ignored:*"]}),
+            ("stateless:session", {"stateless_session_patterns": ["stateless:*"]}),
+        ],
+    )
+    def test_bypassed_compression_boundary_after_rebind_stays_out_of_lcm_storage(
+        self,
+        tmp_path,
+        session_id,
+        config_kwargs,
+    ):
+        child_session_id = "compressed-after-rebind"
+        config = LCMConfig(
+            database_path=str(tmp_path / f"boundary-rebind-{session_id.replace(':', '-')}.db"),
+            **config_kwargs,
+        )
+        instance = LCMEngine(config=config)
+        child_messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "child after rebind " + "x" * 400},
+        ]
+        try:
+            instance.on_session_start(session_id, platform="cli", context_length=1_000)
+            instance.on_session_start("foreground:normal", platform="cli", context_length=1_000)
+
+            instance.on_session_start(
+                child_session_id,
+                boundary_reason="compression",
+                old_session_id=session_id,
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.ingest(child_messages)
+            instance.on_session_end(child_session_id, child_messages)
+
+            assert instance._store.get_session_count(session_id) == 0
+            assert instance._store.get_session_count(child_session_id) == 0
+            assert instance._dag.get_session_node_count(session_id) == 0
+            assert instance._dag.get_session_node_count(child_session_id) == 0
+        finally:
+            instance.shutdown()
+
+    def test_platform_drift_does_not_turn_normal_boundary_child_stateless(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "normal-boundary-platform-drift.db"),
+            ignore_session_patterns=["cron:*"],
+        )
+        instance = LCMEngine(config=config)
+        child_messages = [{"role": "user", "content": "normal child should persist"}]
+        try:
+            instance.on_session_start("normal:source", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal source persists"}])
+            instance.on_session_start("cron:tick", platform="cron", context_length=1_000)
+
+            instance.on_session_start(
+                "normal:child",
+                boundary_reason="compression",
+                old_session_id="normal:source",
+                platform="cron",
+                context_length=1_000,
+            )
+            instance.ingest(child_messages)
+
+            assert instance._store.get_session_count("normal:child") == 1
+            assert not instance._has_lcm_bypass_lineage_session("normal:child")
+        finally:
+            instance.shutdown()
+
+    def test_bypass_lineage_does_not_poison_reused_normal_session_id(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "reused-normal-session-id.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored must not persist"}])
+            instance.on_session_end("reused-id", [{"role": "user", "content": "ignored end"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal should persist"}])
+
+            assert instance._store.get_session_count("reused-id") == 1
+            assert instance._has_lcm_bypass_lineage_session("reused-id")
+            assert not instance._has_lcm_bypass_lineage_session("reused-id", platform="cli")
+        finally:
+            instance.shutdown()
+
+    def test_bypass_lineage_does_not_poison_reused_normal_session_id_without_end(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "reused-normal-session-id-no-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored must not persist"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal should persist"}])
+
+            assert instance._store.get_session_count("reused-id") == 1
+            assert not instance._has_lcm_bypass_lineage_session("reused-id", platform="cli")
+        finally:
+            instance.shutdown()
+
+    def test_same_id_reused_unmatched_suffix_only_end_flushes_current_normal(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "reused-unmatched-suffix-normal-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored prefix must not persist"}])
+            assert instance._store.get_session_count("reused-id") == 0
+            assert instance._dag.get_session_node_count("reused-id") == 0
+            assert instance._has_lcm_bypass_lineage_session("reused-id")
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            foreground_session_id = instance.current_session_id
+            foreground_platform = instance.current_session_platform
+            foreground_conversation_id = instance.current_conversation_id
+            assert foreground_session_id == "reused-id"
+            assert foreground_platform == "cli"
+            assert not instance.current_session_ignored
+            assert not instance.current_session_stateless
+            assert not instance._has_lcm_bypass_lineage_session("reused-id", platform="cli")
+
+            instance.on_session_end(
+                "reused-id",
+                [{"role": "assistant", "content": "unmatched suffix-only normal final"}],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"]) for row in rows] == [
+                ("assistant", "unmatched suffix-only normal final"),
+            ]
+            assert instance._dag.get_session_node_count("reused-id") == 0
+            assert instance.current_session_id == foreground_session_id
+            assert instance.current_session_platform == foreground_platform
+            assert instance.current_conversation_id == foreground_conversation_id
+            state = instance._lifecycle.get_by_conversation(foreground_conversation_id)
+            assert state is not None
+            assert state.current_session_id is None
+            assert state.last_finalized_session_id == "reused-id"
+            assert not instance.current_session_ignored
+            assert not instance.current_session_stateless
+        finally:
+            instance.shutdown()
+
+    def test_bypass_lineage_does_not_poison_reused_normal_compression_boundary(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "reused-normal-boundary.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored must not persist"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal should persist"}])
+            instance.on_session_start(
+                "normal-child",
+                boundary_reason="compression",
+                old_session_id="reused-id",
+                platform="cli",
+                context_length=1_000,
+            )
+
+            assert not instance._session_stateless
+            assert not instance._bypasses_lcm_context_management()
+            assert not instance._has_lcm_bypass_lineage_session("normal-child", platform="cli")
+        finally:
+            instance.shutdown()
+
+    def test_later_bypass_rebind_keeps_boundary_child_out_of_lcm(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "prior-normal-boundary-after-bypass-rebind.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal should persist"}])
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored must not persist"}])
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+
+            instance.on_session_start(
+                "normal-looking-child",
+                boundary_reason="compression",
+                old_session_id="reused-id",
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.ingest([{"role": "user", "content": "boundary child must stay out of LCM"}])
+
+            assert instance._session_stateless
+            assert instance._bypasses_lcm_context_management()
+            assert instance._has_lcm_bypass_lineage_session("normal-looking-child", platform="cli")
+            assert instance._store.get_session_count("reused-id") == 1
+            assert instance._store.get_session_count("normal-looking-child") == 0
+        finally:
+            instance.shutdown()
+
+    def test_platform_only_bypass_boundary_after_source_end_stays_out_of_lcm(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "platform-only-boundary-after-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("old-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored source"}])
+            instance.on_session_end("old-id", [{"role": "user", "content": "ignored source end"}])
+
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+            instance.on_session_start(
+                "child-id",
+                boundary_reason="compression",
+                old_session_id="old-id",
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.ingest([{"role": "user", "content": "child must stay out of LCM"}])
+
+            assert instance._store.get_session_count("old-id") == 0
+            assert instance._store.get_session_count("child-id") == 0
+            assert instance._has_lcm_bypass_lineage_session("child-id", platform="cli")
+        finally:
+            instance.shutdown()
+
+    def test_ended_bypass_boundary_child_can_reuse_id_as_normal_session(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-child-reused-normal.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("ignored:old", platform="cli", context_length=1_000)
+            instance.on_session_start(
+                "child-id",
+                boundary_reason="compression",
+                old_session_id="ignored:old",
+                platform="cli",
+                context_length=1_000,
+            )
+            instance.on_session_end("child-id", [{"role": "user", "content": "bypass child end"}])
+
+            instance.on_session_start("child-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal child-id reuse"}])
+
+            assert not instance._session_stateless
+            assert not instance._bypasses_lcm_context_management()
+            assert instance._store.get_session_count("child-id") == 1
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_session_end_does_not_flush_raw_messages(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-session-end.db"))
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "must not persist while thread stateless"}]
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            instance.on_session_end("foreground:session", messages)
+
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_requests_host_compaction_without_lcm_writes(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless.db"))
+        instance = LCMEngine(config=config)
+        messages = self._oversized_bypass_messages()
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert count_messages_tokens(messages) >= instance.threshold_tokens
+            instance.ingest(messages)
+
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._dag.get_session_node_count("foreground:session") == 0
+            assert instance.should_compress_preflight(messages)
+            assert instance.should_compress(instance.threshold_tokens + 1)
+        finally:
+            instance.shutdown()
+
+    @pytest.mark.parametrize(
+        ("session_id", "config_kwargs"),
+        [
+            ("ignored:session", {"ignore_session_patterns": ["ignored:*"]}),
+            ("stateless:session", {"stateless_session_patterns": ["stateless:*"]}),
+        ],
+    )
+    def test_bypassed_sessions_delegate_compress_to_host_native_compressor(
+        self,
+        tmp_path,
+        monkeypatch,
+        session_id,
+        config_kwargs,
+    ):
+        calls = []
+        compacted = [
+            {"role": "system", "content": "native summary"},
+            {"role": "user", "content": "fresh tail"},
+        ]
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.compression_count = 0
+                self._last_compress_aborted = False
+                self._last_summary_error = None
+                self._last_summary_auth_failure = False
+                self._last_summary_network_failure = False
+                self._last_summary_dropped_count = 0
+                self._last_summary_fallback_used = False
+                self._last_aux_model_failure_error = None
+                self._last_aux_model_failure_model = None
+
+            def on_session_start(self, bound_session_id, **kwargs):
+                calls.append(("start", bound_session_id, kwargs))
+
+            def update_model(self, **kwargs):
+                calls.append(("update_model", kwargs))
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                calls.append(("compress", list(messages), current_tokens, focus_topic, force))
+                self.compression_count += 1
+                return list(compacted)
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / f"delegate-{session_id.replace(':', '-')}.db"),
+            **config_kwargs,
+        )
+        instance = LCMEngine(config=config)
+        messages = self._oversized_bypass_messages()
+        try:
+            instance.on_session_start(
+                session_id,
+                platform="cli",
+                model="test-model",
+                provider="test-provider",
+                base_url="https://example.invalid/v1",
+                api_key="test-key",
+                api_mode="chat_completions",
+                context_length=1_000,
+            )
+            instance.threshold_tokens = 20
+
+            result = instance.compress(messages, current_tokens=123, focus_topic="focus")
+
+            assert result == compacted
+            assert ("compress", messages, 123, "focus", False) in calls
+            assert instance.compression_count == 1
+            assert instance._store.get_session_count(session_id) == 0
+            assert instance._dag.get_session_node_count(session_id) == 0
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_sessions_honor_assembly_cap_below_threshold(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "ignored-assembly-cap.db"),
+            ignore_session_patterns=["ignored:*"],
+            max_assembly_tokens=90,
+        )
+        instance = LCMEngine(config=config)
+        messages = self._oversized_bypass_messages()
+        try:
+            instance.on_session_start("ignored:cap", platform="cli", context_length=10_000)
+            instance.threshold_tokens = 1_000
+
+            assert count_messages_tokens(messages) < instance.threshold_tokens
+            assert count_messages_tokens(messages) >= config.max_assembly_tokens
+            assert instance.should_compress_preflight(messages)
+            assert instance.should_compress(config.max_assembly_tokens)
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_fallback_uses_effective_context_length_and_auxiliary_session(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        calls = []
+        init_kwargs = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                init_kwargs.append(kwargs)
+                self.compression_count = 0
+
+            def on_session_start(self, bound_session_id, **kwargs):
+                calls.append(("start", bound_session_id, kwargs))
+
+            def update_model(self, **kwargs):
+                calls.append(("update_model", kwargs))
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "system", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(database_path=str(tmp_path / "thread-effective-context.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start(
+                "foreground:session",
+                platform="cli",
+                model="gpt-5.5",
+                provider="openai-codex",
+                context_length=500_000,
+            )
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            result = instance.compress(self._oversized_bypass_messages(), current_tokens=123)
+
+            assert result == [{"role": "system", "content": "native compacted"}]
+            assert init_kwargs[0]["config_context_length"] == 272_000
+            assert any(call[0] == "start" and call[1] == "auxiliary:session" for call in calls)
+            assert any(
+                call[0] == "update_model" and call[1].get("context_length") == 272_000
+                for call in calls
+            )
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_update_model_failure_still_compacts(self, tmp_path, monkeypatch):
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def update_model(self, **kwargs):
+                raise RuntimeError("metadata sync failed")
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "system", "content": "native compacted despite sync failure"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-update-model-failure.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("ignored:sync-failure", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+
+            result = instance.compress(
+                [{"role": "user", "content": "oversized " + "x" * 1_000}],
+                current_tokens=600,
+            )
+
+            assert result == [
+                {"role": "system", "content": "native compacted despite sync failure"}
+            ]
+            assert instance._store.get_session_count("ignored:sync-failure") == 0
+            assert instance._dag.get_session_node_count("ignored:sync-failure") == 0
+        finally:
+            instance.shutdown()
+
+    def test_unavailable_native_fallback_sanitizes_tool_pairs(self, tmp_path, monkeypatch):
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "fallback-tool-pairs.db"),
+            ignore_session_patterns=["ignored:*"],
+            fresh_tail_count=2,
+        )
+        instance = LCMEngine(config=config)
+        messages = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "content": "calling tool",
+                "tool_calls": [{"id": "call_head", "type": "function"}],
+            },
+            {"role": "user", "content": "large middle " + "x" * 400},
+            {"role": "tool", "tool_call_id": "orphan_tail", "content": "orphan tool result"},
+            {"role": "user", "content": "fresh tail"},
+        ]
+        try:
+            instance.on_session_start("ignored:tools", platform="cli", context_length=1_000)
+
+            result = instance.compress(messages, force=True)
+
+            assert any(msg.get("tool_call_id") == "call_head" for msg in result)
+            assert not any(msg.get("tool_call_id") == "orphan_tail" for msg in result)
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_fallback_receives_redacted_messages(self, tmp_path, monkeypatch):
+        captured_messages = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                captured_messages.extend(messages)
+                self.compression_count += 1
+                return list(messages)
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-redacted-native.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        config.sensitive_patterns_enabled = True
+        config.sensitive_patterns = ["password_assignment"]
+        instance = LCMEngine(config=config)
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "password: supersecret1234 " + "x" * 400},
+            {"role": "assistant", "content": "ack"},
+        ]
+        try:
+            instance.on_session_start("ignored:redact", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+
+            instance.compress(messages, current_tokens=200)
+
+            serialized = json.dumps(captured_messages)
+            assert "supersecret1234" not in serialized
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_result_is_sanitized_under_cap(self, tmp_path, monkeypatch):
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [
+                    {
+                        "role": "assistant",
+                        "content": "calling tool",
+                        "tool_calls": [{"id": "call_1", "type": "function"}],
+                    },
+                    {"role": "user", "content": "interrupt before tool result"},
+                    {"role": "tool", "tool_call_id": "orphan", "content": "late result"},
+                ]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-sanitize-under-cap.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("ignored:native-invalid", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+
+            result = instance.compress(messages, current_tokens=600)
+
+            assert not any(msg.get("tool_call_id") == "orphan" for msg in result)
+            assert any(msg.get("tool_call_id") == "call_1" for msg in result)
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_fallback_resets_between_sessions(self, tmp_path, monkeypatch):
+        instances = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.ended = False
+                self.reset = False
+                instances.append(self)
+
+            def on_session_end(self, session_id, messages):
+                self.ended = session_id
+
+            def on_session_reset(self):
+                self.reset = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-reset.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("ignored:first", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            instance.on_session_start("ignored:second", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            assert len(instances) == 2
+            assert instances[0].ended == "ignored:first"
+            assert instances[0].reset is True
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_fallback_resets_on_session_end_even_for_same_session_id(self, tmp_path, monkeypatch):
+        instances = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.ended = False
+                self.reset = False
+                instances.append(self)
+
+            def on_session_end(self, session_id, messages):
+                self.ended = session_id
+
+            def on_session_reset(self):
+                self.reset = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-reset-same-id.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("ignored:reused", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+            instance.on_session_end("ignored:reused", messages)
+
+            instance.on_session_start("ignored:reused", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            assert len(instances) == 2
+            assert instances[0].ended == "ignored:reused"
+            assert instances[0].reset is True
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_fallback_resets_when_same_session_id_rebinds_platform(self, tmp_path, monkeypatch):
+        instances = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.ended = False
+                self.reset = False
+                instances.append(self)
+
+            def on_session_end(self, session_id, messages):
+                self.ended = session_id
+
+            def on_session_reset(self):
+                self.reset = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-reset-rebind-platform.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            instance.on_session_start("reused-id", platform="cli", context_length=2_000)
+            instance.ingest([{"role": "user", "content": "normal"}])
+            instance.on_session_start("reused-id", platform="cron", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            assert len(instances) == 2
+            assert instances[0].ended == "reused-id"
+            assert instances[0].reset is True
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_fallback_resets_on_session_reset(self, tmp_path, monkeypatch):
+        instances = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.reset = False
+                instances.append(self)
+
+            def on_session_reset(self):
+                self.reset = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-session-reset.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("ignored:reset", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+            instance.on_session_reset()
+            instance.on_session_start("ignored:reset", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            assert len(instances) == 2
+            assert instances[0].reset is True
+        finally:
+            instance.shutdown()
+
+    def test_late_bypassed_session_end_does_not_reset_active_fallback_compressor(self, tmp_path, monkeypatch):
+        instances = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.ended = []
+                self.reset = False
+                instances.append(self)
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append(session_id)
+
+            def on_session_reset(self):
+                self.reset = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-late-end-active-fallback.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 1_000}]
+        try:
+            instance.on_session_start("ignored:old", platform="cli", context_length=2_000)
+            instance.on_session_end("ignored:old", [])
+            instance.on_session_start("ignored:active", platform="cli", context_length=2_000)
+            instance.threshold_tokens = 500
+            instance.compress(messages, current_tokens=600)
+
+            instance.on_session_end("ignored:old", [])
+
+            assert len(instances) == 1
+            assert instances[0].ended == []
+            assert instances[0].reset is False
+            assert instance._host_fallback_compressor is instances[0]
+        finally:
+            instance.shutdown()
+
+    def test_late_reused_lineage_suffix_only_session_end_stays_stateless(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-reused-normal-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored"}])
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal"}])
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+
+            instance.on_session_end("reused-id", [{"role": "assistant", "content": "ambiguous late final"}])
+
+            assert instance._store.get_session_count("reused-id") == 1
+            assert instance._store.get_session_count("foreground") == 0
+        finally:
+            instance.shutdown()
+
+    def test_late_reused_bypass_session_end_does_not_write_to_foreground(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-reused-bypass-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal"}])
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored"}])
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+
+            instance.on_session_end("reused-id", [{"role": "assistant", "content": "late ignored final"}])
+
+            assert instance._store.get_session_count("reused-id") == 1
+            assert instance._store.get_session_count("foreground") == 0
+        finally:
+            instance.shutdown()
+
+    def test_late_same_id_bypass_session_end_does_not_append_to_reused_normal_session(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-same-id-bypass-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored start"}])
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal start"}])
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    {"role": "user", "content": "ignored start"},
+                    {"role": "assistant", "content": "late bypass final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"]) for row in rows] == [("user", "normal start")]
+        finally:
+            instance.shutdown()
+
+    def test_late_same_id_normal_session_end_flushes_when_prefix_matches_current_store(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-same-id-normal-end.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored start"}])
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "normal start"}])
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    {"role": "user", "content": "normal start"},
+                    {"role": "assistant", "content": "normal final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"]) for row in rows] == [
+                ("user", "normal start"),
+                ("assistant", "normal final"),
+            ]
+        finally:
+            instance.shutdown()
+
+    def test_same_id_current_normal_first_flush_after_bypass_lineage_persists(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "same-id-normal-first-flush-after-bypass.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored start"}])
+            instance.on_session_end("reused-id", [{"role": "user", "content": "ignored end"}])
+
+            instance.on_session_start(
+                "reused-id",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=1_000,
+            )
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    {"role": "user", "content": "normal start"},
+                    {"role": "assistant", "content": "normal final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"], row["conversation_id"]) for row in rows] == [
+                ("user", "normal start", "normal-conversation"),
+                ("assistant", "normal final", "normal-conversation"),
+            ]
+            state = instance._lifecycle.get_by_conversation("normal-conversation")
+            assert state is not None
+            assert state.current_session_id is None
+            assert state.last_finalized_session_id == "reused-id"
+        finally:
+            instance.shutdown()
+
+    def test_off_current_normal_first_flush_after_bypass_lineage_persists_without_bypass_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "off-current-normal-first-flush-after-bypass.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored start"}])
+            instance.on_session_end("reused-id", [{"role": "user", "content": "ignored end"}])
+
+            instance.on_session_start(
+                "reused-id",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=1_000,
+            )
+            instance.on_session_start(
+                "foreground",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=1_000,
+            )
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    {"role": "user", "content": "normal start"},
+                    {"role": "assistant", "content": "normal final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"], row["conversation_id"]) for row in rows] == [
+                ("user", "normal start", "normal-conversation"),
+                ("assistant", "normal final", "normal-conversation"),
+            ]
+            assert instance._store.get_session_count("foreground") == 0
+            state = instance._lifecycle.get_by_conversation("normal-conversation")
+            assert state is not None
+            assert state.current_session_id is None
+            assert state.last_finalized_session_id == "reused-id"
+        finally:
+            instance.shutdown()
+
+    def test_late_same_id_bypass_prefix_end_skips_when_current_normal_store_empty(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-same-id-bypass-prefix-empty-store.db"),
+            ignore_session_patterns=["cron"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            opener = {"role": "user", "content": "shared opener"}
+
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([opener])
+            assert instance._store.get_session_count("reused-id") == 0
+            assert instance._dag.get_session_nodes("reused-id") == []
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    opener,
+                    {"role": "assistant", "content": "late ignored final"},
+                ],
+            )
+
+            assert instance._store.get_range("reused-id") == []
+            assert instance._dag.get_session_nodes("reused-id") == []
+        finally:
+            instance.shutdown()
+
+    def test_late_off_current_normal_session_end_dedupes_protected_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-off-current-protected-prefix.db"),
+            ignore_session_patterns=["cron"],
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["password_assignment"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            raw_opener = {"role": "user", "content": "password = supersecret123 normal opener"}
+
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored opener"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([raw_opener])
+            stored_before = instance._store.get_range("reused-id")
+            assert len(stored_before) == 1
+            assert "supersecret123" not in stored_before[0]["content"]
+            assert "LCM sensitive redaction" in stored_before[0]["content"]
+
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    raw_opener,
+                    {"role": "assistant", "content": "normal final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert len(rows) == 2
+            assert rows[0]["content"] == stored_before[0]["content"]
+            assert rows[1]["content"] == "normal final"
+            assert all("supersecret123" not in (row["content"] or "") for row in rows)
+            assert instance._store.get_session_count("foreground") == 0
+        finally:
+            instance.shutdown()
+
+    def test_late_off_current_normal_session_end_filters_ignored_suffix(self, tmp_path, monkeypatch):
+        from hermes_lcm import message_patterns as message_patterns_mod
+
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", _FakeTimeoutRegexEngine)
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-off-current-ignored-suffix.db"),
+            ignore_session_patterns=["cron"],
+            ignore_message_patterns=["DROP_LATE_SUFFIX"],
+        )
+        instance = LCMEngine(config=config)
+        try:
+            normal_opener = {"role": "user", "content": "normal opener"}
+
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored opener"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([normal_opener])
+
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+            instance.on_session_end(
+                "reused-id",
+                [
+                    normal_opener,
+                    {"role": "assistant", "content": "normal final"},
+                    {"role": "user", "content": "DROP_LATE_SUFFIX must stay out"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert [(row["role"], row["content"]) for row in rows] == [
+                ("user", "normal opener"),
+                ("assistant", "normal final"),
+            ]
+            assert instance._store.get_session_count("foreground") == 0
+            assert instance._ignored_message_count == 1
+        finally:
+            instance.shutdown()
+
+    def test_late_off_current_normal_session_end_dedupes_externalized_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "late-off-current-externalized-prefix.db"),
+            ignore_session_patterns=["cron"],
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=50,
+            large_output_externalization_path=str(tmp_path / "externalized"),
+        )
+        instance = LCMEngine(config=config)
+        try:
+            raw_opener = {"role": "user", "content": "externalized opener " + "x" * 200}
+
+            instance.on_session_start("reused-id", platform="cron", context_length=1_000)
+            instance.ingest([{"role": "user", "content": "ignored opener"}])
+
+            instance.on_session_start("reused-id", platform="cli", context_length=1_000)
+            instance.ingest([raw_opener])
+            stored_before = instance._store.get_range("reused-id")
+            assert len(stored_before) == 1
+            assert stored_before[0]["content"].startswith("[Externalized payload:")
+            assert "externalized opener" not in stored_before[0]["content"]
+
+            instance.on_session_start("foreground", platform="cli", context_length=1_000)
+
+            instance.on_session_end(
+                "reused-id",
+                [
+                    raw_opener,
+                    {"role": "assistant", "content": "normal final"},
+                ],
+            )
+
+            rows = instance._store.get_range("reused-id")
+            assert len(rows) == 2
+            assert rows[0]["content"] == stored_before[0]["content"]
+            assert rows[1]["content"] == "normal final"
+            assert instance._store.get_session_count("foreground") == 0
+        finally:
+            instance.shutdown()
+
+    def test_bypass_tail_trim_makes_progress_when_first_message_has_tool_call(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "bypass-trim-tool-call.db"))
+        instance = LCMEngine(config=config)
+        messages = [
+            {
+                "role": "assistant",
+                "content": "large assistant " + "x" * 1_000,
+                "tool_calls": [{"id": "call_1", "type": "function"}],
+            },
+            {"role": "user", "content": "fresh tail"},
+            {"role": "user", "content": "fresh tail 2"},
+        ]
+        try:
+            result = instance._trim_bypass_compacted_to_cap(messages, target_tokens=80)
+
+            assert count_messages_tokens(result) <= 80
+        finally:
+            instance.shutdown()
+
+    def test_bypass_tail_trim_preserves_live_user_when_dropping_oversized_tool_call_pair(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "bypass-trim-tool-call-pair.db"))
+        instance = LCMEngine(config=config)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "latest request"},
+            {
+                "role": "assistant",
+                "content": "calling",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "big", "arguments": "x" * 10_000},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+        try:
+            result = instance._trim_bypass_compacted_to_cap(messages, target_tokens=80)
+
+            assert count_messages_tokens(result) <= 80
+            assert [(msg.get("role"), msg.get("content")) for msg in result] == [
+                ("system", "sys"),
+                ("user", "latest request"),
+            ]
+        finally:
+            instance.shutdown()
+
+    def test_bypass_tail_trim_reduces_one_or_two_oversized_messages_under_cap(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "bypass-trim-low-cap.db"))
+        instance = LCMEngine(config=config)
+        cases = [
+            [{"role": "user", "content": "x" * 10_000}],
+            [
+                {"role": "user", "content": "x" * 10_000},
+                {"role": "assistant", "content": "y" * 10_000},
+            ],
+        ]
+        try:
+            for messages in cases:
+                result = instance._trim_bypass_compacted_to_cap(messages, target_tokens=40)
+                assert count_messages_tokens(result) <= 40
+        finally:
+            instance.shutdown()
+
+    def test_bypass_tail_trim_reduces_structured_text_content_under_cap(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "bypass-trim-structured-content.db"))
+        instance = LCMEngine(config=config)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x" * 10_000},
+                    {"type": "input_text", "text": {"value": "y" * 10_000}},
+                ],
+            }
+        ]
+        try:
+            result = instance._trim_bypass_compacted_to_cap(messages, target_tokens=80)
+            assert count_messages_tokens(result) <= 80
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_compress_uses_message_tokens_when_current_tokens_unknown(self, tmp_path, monkeypatch):
+        native_called = False
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                nonlocal native_called
+                native_called = True
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-current-tokens-zero.db"),
+            ignore_session_patterns=["ignored:*"],
+        )
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "oversized " + "x" * 2_000}]
+        try:
+            instance.on_session_start("ignored:zero-tokens", platform="cli", context_length=4_000)
+            instance.threshold_tokens = 100
+            result = instance.compress(messages, current_tokens=0)
+
+            assert native_called
+            assert result == [{"role": "user", "content": "native compacted"}]
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_result_falls_back_when_still_over_cap(self, tmp_path, monkeypatch):
+        native_called = False
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self._last_compress_aborted = False
+                self._last_summary_error = None
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                nonlocal native_called
+                native_called = True
+                self.compression_count += 1
+                self._last_compress_aborted = True
+                self._last_summary_error = "native aborted"
+                return list(messages)
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-over-cap-native.db"),
+            ignore_session_patterns=["ignored:*"],
+            max_assembly_tokens=200,
+        )
+        instance = LCMEngine(config=config)
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "older " + "x" * 2_000},
+            {"role": "assistant", "content": "middle " + "y" * 2_000},
+            {"role": "user", "content": "fresh " + "z" * 2_000},
+        ]
+        try:
+            instance.on_session_start("ignored:over-cap", platform="cli", context_length=10_000)
+            instance.threshold_tokens = 1_000
+
+            result = instance.compress(messages, current_tokens=250)
+
+            assert native_called
+            assert count_messages_tokens(result) <= config.max_assembly_tokens
+            assert instance._last_compress_aborted is False
+        finally:
+            instance.shutdown()
+
+    def test_bypassed_native_exception_uses_deterministic_fallback(self, tmp_path, monkeypatch):
+        native_called = False
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self._last_compress_aborted = True
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                nonlocal native_called
+                native_called = True
+                raise RuntimeError("native compressor failed")
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "bypass-native-exception.db"),
+            ignore_session_patterns=["ignored:*"],
+            max_assembly_tokens=200,
+        )
+        instance = LCMEngine(config=config)
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "older " + "x" * 2_000},
+            {"role": "assistant", "content": "middle " + "y" * 2_000},
+            {"role": "user", "content": "fresh " + "z" * 2_000},
+        ]
+        try:
+            instance.on_session_start("ignored:native-error", platform="cli", context_length=10_000)
+            instance.threshold_tokens = 1_000
+
+            result = instance.compress(messages, current_tokens=250)
+
+            assert native_called
+            assert count_messages_tokens(result) <= config.max_assembly_tokens
+            assert instance._last_compress_aborted is False
+            assert instance._store.get_session_count("ignored:native-error") == 0
+            assert instance._dag.get_session_node_count("ignored:native-error") == 0
         finally:
             instance.shutdown()
 
@@ -11150,6 +12695,607 @@ class TestSessionRollover:
         assert [
             node.node_id for node in engine._dag.get_session_nodes("reused-continuation")
         ] == [node_id]
+
+    def test_off_current_suffix_only_late_bypass_end_after_normal_rebound_stays_stateless(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_late_bypass_suffix_after_normal.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "reused-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            bypass_messages = [
+                {"role": "user", "content": "ignored prefix that must stay out"},
+            ]
+            engine.ingest(bypass_messages)
+            engine.on_session_end("reused-session", bypass_messages)
+            assert engine._store.get_session_count("reused-session") == 0
+
+            engine.on_session_start(
+                "reused-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_messages = [
+                {"role": "user", "content": "normal rebound prefix"},
+            ]
+            engine.ingest(normal_messages)
+            assert engine._store.get_session_count("reused-session") == 1
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_suffix_only_bypass_end = [
+                {"role": "assistant", "content": "late ignored suffix must not persist"},
+            ]
+
+            engine.on_session_end("reused-session", late_suffix_only_bypass_end)
+
+            assert engine._store.get_session_count("reused-session") == 1
+            assert engine._store.get_session_count("foreground-session") == 0
+            assert engine._dag.get_session_node_count("reused-session") == 0
+            assert engine._dag.get_session_node_count("foreground-session") == 0
+            assert engine.current_session_id == "foreground-session"
+            assert engine.current_conversation_id == "foreground-conversation"
+        finally:
+            engine.shutdown()
+
+    @pytest.mark.parametrize(
+        ("bypass_session_id", "config_kwargs"),
+        [
+            ("ignored:late", {"ignore_session_patterns": ["ignored:*"]}),
+            ("stateless:late", {"stateless_session_patterns": ["stateless:*"]}),
+        ],
+    )
+    def test_direct_off_current_bypass_session_end_does_not_write_or_finalize_foreground(
+        self,
+        tmp_path,
+        bypass_session_id,
+        config_kwargs,
+    ):
+        payload_dir = tmp_path / f"payloads-{bypass_session_id.replace(':', '-')}"
+        config = LCMConfig(
+            database_path=str(tmp_path / f"direct-{bypass_session_id.replace(':', '-')}.db"),
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=64,
+            large_output_externalization_path=str(payload_dir),
+            **config_kwargs,
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_bypass_end = [
+                {"role": "user", "content": "should not store " + ("x" * 200)},
+            ]
+
+            engine.on_session_end(bypass_session_id, late_bypass_end)
+
+            assert engine._store.get_session_count("foreground-session") == 0
+            assert engine._store.get_session_count(bypass_session_id) == 0
+            assert engine._dag.get_session_node_count("foreground-session") == 0
+            assert engine._dag.get_session_node_count(bypass_session_id) == 0
+            assert not payload_dir.exists() or list(payload_dir.glob("*.json")) == []
+            assert engine.current_session_id == "foreground-session"
+            assert engine.current_conversation_id == "foreground-conversation"
+            foreground_state = engine._lifecycle.get_by_conversation("foreground-conversation")
+            assert foreground_state is not None
+            assert foreground_state.current_session_id == "foreground-session"
+            assert foreground_state.last_finalized_session_id != bypass_session_id
+            assert engine._lifecycle.get_by_session(bypass_session_id) is None
+        finally:
+            engine.shutdown()
+
+    def test_suffix_only_late_bypass_end_does_not_externalize_when_skipped(self, tmp_path):
+        payload_dir = tmp_path / "payloads"
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_late_bypass_no_externalized_payload.db"),
+            stateless_session_patterns=["stateless"],
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=64,
+            large_output_externalization_path=str(payload_dir),
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "reused-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "bypass seed"}])
+
+            engine.on_session_start(
+                "reused-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_messages = [
+                {"role": "user", "content": "normal rebound prefix"},
+            ]
+            engine.ingest(normal_messages)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_suffix_only_bypass_end = [
+                {"role": "assistant", "content": "late bypass payload " + ("x" * 200)},
+            ]
+
+            engine.on_session_end("reused-session", late_suffix_only_bypass_end)
+
+            assert engine._store.get_session_count("reused-session") == 1
+            assert not payload_dir.exists() or list(payload_dir.glob("*.json")) == []
+        finally:
+            engine.shutdown()
+
+    def test_shared_opener_bypass_and_normal_ambiguity_does_not_append_bypass_suffix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_shared_opener_bypass_normal_ambiguity.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_opener = {"role": "user", "content": "shared opener"}
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_bypass_end = [
+                shared_opener,
+                {"role": "assistant", "content": "bypass suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == ["shared opener"]
+            assert all(row["content"] != "bypass suffix must not append" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_multiple_bypass_prefixes_do_not_append_older_late_bypass_suffix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_multiple_bypass_prefixes.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_opener = {"role": "user", "content": "shared opener A"}
+            newer_bypass_opener = {"role": "user", "content": "newer bypass opener B"}
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation-a",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation-b",
+                context_length=200000,
+            )
+            engine.ingest([newer_bypass_opener])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_older_bypass_end = [
+                shared_opener,
+                {"role": "assistant", "content": "older bypass suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", late_older_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == ["shared opener A"]
+            assert all(row["content"] != "older bypass suffix must not append" for row in rows)
+        finally:
+            engine.shutdown()
+
+    @pytest.mark.parametrize("bypass_probe", ["preflight", "compress"])
+    def test_shared_opener_bypass_probe_ambiguity_does_not_append_bypass_suffix(self, tmp_path, bypass_probe):
+        config = LCMConfig(
+            database_path=str(tmp_path / f"lcm_shared_opener_bypass_{bypass_probe}_ambiguity.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_opener = {"role": "user", "content": f"shared opener from {bypass_probe}"}
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            if bypass_probe == "preflight":
+                engine.should_compress_preflight([shared_opener])
+            else:
+                engine.compress([shared_opener], force=True)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            late_bypass_end = [
+                shared_opener,
+                {"role": "assistant", "content": f"{bypass_probe} bypass suffix must not append"},
+            ]
+
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            assert [row["content"] for row in normal_rows] == [f"shared opener from {bypass_probe}"]
+            assert all(row["content"] != f"{bypass_probe} bypass suffix must not append" for row in rows)
+            assert engine._store.get_session_count("foreground-session") == 0
+        finally:
+            engine.shutdown()
+
+    def test_current_normal_reuse_with_tied_bypass_prefix_stores_final_suffix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_current_normal_tied_bypass_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            shared_opener = {"role": "user", "content": "shared opener reused as normal"}
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([shared_opener])
+            engine.on_session_end("shared-session", [shared_opener])
+            assert engine._store.get_session_count("shared-session") == 0
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_prefix = [shared_opener]
+            engine.ingest(normal_prefix)
+
+            normal_end = normal_prefix + [
+                {"role": "assistant", "content": "normal final suffix after tied prefix"},
+            ]
+            engine.on_session_end("shared-session", normal_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                "shared opener reused as normal",
+                "normal final suffix after tied prefix",
+            ]
+            assert bypass_rows == []
+
+            normal_state = engine._lifecycle.get_by_conversation("normal-conversation")
+            assert normal_state is not None
+            assert normal_state.current_session_id is None
+            assert normal_state.last_finalized_session_id == "shared-session"
+        finally:
+            engine.shutdown()
+
+    def test_current_normal_reuse_does_not_tie_distinct_bypass_tool_call_prefix(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_current_normal_distinct_tool_call_prefix.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            bypass_prefix = [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "bypass_call",
+                            "type": "function",
+                            "function": {"name": "side_channel", "arguments": "{}"},
+                        }
+                    ],
+                }
+            ]
+            normal_prefix = [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "normal_call",
+                            "type": "function",
+                            "function": {"name": "foreground", "arguments": "{}"},
+                        }
+                    ],
+                }
+            ]
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest(bypass_prefix)
+            engine.on_session_end("shared-session", bypass_prefix)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            engine.ingest(normal_prefix)
+
+            late_bypass_end = bypass_prefix + [
+                {"role": "assistant", "content": "late bypass suffix must not persist"},
+            ]
+            engine.on_session_end("shared-session", late_bypass_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == [""]
+            assert normal_rows[0]["tool_calls"][0]["id"] == "normal_call"
+            assert bypass_rows == []
+            assert all(row["content"] != "late bypass suffix must not persist" for row in rows)
+        finally:
+            engine.shutdown()
+
+    def test_normal_final_after_later_stateless_rebind_uses_normal_source(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_later_stateless_rebind_normal_source.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_prefix = [
+                {"role": "user", "content": "normal prefix before stateless rebind"},
+            ]
+            engine.ingest(normal_prefix)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="stateless-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "stateless same-id turn"}])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            normal_end = normal_prefix + [
+                {"role": "assistant", "content": "normal final after stateless rebind"},
+            ]
+
+            engine.on_session_end("shared-session", normal_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            final_rows = [
+                row
+                for row in normal_rows
+                if row["content"] == "normal final after stateless rebind"
+            ]
+            stateless_rows = [row for row in rows if row["conversation_id"] == "stateless-conversation"]
+            assert len(final_rows) == 1
+            assert final_rows[0]["source"] == "cli"
+            assert stateless_rows == []
+        finally:
+            engine.shutdown()
+
+    def test_reused_normal_session_id_scopes_off_current_dedupe_to_current_conversation(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_reused_normal_id_current_conversation.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "bypass seed"}])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="old-normal-conversation",
+                context_length=200000,
+            )
+            old_messages = [
+                {"role": "user", "content": "old conversation prefix"},
+                {"role": "assistant", "content": "old conversation answer"},
+            ]
+            engine.ingest(old_messages)
+            engine.on_session_end("shared-session", old_messages)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="current-normal-conversation",
+                context_length=200000,
+            )
+            current_prefix = [
+                {"role": "user", "content": "current conversation prefix"},
+            ]
+            engine.ingest(current_prefix)
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            current_end = current_prefix + [
+                {"role": "assistant", "content": "current conversation final"},
+            ]
+
+            engine.on_session_end("shared-session", current_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            old_rows = [row for row in rows if row["conversation_id"] == "old-normal-conversation"]
+            current_rows = [row for row in rows if row["conversation_id"] == "current-normal-conversation"]
+            bypass_rows = [row for row in rows if row["conversation_id"] == "bypass-conversation"]
+
+            assert [row["content"] for row in old_rows] == [
+                "old conversation prefix",
+                "old conversation answer",
+            ]
+            assert [row["content"] for row in current_rows] == [
+                "current conversation prefix",
+                "current conversation final",
+            ]
+            assert bypass_rows == []
+            current_state = engine._lifecycle.get_by_conversation("current-normal-conversation")
+            old_state = engine._lifecycle.get_by_conversation("old-normal-conversation")
+            assert current_state is not None
+            assert old_state is not None
+            assert current_state.last_finalized_session_id == "shared-session"
+            assert old_state.last_finalized_session_id == "shared-session"
+        finally:
+            engine.shutdown()
+
+    def test_later_bypass_bind_does_not_replace_normal_conversation_for_off_current_finalization(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_later_bypass_preserves_normal_conversation.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config)
+        try:
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="initial-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "initial bypass seed"}])
+
+            engine.on_session_start(
+                "shared-session",
+                platform="cli",
+                conversation_id="normal-conversation",
+                context_length=200000,
+            )
+            normal_prefix = [
+                {"role": "user", "content": "normal prefix before later bypass"},
+            ]
+            engine.ingest(normal_prefix)
+
+            engine.on_session_start(
+                "shared-session",
+                platform="stateless",
+                conversation_id="later-bypass-conversation",
+                context_length=200000,
+            )
+            engine.ingest([{"role": "user", "content": "later bypass must not own final"}])
+
+            engine.on_session_start(
+                "foreground-session",
+                platform="cli",
+                conversation_id="foreground-conversation",
+                context_length=200000,
+            )
+            normal_end = normal_prefix + [
+                {"role": "assistant", "content": "normal final after later bypass"},
+            ]
+
+            engine.on_session_end("shared-session", normal_end)
+
+            rows = engine._store.get_session_messages("shared-session")
+            normal_rows = [row for row in rows if row["conversation_id"] == "normal-conversation"]
+            later_bypass_rows = [row for row in rows if row["conversation_id"] == "later-bypass-conversation"]
+            assert [row["content"] for row in normal_rows] == [
+                "normal prefix before later bypass",
+                "normal final after later bypass",
+            ]
+            assert later_bypass_rows == []
+
+            normal_state = engine._lifecycle.get_by_conversation("normal-conversation")
+            bypass_state = engine._lifecycle.get_by_conversation("later-bypass-conversation")
+            assert normal_state is not None
+            assert normal_state.last_finalized_session_id == "shared-session"
+            assert bypass_state is not None
+            assert bypass_state.last_finalized_session_id != "shared-session"
+        finally:
+            engine.shutdown()
 
     def test_auxiliary_child_worker_thread_stays_stateless_without_parent_thread_leak(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"


### PR DESCRIPTION
## Summary
- Bound ignored/stateless/thread-context-stateless sessions with host/native fallback compaction instead of letting them grow unbounded.
- Kept bypassed sessions out of LCM raw-message/DAG storage, including compression-boundary rollover, missing-platform boundary children, reused session-id, and late session-end edge cases.
- Added bypass-lineage, native fallback reset/isolation, tool-pair sanitization, redaction/externalized-prefix-safe session-end handling, deterministic trim regressions, and native fallback failure handling.
- Hardened same-id/off-current session-end prefix handling for tied normal/bypass prefixes, first-flush reused normal sessions, preflight/compress-only bypass evidence, ignored late suffixes, and tool-call identity.
- Documented ignored/stateless storage ownership vs host context-window protection.

## Why
- Ignored/stateless sessions should remain outside LCM storage, but they must not bypass all context-window protection.
- Compression-boundary children of bypassed sessions must inherit bypass lineage even when the host omits platform metadata.
- Reused session IDs and late `on_session_end()` callbacks can otherwise either leak bypass content into normal LCM storage or drop valid normal final messages.
- Native fallback errors should fail closed into deterministic trim, not leave bypassed transcripts unbounded.

## Validation
- Local Codex CLI GitHub-style P1/P2 review loop on the full branch / affected risk classes:
  - fixed public Codex P2 `r3524015102`
  - local Codex found/fixed adjacent P2s for off-current first-flush normal sessions and native fallback failure handling
  - fixed public Codex P1 `r3524050138`
  - latest local Codex pass after that fix: `no P1/P2 issues found`
- `python -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py tests/test_packaging_install.py -q -o addopts=` → `863 passed`
- `python -m pytest -q -o addopts=` → `1239 passed, 12 xfailed`
- `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-ignored-stateless-host-fallback-final3-20260705024148` → `PASS: release validation full`
- `git diff --check`
- `python -m py_compile engine.py store.py tests/test_lcm_engine.py tests/test_lcm_core.py`
- Security/scope scan: expected files only; no secret material.

## Notes
- This intentionally preserves the LCM storage boundary for ignored/stateless sessions while using host/native fallback behavior for context-size protection.
