### PR TITLE
fix: use auxiliary usage for bypass checks

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -2525,10 +2525,17 @@ class LCMEngine(ContextEngine):
             if session_id not in self._auxiliary_session_ids:
                 return 0
             active_generation = self._auxiliary_session_generations.get(session_id)
+            stack = self._thread_context_auxiliary_stack()
+            stack_marks_current_session = bool(
+                active_generation is not None
+                and caller_generation == 0
+                and stack
+                and stack[-1] == session_id
+            )
             generation_matches = (
                 caller_generation == 0
                 if active_generation is None
-                else caller_generation == active_generation
+                else caller_generation == active_generation or stack_marks_current_session
             )
             if not generation_matches:
                 return 0

--- a/engine.py
+++ b/engine.py
@@ -577,6 +577,14 @@ class LCMEngine(ContextEngine):
         self._thread_context = threading.local()
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
+        self._auxiliary_last_prompt_tokens: dict[str, int] = {}
+        self._auxiliary_session_generations: dict[str, int] = {}
+        self._auxiliary_generation_tokens: dict[int, tuple[Any, int]] = {}
+        self._auxiliary_next_generation_token = 0
+        self._auxiliary_direct_end_guard_session_ids: set[str] = set()
+        self._auxiliary_handoff_parent_session_ids: dict[str, str] = {}
+        self._auxiliary_retired_session_generations: dict[str, set[int]] = {}
+        self._auxiliary_foreground_reused_session_ids: set[str] = set()
         self._lcm_bypass_lineage_session_ids: set[str] = set()
         self._lcm_bypass_lineage_platforms: dict[str, set[str]] = {}
         self._lcm_non_bypass_platforms: dict[str, set[str]] = {}
@@ -704,6 +712,14 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.clear()
             self._auxiliary_lineage_session_ids.clear()
+            self._auxiliary_last_prompt_tokens.clear()
+            self._auxiliary_session_generations.clear()
+            self._auxiliary_generation_tokens.clear()
+            self._auxiliary_next_generation_token = 0
+            self._auxiliary_direct_end_guard_session_ids.clear()
+            self._auxiliary_handoff_parent_session_ids.clear()
+            self._auxiliary_retired_session_generations.clear()
+            self._auxiliary_foreground_reused_session_ids.clear()
             self._lcm_bypass_lineage_session_ids.clear()
             self._lcm_bypass_lineage_platforms.clear()
             self._lcm_non_bypass_platforms.clear()
@@ -973,6 +989,53 @@ class LCMEngine(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         if self._thread_context_stateless():
+            auxiliary_session_id = self._thread_context_session_id()
+            if auxiliary_session_id:
+                prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+                caller_generation = self._in_process_auxiliary_caller_generation(
+                    auxiliary_session_id
+                )
+                with self._auxiliary_session_lock:
+                    if auxiliary_session_id not in self._auxiliary_session_ids:
+                        return
+                    if self._auxiliary_generation_is_retired(
+                        auxiliary_session_id,
+                        caller_generation,
+                    ):
+                        return
+                    active_generation = self._auxiliary_session_generations.get(
+                        auxiliary_session_id
+                    )
+                    if active_generation is None and caller_generation:
+                        expected_parent = self._auxiliary_handoff_parent_session_ids.get(
+                            auxiliary_session_id
+                        )
+                        if expected_parent and self._in_process_parent_session_id(
+                            {},
+                            session_id=auxiliary_session_id,
+                            include_explicit=False,
+                        ) != expected_parent:
+                            return
+                        if auxiliary_session_id in self._auxiliary_last_prompt_tokens:
+                            self._auxiliary_direct_end_guard_session_ids.add(
+                                auxiliary_session_id
+                            )
+                        self._auxiliary_last_prompt_tokens.pop(auxiliary_session_id, None)
+                        self._auxiliary_session_generations[
+                            auxiliary_session_id
+                        ] = caller_generation
+                        self._auxiliary_handoff_parent_session_ids.pop(
+                            auxiliary_session_id,
+                            None,
+                        )
+                        active_generation = caller_generation
+                    generation_matches = (
+                        caller_generation == 0
+                        if active_generation is None
+                        else caller_generation == active_generation
+                    )
+                    if generation_matches:
+                        self._auxiliary_last_prompt_tokens[auxiliary_session_id] = prompt_tokens
             return
         self.last_prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
         self.last_completion_tokens = int(usage.get("completion_tokens", 0) or 0)
@@ -1519,7 +1582,14 @@ class LCMEngine(ContextEngine):
         if self._bypasses_lcm_context_management():
             if self._compression_boundary_cooldown_active():
                 return False
-            tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+            if prompt_tokens is not None:
+                tokens = prompt_tokens
+            else:
+                auxiliary_session_id = self._thread_context_session_id()
+                if auxiliary_session_id:
+                    tokens = self._current_auxiliary_prompt_tokens(auxiliary_session_id)
+                else:
+                    tokens = self.last_prompt_tokens
             if self._should_force_overflow_recovery(observed_tokens=tokens):
                 return True
             if self.threshold_tokens <= 0:
@@ -1893,9 +1963,18 @@ class LCMEngine(ContextEngine):
         self._last_compression_noop_reason = ""
 
         if self._bypasses_lcm_context_management():
+            bypass_current_tokens = current_tokens
+            if bypass_current_tokens is None:
+                auxiliary_session_id = self._thread_context_session_id()
+                if auxiliary_session_id:
+                    auxiliary_prompt_tokens = self._current_auxiliary_prompt_tokens(
+                        auxiliary_session_id
+                    )
+                    if auxiliary_prompt_tokens > 0:
+                        bypass_current_tokens = auxiliary_prompt_tokens
             return self._compress_lcm_bypassed_session(
                 messages,
-                current_tokens=current_tokens,
+                current_tokens=bypass_current_tokens,
                 focus_topic=focus_topic,
                 force=force,
             )
@@ -2438,6 +2517,23 @@ class LCMEngine(ContextEngine):
             return stack[-1]
         return ""
 
+    def _current_auxiliary_prompt_tokens(self, session_id: str) -> int:
+        if not session_id:
+            return 0
+        caller_generation = self._in_process_auxiliary_caller_generation(session_id)
+        with self._auxiliary_session_lock:
+            if session_id not in self._auxiliary_session_ids:
+                return 0
+            active_generation = self._auxiliary_session_generations.get(session_id)
+            generation_matches = (
+                caller_generation == 0
+                if active_generation is None
+                else caller_generation == active_generation
+            )
+            if not generation_matches:
+                return 0
+            return self._auxiliary_last_prompt_tokens.get(session_id, 0)
+
     def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_session_ids
@@ -2450,9 +2546,19 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             return set(self._auxiliary_lineage_session_ids)
 
+    def _known_auxiliary_parent_lineage_session_ids(self) -> set[str]:
+        with self._auxiliary_session_lock:
+            return set(self._auxiliary_lineage_session_ids) - set(
+                self._auxiliary_foreground_reused_session_ids
+            )
+
     def _has_auxiliary_lineage_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_lineage_session_ids
+
+    def _auxiliary_lineage_suppressed_as_foreground(self, session_id: str) -> bool:
+        with self._auxiliary_session_lock:
+            return session_id in self._auxiliary_foreground_reused_session_ids
 
     def _has_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> bool:
         with self._auxiliary_session_lock:
@@ -2518,19 +2624,120 @@ class LCMEngine(ContextEngine):
     def _thread_context_stateless(self) -> bool:
         return bool(self._thread_context_session_id())
 
-    def _register_auxiliary_session(self, session_id: str) -> None:
+    def _register_auxiliary_session(
+        self,
+        session_id: str,
+        *,
+        preserve_foreground_reuse_marker: bool = False,
+    ) -> bool:
+        generation = self._in_process_auxiliary_caller_generation(session_id)
         with self._auxiliary_session_lock:
+            previous_generation = self._auxiliary_session_generations.get(session_id)
+            had_active_session = session_id in self._auxiliary_session_ids
+            if generation and self._auxiliary_generation_is_retired(session_id, generation):
+                if previous_generation is not None and previous_generation != generation:
+                    return False
+                if had_active_session and previous_generation is None:
+                    return False
+                generation = self._in_process_auxiliary_caller_generation(
+                    session_id,
+                    refresh_retired=True,
+                )
+            had_cached_usage = session_id in self._auxiliary_last_prompt_tokens
             self._auxiliary_session_ids.add(session_id)
             self._auxiliary_lineage_session_ids.add(session_id)
+            if not preserve_foreground_reuse_marker:
+                self._auxiliary_foreground_reused_session_ids.discard(session_id)
+            if generation:
+                if previous_generation != generation:
+                    if previous_generation is not None:
+                        self._retire_auxiliary_generation(session_id, previous_generation)
+                    if (
+                        had_active_session
+                        or had_cached_usage
+                        or previous_generation is not None
+                    ):
+                        self._auxiliary_direct_end_guard_session_ids.add(session_id)
+                    self._auxiliary_last_prompt_tokens.pop(session_id, None)
+                self._auxiliary_session_generations[session_id] = generation
+                self._auxiliary_handoff_parent_session_ids.pop(session_id, None)
+            else:
+                if previous_generation is not None:
+                    self._retire_auxiliary_generation(session_id, previous_generation)
+                self._auxiliary_last_prompt_tokens.pop(session_id, None)
+                self._auxiliary_session_generations.pop(session_id, None)
+                self._auxiliary_direct_end_guard_session_ids.discard(session_id)
+                self._auxiliary_handoff_parent_session_ids.pop(session_id, None)
+            return True
 
-    def _deactivate_auxiliary_session(self, session_id: str) -> None:
-        if not session_id:
-            return
+    def _retire_auxiliary_generation(self, session_id: str, generation: int | None) -> None:
+        if session_id and generation:
+            self._auxiliary_retired_session_generations.setdefault(session_id, set()).add(generation)
+
+    def _drop_auxiliary_generation_token(
+        self,
+        object_id: int,
+        token: int,
+        token_ref: weakref.ReferenceType[Any],
+    ) -> None:
         with self._auxiliary_session_lock:
-            self._auxiliary_session_ids.discard(session_id)
+            existing = self._auxiliary_generation_tokens.get(object_id)
+            if existing is not None and existing == (token_ref, token):
+                self._auxiliary_generation_tokens.pop(object_id, None)
 
-    def _mark_thread_context_stateless(self, session_id: str) -> None:
-        self._register_auxiliary_session(session_id)
+    def _auxiliary_generation_is_retired(self, session_id: str, generation: int) -> bool:
+        return bool(generation) and generation in self._auxiliary_retired_session_generations.get(
+            session_id,
+            set(),
+        )
+
+    def _deactivate_auxiliary_session(self, session_id: str, *, generation: int = 0) -> bool:
+        if not session_id:
+            return False
+        with self._auxiliary_session_lock:
+            if self._auxiliary_generation_is_retired(session_id, generation):
+                return False
+            active_generation = self._auxiliary_session_generations.get(session_id)
+            if active_generation is None:
+                expected_parent = self._auxiliary_handoff_parent_session_ids.get(session_id)
+                caller_parent = self._in_process_parent_session_id(
+                    {},
+                    session_id=session_id,
+                    include_explicit=False,
+                )
+                if session_id in self._auxiliary_direct_end_guard_session_ids:
+                    has_usage = session_id in self._auxiliary_last_prompt_tokens
+                    if not generation and not has_usage:
+                        return False
+                    if expected_parent and caller_parent and caller_parent != expected_parent:
+                        return False
+            elif generation != active_generation:
+                expected_parent = self._auxiliary_handoff_parent_session_ids.get(session_id)
+                has_cached_usage = session_id in self._auxiliary_last_prompt_tokens
+                if generation != 0 or (
+                    session_id in self._auxiliary_direct_end_guard_session_ids
+                    and not (expected_parent and has_cached_usage)
+                ):
+                    return False
+            self._auxiliary_session_ids.discard(session_id)
+            self._auxiliary_last_prompt_tokens.pop(session_id, None)
+            self._retire_auxiliary_generation(session_id, active_generation or generation)
+            self._auxiliary_session_generations.pop(session_id, None)
+            self._auxiliary_direct_end_guard_session_ids.discard(session_id)
+            self._auxiliary_handoff_parent_session_ids.pop(session_id, None)
+            return True
+
+    def _mark_thread_context_stateless(
+        self,
+        session_id: str,
+        *,
+        preserve_foreground_reuse_marker: bool = False,
+    ) -> None:
+        if not self._register_auxiliary_session(
+            session_id,
+            preserve_foreground_reuse_marker=preserve_foreground_reuse_marker,
+        ):
+            return
         stack = self._thread_context_auxiliary_stack()
         stack[:] = [existing for existing in stack if existing != session_id]
         stack.append(session_id)
@@ -2544,13 +2751,91 @@ class LCMEngine(ContextEngine):
             stack.clear()
         self._sync_thread_context_current_auxiliary()
 
-    def _handoff_auxiliary_session(self, old_session_id: str, new_session_id: str) -> None:
+    def _handoff_auxiliary_session(
+        self,
+        old_session_id: str,
+        new_session_id: str,
+        *,
+        preserve_old_session: bool = False,
+        preserve_old_foreground_marker: bool = False,
+    ) -> None:
+        generation = self._in_process_auxiliary_caller_generation(new_session_id)
+        stack = self._thread_context_auxiliary_stack()
+        handoff_from_active_thread_marker = old_session_id in stack
         with self._auxiliary_session_lock:
             if old_session_id:
-                self._auxiliary_session_ids.discard(old_session_id)
+                if not preserve_old_session:
+                    self._auxiliary_last_prompt_tokens.pop(old_session_id, None)
+                    self._retire_auxiliary_generation(
+                        old_session_id,
+                        self._auxiliary_session_generations.get(old_session_id),
+                    )
+                    self._auxiliary_session_generations.pop(old_session_id, None)
+                    self._auxiliary_direct_end_guard_session_ids.discard(old_session_id)
+                    self._auxiliary_handoff_parent_session_ids.pop(old_session_id, None)
+                    self._auxiliary_session_ids.discard(old_session_id)
                 self._auxiliary_lineage_session_ids.add(old_session_id)
             if new_session_id:
-                self._auxiliary_session_ids.add(new_session_id)
+                previous_new_generation = self._auxiliary_session_generations.get(new_session_id)
+                had_new_runtime_state = (
+                    new_session_id in self._auxiliary_session_ids
+                    or new_session_id in self._auxiliary_last_prompt_tokens
+                    or previous_new_generation is not None
+                    or new_session_id in self._auxiliary_direct_end_guard_session_ids
+                )
+                had_new_session_state = (
+                    had_new_runtime_state
+                    or new_session_id in self._auxiliary_lineage_session_ids
+                )
+                had_direct_end_guard = new_session_id in self._auxiliary_direct_end_guard_session_ids
+                new_generation_replaces_old = (
+                    previous_new_generation is not None
+                    and (
+                        (bool(generation) and previous_new_generation != generation)
+                        or (not generation and had_direct_end_guard)
+                    )
+                )
+                if had_new_session_state and new_generation_replaces_old:
+                    self._retire_auxiliary_generation(new_session_id, previous_new_generation)
+                boundary_from_live_new_generation = bool(generation) and previous_new_generation == generation
+                preserve_new_foreground_marker = (
+                    new_session_id in self._auxiliary_foreground_reused_session_ids
+                    and not boundary_from_live_new_generation
+                )
+                if not preserve_new_foreground_marker:
+                    self._auxiliary_last_prompt_tokens.pop(new_session_id, None)
+                    self._auxiliary_direct_end_guard_session_ids.discard(new_session_id)
+                    if had_new_session_state and (
+                        new_generation_replaces_old
+                        or had_direct_end_guard
+                        or (bool(generation) and previous_new_generation is None and had_new_runtime_state)
+                        or (
+                            previous_new_generation is None
+                            and not generation
+                            and new_session_id in self._auxiliary_lineage_session_ids
+                            and (
+                                handoff_from_active_thread_marker
+                                or (
+                                    old_session_id
+                                    and had_new_runtime_state
+                                    and (
+                                        old_session_id in self._auxiliary_lineage_session_ids
+                                        or old_session_id in self._auxiliary_session_ids
+                                    )
+                                )
+                            )
+                        )
+                    ):
+                        self._auxiliary_direct_end_guard_session_ids.add(new_session_id)
+                        if old_session_id:
+                            self._auxiliary_handoff_parent_session_ids[new_session_id] = old_session_id
+                    self._auxiliary_session_ids.add(new_session_id)
+                    self._auxiliary_foreground_reused_session_ids.discard(new_session_id)
+                    if generation:
+                        self._auxiliary_session_generations[new_session_id] = generation
+                        self._auxiliary_handoff_parent_session_ids.pop(new_session_id, None)
+                    elif previous_new_generation is None or new_generation_replaces_old:
+                        self._auxiliary_session_generations.pop(new_session_id, None)
                 self._auxiliary_lineage_session_ids.add(new_session_id)
         stack = self._thread_context_auxiliary_stack()
         had_thread_marker = old_session_id in stack or new_session_id in stack
@@ -2563,9 +2848,23 @@ class LCMEngine(ContextEngine):
             stack.append(new_session_id)
         self._sync_thread_context_current_auxiliary()
 
-    def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
+    def _unmark_thread_context_auxiliary_session(
+        self,
+        session_id: str,
+        *,
+        suppress_as_foreground_reuse: bool = True,
+    ) -> None:
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.discard(session_id)
+            if suppress_as_foreground_reuse and session_id in self._auxiliary_lineage_session_ids:
+                self._auxiliary_foreground_reused_session_ids.add(session_id)
+            self._auxiliary_last_prompt_tokens.pop(session_id, None)
+            self._retire_auxiliary_generation(
+                session_id,
+                self._auxiliary_session_generations.pop(session_id, None),
+            )
+            self._auxiliary_direct_end_guard_session_ids.discard(session_id)
+            self._auxiliary_handoff_parent_session_ids.pop(session_id, None)
         self._clear_thread_context_stateless(session_id)
 
     def _get_allowed_hermes_base(self) -> Path | None:
@@ -2619,6 +2918,74 @@ class LCMEngine(ContextEngine):
         if getattr(caller_self, "ephemeral_system_prompt", None) and log_prefix.startswith("[subagent-"):
             return True
         return False
+
+    def _auxiliary_generation_token_for(self, caller_self: object, *, force_new: bool = False) -> int:
+        """Return a process-local, non-reusable token for an auxiliary frame.
+
+        ``id(obj)`` can be reused after GC, which makes retired-generation
+        checks incorrectly reject later live frames. Key by id for lookup speed,
+        but verify object identity with ``is`` before reusing a token. Weak refs
+        avoid retaining ordinary frames; objects that cannot be weak-referenced
+        are held strongly so their id cannot be recycled while the token remains
+        live in this engine runtime.
+        """
+        with self._auxiliary_session_lock:
+            object_id = id(caller_self)
+            existing = self._auxiliary_generation_tokens.get(object_id)
+            if existing is not None and not force_new:
+                existing_ref, token = existing
+                if isinstance(existing_ref, weakref.ReferenceType):
+                    existing_obj = existing_ref()
+                else:
+                    existing_obj = existing_ref
+                if existing_obj is caller_self:
+                    return token
+
+            self._auxiliary_next_generation_token += 1
+            token = self._auxiliary_next_generation_token
+            try:
+                token_ref: Any = weakref.ref(
+                    caller_self,
+                    lambda ref, object_id=object_id, token=token: self._drop_auxiliary_generation_token(
+                        object_id,
+                        token,
+                        ref,
+                    ),
+                )
+            except TypeError:
+                token_ref = caller_self
+            self._auxiliary_generation_tokens[object_id] = (token_ref, token)
+            return token
+
+    def _in_process_auxiliary_caller_generation(
+        self,
+        session_id: str,
+        *,
+        refresh_retired: bool = False,
+    ) -> int:
+        frame = inspect.currentframe()
+        try:
+            frame = frame.f_back if frame is not None else None
+            for _ in range(32):
+                if frame is None:
+                    return 0
+                caller_self = frame.f_locals.get("self")
+                if not self._caller_is_auxiliary_agent_frame(caller_self):
+                    frame = frame.f_back
+                    continue
+                caller_session = str(getattr(caller_self, "session_id", "") or "")
+                if not session_id or caller_session == session_id:
+                    token = self._auxiliary_generation_token_for(caller_self)
+                    if refresh_retired and self._auxiliary_generation_is_retired(
+                        session_id,
+                        token,
+                    ):
+                        token = self._auxiliary_generation_token_for(caller_self, force_new=True)
+                    return token
+                frame = frame.f_back
+        finally:
+            del frame
+        return 0
 
     def _in_process_parent_session_id(
         self,
@@ -2698,6 +3065,7 @@ class LCMEngine(ContextEngine):
         if not session_id or session_id == parent_session_id:
             return False
         known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
+        known_auxiliary_parent_ids = self._known_auxiliary_parent_lineage_session_ids()
         explicit_parent_id = str(kwargs.get("parent_session_id") or "")
         in_process_parent_id = self._in_process_parent_session_id(
             kwargs,
@@ -2712,7 +3080,12 @@ class LCMEngine(ContextEngine):
         if explicit_parent_id:
             if self._thread_context_has_auxiliary_session(explicit_parent_id):
                 return True
-            if explicit_parent_id in known_auxiliary_ids and explicit_parent_id != self._session_id:
+            if explicit_parent_id in known_auxiliary_parent_ids and explicit_parent_id != self._session_id:
+                return True
+            if (
+                explicit_parent_id in known_auxiliary_ids
+                and self._lcm_session_last_bypassed.get(explicit_parent_id)
+            ):
                 return True
             return False
         if not parent_session_id:
@@ -2754,14 +3127,15 @@ class LCMEngine(ContextEngine):
 
         active_auxiliary_ids = self._active_auxiliary_session_ids()
         known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
+        known_auxiliary_parent_ids = self._known_auxiliary_parent_lineage_session_ids()
         if child_parent_id in active_auxiliary_ids:
             return True
-        if child_parent_id in known_auxiliary_ids and child_parent_id != self._session_id:
+        if child_parent_id in known_auxiliary_parent_ids and child_parent_id != self._session_id:
             return True
         if child_parent_id != parent_session_id:
             return self._session_has_auxiliary_ancestor(
                 str(child_parent_id or ""),
-                known_auxiliary_ids | active_auxiliary_ids,
+                known_auxiliary_parent_ids | active_auxiliary_ids,
                 path,
             )
         return False
@@ -3429,11 +3803,37 @@ class LCMEngine(ContextEngine):
             self._host_fallback_compressor = None
             self._host_fallback_session_id = ""
         if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
+            old_session_is_suppressed_foreground = self._auxiliary_lineage_suppressed_as_foreground(
+                old_session_id
+            )
+            old_session_auxiliary_generation = self._in_process_auxiliary_caller_generation(
+                old_session_id
+            )
+            new_session_auxiliary_parent = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+            )
+            new_session_is_auxiliary_continuation = new_session_auxiliary_parent == old_session_id
             if (
                 self._has_auxiliary_lineage_session(old_session_id)
-                and old_session_id != self._session_id
+                and (
+                    old_session_id != self._session_id
+                    or old_session_auxiliary_generation
+                    or new_session_is_auxiliary_continuation
+                )
+                and (
+                    not old_session_is_suppressed_foreground
+                    or old_session_auxiliary_generation
+                    or new_session_is_auxiliary_continuation
+                )
             ):
-                self._handoff_auxiliary_session(old_session_id, session_id)
+                self._handoff_auxiliary_session(
+                    old_session_id,
+                    session_id,
+                    preserve_old_session=old_session_id == self._session_id,
+                    preserve_old_foreground_marker=old_session_is_suppressed_foreground,
+                )
                 logger.info(
                     "LCM auxiliary session %s compressed to %s — keeping boundary stateless",
                     old_session_id,
@@ -3475,14 +3875,35 @@ class LCMEngine(ContextEngine):
             return
 
         if self._is_live_auxiliary_child_session(session_id, previous_session_id, kwargs):
-            self._register_auxiliary_session(session_id)
+            explicit_parent_id = str(kwargs.get("parent_session_id") or "")
+            preserve_foreground_reuse_marker = bool(
+                explicit_parent_id
+                and self._lcm_session_last_bypassed.get(explicit_parent_id)
+            )
+            if preserve_foreground_reuse_marker:
+                if self._lcm_session_last_normal_conversation_id.get(session_id):
+                    self._auxiliary_foreground_reused_session_ids.add(session_id)
+                self._mark_thread_context_stateless(
+                    session_id,
+                    preserve_foreground_reuse_marker=True,
+                )
+            else:
+                self._register_auxiliary_session(session_id)
             logger.info(
                 "LCM session %s is a live child of bound session %s — treating it as auxiliary/stateless",
                 session_id,
                 previous_session_id,
             )
             return
-        self._deactivate_auxiliary_session(session_id)
+        start_platform = str(kwargs.get("platform") or "")
+        side_channel_rebind = self._session_id_matches_lcm_bypass_filters(
+            session_id,
+            platform=start_platform,
+        ) or self._has_lcm_bypass_lineage_session(session_id, platform=start_platform)
+        self._unmark_thread_context_auxiliary_session(
+            session_id,
+            suppress_as_foreground_reuse=not side_channel_rebind,
+        )
         self._clear_thread_context_stateless()
         if previous_session_id and previous_session_id != session_id:
             self._finalize_pending_reset_boundary(previous_session_id)
@@ -3847,21 +4268,65 @@ class LCMEngine(ContextEngine):
         )
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
-        if self._has_auxiliary_lineage_session(session_id) and session_id != self._session_id:
+        ended_generation = self._in_process_auxiliary_caller_generation(session_id)
+        active_auxiliary_end = session_id in self._active_auxiliary_session_ids()
+        if (
+            self._has_auxiliary_lineage_session(session_id)
+            and session_id != self._session_id
+            and (
+                active_auxiliary_end
+                or not self._auxiliary_lineage_suppressed_as_foreground(session_id)
+                or ended_generation
+                or (
+                    session_id in self._auxiliary_last_prompt_tokens
+                    and not self._auxiliary_lineage_suppressed_as_foreground(session_id)
+                )
+            )
+        ):
             current_thread_session_id = self._thread_context_session_id()
-            with self._auxiliary_session_lock:
-                self._auxiliary_session_ids.discard(session_id)
-            if current_thread_session_id == session_id:
+            if current_thread_session_id == session_id or active_auxiliary_end:
+                self._remember_lcm_bypass_message_prefix(session_id, messages)
+            deactivated = self._deactivate_auxiliary_session(
+                session_id,
+                generation=ended_generation,
+            )
+            if deactivated and current_thread_session_id == session_id:
                 self._clear_thread_context_stateless(session_id)
             return
         current_session_bypasses = session_id == self._session_id and self._bypasses_lcm_context_management()
         ended_session_directly_bypasses = self._ended_session_directly_bypasses_lcm(session_id)
-        if ended_session_directly_bypasses:
+        direct_bypass_normal_conversation_id = self._lcm_session_last_normal_conversation_id.get(session_id)
+        direct_bypass_normal_prefix_count = None
+        if (
+            session_id != self._session_id
+            and self._auxiliary_lineage_suppressed_as_foreground(session_id)
+            and direct_bypass_normal_conversation_id
+            and not ended_generation
+        ):
+            direct_bypass_normal_prefix_count = self._session_end_store_prefix_count(
+                session_id,
+                messages,
+                conversation_id=direct_bypass_normal_conversation_id,
+            )
+        direct_bypass_is_suppressed_reused_normal = (
+            session_id != self._session_id
+            and self._auxiliary_lineage_suppressed_as_foreground(session_id)
+            and bool(direct_bypass_normal_conversation_id)
+            and not ended_generation
+            and session_id != self._thread_context_session_id()
+            and direct_bypass_normal_prefix_count is not None
+            and direct_bypass_normal_prefix_count > 0
+        )
+        if ended_session_directly_bypasses and not direct_bypass_is_suppressed_reused_normal:
+            self._remember_lcm_bypass_message_prefix(session_id, messages)
             self._end_host_fallback_compressor_for_session(
                 session_id,
                 messages,
                 current_session_bypasses=current_session_bypasses,
             )
+            if session_id == self._thread_context_session_id():
+                self._deactivate_auxiliary_session(session_id, generation=ended_generation)
+                self._clear_thread_context_stateless(session_id)
             return
         same_id_has_bypass_lineage = (
             session_id == self._session_id
@@ -3914,7 +4379,19 @@ class LCMEngine(ContextEngine):
                 or same_id_strongest_normal_prefix_count >= same_id_bypass_prefix_count
             )
         )
-        off_current_lineage = session_id != self._session_id and self._has_lcm_bypass_lineage_session(session_id)
+        off_current_auxiliary_reused_normal = (
+            session_id != self._session_id
+            and self._auxiliary_lineage_suppressed_as_foreground(session_id)
+            and bool(direct_bypass_normal_conversation_id)
+            and not ended_generation
+        )
+        off_current_lineage = (
+            session_id != self._session_id
+            and (
+                self._has_lcm_bypass_lineage_session(session_id)
+                or off_current_auxiliary_reused_normal
+            )
+        )
         off_current_normal_conversation_id = (
             self._lcm_session_last_normal_conversation_id.get(session_id)
             if off_current_lineage
@@ -3989,6 +4466,7 @@ class LCMEngine(ContextEngine):
             off_current_prefix_count = off_current_recorded_prefix_for_append
         if (
             off_current_lineage
+            and not off_current_auxiliary_reused_normal
             and off_current_normal_conversation_id
             and off_current_store_prefix_count == 0
             and off_current_bypass_prefix_count <= 0

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1,5 +1,6 @@
 """Integration tests for the LCM engine."""
 
+import gc
 import hashlib
 import json
 import logging
@@ -2017,6 +2018,192 @@ class TestEngineABC:
             assert instance._dag.get_session_node_count("foreground:session") == 0
             assert instance.should_compress_preflight(messages)
             assert instance.should_compress(instance.threshold_tokens + 1)
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_no_arg_should_compress_uses_auxiliary_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-no-arg-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+
+            assert instance.last_prompt_tokens == 0
+            assert instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+
+            instance._clear_thread_context_stateless("auxiliary:session")
+            assert not instance.should_compress()
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_compress_uses_auxiliary_usage_when_no_arg(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        calls = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def on_session_start(self, bound_session_id, **kwargs):
+                pass
+
+            def update_model(self, **kwargs):
+                pass
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                calls.append((list(messages), current_tokens, focus_topic, force))
+                self.compression_count += 1
+                return [{"role": "system", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-no-arg-compress.db"))
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "short"}]
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+
+            assert count_messages_tokens(messages) < instance.threshold_tokens
+            assert instance.should_compress()
+            result = instance.compress(messages)
+
+            assert result == [{"role": "system", "content": "native compacted"}]
+            assert calls == [(messages, 25, None, False)]
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_compress_without_auxiliary_usage_keeps_tokens_unknown(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        calls = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def on_session_start(self, bound_session_id, **kwargs):
+                pass
+
+            def update_model(self, **kwargs):
+                pass
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                calls.append((list(messages), current_tokens, focus_topic, force))
+                self.compression_count += 1
+                return [{"role": "system", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-no-usage-compress.db"))
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "first auxiliary payload " + ("x " * 200)}]
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert not instance.should_compress()
+            result = instance.compress(messages)
+
+            assert result == [{"role": "system", "content": "native compacted"}]
+            assert calls == [(messages, None, None, False)]
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_session_end_clears_auxiliary_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-end-clears-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+
+            instance.on_session_end("auxiliary:session", [{"role": "user", "content": "done"}])
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_generationless_reregister_clears_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-reregister-clears-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert instance._auxiliary_last_prompt_tokens == {}
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_adopting_generation_clears_generationless_usage(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-adopt-generation-clears.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+            assert instance._auxiliary_session_generations == {}
+
+            monkeypatch.setattr(
+                instance,
+                "_in_process_auxiliary_caller_generation",
+                lambda session_id, **kwargs: 123 if session_id == "auxiliary:session" else 0,
+            )
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert instance._auxiliary_session_generations == {"auxiliary:session": 123}
+            assert instance._auxiliary_last_prompt_tokens == {}
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
         finally:
             instance.shutdown()
 
@@ -11433,6 +11620,9 @@ class TestSessionRollover:
         def should_compress_preflight(self, engine: LCMEngine, messages):
             return engine.should_compress_preflight(messages)
 
+        def should_compress(self, engine: LCMEngine):
+            return engine.should_compress()
+
         def compress(self, engine: LCMEngine, messages):
             return engine.compress(messages)
 
@@ -11447,6 +11637,33 @@ class TestSessionRollover:
 
         def on_session_end(self, engine: LCMEngine, messages) -> None:
             engine.on_session_end(self.session_id, messages)
+
+        def on_compression_boundary(self, engine: LCMEngine, new_session_id: str, **kwargs) -> None:
+            engine.on_session_start(
+                new_session_id,
+                hermes_home=str(self._hermes_home),
+                boundary_reason="compression",
+                old_session_id=self.session_id,
+                platform=kwargs.pop("platform", "telegram"),
+                context_length=kwargs.pop("context_length", 200000),
+                **kwargs,
+            )
+
+        def on_compression_boundary_from(
+            self,
+            engine: LCMEngine,
+            old_session_id: str,
+            **kwargs,
+        ) -> None:
+            engine.on_session_start(
+                self.session_id,
+                hermes_home=str(self._hermes_home),
+                boundary_reason="compression",
+                old_session_id=old_session_id,
+                platform=kwargs.pop("platform", "telegram"),
+                context_length=kwargs.pop("context_length", 200000),
+                **kwargs,
+            )
 
     def _start_host_child(
         self,
@@ -12688,6 +12905,206 @@ class TestSessionRollover:
         ])
         assert engine._store.get_session_count("reused-child-explicit") == 1
 
+    def test_guarded_auxiliary_reuse_does_not_poison_later_foreground_children(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_guarded_reuse_foreground.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-parent",
+            "foreground-session",
+        )
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-parent",
+            "foreground-session",
+        )
+        replacement.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_end("reused-parent", [])
+        assert engine._thread_context_has_auxiliary_session("reused-parent")
+        assert not old_child.should_compress(engine)
+
+        engine.on_session_start(
+            "reused-parent",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        assert engine._session_id == "reused-parent"
+        assert engine._has_auxiliary_lineage_session("reused-parent")
+        assert not engine._thread_context_has_auxiliary_session("reused-parent")
+        old_child.should_compress_preflight(engine, [
+            {"role": "user", "content": "stale old child must stay stateless"},
+        ])
+        assert engine._store.get_session_count("reused-parent") == 0
+
+        engine.on_session_start(
+            "other-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        old_child.on_compression_boundary(
+            engine,
+            "stale-reused-parent-continuation",
+            context_length=1_000,
+        )
+        assert "reused-parent" in engine._auxiliary_foreground_reused_session_ids
+
+        stale_descendant = self._start_host_child(
+            engine,
+            hermes_home,
+            "stale-reused-parent-descendant",
+            "reused-parent",
+            context_length=1_000,
+        )
+        assert engine._session_id == "other-foreground-session"
+        assert engine._thread_context_has_auxiliary_session("stale-reused-parent-descendant")
+        stale_descendant.should_compress_preflight(engine, [
+            {"role": "user", "content": "stale in-process descendant must stay stateless"},
+        ])
+        assert engine._store.get_session_count("stale-reused-parent-descendant") == 0
+        assert engine._store.get_session_count("other-foreground-session") == 0
+
+        engine.on_session_start(
+            "reused-child-explicit",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=1_000,
+            parent_session_id="reused-parent",
+        )
+        assert engine._session_id == "reused-child-explicit"
+        assert not engine._thread_context_has_auxiliary_session("reused-child-explicit")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "guarded reuse child persists"},
+        ])
+        assert engine._store.get_session_count("reused-child-explicit") == 1
+
+        engine.on_session_start(
+            "reused-child-sibling",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=1_000,
+            parent_session_id="reused-parent",
+        )
+        assert engine._session_id == "reused-child-sibling"
+        assert not engine._thread_context_has_auxiliary_session("reused-child-sibling")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "guarded reuse sibling persists"},
+        ])
+        assert engine._store.get_session_count("reused-child-sibling") == 1
+
+    def test_stateless_auxiliary_rebind_preserves_parent_lineage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_stateless_aux_rebind_lineage.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-auxiliary",
+            "foreground-session",
+        )
+        child.on_session_end(engine, [])
+        assert engine._has_auxiliary_lineage_session("reused-auxiliary")
+        assert not engine._auxiliary_lineage_suppressed_as_foreground("reused-auxiliary")
+
+        engine.on_session_start(
+            "reused-auxiliary",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=1_000,
+        )
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-auxiliary")
+        normal_prefix = [{"role": "user", "content": "normal prefix before stateless rebind"}]
+        engine.ingest(normal_prefix)
+        assert engine._store.get_session_count("reused-auxiliary") == 1
+
+        engine.on_session_start(
+            "reused-auxiliary",
+            hermes_home=str(hermes_home),
+            platform="stateless",
+            context_length=1_000,
+        )
+        assert engine._session_stateless
+        assert not engine._thread_context_has_auxiliary_session("reused-auxiliary")
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-auxiliary")
+
+        engine.on_session_start(
+            "explicit-child-of-bound-stateless-rebind",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            parent_session_id="reused-auxiliary",
+            context_length=1_000,
+        )
+        assert engine._session_id == "reused-auxiliary"
+        assert engine._thread_context_has_auxiliary_session(
+            "explicit-child-of-bound-stateless-rebind"
+        )
+        engine.should_compress_preflight([
+            {"role": "user", "content": "bound stateless child must stay stateless"},
+        ])
+        assert engine._store.get_session_count("explicit-child-of-bound-stateless-rebind") == 0
+        assert engine._store.get_session_count("reused-auxiliary") == 1
+        engine.on_session_end("explicit-child-of-bound-stateless-rebind", [])
+        assert not engine._thread_context_has_auxiliary_session(
+            "explicit-child-of-bound-stateless-rebind"
+        )
+
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        engine.on_session_start(
+            "explicit-child-of-stateless-rebind",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            parent_session_id="reused-auxiliary",
+            context_length=1_000,
+        )
+        assert engine._session_id == "foreground-2"
+        assert engine._thread_context_has_auxiliary_session("explicit-child-of-stateless-rebind")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "child of stateless side channel must stay stateless"},
+        ])
+        assert engine._store.get_session_count("explicit-child-of-stateless-rebind") == 0
+        assert engine._store.get_session_count("foreground-2") == 0
+
+        engine.on_session_end(
+            "reused-auxiliary",
+            normal_prefix + [
+                {"role": "assistant", "content": "normal final after stateless rebind"},
+            ],
+        )
+        rows = engine._store.get_range("reused-auxiliary")
+        assert [row["content"] for row in rows] == [
+            "normal prefix before stateless rebind",
+            "normal final after stateless rebind",
+        ]
+
     def test_auxiliary_lineage_does_not_block_reused_root_compression_boundary(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -12748,6 +13165,455 @@ class TestSessionRollover:
         assert engine._thread_context_session_id() == ""
         assert engine._store.get_session_count("reused-session") == 1
         assert engine._store.get_session_count("reused-continuation") == 0
+        assert engine._dag.get_session_nodes("reused-session") == []
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("reused-continuation")
+        ] == [node_id]
+
+    def test_side_channel_child_preserves_own_foreground_reuse_suffix(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_side_channel_child_own_reuse.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stateless_parent = self._start_host_child(
+            engine,
+            hermes_home,
+            "stateless-parent",
+            "foreground-session",
+        )
+        stateless_parent.on_session_end(engine, [])
+        engine.on_session_start(
+            "stateless-parent",
+            hermes_home=str(hermes_home),
+            platform="stateless",
+            context_length=1_000,
+        )
+        assert engine._lcm_session_last_bypassed["stateless-parent"]
+
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        reused_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-child",
+            "foreground-2",
+        )
+        reused_child.on_session_end(engine, [])
+        engine.on_session_start(
+            "reused-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="reused-child-normal",
+            context_length=1_000,
+        )
+        normal_prefix = [{"role": "user", "content": "reused child normal prefix"}]
+        engine.ingest(normal_prefix)
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-child")
+
+        engine.on_session_start(
+            "foreground-3",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        side_channel_child = self.HostAgentFrame(
+            "reused-child",
+            "stateless-parent",
+            hermes_home,
+        )
+        side_channel_child.on_session_start(
+            engine,
+            parent_session_id="stateless-parent",
+        )
+        assert engine.current_session_id == "foreground-3"
+        assert engine._thread_context_has_auxiliary_session("reused-child")
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-child")
+        side_channel_child.should_compress_preflight(engine, [
+            {"role": "user", "content": "side-channel child payload"},
+        ])
+        assert engine._store.get_session_count("reused-child") == 1
+        assert engine._store.get_session_count("foreground-3") == 0
+
+        side_channel_end = normal_prefix + [
+            {"role": "assistant", "content": "side-channel final must not append"},
+        ]
+        errors = []
+
+        def end_side_channel_from_other_thread():
+            try:
+                engine.on_session_end("reused-child", side_channel_end)
+            except Exception as exc:  # pragma: no cover - surfaced by assertion below
+                errors.append(exc)
+
+        end_thread = threading.Thread(target=end_side_channel_from_other_thread)
+        end_thread.start()
+        end_thread.join()
+        assert errors == []
+        assert not engine._thread_context_has_auxiliary_session("reused-child")
+        rows = engine._store.get_range("reused-child")
+        assert [row["content"] for row in rows] == ["reused child normal prefix"]
+        engine.on_session_end("reused-child", side_channel_end)
+        rows = engine._store.get_range("reused-child")
+        assert [row["content"] for row in rows] == ["reused child normal prefix"]
+
+        engine.on_session_end(
+            "reused-child",
+            normal_prefix + [
+                {"role": "assistant", "content": "reused child normal final"},
+            ],
+        )
+        rows = engine._store.get_range("reused-child")
+        assert [row["content"] for row in rows] == [
+            "reused child normal prefix",
+            "reused child normal final",
+        ]
+
+    def test_side_channel_child_marks_prior_normal_id_as_foreground_reuse(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_side_channel_child_prior_normal.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stateless_parent = self._start_host_child(
+            engine,
+            hermes_home,
+            "stateless-parent",
+            "foreground-session",
+        )
+        stateless_parent.on_session_end(engine, [])
+        engine.on_session_start(
+            "stateless-parent",
+            hermes_home=str(hermes_home),
+            platform="stateless",
+            context_length=1_000,
+        )
+
+        engine.on_session_start(
+            "prior-normal-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="prior-normal-child-conversation",
+            context_length=1_000,
+        )
+        normal_prefix = [{"role": "user", "content": "prior normal child prefix"}]
+        engine.ingest(normal_prefix)
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        engine.on_session_start(
+            "prior-normal-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            parent_session_id="stateless-parent",
+            context_length=1_000,
+        )
+        assert engine._auxiliary_lineage_suppressed_as_foreground("prior-normal-child")
+
+        side_channel_end = normal_prefix + [
+            {"role": "assistant", "content": "prior normal side-channel final"},
+        ]
+        engine.on_session_end("prior-normal-child", side_channel_end)
+        assert not engine._thread_context_has_auxiliary_session("prior-normal-child")
+        assert [row["content"] for row in engine._store.get_range("prior-normal-child")] == [
+            "prior normal child prefix",
+        ]
+
+        engine.on_session_end(
+            "prior-normal-child",
+            normal_prefix + [
+                {"role": "assistant", "content": "prior normal child final"},
+            ],
+        )
+        assert [row["content"] for row in engine._store.get_range("prior-normal-child")] == [
+            "prior normal child prefix",
+            "prior normal child final",
+        ]
+
+    def test_side_channel_prefix_only_end_fails_closed_for_ambiguous_suffix(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_side_channel_prefix_only_end.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stateless_parent = self._start_host_child(
+            engine,
+            hermes_home,
+            "stateless-parent",
+            "foreground-session",
+        )
+        stateless_parent.on_session_end(engine, [])
+        engine.on_session_start(
+            "stateless-parent",
+            hermes_home=str(hermes_home),
+            platform="stateless",
+            context_length=1_000,
+        )
+
+        engine.on_session_start(
+            "reused-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="reused-child-normal",
+            context_length=1_000,
+        )
+        normal_prefix = [{"role": "user", "content": "prefix-only normal prefix"}]
+        engine.ingest(normal_prefix)
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        side_channel_child = self.HostAgentFrame(
+            "reused-child",
+            "stateless-parent",
+            hermes_home,
+        )
+        side_channel_child.on_session_start(
+            engine,
+            parent_session_id="stateless-parent",
+        )
+        side_channel_child.on_session_end(engine, normal_prefix)
+
+        engine.on_session_end(
+            "reused-child",
+            normal_prefix + [
+                {"role": "assistant", "content": "ambiguous side-channel final must not append"},
+            ],
+        )
+        assert [row["content"] for row in engine._store.get_range("reused-child")] == [
+            "prefix-only normal prefix",
+        ]
+
+    def test_off_current_reused_auxiliary_root_end_preserves_normal_suffix(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_off_current_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        engine.on_session_end("reused-session", [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=200000,
+        )
+        normal_prefix = [{"role": "user", "content": "normal prefix"}]
+        engine.ingest(normal_prefix)
+        assert engine._store.get_session_count("reused-session") == 1
+
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="foreground-conversation",
+            context_length=200000,
+        )
+        engine.on_session_end(
+            "reused-session",
+            normal_prefix + [{"role": "assistant", "content": "normal final"}],
+        )
+
+        rows = engine._store.get_range("reused-session")
+        assert [row["content"] for row in rows] == ["normal prefix", "normal final"]
+        normal_state = engine._lifecycle.get_by_conversation("normal-conversation")
+        assert normal_state is not None
+        assert normal_state.last_finalized_session_id == "reused-session"
+        assert engine.current_session_id == "foreground-2"
+
+    def test_stale_auxiliary_boundary_preserves_off_current_reused_normal_suffix(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_stale_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        stale_child.on_session_end(engine, [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=200000,
+        )
+        normal_prefix = [{"role": "user", "content": "normal prefix"}]
+        engine.ingest(normal_prefix)
+        reused_node_id = engine._dag.add_node(SummaryNode(
+            session_id="reused-session",
+            depth=0,
+            summary="reused normal node must not move",
+            token_count=5,
+            source_token_count=5,
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-session")
+
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="foreground-conversation",
+            context_length=200000,
+        )
+        new_frame_stale_continuation = self.HostAgentFrame(
+            "stale-continuation",
+            "reused-session",
+            hermes_home,
+        )
+        new_frame_stale_continuation.on_compression_boundary_from(
+            engine,
+            old_session_id="reused-session",
+        )
+        assert engine.current_session_id == "foreground-2"
+        assert engine._dag.get_node(reused_node_id).session_id == "reused-session"
+        assert engine._dag.get_session_nodes("stale-continuation") == []
+        assert engine._thread_context_has_auxiliary_session("stale-continuation")
+        stale_child.on_compression_boundary(engine, "stale-continuation")
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-session")
+
+        engine.on_session_end(
+            "reused-session",
+            normal_prefix + [{"role": "assistant", "content": "normal final"}],
+        )
+
+        rows = engine._store.get_range("reused-session")
+        assert [row["content"] for row in rows] == ["normal prefix", "normal final"]
+        normal_state = engine._lifecycle.get_by_conversation("normal-conversation")
+        assert normal_state is not None
+        assert normal_state.last_finalized_session_id == "reused-session"
+        assert engine.current_session_id == "foreground-2"
+
+    def test_off_current_reused_auxiliary_root_boundary_keeps_normal_carryover(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_aux_off_current_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=200000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        engine.on_session_end("reused-session", [])
+        assert engine._has_auxiliary_lineage_session("reused-session")
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=200000,
+        )
+        store_id = engine._store.append(
+            "reused-session",
+            {"role": "user", "content": "normal node source"},
+            token_estimate=5,
+            source="cli",
+            conversation_id="normal-conversation",
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="reused-session",
+            depth=0,
+            summary="normal reused root node should move",
+            token_count=4,
+            source_token_count=5,
+            source_ids=[store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = store_id
+
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="foreground-conversation",
+            context_length=200000,
+        )
+        engine.on_session_start(
+            "reused-continuation",
+            boundary_reason="compression",
+            old_session_id="reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=200000,
+        )
+
+        assert engine._session_id == "reused-continuation"
+        assert engine._conversation_id == "normal-conversation"
+        assert not engine._thread_context_has_auxiliary_session("reused-continuation")
         assert engine._dag.get_session_nodes("reused-session") == []
         assert [
             node.node_id for node in engine._dag.get_session_nodes("reused-continuation")
@@ -14282,6 +15148,309 @@ class TestSessionRollover:
         assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
 
+    def test_stale_generated_auxiliary_boundary_cannot_reassign_reused_foreground(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_aux_reused_fg_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            conversation_id="foreground-conversation",
+            context_length=200000,
+        )
+        stale_auxiliary = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+        stale_auxiliary.on_session_end(engine, [])
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=200000,
+        )
+        foreground_store_id = engine._store.append(
+            "reused-session",
+            {"role": "user", "content": "normal foreground state must stay put"},
+            token_estimate=11,
+            source="cli",
+            conversation_id="normal-conversation",
+        )
+        foreground_node_id = engine._dag.add_node(SummaryNode(
+            session_id="reused-session",
+            depth=0,
+            summary="normal reused foreground summary",
+            token_count=5,
+            source_token_count=11,
+            source_ids=[foreground_store_id],
+            source_type="messages",
+            created_at=time.time(),
+        ))
+        engine._last_compacted_store_id = foreground_store_id
+
+        stale_auxiliary.on_compression_boundary(engine, "stale-continuation")
+
+        assert engine._session_id == "reused-session"
+        assert engine._conversation_id == "normal-conversation"
+        assert engine._thread_context_session_id() == ""
+        assert engine._thread_context_has_auxiliary_session("stale-continuation")
+        assert [
+            node.node_id for node in engine._dag.get_session_nodes("reused-session")
+        ] == [foreground_node_id]
+        assert engine._dag.get_session_nodes("stale-continuation") == []
+        assert engine._store.get_session_count("reused-session") == 1
+        assert engine._store.get_session_count("stale-continuation") == 0
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-session")
+
+    def test_direct_end_clears_active_generated_auxiliary_with_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_generated_aux_direct_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 45})
+        assert child.should_compress(engine)
+
+        engine.on_session_end("background-review-session", [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_direct_end_clears_restarted_generated_auxiliary_after_clean_end(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_reused_generated_aux_direct_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        first = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        first.update_from_response(engine, {"prompt_tokens": 45})
+        assert first.should_compress(engine)
+        first.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        replacement.update_from_response(engine, {"prompt_tokens": 25})
+        assert replacement.should_compress(engine)
+
+        engine.on_session_end("background-review-session", [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not replacement.should_compress(engine)
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_direct_end_allows_same_generated_auxiliary_object_to_restart(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_same_generated_aux_restart.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert child.should_compress(engine)
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+
+        child.on_session_start(engine)
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert child.should_compress(engine)
+        child.on_session_end(engine, [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_late_retired_generated_auxiliary_restart_does_not_replace_active_generation(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_late_retired_aux_restart.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        stale_generation = engine._auxiliary_session_generations["background-review-session"]
+        stale_child.update_from_response(engine, {"prompt_tokens": 25})
+        stale_child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        replacement_generation = engine._auxiliary_session_generations["background-review-session"]
+        assert replacement_generation != stale_generation
+        replacement.update_from_response(engine, {"prompt_tokens": 25})
+        assert replacement.should_compress(engine)
+
+        stale_child.on_session_start(engine)
+        stale_child.update_from_response(engine, {"prompt_tokens": 35})
+
+        assert engine._auxiliary_session_generations == {
+            "background-review-session": replacement_generation
+        }
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 25}
+        assert replacement.should_compress(engine)
+        replacement.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_retired_auxiliary_generation_cannot_adopt_generationless_reuse(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_retired_aux_generationless.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        stale_generation = engine._auxiliary_session_generations["background-review-session"]
+
+        engine.on_session_start(
+            "background-review-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        assert stale_generation in engine._auxiliary_retired_session_generations[
+            "background-review-session"
+        ]
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+
+        engine._mark_thread_context_stateless("background-review-session")
+        stale_child.on_session_start(engine)
+        stale_child.update_from_response(engine, {"prompt_tokens": 35})
+
+        assert engine._auxiliary_session_generations == {}
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not stale_child.should_compress(engine)
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_late_reused_auxiliary_end_without_normal_prefix_does_not_persist(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_late_reused_aux_no_prefix.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-session",
+            "foreground-session",
+        )
+
+        engine.on_session_start(
+            "reused-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="normal-conversation",
+            context_length=1_000,
+        )
+        assert engine._session_id == "reused-session"
+        assert engine._auxiliary_lineage_suppressed_as_foreground("reused-session")
+        assert engine._store.get_session_count("reused-session") == 0
+
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="next-conversation",
+            context_length=1_000,
+        )
+        engine.on_session_end(
+            "reused-session",
+            [{"role": "user", "content": "late old auxiliary must not persist"}],
+        )
+
+        assert engine._store.get_session_count("reused-session") == 0
+        assert engine._store.get_session_count("next-foreground-session") == 0
+
     def test_auxiliary_compression_boundary_retires_old_child_if_old_end_is_missing(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -14922,6 +16091,854 @@ class TestSessionRollover:
             {"role": "user", "content": "foreground followup persists after marker clear"},
         ])
         assert engine._store.get_session_count("foreground-followup-session") == 1
+
+    def test_same_thread_late_auxiliary_usage_after_end_is_not_reused(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_late_aux_usage_after_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert child.should_compress(engine)
+
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._auxiliary_last_prompt_tokens == {}
+
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert "background-review-session" not in engine._auxiliary_direct_end_guard_session_ids
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert not replacement.should_compress(engine)
+        engine.on_session_end("background-review-session", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_late_auxiliary_usage_from_old_generation_does_not_pollute_reused_id(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_usage_generation_reuse.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.on_session_end(engine, [])
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert not replacement.should_compress(engine)
+
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not replacement.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_reused_generation_clears_usage_and_ignores_old_end(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_replace_before_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+        assert old_child.should_compress(engine)
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not replacement.should_compress(engine)
+
+        old_child.on_session_end(engine, [])
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not replacement.should_compress(engine)
+
+        replacement.update_from_response(engine, {"prompt_tokens": 25})
+        assert replacement.should_compress(engine)
+        engine.on_session_end("background-review-session", [])
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert replacement.should_compress(engine)
+        old_messages = [{"role": "user", "content": "old frame short payload"}]
+        assert count_messages_tokens(old_messages) < engine.threshold_tokens
+        assert not old_child.should_compress(engine)
+        assert old_child.compress(engine, old_messages) == old_messages
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_no_arg_should_compress_without_usage_ignores_foreground_tokens(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_no_foreground_fallback.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        engine.update_from_response({"prompt_tokens": 25})
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        assert engine.last_prompt_tokens == 25
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not child.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_handoff_accepts_new_continuation_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 15})
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not continuation.should_compress(engine)
+
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-continuation": 25}
+        assert continuation.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_handoff_preserves_same_active_continuation_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_same_generation_handoff.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 15})
+        continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        continuation.update_from_response(engine, {"prompt_tokens": 10})
+
+        continuation.on_compression_boundary_from(
+            engine,
+            old_session_id="background-review-session",
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-continuation": 25}
+        assert continuation.should_compress(engine)
+        engine.on_session_end("background-review-continuation", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_handoff_generationless_boundary_preserves_active_continuation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generationless_active_handoff.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 15})
+        continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        continuation.update_from_response(engine, {"prompt_tokens": 10})
+        active_generation = engine._auxiliary_session_generations["background-review-continuation"]
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+
+        assert engine._auxiliary_session_generations == {
+            "background-review-continuation": active_generation
+        }
+        assert active_generation not in engine._auxiliary_retired_session_generations.get(
+            "background-review-continuation",
+            set(),
+        )
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-continuation": 25}
+        assert continuation.should_compress(engine)
+        engine.on_session_end("background-review-continuation", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_handoff_retired_displaced_generation_rejects_stale_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_retired_displaced_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        parent = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        parent.update_from_response(engine, {"prompt_tokens": 15})
+        stale_continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 10})
+        replacement_continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        replacement_continuation.update_from_response(engine, {"prompt_tokens": 11})
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 99})
+
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not stale_continuation.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_handoff_retires_old_generation_before_generationless_reuse(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_retired_old_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 10})
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine._mark_thread_context_stateless("background-review-session")
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not old_child.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_generation_token_is_not_reusable_object_id(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_token.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        token = engine._auxiliary_session_generations["background-review-session"]
+        assert token != id(child)
+
+        engine._auxiliary_retired_session_generations["background-review-session"] = {id(child)}
+        child.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 25}
+        assert child.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_generationless_reused_handoff_cleans_up_after_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generationless_handoff_cleanup.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session-1",
+            "foreground-session",
+        )
+        old_child.on_compression_boundary(
+            engine,
+            "background-review-continuation",
+            context_length=1_000,
+        )
+        engine.on_session_end("background-review-continuation", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        next_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session-2",
+            "foreground-session",
+        )
+        engine._handoff_auxiliary_session(
+            "background-review-session-2",
+            "background-review-continuation",
+        )
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        engine.on_session_end("background-review-continuation", [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_clean_generated_continuation_reuse_does_not_guard_direct_end(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_clean_generated_reuse.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.on_compression_boundary(
+            engine,
+            "background-review-continuation",
+            context_length=1_000,
+        )
+        engine.on_session_end("background-review-continuation", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        next_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        continuation.on_compression_boundary_from(
+            engine,
+            "background-review-session",
+            context_length=1_000,
+        )
+        assert next_child.session_id == "background-review-session"
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        engine.on_session_end("background-review-continuation", [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_session_generations == {}
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_generation_token_uses_identity_not_equality(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_identity.db"))
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))
+
+        class EqualFrame:
+            def __eq__(self, other):
+                return isinstance(other, EqualFrame)
+
+            def __hash__(self):
+                return 1
+
+        first = EqualFrame()
+        second = EqualFrame()
+        assert first == second
+        assert first is not second
+
+        first_token = engine._auxiliary_generation_token_for(first)
+        second_token = engine._auxiliary_generation_token_for(second)
+
+        assert first_token != second_token
+        assert engine._auxiliary_generation_token_for(first) == first_token
+        assert engine._auxiliary_generation_token_for(second) == second_token
+
+    def test_auxiliary_generation_token_handles_nonweakref_slotted_callers(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_slotted.db"))
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))
+
+        class SlottedFrame:
+            __slots__ = ()
+
+        frame = SlottedFrame()
+        token = engine._auxiliary_generation_token_for(frame)
+
+        assert token
+        assert engine._auxiliary_generation_token_for(frame) == token
+
+    def test_auxiliary_generation_token_prunes_dead_weakref_callers(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_weakref_prune.db"))
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))
+
+        class WeakrefableFrame:
+            pass
+
+        frame = WeakrefableFrame()
+        object_id = id(frame)
+        token = engine._auxiliary_generation_token_for(frame)
+        assert engine._auxiliary_generation_tokens[object_id][1] == token
+
+        del frame
+        gc.collect()
+
+        assert object_id not in engine._auxiliary_generation_tokens
+
+    def test_auxiliary_generation_token_handles_callable_nonweakref_slotted_callers(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_callable_slotted.db"))
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes-home"))
+
+        class CallableSlottedFrame:
+            __slots__ = ()
+
+            def __call__(self):
+                return "not-self"
+
+        frame = CallableSlottedFrame()
+        token = engine._auxiliary_generation_token_for(frame)
+
+        assert token
+        assert engine._auxiliary_generation_token_for(frame) == token
+
+    def test_auxiliary_handoff_reused_continuation_clears_stale_state(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_reused_continuation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 15})
+
+        stale_continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 45})
+        engine._auxiliary_direct_end_guard_session_ids.add("background-review-continuation")
+        assert engine._auxiliary_last_prompt_tokens["background-review-continuation"] == 45
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert "background-review-continuation" in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._auxiliary_handoff_parent_session_ids == {
+            "background-review-continuation": "background-review-session"
+        }
+        stale_continuation.on_session_end(engine, [])
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        engine.on_session_end("background-review-continuation", [])
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-continuation": 25}
+        assert continuation.should_compress(engine)
+        continuation.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        assert "background-review-continuation" not in engine._auxiliary_handoff_parent_session_ids
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_handoff_reused_generationless_continuation_rejects_stale_parent(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_reused_generationless.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        parent_one = self._start_host_child(
+            engine,
+            hermes_home,
+            "parent-one",
+            "foreground-session",
+        )
+        parent_one.on_compression_boundary(
+            engine,
+            "shared-continuation",
+            context_length=1_000,
+        )
+        stale_continuation = self.HostAgentFrame(
+            "shared-continuation",
+            "parent-one",
+            hermes_home,
+        )
+
+        parent_two = self._start_host_child(
+            engine,
+            hermes_home,
+            "parent-two",
+            "foreground-session",
+        )
+        parent_two.on_compression_boundary(
+            engine,
+            "shared-continuation",
+            context_length=1_000,
+        )
+        real_continuation = self.HostAgentFrame(
+            "shared-continuation",
+            "parent-two",
+            hermes_home,
+        )
+
+        assert engine._auxiliary_handoff_parent_session_ids == {
+            "shared-continuation": "parent-two"
+        }
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+
+        real_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        assert engine._auxiliary_last_prompt_tokens == {"shared-continuation": 30}
+        assert real_continuation.should_compress(engine)
+        assert not stale_continuation.should_compress(engine)
+
+    def test_auxiliary_handoff_reused_clean_continuation_rejects_stale_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_reused_clean_continuation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.on_compression_boundary(
+            engine,
+            "background-review-continuation",
+            context_length=1_000,
+        )
+        stale_continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        stale_continuation.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.on_compression_boundary(
+            engine,
+            "background-review-continuation",
+            context_length=1_000,
+        )
+        real_continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        assert "background-review-continuation" not in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._auxiliary_handoff_parent_session_ids == {}
+
+        engine.on_session_end("background-review-continuation", [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_usage_update_racing_session_end_does_not_restore_stale_tokens(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_usage_race.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        reached_active_probe = threading.Event()
+        continue_update = threading.Event()
+        original_active_auxiliary_session_ids = engine._active_auxiliary_session_ids
+
+        def delayed_active_auxiliary_session_ids():
+            if threading.current_thread() is thread:
+                reached_active_probe.set()
+                assert continue_update.wait(timeout=5)
+            return original_active_auxiliary_session_ids()
+
+        monkeypatch.setattr(
+            engine,
+            "_active_auxiliary_session_ids",
+            delayed_active_auxiliary_session_ids,
+        )
+        errors = []
+
+        def late_update():
+            try:
+                child.update_from_response(engine, {"prompt_tokens": 25})
+            except Exception as exc:  # pragma: no cover - assertion helper
+                errors.append(exc)
+
+        thread = threading.Thread(target=late_update)
+        thread.start()
+        assert reached_active_probe.wait(timeout=5)
+
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        continue_update.set()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
 
     def test_ended_auxiliary_marker_stays_stateless_until_next_normal_session_start(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -16253,6 +16253,52 @@ class TestSessionRollover:
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-session") == 0
 
+    def test_stack_marked_auxiliary_no_arg_calls_use_generation_usage_without_caller_frame(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_stack_marked_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_session_generations["background-review-session"]
+        stack = engine._thread_context_auxiliary_stack()
+        stack[:] = ["background-review-session"]
+        engine._thread_context.current_auxiliary_session_id = "background-review-session"
+        assert engine._thread_context_session_id() == "background-review-session"
+
+        calls = []
+
+        def fake_bypassed_compress(messages, *, current_tokens=None, focus_topic=None, force=False):
+            calls.append((current_tokens, focus_topic, force))
+            return list(messages)
+
+        monkeypatch.setattr(engine, "_compress_lcm_bypassed_session", fake_bypassed_compress)
+        messages = [{"role": "user", "content": "short bypass payload"}]
+
+        assert count_messages_tokens(messages) < engine.threshold_tokens
+        assert engine.should_compress()
+        assert engine.compress(messages) == messages
+        assert calls == [(25, None, False)]
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
     def test_auxiliary_handoff_accepts_new_continuation_generation(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- Tracks prompt-token usage for active auxiliary/thread-stateless sessions without mutating foreground session counters.
- Lets bypass-mode `should_compress()` and `compress()` use active auxiliary token totals when callers do not pass explicit prompt-token counts.
- Leaves auxiliary `compress()` token counts unknown when no usage has been recorded yet, so native host fallback compressors do not see a false zero for oversized first-turn payloads.
- Clears stale auxiliary usage while preserving the right guard state when compression handoff adopts a continuation ID that was previously used by another auxiliary generation.
- Retires previous in-process auxiliary generations for reused continuation IDs so stale old frames with the same parent cannot end or update the newly active continuation.
- Preserves foreground-reuse suppression when stale auxiliary handoff callbacks arrive after an auxiliary ID has been reused as a real foreground session.
- Allows direct host session-end callbacks to clear the current active generated auxiliary generation with cached usage, while guarded/reused ambiguous generations still reject direct no-frame ends.
- Uses expected handoff parent identity plus retired-generation checks so stale old frames cannot end or update a reused continuation, while the real continuation can still report usage and clean up.
- Preserves auxiliary lineage for stale old-frame detection while preventing reused foreground IDs from poisoning later normal children, off-current session ends, or compression boundaries.

## Why
- Follow-up to #310 after Codex found that oversized in-process auxiliary sessions could still miss host-fallback compaction when callers relied on no-argument compression APIs.
- Those sessions are intentionally excluded from LCM storage, but they still need host/native context bounding.
- Public and local review also found adjacent stale auxiliary token/lineage paths around session-end cleanup, same-ID reuse, handoff, off-current callbacks, and native fallback token propagation; this update closes those cases before final review.

## Validation
- `python -m pytest tests/test_lcm_engine.py::TestSessionRollover::test_stateless_auxiliary_rebind_preserves_parent_lineage tests/test_lcm_engine.py::TestSessionRollover::test_stale_auxiliary_boundary_preserves_off_current_reused_normal_suffix tests/test_lcm_engine.py::TestSessionRollover::test_clean_generated_continuation_reuse_does_not_guard_direct_end tests/test_lcm_engine.py::TestSessionRollover::test_guarded_auxiliary_reuse_does_not_poison_later_foreground_children -q -o addopts= --tb=short` → `4 passed`
- `git diff --check && python -m py_compile engine.py tests/test_lcm_engine.py` → clean
- `python -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py -q -k "thread_context_stateless or auxiliary or bypass or stateless or ignored or host_fallback or native_fallback or session_end or compression_boundary or reused" -o addopts=` → `238 passed, 686 deselected`
- `python -m pytest -q -o addopts=` → `1422 passed, 12 xfailed`
- `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-pr312-local-full16-20260705154608` → `PASS: release validation full`
- Local Codex CLI full review on head `33896436b5dd76d1ec8112e8249b453a08e21cf6` after the final dirty-diff patch → `No discrete correctness issues were found in the changes. The full test suite passes locally.`

## Risk / impact
- Medium-low, focused on process-local token accounting and lifecycle classification for active auxiliary/thread-stateless bypass checks.
- Does not add LCM storage for auxiliary sessions.
- Does not change explicit `should_compress(prompt_tokens=...)` behavior.
- Avoids foreground token bleed into fresh auxiliary sessions without affecting non-aux ignored/stateless fallback decisions.
- Preserves stale-frame protection for auxiliary lineage while suppressing reused foreground IDs as parent/ancestor evidence for normal children and boundaries, even after stale handoff callbacks.
- Avoids forwarding a false `current_tokens=0` to native fallback compressors when an auxiliary frame has not sampled usage yet.
- Avoids carrying stale usage while still guarding reused continuation IDs against stale generated end/update callbacks.
- Allows a real handed-off continuation to report usage and end cleanly after same-parent stale frames are rejected.
- Avoids stale generation adoption from late usage callbacks after an auxiliary session has ended or after its previous in-process generation has been retired by handoff reuse.

## Scope boundaries
- This only lands the auxiliary no-arg compression and lifecycle follow-up that missed the #310 merge window.
- It does not reopen the broader ignored/stateless fallback design from #310.

## Rollout / operator notes
- No migration, config, or operator action required.
- Existing ignored/stateless session behavior remains unchanged except for no-arg auxiliary compression decisions and safer auxiliary lifecycle cleanup.

## Reviewer focus
- Confirm auxiliary prompt-token state cannot leak into foreground `last_prompt_tokens` decisions.
- Confirm bypass sessions still do not write raw messages or DAG nodes while retaining context-bound checks.
- Confirm native fallback compressors receive positive auxiliary usage when available, but not a false zero before usage exists.
- Confirm handoff to a reused auxiliary continuation ID clears stale usage while preserving enough guard state to reject stale generated end/update callbacks.
- Confirm a real handed-off continuation can still clean itself up before usage when its parent identity matches the handoff source.
- Confirm late auxiliary usage callbacks, same-id reuse, foreground reuse, off-current session ends, and compression handoff do not reintroduce stale auxiliary state or poison normal foreground sessions.

