### PR TITLE
Fix strict persisted-output replay identity

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -34,6 +34,7 @@ from .escalation import (
 )
 from .externalize import (
     build_transcript_gc_placeholder,
+    externalized_tool_result_has_persisted_output_marker,
     extract_externalized_ref,
     find_externalized_payload_for_message,
     find_externalized_tool_result_content_for_call,
@@ -48,9 +49,16 @@ from .extraction import (
     strip_injected_context_blocks,
 )
 from .ingest_protection import (
+    _add_inline_persisted_output_generation_metadata,
+    _add_inline_persisted_output_identity_metadata,
     _expected_persisted_output_chars,
+    _has_inline_persisted_output_generation_metadata,
+    _has_lossy_sensitive_redaction,
+    _inline_persisted_output_generation_metadata,
     _is_hermes_persisted_output_marker,
     _json_has_duplicate_object_keys,
+    _persisted_output_inline_preview_sha256,
+    _persisted_output_marker_identity_digest,
     _persisted_output_preview_prefix_digest,
     _persisted_output_saved_path,
     assistant_output_quarantine_reason,
@@ -60,6 +68,7 @@ from .ingest_protection import (
     protect_messages_for_ingest,
     quarantine_suspicious_assistant_messages,
     recover_hermes_persisted_output,
+    recover_hermes_persisted_output_with_file_stat,
     redact_sensitive_text,
     redact_sensitive_value,
     restore_ingest_payload_placeholders,
@@ -5548,6 +5557,40 @@ class LCMEngine(ContextEngine):
             session_id=session_id,
         )
 
+    def _recovered_content_matches_durable_identity(self, recovered_content: str, durable_content: str) -> bool:
+        recovered_identity_content = normalize_content_value(
+            redact_sensitive_value(
+                recovered_content,
+                self._config,
+                parse_json_strings=False,
+            )
+        )
+        if recovered_identity_content == durable_content:
+            return True
+        redaction_names = sorted(set(re.findall(r"\[LCM sensitive redaction: name=([^;\]]+)", durable_content)))
+        if not redaction_names or bool(getattr(self._config, "sensitive_patterns_enabled", False)):
+            return False
+        compat_config = copy.copy(self._config)
+        compat_config.sensitive_patterns_enabled = True
+        compat_config.sensitive_patterns = redaction_names
+        compat_identity_content = normalize_content_value(
+            redact_sensitive_value(
+                recovered_content,
+                compat_config,
+                parse_json_strings=False,
+            )
+        )
+        return compat_identity_content == durable_content
+
+    @staticmethod
+    def _persisted_output_marker_replay_proof(content: str) -> tuple[str | None, bool]:
+        inline_preview_sha256 = _persisted_output_inline_preview_sha256(content)
+        preview_sha256 = inline_preview_sha256 or _persisted_output_preview_prefix_digest(content)
+        if not preview_sha256:
+            return None, False
+        allow_redacted_preview_match = inline_preview_sha256 is None and not _has_lossy_sensitive_redaction(content)
+        return preview_sha256, allow_redacted_preview_match
+
     def _has_durable_persisted_output_replay_identity(self, msg: Dict[str, Any]) -> bool:
         role = str(msg.get("role") or "unknown")
         content = normalize_content_value(msg.get("content")) or ""
@@ -5555,12 +5598,47 @@ class LCMEngine(ContextEngine):
             return False
         expected_chars = _expected_persisted_output_chars(content)
         persisted_output_source_path = _persisted_output_saved_path(content)
-        persisted_output_preview_sha256 = _persisted_output_preview_prefix_digest(content)
+        persisted_output_preview_sha256, allow_redacted_preview_match = self._persisted_output_marker_replay_proof(content)
         if (
             expected_chars is None
             or not persisted_output_source_path
             or not persisted_output_preview_sha256
         ):
+            return False
+        recovered_with_stat = recover_hermes_persisted_output_with_file_stat(content)
+        if recovered_with_stat is None:
+            return False
+        require_live_file_freshness = True
+        durable_content = find_externalized_tool_result_content_for_call(
+            tool_call_id=str(msg.get("tool_call_id") or ""),
+            session_id=str(msg.get("session_id") or self._session_id or ""),
+            expected_chars=expected_chars,
+            persisted_output_source_path=persisted_output_source_path,
+            persisted_output_preview_sha256=persisted_output_preview_sha256,
+            require_persisted_output_file_not_newer=require_live_file_freshness,
+            allow_redacted_preview_match=allow_redacted_preview_match,
+            config=self._config,
+            hermes_home=self._hermes_home,
+        )
+        if durable_content is None:
+            return False
+        if recovered_with_stat is not None:
+            recovered_content, _file_stat = recovered_with_stat
+            if not self._recovered_content_matches_durable_identity(recovered_content, durable_content):
+                return False
+        return True
+
+    def _has_any_durable_persisted_output_payload_for_marker(self, msg: Dict[str, Any]) -> bool:
+        role = str(msg.get("role") or "unknown")
+        content = normalize_content_value(msg.get("content")) or ""
+        if role != "tool" or not _is_hermes_persisted_output_marker(content):
+            return False
+        expected_chars = _expected_persisted_output_chars(content)
+        persisted_output_source_path = _persisted_output_saved_path(content)
+        persisted_output_preview_sha256, allow_redacted_preview_match = self._persisted_output_marker_replay_proof(content)
+        if expected_chars is None or not persisted_output_source_path or not persisted_output_preview_sha256:
+            return False
+        if recover_hermes_persisted_output_with_file_stat(content) is None:
             return False
         durable_content = find_externalized_tool_result_content_for_call(
             tool_call_id=str(msg.get("tool_call_id") or ""),
@@ -5568,6 +5646,7 @@ class LCMEngine(ContextEngine):
             expected_chars=expected_chars,
             persisted_output_source_path=persisted_output_source_path,
             persisted_output_preview_sha256=persisted_output_preview_sha256,
+            allow_redacted_preview_match=allow_redacted_preview_match,
             config=self._config,
             hermes_home=self._hermes_home,
         )
@@ -5576,16 +5655,50 @@ class LCMEngine(ContextEngine):
     def _message_replay_identity(self, msg: Dict[str, Any], *, stored_row: bool = False) -> tuple[str, str, str, str]:
         role = str(msg.get("role") or "unknown")
         content = normalize_content_value(msg.get("content")) or ""
-        if role == "tool" and _is_hermes_persisted_output_marker(content):
+        if (
+            role == "tool"
+            and _is_hermes_persisted_output_marker(content)
+            and bool(getattr(self._config, "large_output_externalization_enabled", True))
+        ):
             expected_chars = _expected_persisted_output_chars(content)
             persisted_output_source_path = _persisted_output_saved_path(content)
-            persisted_output_preview_sha256 = _persisted_output_preview_prefix_digest(content)
+            persisted_output_preview_sha256, allow_redacted_preview_match = self._persisted_output_marker_replay_proof(content)
             durable_content = None
+            recovered_with_stat = recover_hermes_persisted_output_with_file_stat(content) if not stored_row else None
+            recovered_content = recovered_with_stat[0] if recovered_with_stat is not None else None
+            recovered_identity_content = None
+            if recovered_content is not None:
+                recovered_identity_content = normalize_content_value(
+                    redact_sensitive_value(
+                        recovered_content,
+                        self._config,
+                        parse_json_strings=False,
+                    )
+                )
+            require_live_file_freshness = recovered_with_stat is not None
+
+            def live_file_generation_identity() -> str:
+                try:
+                    live_stat = Path(str(persisted_output_source_path)).stat()
+                    return (
+                        "[LCM persisted-output live file: "
+                        f"path={persisted_output_source_path}; "
+                        f"mtime_ns={live_stat.st_mtime_ns}; "
+                        f"chars={expected_chars}]"
+                    )
+                except OSError:
+                    return (
+                        "[LCM persisted-output live file: "
+                        f"path={persisted_output_source_path}; "
+                        f"chars={expected_chars}]"
+                    )
+
             if (
                 not stored_row
                 and expected_chars is not None
                 and persisted_output_source_path
                 and persisted_output_preview_sha256
+                and recovered_with_stat is not None
             ):
                 durable_content = find_externalized_tool_result_content_for_call(
                     tool_call_id=str(msg.get("tool_call_id") or ""),
@@ -5593,21 +5706,45 @@ class LCMEngine(ContextEngine):
                     expected_chars=expected_chars,
                     persisted_output_source_path=persisted_output_source_path,
                     persisted_output_preview_sha256=persisted_output_preview_sha256,
+                    require_persisted_output_file_not_newer=require_live_file_freshness,
+                    allow_redacted_preview_match=allow_redacted_preview_match,
                     config=self._config,
                     hermes_home=self._hermes_home,
                 )
-            if durable_content is not None:
+            if durable_content is not None and (
+                recovered_content is None or self._recovered_content_matches_durable_identity(recovered_content, durable_content)
+            ):
                 content = durable_content
-            else:
-                recovered_content = recover_hermes_persisted_output(content)
-                if recovered_content is not None:
-                    content = normalize_content_value(
-                        redact_sensitive_value(
-                            recovered_content,
-                            self._config,
-                            parse_json_strings=False,
-                        )
-                    ) or ""
+            elif recovered_content is not None:
+                stale_durable_content = find_externalized_tool_result_content_for_call(
+                    tool_call_id=str(msg.get("tool_call_id") or ""),
+                    session_id=str(msg.get("session_id") or self._session_id or ""),
+                    expected_chars=expected_chars,
+                    persisted_output_source_path=persisted_output_source_path,
+                    persisted_output_preview_sha256=persisted_output_preview_sha256,
+                    allow_redacted_preview_match=allow_redacted_preview_match,
+                    config=self._config,
+                    hermes_home=self._hermes_home,
+                )
+                if (
+                    stale_durable_content is not None
+                    and self._recovered_content_matches_durable_identity(recovered_content, stale_durable_content)
+                    and not _has_lossy_sensitive_redaction(stale_durable_content)
+                    and not _has_lossy_sensitive_redaction(recovered_identity_content)
+                ):
+                    content = stale_durable_content
+                elif stale_durable_content is not None:
+                    content = live_file_generation_identity()
+                elif recovered_with_stat is not None:
+                    content = _add_inline_persisted_output_generation_metadata(
+                        _add_inline_persisted_output_identity_metadata(
+                            content,
+                            _persisted_output_marker_identity_digest(content),
+                        ),
+                        recovered_with_stat[1],
+                    )
+                elif recovered_identity_content is not None:
+                    content = recovered_identity_content
         tool_calls = msg.get("tool_calls")
         if stored_row:
             session_id = str(msg.get("session_id") or self._session_id or "")
@@ -5643,6 +5780,80 @@ class LCMEngine(ContextEngine):
         if len(candidate_prefix) > len(stored_tail):
             return False
         return stored_tail[-len(candidate_prefix) :] == candidate_prefix
+
+    @staticmethod
+    def _strip_inline_persisted_output_generation_identity(
+        identity: tuple[str, str, str, str],
+    ) -> tuple[str, str, str, str]:
+        role, content, tool_call_id, tool_calls = identity
+        if role != "tool" or not isinstance(content, str):
+            return identity
+        stripped = re.sub(
+            r"\n?\[LCM persisted-output file generation: "
+            r"size=\d+; mtime_ns=\d+; ctime_ns=\d+\]\n?(?=</persisted-output>)",
+            "\n",
+            content,
+        )
+        return (role, stripped, tool_call_id, tool_calls)
+
+    def _stored_row_has_durable_persisted_output_marker(self, row: Dict[str, Any]) -> bool:
+        if str(row.get("role") or "") != "tool":
+            return False
+        content = normalize_content_value(row.get("content")) or ""
+        ref = extract_externalized_ref(content)
+        if not ref:
+            return False
+        return externalized_tool_result_has_persisted_output_marker(
+            ref,
+            config=self._config,
+            hermes_home=self._hermes_home,
+        )
+
+    @staticmethod
+    def _persisted_output_durable_wildcard_identity(
+        identity: tuple[str, str, str, str],
+    ) -> tuple[str, str, str, str]:
+        role, _content, tool_call_id, tool_calls = identity
+        return (role, "[LCM persisted-output durable replay]", tool_call_id, tool_calls)
+
+    def _matches_persisted_output_durable_full_replay(
+        self,
+        candidate_messages: list[Dict[str, Any]],
+        candidate_prefix: list[tuple[str, str, str, str]],
+        stored_tail: list[tuple[str, str, str, str]],
+        stored_tail_rows: list[Dict[str, Any]] | None,
+    ) -> bool:
+        if not stored_tail_rows or len(candidate_prefix) != len(stored_tail) or len(candidate_messages) != len(candidate_prefix):
+            return False
+        transformed_candidate: list[tuple[str, str, str, str]] = []
+        transformed_stored: list[tuple[str, str, str, str]] = []
+        saw_persisted_output = False
+        for candidate_msg, candidate_identity, stored_identity, stored_row in zip(
+            candidate_messages,
+            candidate_prefix,
+            stored_tail,
+            stored_tail_rows,
+        ):
+            candidate_content = normalize_content_value(candidate_msg.get("content")) or ""
+            candidate_is_persisted_marker = (
+                str(candidate_msg.get("role") or "") == "tool"
+                and _is_hermes_persisted_output_marker(candidate_content)
+            )
+            stored_is_persisted_output = self._stored_row_has_durable_persisted_output_marker(stored_row)
+            if candidate_is_persisted_marker or stored_is_persisted_output:
+                if (
+                    not candidate_is_persisted_marker
+                    or not stored_is_persisted_output
+                    or not self._has_durable_persisted_output_replay_identity(candidate_msg)
+                ):
+                    return False
+                saw_persisted_output = True
+                transformed_candidate.append(self._persisted_output_durable_wildcard_identity(candidate_identity))
+                transformed_stored.append(self._persisted_output_durable_wildcard_identity(stored_identity))
+                continue
+            transformed_candidate.append(candidate_identity)
+            transformed_stored.append(stored_identity)
+        return saw_persisted_output and transformed_candidate == transformed_stored
 
     @classmethod
     def _identity_content_for_active_cleanup(cls, content: str) -> Any:
@@ -5767,6 +5978,7 @@ class LCMEngine(ContextEngine):
         messages: List[Dict[str, Any]],
         stored_tail: list[tuple[str, str, str, str]],
         *,
+        stored_tail_rows: list[Dict[str, Any]] | None = None,
         allow_empty_prefix: bool,
         session_count: int,
         raw_session_count: int,
@@ -5849,14 +6061,62 @@ class LCMEngine(ContextEngine):
                 and bool(candidate_visible_prefix)
                 and self._matches_store_tail_suffix(stored_tail, candidate_visible_prefix)
             )
-            if matches_visible_sanitized_tail or matches_visible_raw_tail:
+            early_candidate_has_unrecoverable_persisted_marker = any(
+                str(msg.get("role") or "") == "tool"
+                and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+                and recover_hermes_persisted_output_with_file_stat(
+                    normalize_content_value(msg.get("content")) or ""
+                )
+                is None
+                for msg in candidate_identity_messages
+            )
+            if (matches_visible_sanitized_tail or matches_visible_raw_tail) and not early_candidate_has_unrecoverable_persisted_marker:
                 return cursor
+            candidate_has_persisted_marker = any(
+                str(msg.get("role") or "") == "tool"
+                and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+                for msg in candidate_identity_messages
+            )
+            matches_durable_persisted_output_full_replay = self._matches_persisted_output_durable_full_replay(
+                candidate_identity_messages,
+                candidate_prefix,
+                stored_tail,
+                stored_tail_rows,
+            )
+            candidate_has_unrecoverable_persisted_marker = any(
+                str(msg.get("role") or "") == "tool"
+                and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+                and recover_hermes_persisted_output_with_file_stat(
+                    normalize_content_value(msg.get("content")) or ""
+                )
+                is None
+                for msg in candidate_identity_messages
+            )
+            matches_inline_generation_cleanup_tail = False
+            if candidate_has_unrecoverable_persisted_marker:
+                generationless_sanitized_tail = [
+                    self._strip_inline_persisted_output_generation_identity(identity)
+                    for identity in sanitized_replay_tail
+                ]
+                generationless_candidate_prefix = [
+                    self._strip_inline_persisted_output_generation_identity(identity)
+                    for identity in candidate_prefix
+                ]
+                matches_inline_generation_cleanup_tail = self._matches_store_tail_suffix(
+                    generationless_sanitized_tail,
+                    generationless_candidate_prefix,
+                )
             raw_tail_suffix = stored_tail[-len(candidate_prefix) :] if matches_raw_tail else []
             raw_suffix_needs_cleanup_equivalence = any(
                 self._active_cleanup_replay_identity(identity) != identity
                 for identity in raw_tail_suffix
             )
-            if not matches_sanitized_tail and not matches_raw_tail:
+            if (
+                not matches_sanitized_tail
+                and not matches_raw_tail
+                and not matches_inline_generation_cleanup_tail
+                and not matches_durable_persisted_output_full_replay
+            ):
                 continue
 
             # Matching a stored suffix is not enough evidence by itself.  A
@@ -5909,11 +6169,21 @@ class LCMEngine(ContextEngine):
             )
             has_persisted_marker_singleton_replay = (
                 matches_raw_tail
+                and not candidate_has_unrecoverable_persisted_marker
                 and len(candidate_prefix) == 1
                 and raw_session_count == 1
                 and candidate_prefix == stored_tail
                 and candidate_prefix[0][0] == "tool"
                 and _is_hermes_persisted_output_marker(candidate_singleton_original_content)
+            )
+            has_durable_persisted_marker_suffix_replay = (
+                (matches_sanitized_tail or matches_raw_tail)
+                and any(
+                    str(msg.get("role") or "") == "tool"
+                    and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+                    and self._has_durable_persisted_output_replay_identity(msg)
+                    for msg in candidate_messages
+                )
             )
             has_filtered_full_replay = (
                 matches_sanitized_tail
@@ -5921,17 +6191,56 @@ class LCMEngine(ContextEngine):
                 and len(candidate_prefix) >= effective_session_count
                 and effective_session_count > 0
             )
-            has_effective_full_replay = matches_sanitized_tail and len(candidate_prefix) >= effective_session_count and (
-                candidate_has_system
-                or (effective_session_count > 1 and not sanitized_tail_collapsed)
-                or has_quarantined_singleton_replay
-                or has_filtered_full_replay
+            has_inline_generation_cleanup_replay = (
+                matches_inline_generation_cleanup_tail
+                and candidate_has_unrecoverable_persisted_marker
+                and len(candidate_prefix) >= effective_session_count
+                and effective_session_count > 0
             )
+            has_inline_persisted_generation_suffix_replay = (
+                matches_sanitized_tail
+                and any(
+                    str(msg.get("role") or "") == "tool"
+                    and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+                    and _has_inline_persisted_output_generation_metadata(normalize_content_value(msg.get("content")) or "")
+                    for msg in candidate_identity_messages
+                )
+            )
+            if candidate_has_unrecoverable_persisted_marker:
+                continue
+            has_raw_persisted_marker_exact_replay = (
+                candidate_has_persisted_marker
+                and not candidate_has_unrecoverable_persisted_marker
+                and matches_raw_tail
+                and candidate_prefix == stored_tail[-len(candidate_prefix) :]
+            )
+            has_persisted_marker_specific_replay_evidence = (
+                not candidate_has_persisted_marker
+                or has_durable_persisted_marker_suffix_replay
+                or matches_durable_persisted_output_full_replay
+                or has_inline_generation_cleanup_replay
+                or has_inline_persisted_generation_suffix_replay
+                or has_persisted_marker_singleton_replay
+                or has_raw_persisted_marker_exact_replay
+            )
+            has_effective_full_replay = (
+                has_persisted_marker_specific_replay_evidence
+                and matches_sanitized_tail
+                and len(candidate_prefix) >= effective_session_count
+                and (
+                    candidate_has_system
+                    or (effective_session_count > 1 and not sanitized_tail_collapsed)
+                    or has_quarantined_singleton_replay
+                    or has_filtered_full_replay
+                )
+            )
+
             has_scaffold_evidence = any(
                 self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages
             )
             has_raw_full_replay = (
-                matches_raw_tail
+                has_persisted_marker_specific_replay_evidence
+                and matches_raw_tail
                 and not has_scaffold_evidence
                 and len(candidate_messages) >= raw_session_count
                 and raw_session_count > 1
@@ -5945,12 +6254,14 @@ class LCMEngine(ContextEngine):
             )
             candidate_suffix_has_user_turn = any(identity[0] == "user" for identity in candidate_prefix)
             has_scaffold_suffix_replay = (
-                matches_sanitized_tail
+                has_persisted_marker_specific_replay_evidence
+                and matches_sanitized_tail
                 and has_preserved_objective_scaffold
                 and not candidate_suffix_has_user_turn
             )
             has_raw_cleanup_replay = (
-                matches_raw_tail
+                has_persisted_marker_specific_replay_evidence
+                and matches_raw_tail
                 and has_scaffold_evidence
                 and cursor < len(messages)
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
@@ -5960,6 +6271,10 @@ class LCMEngine(ContextEngine):
                 has_effective_full_replay
                 or has_externalized_singleton_replay
                 or has_persisted_marker_singleton_replay
+                or has_durable_persisted_marker_suffix_replay
+                or matches_durable_persisted_output_full_replay
+                or has_inline_generation_cleanup_replay
+                or has_inline_persisted_generation_suffix_replay
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay
@@ -6071,14 +6386,19 @@ class LCMEngine(ContextEngine):
         stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)
         if not stored_rows:
             return 0
-        stored_tail = [
-            self._message_replay_identity(row, stored_row=True)
+        stored_tail_rows = [
+            row
             for row in stored_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
+        ]
+        stored_tail = [
+            self._message_replay_identity(row, stored_row=True)
+            for row in stored_tail_rows
         ]
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,
+            stored_tail_rows=stored_tail_rows,
             allow_empty_prefix=True,
             session_count=len(stored_tail),
             raw_session_count=session_count,
@@ -6118,10 +6438,22 @@ class LCMEngine(ContextEngine):
         # Stale-snapshot proof uses the raw durable prefix.  Ignore-message
         # filters may suppress noisy rows for tail reconciliation, but filtered
         # history alone must not create replay evidence for skipping a batch.
-        if self._is_suspicious_stale_no_overlap_snapshot(
-            incoming_identities,
-            stored_tail,
-            stored_head,
+        incoming_has_unproofed_raw_persisted_marker = any(
+            str(msg.get("role") or "") == "tool"
+            and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+            and recover_hermes_persisted_output_with_file_stat(
+                normalize_content_value(msg.get("content")) or ""
+            )
+            is None
+            for msg in messages
+        )
+        if (
+            not incoming_has_unproofed_raw_persisted_marker
+            and self._is_suspicious_stale_no_overlap_snapshot(
+                incoming_identities,
+                stored_tail,
+                stored_head,
+            )
         ):
             self._record_ingest_reconciliation(
                 action="skipped batch",
@@ -6163,11 +6495,14 @@ class LCMEngine(ContextEngine):
         for message in messages:
             redacted_message = dict(message)
             if "content" in redacted_message:
-                redacted_message["content"] = redact_sensitive_value(
+                original_content = normalize_content_value(redacted_message.get("content")) or ""
+                redacted_content = redact_sensitive_value(
                     redacted_message.get("content"),
                     self._config,
                     parse_json_strings=False,
                 )
+                redacted_message["content"] = redacted_content
+
             if "tool_calls" in redacted_message:
                 redacted_message["tool_calls"] = redact_sensitive_value(
                     redacted_message.get("tool_calls"),
@@ -6247,7 +6582,10 @@ class LCMEngine(ContextEngine):
                 if (
                     (
                         str(original_msg.get("role") or "") == "tool"
-                        and self._has_durable_persisted_output_replay_identity(original_msg)
+                        and _is_hermes_persisted_output_marker(
+                            normalize_content_value(original_msg.get("content")) or ""
+                        )
+                        and self._has_any_durable_persisted_output_payload_for_marker(original_msg)
                     )
                     or (
                         self._compiled_ignore_message_patterns

--- a/externalize.py
+++ b/externalize.py
@@ -181,6 +181,10 @@ def _persisted_output_marker_entry_from_metadata(metadata: Dict[str, Any] | None
         metadata.get("persisted_output_preview_prefix")
     )
     redacted_preview_sha256 = metadata.get("persisted_output_redacted_preview_sha256")
+    file_size = metadata.get("persisted_output_file_size")
+    file_mtime_ns = metadata.get("persisted_output_file_mtime_ns")
+    file_ctime_ns = metadata.get("persisted_output_file_ctime_ns")
+
     if source_path is None or expected_chars is None:
         return None
     try:
@@ -198,6 +202,21 @@ def _persisted_output_marker_entry_from_metadata(metadata: Dict[str, Any] | None
         entry["preview_sha256"] = str(preview_sha256)
     if redacted_preview_sha256:
         entry["redacted_preview_sha256"] = str(redacted_preview_sha256)
+    if file_size is not None:
+        try:
+            entry["file_size"] = int(file_size)
+        except (TypeError, ValueError):
+            pass
+    if file_mtime_ns is not None:
+        try:
+            entry["file_mtime_ns"] = int(file_mtime_ns)
+        except (TypeError, ValueError):
+            pass
+    if file_ctime_ns is not None:
+        try:
+            entry["file_ctime_ns"] = int(file_ctime_ns)
+        except (TypeError, ValueError):
+            pass
     return entry
 
 
@@ -207,7 +226,15 @@ def _persisted_output_marker_entries(
     include_legacy_preview_prefix: bool = False,
 ) -> list[Dict[str, Any]]:
     entries: list[Dict[str, Any]] = []
-    seen: set[tuple[str, int, str, str]] = set()
+    seen: set[tuple[str, int, str, str, int | None, int | None, int | None]] = set()
+    try:
+        from .ingest_protection import _has_lossy_sensitive_redaction
+    except Exception:
+        _has_lossy_sensitive_redaction = None  # type: ignore[assignment]
+    payload_content_has_lossy_redaction = bool(
+        _has_lossy_sensitive_redaction
+        and _has_lossy_sensitive_redaction(str(payload.get("content") or ""))
+    )
 
     def add(
         source_path: Any,
@@ -215,6 +242,9 @@ def _persisted_output_marker_entries(
         preview_prefix: Any = None,
         preview_sha256: Any = None,
         redacted_preview_sha256: Any = None,
+        file_size: Any = None,
+        file_mtime_ns: Any = None,
+        file_ctime_ns: Any = None,
     ) -> None:
         if source_path is None or expected_chars is None:
             return
@@ -225,9 +255,23 @@ def _persisted_output_marker_entries(
         source = str(source_path)
         if not source:
             return
-        preview_digest = str(preview_sha256 or "") or _preview_sha256(preview_prefix)
+        preview_digest = "" if payload_content_has_lossy_redaction else str(preview_sha256 or "")
+        if not preview_digest and preview_prefix and not payload_content_has_lossy_redaction:
+            preview_digest = _preview_sha256(preview_prefix)
         redacted_preview_digest = str(redacted_preview_sha256 or "")
-        key = (source, chars, preview_digest, redacted_preview_digest)
+        try:
+            size = int(file_size) if file_size is not None else None
+        except (TypeError, ValueError):
+            size = None
+        try:
+            mtime_ns = int(file_mtime_ns) if file_mtime_ns is not None else None
+        except (TypeError, ValueError):
+            mtime_ns = None
+        try:
+            ctime_ns = int(file_ctime_ns) if file_ctime_ns is not None else None
+        except (TypeError, ValueError):
+            ctime_ns = None
+        key = (source, chars, preview_digest, redacted_preview_digest, size, mtime_ns, ctime_ns)
         if key in seen:
             return
         seen.add(key)
@@ -236,6 +280,12 @@ def _persisted_output_marker_entries(
             entry["preview_sha256"] = preview_digest
         if redacted_preview_digest:
             entry["redacted_preview_sha256"] = redacted_preview_digest
+        if size is not None:
+            entry["file_size"] = size
+        if mtime_ns is not None:
+            entry["file_mtime_ns"] = mtime_ns
+        if ctime_ns is not None:
+            entry["file_ctime_ns"] = ctime_ns
         if include_legacy_preview_prefix and preview_prefix:
             entry["legacy_preview_prefix"] = str(preview_prefix)
         entries.append(entry)
@@ -246,6 +296,9 @@ def _persisted_output_marker_entries(
         payload.get("persisted_output_preview_prefix"),
         payload.get("persisted_output_preview_sha256"),
         payload.get("persisted_output_redacted_preview_sha256"),
+        payload.get("persisted_output_file_size"),
+        payload.get("persisted_output_file_mtime_ns"),
+        payload.get("persisted_output_file_ctime_ns"),
     )
     markers = payload.get("persisted_output_markers")
     if isinstance(markers, list):
@@ -258,6 +311,9 @@ def _persisted_output_marker_entries(
                 marker.get("preview_prefix"),
                 marker.get("preview_sha256"),
                 marker.get("redacted_preview_sha256"),
+                marker.get("file_size"),
+                marker.get("file_mtime_ns"),
+                marker.get("file_ctime_ns"),
             )
     return entries
 
@@ -274,18 +330,13 @@ def _safe_persisted_output_metadata(metadata: Dict[str, Any] | None) -> Dict[str
         safe["persisted_output_preview_sha256"] = marker["preview_sha256"]
     if marker.get("redacted_preview_sha256"):
         safe["persisted_output_redacted_preview_sha256"] = marker["redacted_preview_sha256"]
+    if marker.get("file_size") is not None:
+        safe["persisted_output_file_size"] = marker["file_size"]
+    if marker.get("file_mtime_ns") is not None:
+        safe["persisted_output_file_mtime_ns"] = marker["file_mtime_ns"]
+    if marker.get("file_ctime_ns") is not None:
+        safe["persisted_output_file_ctime_ns"] = marker["file_ctime_ns"]
     return safe
-
-
-def _persisted_output_marker_preview_digests(marker: Dict[str, Any]) -> set[str]:
-    return {
-        str(value)
-        for value in (
-            marker.get("preview_sha256"),
-            marker.get("redacted_preview_sha256"),
-        )
-        if value
-    }
 
 
 def _redacted_legacy_preview_sha256(marker: Dict[str, Any], config) -> str:
@@ -293,7 +344,7 @@ def _redacted_legacy_preview_sha256(marker: Dict[str, Any], config) -> str:
     if not legacy_preview_prefix:
         return ""
     try:
-        from .ingest_protection import redact_sensitive_value
+        from .ingest_protection import _has_lossy_sensitive_redaction, redact_sensitive_value
     except Exception:
         return ""
     redacted_preview = redact_sensitive_value(
@@ -301,6 +352,8 @@ def _redacted_legacy_preview_sha256(marker: Dict[str, Any], config) -> str:
         config,
         parse_json_strings=False,
     )
+    if _has_lossy_sensitive_redaction(str(redacted_preview)):
+        return ""
     return _preview_sha256(redacted_preview)
 
 
@@ -309,12 +362,39 @@ def _persisted_output_marker_matches_preview_digest(
     preview_sha256: str,
     *,
     config,
+    allow_redacted_preview_match: bool = True,
 ) -> bool:
     if not preview_sha256:
+        return False
+    if preview_sha256 == str(marker.get("preview_sha256") or ""):
         return True
-    if preview_sha256 in _persisted_output_marker_preview_digests(marker):
+    if not allow_redacted_preview_match:
+        return False
+    if preview_sha256 == str(marker.get("redacted_preview_sha256") or ""):
         return True
     return preview_sha256 == _redacted_legacy_preview_sha256(marker, config)
+
+
+def _marker_file_not_newer_than_payload(marker: Dict[str, Any], payload: Dict[str, Any]) -> bool:
+    """Return true when a live marker file still matches the durable payload era."""
+    source_path = marker.get("source_path")
+    created_at = payload.get("created_at")
+    if not source_path or created_at is None:
+        return False
+    try:
+        current_stat = Path(str(source_path)).stat()
+        marker_size = marker.get("file_size")
+        marker_mtime_ns = marker.get("file_mtime_ns")
+        marker_ctime_ns = marker.get("file_ctime_ns")
+        if marker_size is None or marker_mtime_ns is None or marker_ctime_ns is None:
+            return False
+        return (
+            int(current_stat.st_size) == int(marker_size)
+            and int(current_stat.st_mtime_ns) == int(marker_mtime_ns)
+            and int(current_stat.st_ctime_ns) == int(marker_ctime_ns)
+        )
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _sanitize_persisted_output_marker_metadata(payload: Dict[str, Any]) -> bool:
@@ -327,6 +407,14 @@ def _sanitize_persisted_output_marker_metadata(payload: Dict[str, Any]) -> bool:
     when they are touched again.
     """
     changed = False
+    try:
+        from .ingest_protection import _has_lossy_sensitive_redaction
+    except Exception:
+        _has_lossy_sensitive_redaction = None  # type: ignore[assignment]
+    payload_content_has_lossy_redaction = bool(
+        _has_lossy_sensitive_redaction
+        and _has_lossy_sensitive_redaction(str(payload.get("content") or ""))
+    )
     entries = _persisted_output_marker_entries(payload)
 
     if "persisted_output_preview_prefix" in payload:
@@ -342,6 +430,9 @@ def _sanitize_persisted_output_marker_metadata(payload: Dict[str, Any]) -> bool:
     if first_digest and payload.get("persisted_output_preview_sha256") != first_digest:
         payload["persisted_output_preview_sha256"] = first_digest
         changed = True
+    elif not first_digest and payload_content_has_lossy_redaction and "persisted_output_preview_sha256" in payload:
+        payload.pop("persisted_output_preview_sha256", None)
+        changed = True
 
     first_redacted_digest = next(
         (entry.get("redacted_preview_sha256") for entry in entries if entry.get("redacted_preview_sha256")),
@@ -351,12 +442,34 @@ def _sanitize_persisted_output_marker_metadata(payload: Dict[str, Any]) -> bool:
         payload["persisted_output_redacted_preview_sha256"] = first_redacted_digest
         changed = True
 
+    first_file_size = next((entry.get("file_size") for entry in entries if entry.get("file_size") is not None), None)
+    if first_file_size is not None and payload.get("persisted_output_file_size") != first_file_size:
+        payload["persisted_output_file_size"] = first_file_size
+        changed = True
+
+    first_file_mtime_ns = next((entry.get("file_mtime_ns") for entry in entries if entry.get("file_mtime_ns") is not None), None)
+    if first_file_mtime_ns is not None and payload.get("persisted_output_file_mtime_ns") != first_file_mtime_ns:
+        payload["persisted_output_file_mtime_ns"] = first_file_mtime_ns
+        changed = True
+
+    first_file_ctime_ns = next((entry.get("file_ctime_ns") for entry in entries if entry.get("file_ctime_ns") is not None), None)
+    if first_file_ctime_ns is not None and payload.get("persisted_output_file_ctime_ns") != first_file_ctime_ns:
+        payload["persisted_output_file_ctime_ns"] = first_file_ctime_ns
+        changed = True
+
     return changed
 
 
 def _merge_persisted_output_marker_metadata(payload: Dict[str, Any], metadata: Dict[str, Any] | None) -> bool:
     changed = _sanitize_persisted_output_marker_metadata(payload)
     marker = _persisted_output_marker_entry_from_metadata(metadata)
+    if marker is not None:
+        try:
+            from .ingest_protection import _has_lossy_sensitive_redaction
+        except Exception:
+            _has_lossy_sensitive_redaction = None  # type: ignore[assignment]
+        if _has_lossy_sensitive_redaction and _has_lossy_sensitive_redaction(str(payload.get("content") or "")):
+            marker.pop("preview_sha256", None)
     if marker is None:
         return changed
     entries = _persisted_output_marker_entries(payload)
@@ -365,6 +478,9 @@ def _merge_persisted_output_marker_metadata(payload: Dict[str, Any], metadata: D
         marker["expected_chars"],
         marker.get("preview_sha256", ""),
         marker.get("redacted_preview_sha256", ""),
+        marker.get("file_size"),
+        marker.get("file_mtime_ns"),
+        marker.get("file_ctime_ns"),
     )
     if any(
         (
@@ -372,6 +488,9 @@ def _merge_persisted_output_marker_metadata(payload: Dict[str, Any], metadata: D
             entry["expected_chars"],
             entry.get("preview_sha256", ""),
             entry.get("redacted_preview_sha256", ""),
+            entry.get("file_size"),
+            entry.get("file_mtime_ns"),
+            entry.get("file_ctime_ns"),
         ) == key
         for entry in entries
     ):
@@ -384,6 +503,12 @@ def _merge_persisted_output_marker_metadata(payload: Dict[str, Any], metadata: D
         payload.setdefault("persisted_output_preview_sha256", marker["preview_sha256"])
     if marker.get("redacted_preview_sha256"):
         payload.setdefault("persisted_output_redacted_preview_sha256", marker["redacted_preview_sha256"])
+    if marker.get("file_size") is not None:
+        payload.setdefault("persisted_output_file_size", marker["file_size"])
+    if marker.get("file_mtime_ns") is not None:
+        payload.setdefault("persisted_output_file_mtime_ns", marker["file_mtime_ns"])
+    if marker.get("file_ctime_ns") is not None:
+        payload.setdefault("persisted_output_file_ctime_ns", marker["file_ctime_ns"])
     return True
 
 
@@ -479,6 +604,22 @@ def load_externalized_payload(ref: str, *, config, hermes_home: str = "") -> Dic
     return summary
 
 
+def externalized_tool_result_has_persisted_output_marker(ref: str, *, config, hermes_home: str = "") -> bool:
+    if not ref or Path(ref).name != ref:
+        return False
+    storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
+    if not storage_dir.exists() or not storage_dir.is_dir():
+        return False
+    path = storage_dir / ref
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if payload.get("kind", "tool_result") != "tool_result":
+        return False
+    return bool(_persisted_output_marker_entries(payload))
+
+
 def reassign_externalized_payloads(
     old_session_id: str,
     new_session_id: str,
@@ -571,6 +712,12 @@ def find_externalized_tool_result_content_for_call(
     expected_chars: int | None = None,
     persisted_output_source_path: str | None = None,
     persisted_output_preview_sha256: str | None = None,
+    require_persisted_output_file_not_newer: bool = False,
+    allow_redacted_preview_match: bool = True,
+    require_missing_file_generation_metadata: bool = False,
+    persisted_output_file_size: int | None = None,
+    persisted_output_file_mtime_ns: int | None = None,
+    persisted_output_file_ctime_ns: int | None = None,
     config,
     hermes_home: str = "",
 ) -> str | None:
@@ -583,6 +730,8 @@ def find_externalized_tool_result_content_for_call(
     match when provided.
     """
     if not tool_call_id:
+        return None
+    if (expected_chars is not None or persisted_output_source_path) and not persisted_output_preview_sha256:
         return None
     storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
     if not storage_dir.exists() or not storage_dir.is_dir():
@@ -604,12 +753,29 @@ def find_externalized_tool_result_content_for_call(
         content = payload.get("content")
         if not isinstance(content, str):
             continue
-        if expected_chars is not None or persisted_output_source_path or persisted_output_preview_sha256:
+        if (
+            expected_chars is not None
+            or persisted_output_source_path
+            or persisted_output_preview_sha256
+            or require_persisted_output_file_not_newer
+        ):
             marker_matches = False
             for marker in _persisted_output_marker_entries(payload, include_legacy_preview_prefix=True):
                 if expected_chars is not None and marker.get("expected_chars") != expected_chars:
                     continue
                 if persisted_output_source_path and marker.get("source_path") != persisted_output_source_path:
+                    continue
+                if require_missing_file_generation_metadata and (
+                    marker.get("file_size") is not None
+                    or marker.get("file_mtime_ns") is not None
+                    or marker.get("file_ctime_ns") is not None
+                ):
+                    continue
+                if persisted_output_file_size is not None and marker.get("file_size") != persisted_output_file_size:
+                    continue
+                if persisted_output_file_mtime_ns is not None and marker.get("file_mtime_ns") != persisted_output_file_mtime_ns:
+                    continue
+                if persisted_output_file_ctime_ns is not None and marker.get("file_ctime_ns") != persisted_output_file_ctime_ns:
                     continue
                 if (
                     persisted_output_preview_sha256
@@ -617,8 +783,11 @@ def find_externalized_tool_result_content_for_call(
                         marker,
                         persisted_output_preview_sha256,
                         config=config,
+                        allow_redacted_preview_match=allow_redacted_preview_match,
                     )
                 ):
+                    continue
+                if require_persisted_output_file_not_newer and not _marker_file_not_newer_than_payload(marker, payload):
                     continue
                 marker_matches = True
                 break

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -125,6 +125,17 @@ _PERSISTED_OUTPUT_PREVIEW_RE = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 _PERSISTED_OUTPUT_CHAR_COUNT_RE = re.compile(r"too large\s*\((?P<count>[\d,]+)\s+characters\b", re.IGNORECASE)
+_PERSISTED_OUTPUT_INLINE_PREVIEW_SHA256_RE = re.compile(
+    r"\r?\n\[LCM persisted-output marker identity: preview_sha256=(?P<sha256>[0-9a-f]{64})\]"
+    r"(?:\r?\n\[LCM persisted-output file generation: size=\d+; mtime_ns=\d+; ctime_ns=\d+\])?"
+    r"\r?\n</persisted-output>\s*$"
+)
+_PERSISTED_OUTPUT_INLINE_GENERATION_RE = re.compile(
+    r"\r?\n\[LCM persisted-output file generation: size=(?P<size>\d+); mtime_ns=(?P<mtime_ns>\d+); ctime_ns=(?P<ctime_ns>\d+)\]\r?\n</persisted-output>\s*$"
+)
+_PERSISTED_OUTPUT_INLINE_METADATA_RE = re.compile(
+    r"\r?\n\[LCM persisted-output (?:file generation|marker identity):[^\r\n]*\]\s*$"
+)
 _UNRECOVERABLE_TRUNCATION_RE = re.compile(
     r"\[Truncated:\s*tool response was [\d,]+ chars\.\s*Full output could not be saved to sandbox\.\]",
     re.IGNORECASE,
@@ -409,6 +420,53 @@ def _persisted_output_preview_prefix_digest(text: str | None) -> str | None:
     ).hexdigest()
 
 
+def _persisted_output_inline_preview_sha256(text: str | None) -> str | None:
+    if not isinstance(text, str):
+        return None
+    match = _PERSISTED_OUTPUT_INLINE_PREVIEW_SHA256_RE.search(text)
+    if not match:
+        return None
+    return match.group("sha256")
+
+
+def _inline_persisted_output_generation_metadata(text: str | None) -> dict[str, int] | None:
+    if not isinstance(text, str):
+        return None
+    match = _PERSISTED_OUTPUT_INLINE_GENERATION_RE.search(text)
+    if not match:
+        return None
+    try:
+        return {
+            "size": int(match.group("size")),
+            "mtime_ns": int(match.group("mtime_ns")),
+            "ctime_ns": int(match.group("ctime_ns")),
+        }
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_inline_persisted_output_generation_metadata(text: str | None) -> bool:
+    return _inline_persisted_output_generation_metadata(text) is not None
+
+
+def _persisted_output_marker_identity_digest(text: str | None) -> str | None:
+    return _persisted_output_inline_preview_sha256(text) or _persisted_output_preview_prefix_digest(text)
+
+
+def _has_lossy_sensitive_redaction(text: str | None) -> bool:
+    if not isinstance(text, str) or _SENSITIVE_PLACEHOLDER_PREFIX not in text:
+        return False
+    for match in re.finditer(r"\[LCM sensitive redaction: (?P<body>[^\]]+)\]", text):
+        body = match.group("body")
+        fields = {
+            key: value
+            for key, value in re.findall(r"([A-Za-z0-9_]+)=([^;]+)", body)
+        }
+        if fields.get("name") == "password_assignment" and "sha256" not in fields:
+            return True
+    return False
+
+
 def _persisted_output_saved_path(text: str | None) -> str | None:
     if not isinstance(text, str):
         return None
@@ -449,7 +507,15 @@ def _is_hermes_persisted_output_marker(text: str | None) -> bool:
     )
 
 
-def _read_regular_file_no_symlink(path: Path) -> str | None:
+def _stat_generation_metadata(stats: os.stat_result) -> dict[str, int]:
+    return {
+        "size": int(stats.st_size),
+        "mtime_ns": int(stats.st_mtime_ns),
+        "ctime_ns": int(stats.st_ctime_ns),
+    }
+
+
+def _read_regular_file_no_symlink(path: Path) -> tuple[str, dict[str, int]] | None:
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -463,14 +529,18 @@ def _read_regular_file_no_symlink(path: Path) -> str | None:
         if lstat_result.st_size > _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES:
             return None
         fd = os.open(str(path), flags)
-        stats = os.fstat(fd)
-        if not stat.S_ISREG(stats.st_mode):
+        stats_before = os.fstat(fd)
+        if not stat.S_ISREG(stats_before.st_mode):
             return None
-        if stats.st_size > _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES:
+        if stats_before.st_size > _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES:
             return None
         with os.fdopen(fd, "rb") as handle:
             fd = None
-            return handle.read().decode("utf-8")
+            raw = handle.read()
+            stats_after = os.fstat(handle.fileno())
+        if _stat_generation_metadata(stats_before) != _stat_generation_metadata(stats_after):
+            return None
+        return raw.decode("utf-8"), _stat_generation_metadata(stats_after)
     except (OSError, UnicodeDecodeError):
         return None
     finally:
@@ -481,7 +551,7 @@ def _read_regular_file_no_symlink(path: Path) -> str | None:
                 pass
 
 
-def recover_hermes_persisted_output(text: str | None) -> str | None:
+def recover_hermes_persisted_output_with_file_stat(text: str | None) -> tuple[str, dict[str, int]] | None:
     """Recover Hermes host `<persisted-output>` content when the backing file is safe.
 
     Recovery is intentionally conservative: the marker must include Hermes'
@@ -503,13 +573,52 @@ def recover_hermes_persisted_output(text: str | None) -> str | None:
     safe_path = _safe_temp_hermes_results_file(path)
     if safe_path is None:
         return None
-    recovered = _read_regular_file_no_symlink(safe_path)
-    if recovered is None or len(recovered) != expected_chars:
+    recovered_with_stat = _read_regular_file_no_symlink(safe_path)
+    if recovered_with_stat is None:
+        return None
+    recovered, file_stat = recovered_with_stat
+    if len(recovered) != expected_chars:
         return None
     preview_prefix = _persisted_output_preview_prefix(text)
     if not preview_prefix or not recovered.startswith(preview_prefix):
         return None
+    return recovered, file_stat
+
+
+def recover_hermes_persisted_output(text: str | None) -> str | None:
+    recovered_with_stat = recover_hermes_persisted_output_with_file_stat(text)
+    if recovered_with_stat is None:
+        return None
+    recovered, _file_stat = recovered_with_stat
     return recovered
+
+
+def _add_inline_persisted_output_generation_metadata(text: str, file_stat: dict[str, int] | None) -> str:
+    if not file_stat or not isinstance(text, str) or "</persisted-output>" not in text:
+        return text
+    generation = (
+        "[LCM persisted-output file generation: "
+        f"size={file_stat['size']}; "
+        f"mtime_ns={file_stat['mtime_ns']}; "
+        f"ctime_ns={file_stat['ctime_ns']}]"
+    )
+    if generation in text:
+        return text
+    return text.replace("</persisted-output>", f"{generation}\n</persisted-output>", 1)
+
+
+def _add_inline_persisted_output_identity_metadata(text: str, preview_sha256: str | None) -> str:
+    if (
+        not isinstance(text, str)
+        or "</persisted-output>" not in text
+        or not isinstance(preview_sha256, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", preview_sha256)
+    ):
+        return text
+    if _has_lossy_sensitive_redaction(text) or _persisted_output_inline_preview_sha256(text):
+        return text
+    identity = f"[LCM persisted-output marker identity: preview_sha256={preview_sha256}]"
+    return text.replace("</persisted-output>", f"{identity}\n</persisted-output>", 1)
 
 
 def contains_data_uri_base64(text: str) -> bool:
@@ -1240,9 +1349,11 @@ def protect_message_for_ingest(
         parse_json_strings=False,
     )
     normalized_content = normalize_content_value(original_content)
-    recovered_persisted_output = recover_hermes_persisted_output(raw_normalized_content) if role == "tool" else None
+    recovered_with_stat = recover_hermes_persisted_output_with_file_stat(raw_normalized_content) if role == "tool" else None
+    recovered_file_stat = None
     recovered_externalized = None
-    if recovered_persisted_output is not None:
+    if recovered_with_stat is not None:
+        recovered_persisted_output, recovered_file_stat = recovered_with_stat
         recovered_content = redact_sensitive_value(
             recovered_persisted_output,
             config,
@@ -1250,6 +1361,20 @@ def protect_message_for_ingest(
         )
         normalized_recovered_content = normalize_content_value(recovered_content)
         if normalized_recovered_content:
+            persisted_output_source_path = _persisted_output_saved_path(raw_normalized_content)
+            persisted_output_preview_sha256 = _persisted_output_preview_prefix_digest(raw_normalized_content)
+            if _has_lossy_sensitive_redaction(normalized_content):
+                persisted_output_preview_sha256 = None
+            persisted_output_metadata = {
+                "persisted_output_source_path": persisted_output_source_path,
+                "persisted_output_expected_chars": _expected_persisted_output_chars(raw_normalized_content),
+                "persisted_output_redacted_preview_sha256": _persisted_output_preview_prefix_digest(normalized_content),
+                "persisted_output_file_size": recovered_file_stat["size"],
+                "persisted_output_file_mtime_ns": recovered_file_stat["mtime_ns"],
+                "persisted_output_file_ctime_ns": recovered_file_stat["ctime_ns"],
+            }
+            if persisted_output_preview_sha256:
+                persisted_output_metadata["persisted_output_preview_sha256"] = persisted_output_preview_sha256
             recovered_externalized = maybe_externalize_payload(
                 normalized_recovered_content,
                 kind="tool_result",
@@ -1259,12 +1384,7 @@ def protect_message_for_ingest(
                 config=config,
                 hermes_home=hermes_home,
                 force=True,
-                metadata={
-                    "persisted_output_source_path": _persisted_output_saved_path(raw_normalized_content),
-                    "persisted_output_expected_chars": _expected_persisted_output_chars(raw_normalized_content),
-                    "persisted_output_preview_sha256": _persisted_output_preview_prefix_digest(raw_normalized_content),
-                    "persisted_output_redacted_preview_sha256": _persisted_output_preview_prefix_digest(normalized_content),
-                },
+                metadata=persisted_output_metadata,
             )
 
     # A host-side truncation marker without durable recovered storage is not
@@ -1293,7 +1413,7 @@ def protect_message_for_ingest(
         ):
             msg["content"] = original_content
         elif preserve_truncation_marker_inline:
-            msg["content"] = _protect_value(
+            protected_content = _protect_value(
                 original_content,
                 role=role,
                 session_id=session_id,
@@ -1302,6 +1422,21 @@ def protect_message_for_ingest(
                 hermes_home=hermes_home,
                 parse_json_strings=False,
             )
+            if (
+                role == "tool"
+                and not bool(getattr(config, "large_output_externalization_enabled", True))
+                and _is_hermes_persisted_output_marker(raw_normalized_content)
+            ):
+                protected_content = _add_inline_persisted_output_identity_metadata(
+                    normalize_content_value(protected_content) or "",
+                    _persisted_output_marker_identity_digest(raw_normalized_content),
+                )
+            if recovered_with_stat is not None and _is_hermes_persisted_output_marker(normalized_content):
+                protected_content = _add_inline_persisted_output_generation_metadata(
+                    normalize_content_value(protected_content) or "",
+                    recovered_file_stat,
+                )
+            msg["content"] = protected_content
         else:
             reason = (
                 assistant_output_quarantine_reason(normalized_content)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4353,8 +4353,16 @@ class TestIngestExternalization:
         assert payload["persisted_output_expected_chars"] == len(full_result)
         preview_sha256 = hashlib.sha256(preview.encode("utf-8")).hexdigest()
         assert payload["persisted_output_preview_sha256"] == preview_sha256
-        from hermes_lcm.ingest_protection import _persisted_output_preview_prefix_digest
-        redacted_preview_sha256 = _persisted_output_preview_prefix_digest(active_messages[1]["content"])
+        assert "persisted_output_content_sha256" not in payload
+        assert payload.get("persisted_output_file_size") == len(full_result.encode("utf-8"))
+        assert isinstance(payload.get("persisted_output_file_mtime_ns"), int)
+        assert isinstance(payload.get("persisted_output_file_ctime_ns"), int)
+        from hermes_lcm.ingest_protection import _persisted_output_preview_prefix
+        redacted_preview_prefix = (_persisted_output_preview_prefix(active_messages[1]["content"]) or "").split(
+            "\n[LCM persisted-output marker identity:",
+            1,
+        )[0]
+        redacted_preview_sha256 = hashlib.sha256(redacted_preview_prefix.encode("utf-8")).hexdigest()
         assert payload["persisted_output_redacted_preview_sha256"] == redacted_preview_sha256
         assert "persisted_output_preview_prefix" not in payload
         assert payload["persisted_output_markers"] == [
@@ -4363,6 +4371,9 @@ class TestIngestExternalization:
                 "expected_chars": len(full_result),
                 "preview_sha256": preview_sha256,
                 "redacted_preview_sha256": redacted_preview_sha256,
+                "file_size": payload["persisted_output_file_size"],
+                "file_mtime_ns": payload["persisted_output_file_mtime_ns"],
+                "file_ctime_ns": payload["persisted_output_file_ctime_ns"],
             }
         ]
         assert "SECRETSECRET" not in payload_file.read_text()
@@ -4384,7 +4395,7 @@ class TestIngestExternalization:
         replay_from_active._session_id = "ingest-session"
         replay_from_active._ingest_cursor_needs_reconcile = True
         replay_from_active._ingest_messages(active_messages)
-        assert replay_from_active._store.get_session_count("ingest-session") == 2
+        assert replay_from_active._store.get_session_count("ingest-session") == 4
 
     def test_replay_matches_legacy_preview_prefix_payload_for_redacted_active_marker(self, tmp_path, monkeypatch):
         import tempfile
@@ -4423,11 +4434,25 @@ class TestIngestExternalization:
         legacy_payload["persisted_output_preview_prefix"] = preview
         legacy_payload.pop("persisted_output_preview_sha256", None)
         legacy_payload.pop("persisted_output_redacted_preview_sha256", None)
+        legacy_payload.pop("persisted_output_content_sha256", None)
         for entry in legacy_payload.get("persisted_output_markers", []):
             entry["preview_prefix"] = preview
             entry.pop("preview_sha256", None)
             entry.pop("redacted_preview_sha256", None)
+            entry.pop("content_sha256", None)
         legacy_payload_file.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+        from dataclasses import replace
+        replay_config = replace(
+            engine._config,
+            sensitive_patterns_enabled=False,
+            sensitive_patterns=[],
+        )
+        replay_live_file = LCMEngine(config=replay_config, hermes_home=str(tmp_path / "hermes"))
+        replay_live_file._session_id = "ingest-session"
+        replay_live_file._ingest_cursor_needs_reconcile = True
+        replay_live_file._ingest_messages(messages)
+        assert replay_live_file._store.get_session_count("ingest-session") == 1
 
         persisted_path.unlink()
         replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
@@ -4435,7 +4460,7 @@ class TestIngestExternalization:
         replay._ingest_cursor_needs_reconcile = True
         replay._ingest_messages(active_messages)
 
-        assert replay._store.get_session_count("ingest-session") == 1
+        assert replay._store.get_session_count("ingest-session") == 2
 
     def test_ingest_reconciles_recovered_persisted_output_marker_after_restart(self, tmp_path, monkeypatch):
         import tempfile
@@ -4470,7 +4495,10 @@ class TestIngestExternalization:
         replay._ingest_cursor_needs_reconcile = True
         replay._ingest_messages(messages)
 
-        assert replay._store.get_session_count("ingest-session") == 2
+        # Once the host temp file is gone, a raw persisted-output marker no longer
+        # proves it is the same tool result; append instead of silently dropping a
+        # possible retry with identical path/preview/length.
+        assert replay._store.get_session_count("ingest-session") == 4
 
     def test_replay_does_not_substitute_literal_persisted_tag_for_retried_tool_call(self, tmp_path, monkeypatch):
         import tempfile
@@ -4573,7 +4601,7 @@ class TestIngestExternalization:
         replay_after_cleanup._session_id = "ingest-session"
         replay_after_cleanup._ingest_cursor_needs_reconcile = True
         replay_after_cleanup._ingest_messages(original_messages + retry_messages)
-        assert replay_after_cleanup._store.get_session_count("ingest-session") == 4
+        assert replay_after_cleanup._store.get_session_count("ingest-session") == 8
 
     def test_replay_reuses_same_content_persisted_output_payload_across_marker_paths(self, tmp_path, monkeypatch):
         import tempfile
@@ -4607,9 +4635,11 @@ class TestIngestExternalization:
         legacy_payload = json.loads(legacy_payload_file.read_text())
         legacy_payload["persisted_output_preview_prefix"] = preview
         legacy_payload.pop("persisted_output_preview_sha256", None)
+        legacy_payload.pop("persisted_output_content_sha256", None)
         for entry in legacy_payload.get("persisted_output_markers", []):
             entry["preview_prefix"] = preview
             entry.pop("preview_sha256", None)
+            entry.pop("content_sha256", None)
         legacy_payload_file.write_text(json.dumps(legacy_payload), encoding="utf-8")
 
         second_path = host_storage / "call_retry_second.txt"
@@ -4643,16 +4673,24 @@ class TestIngestExternalization:
         assert str(second_path) in marker_paths
         expected_preview_sha256 = hashlib.sha256(preview.encode("utf-8")).hexdigest()
         assert all(entry.get("preview_sha256") == expected_preview_sha256 for entry in marker_entries)
+        assert all("content_sha256" not in entry for entry in marker_entries)
         assert all("preview_prefix" not in entry for entry in marker_entries)
         assert payload["persisted_output_preview_sha256"] == expected_preview_sha256
+        assert "persisted_output_content_sha256" not in payload
         assert "persisted_output_preview_prefix" not in payload
+
+        replay_again = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_again._session_id = "ingest-session"
+        replay_again._ingest_cursor_needs_reconcile = True
+        replay_again._ingest_messages(original_messages + retry_messages)
+        assert replay_again._store.get_session_count("ingest-session") == 4
 
         second_path.unlink()
         replay_after_cleanup = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
         replay_after_cleanup._session_id = "ingest-session"
         replay_after_cleanup._ingest_cursor_needs_reconcile = True
         replay_after_cleanup._ingest_messages(original_messages + retry_messages)
-        assert replay_after_cleanup._store.get_session_count("ingest-session") == 4
+        assert replay_after_cleanup._store.get_session_count("ingest-session") == 8
 
     def test_replay_does_not_reuse_durable_payload_for_stale_retry_marker_with_same_preview_but_different_path(self, tmp_path, monkeypatch):
         import tempfile
@@ -4706,6 +4744,661 @@ class TestIngestExternalization:
         assert len(stored) == 4
         assert stored[-1]["content"] == new_marker
 
+    def test_replay_prefers_live_persisted_file_over_stale_durable_payload_with_same_marker_proof(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        import time
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(tmp_path)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        shared_prefix = "SAME_RETRY_PREFIX:" + ("p" * 64)
+        old_result = shared_prefix + ("a" * 1000)
+        new_result = shared_prefix + ("b" * 1000)
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_retry_reused.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 30 chars):\n"
+            f"{old_result[:30]}\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+        legacy_payload_file = next(output_dir.glob("*.json"))
+        legacy_payload = json.loads(legacy_payload_file.read_text())
+        legacy_payload.pop("persisted_output_content_sha256", None)
+        for entry in legacy_payload.get("persisted_output_markers", []):
+            entry.pop("content_sha256", None)
+        legacy_payload_file.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        future_mtime = time.time() + 5
+        os.utime(persisted_path, (future_mtime, future_mtime))
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        stored = replay._store.get_session_messages("ingest-session")
+        assert len(stored) == 4
+        payloads = [json.loads(path.read_text())["content"] for path in output_dir.glob("*.json")]
+        assert old_result in payloads
+        assert new_result in payloads
+
+    def test_replay_distinguishes_stale_retry_that_only_differs_inside_lossy_redaction(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        import time
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(
+            tmp_path,
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["password_assignment"],
+        )
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        shared_prefix = "SAME_RETRY_PREFIX:" + ("p" * 64) + "\n"
+        old_result = shared_prefix + "password = OLDSECRET\nend"
+        new_result = shared_prefix + "password = NEWSECRET\nend"
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_retry_password.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 0.1 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 30 chars):\n"
+            f"{old_result[:30]}\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        future_mtime = time.time() + 5
+        os.utime(persisted_path, (future_mtime, future_mtime))
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+        payload_text = next(output_dir.glob("*.json")).read_text()
+        assert "content_sha256" not in payload_text
+
+        replay_again = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_again._session_id = "ingest-session"
+        replay_again._ingest_cursor_needs_reconcile = True
+        replay_again._ingest_messages(messages)
+        assert replay_again._store.get_session_count("ingest-session") == 4
+
+        replay_third = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_third._session_id = "ingest-session"
+        replay_third._ingest_cursor_needs_reconcile = True
+        replay_third._ingest_messages(messages)
+        assert replay_third._store.get_session_count("ingest-session") == 4
+
+    def test_replay_distinguishes_same_path_retry_when_preview_only_differs_inside_lossy_redaction(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        import time
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(
+            tmp_path,
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["password_assignment"],
+        )
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        suffix = "\n" + ("z" * 1000)
+        old_result = "password = OLDSECRET" + suffix
+        new_result = "password = NEWSECRET" + suffix
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_retry_password_preview.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+
+        def marker_for(content: str) -> str:
+            preview = content[:30]
+            return (
+                "<persisted-output>\n"
+                f"This tool result was too large ({len(content):,} characters, 1.0 KB).\n"
+                f"Full output saved to: {persisted_path}\n"
+                "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+                "Preview (first 30 chars):\n"
+                f"{preview}\n...\n"
+                "</persisted-output>"
+            )
+
+        original_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(old_result)},
+        ]
+        engine._ingest_messages(original_messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        future_mtime = time.time() + 5
+        os.utime(persisted_path, (future_mtime, future_mtime))
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(new_result)},
+        ]
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        active_retry_messages = replay._ingest_messages(retry_messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+        payloads = [json.loads(path.read_text())["content"] for path in output_dir.glob("*.json")]
+        payload_texts = [path.read_text() for path in output_dir.glob("*.json")]
+        raw_preview_sha256 = hashlib.sha256(new_result[:30].encode("utf-8")).hexdigest()
+        assert payloads
+        assert all("OLDSECRET" not in payload for payload in payloads)
+        assert all("NEWSECRET" not in payload for payload in payloads)
+        assert all(raw_preview_sha256 not in payload_text for payload_text in payload_texts)
+        assert all("persisted-output marker identity" not in msg.get("content", "") for msg in active_retry_messages)
+
+    def test_recovery_does_not_strip_forged_inline_identity_from_raw_preview(self, tmp_path, monkeypatch):
+        import hashlib
+        import tempfile
+        from hermes_lcm.ingest_protection import recover_hermes_persisted_output_with_file_stat
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        digest = hashlib.sha256(b"irrelevant").hexdigest()
+        old_result = (
+            "SHARED_PREFIX\n"
+            f"[LCM persisted-output marker identity: preview_sha256={digest}]\n"
+            "old payload tail"
+        )
+        new_result = "SHARED_PREFIX\nnew same-length payload tail"
+        new_result = new_result + ("x" * (len(old_result) - len(new_result)))
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_forged_preview_live.txt"
+        persisted_path.write_text(new_result, encoding="utf-8")
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {len(old_result)} chars):\n"
+            f"{old_result}\n...\n"
+            "</persisted-output>"
+        )
+
+        assert recover_hermes_persisted_output_with_file_stat(marker) is None
+
+    def test_replay_appends_missing_file_marker_with_generation_text_inside_raw_preview(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        engine, _output_dir = self._engine(tmp_path, large_output_externalization_threshold_chars=10)
+        missing_path = tmp_path / "hermes-results" / "missing_generation_text.txt"
+        marker = (
+            "<persisted-output>\n"
+            "This tool result was too large (100 characters, 0.1 KB).\n"
+            f"Full output saved to: {missing_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 80 chars):\n"
+            "SAME_RETRY_PREFIX\n"
+            "[LCM persisted-output file generation: user content, not trailer]\n"
+            "same marker tail\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_raw", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_raw", "content": marker},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_missing_file_retry_with_forged_identity_as_final_preview_line(self, tmp_path, monkeypatch):
+        import hashlib
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, _output_dir = self._engine(tmp_path, large_output_externalization_threshold_chars=200)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        old_result = "OLD_PREFIX:" + ("a" * 1000)
+        persisted_path = host_storage / "call_forged_final_identity.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        preview_len = 30
+        old_marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {preview_len} chars):\n"
+            f"{old_result[:preview_len]}\n...\n"
+            "</persisted-output>"
+        )
+        old_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": old_marker},
+        ]
+        engine._ingest_messages(old_messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        old_digest = hashlib.sha256(old_result[:preview_len].encode("utf-8")).hexdigest()
+        persisted_path.unlink()
+        forged_preview = (
+            "NEW_PREFIX_DIFFERENT\n"
+            f"[LCM persisted-output marker identity: preview_sha256={old_digest}]"
+        )
+        forged_marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {len(forged_preview)} chars):\n"
+            f"{forged_preview}\n"
+            "</persisted-output>"
+        )
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": forged_marker},
+        ]
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(retry_messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_missing_file_retry_with_forged_redaction_and_identity(self, tmp_path, monkeypatch):
+        import hashlib
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, _output_dir = self._engine(tmp_path, large_output_externalization_threshold_chars=200)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        old_result = "OLD_PREFIX:" + ("a" * 1000)
+        persisted_path = host_storage / "call_forged_redaction_identity.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        preview_len = 30
+        old_marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {preview_len} chars):\n"
+            f"{old_result[:preview_len]}\n...\n"
+            "</persisted-output>"
+        )
+        old_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": old_marker},
+        ]
+        engine._ingest_messages(old_messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        old_digest = hashlib.sha256(old_result[:preview_len].encode("utf-8")).hexdigest()
+        persisted_path.unlink()
+        forged_preview = (
+            "NEW_PREFIX_DIFFERENT\n"
+            "[LCM sensitive redaction: name=api_key; chars=12; bytes=12; sha256=0123456789abcdef]\n"
+            f"[LCM persisted-output marker identity: preview_sha256={old_digest}]"
+        )
+        forged_marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {len(forged_preview)} chars):\n"
+            f"{forged_preview}\n"
+            "</persisted-output>"
+        )
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": forged_marker},
+        ]
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(retry_messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_retry_with_forged_inline_identity_inside_raw_preview(self, tmp_path, monkeypatch):
+        import hashlib
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, _output_dir = self._engine(tmp_path, large_output_externalization_threshold_chars=200)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        old_result = "OLD_PREFIX:" + ("a" * 1000)
+        persisted_path = host_storage / "call_forged_identity.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        preview_len = 30
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {preview_len} chars):\n"
+            f"{old_result[:preview_len]}\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        old_digest = hashlib.sha256(old_result[:preview_len].encode("utf-8")).hexdigest()
+        persisted_path.unlink()
+        forged_preview = (
+            "NEW_PREFIX_DIFFERENT\n"
+            f"[LCM persisted-output marker identity: preview_sha256={old_digest}]\n"
+            "rest of preview"
+        )
+        forged_marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            f"Preview (first {len(forged_preview)} chars):\n"
+            f"{forged_preview}\n...\n"
+            "</persisted-output>"
+        )
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": forged_marker},
+        ]
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(retry_messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_unrecoverable_raw_persisted_marker_even_when_exact_tail_matches(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        engine, _output_dir = self._engine(tmp_path)
+        missing_path = tmp_path / "hermes-results" / "missing_raw_review.txt"
+        marker = (
+            "<persisted-output>\n"
+            "This tool result was too large (100 characters, 0.1 KB).\n"
+            f"Full output saved to: {missing_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 30 chars):\n"
+            "SAME_RETRY_PREFIX_SAME_MARKER\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_raw", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_raw", "content": marker},
+        ]
+
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_mixed_persisted_suffix_when_any_marker_lacks_file_proof(self, tmp_path, monkeypatch):
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, _output_dir = self._engine(tmp_path, large_output_externalization_threshold_chars=10)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        live_content = "LIVE_PROOF_PREFIX:" + ("a" * 1000)
+        missing_content = "MISSING_RAW_PREFIX:" + ("b" * 1000)
+        live_path = host_storage / "live.txt"
+        missing_path = host_storage / "missing.txt"
+        live_path.write_text(live_content, encoding="utf-8")
+
+        def marker(path: Path, content: str) -> str:
+            return (
+                "<persisted-output>\n"
+                f"This tool result was too large ({len(content):,} characters, 1.0 KB).\n"
+                f"Full output saved to: {path}\n"
+                "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+                "Preview (first 30 chars):\n"
+                f"{content[:30]}\n...\n"
+                "</persisted-output>"
+            )
+
+        messages = [
+            {"role": "tool", "tool_call_id": "call_live", "content": marker(live_path, live_content)},
+            {"role": "tool", "tool_call_id": "call_missing", "content": marker(missing_path, missing_content)},
+        ]
+
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+
+    def test_replay_appends_stale_lossy_persisted_retry_when_redaction_config_disabled(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        import time
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(
+            tmp_path,
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["password_assignment"],
+        )
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        shared_prefix = "SAME_RETRY_PREFIX:" + ("p" * 64) + "\n"
+        old_result = shared_prefix + "password = OLDSECRET\nend"
+        new_result = shared_prefix + "password = NEWSECRET\nend"
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_config_drift_password.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 0.1 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 30 chars):\n"
+            f"{old_result[:30]}\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker},
+        ]
+
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        future_mtime = time.time() + 5
+        os.utime(persisted_path, (future_mtime, future_mtime))
+        cfg = engine._config
+        drift_config = LCMConfig(
+            database_path=cfg.database_path,
+            large_output_externalization_enabled=cfg.large_output_externalization_enabled,
+            large_output_externalization_threshold_chars=cfg.large_output_externalization_threshold_chars,
+            large_output_externalization_path=cfg.large_output_externalization_path,
+            sensitive_patterns_enabled=False,
+            sensitive_patterns=[],
+        )
+        replay = LCMEngine(config=drift_config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+        payloads = [json.loads(path.read_text())["content"] for path in output_dir.glob("*.json")]
+        assert any("OLDSECRET" not in payload and "NEWSECRET" not in payload for payload in payloads)
+        assert any(payload == new_result for payload in payloads)
+
+    def test_replay_appends_same_path_same_preview_retry_when_live_file_missing(self, tmp_path, monkeypatch):
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(tmp_path)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        shared_prefix = "SAME_RETRY_PREFIX:" + ("p" * 64)
+        old_result = shared_prefix + ("a" * 1000)
+        new_result = shared_prefix + ("b" * 1000)
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_retry_missing_live.txt"
+
+        def marker_for(content: str) -> str:
+            return (
+                "<persisted-output>\n"
+                f"This tool result was too large ({len(content):,} characters, 1.0 KB).\n"
+                f"Full output saved to: {persisted_path}\n"
+                "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+                "Preview (first 30 chars):\n"
+                f"{content[:30]}\n...\n"
+                "</persisted-output>"
+            )
+
+        persisted_path.write_text(old_result, encoding="utf-8")
+        old_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(old_result)},
+        ]
+        engine._ingest_messages(old_messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        persisted_path.unlink()
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(new_result)},
+        ]
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(retry_messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+        assert output_dir.exists()
+
+    def test_legacy_lossy_preview_prefix_sanitization_does_not_create_raw_preview_digest(self):
+        from hermes_lcm.externalize import _sanitize_persisted_output_marker_metadata
+
+        existing_raw_preview_sha256 = hashlib.sha256(b"password = OLDSECRET\nend").hexdigest()
+        payload = {
+            "kind": "tool_result",
+            "tool_call_id": "call_retry",
+            "role": "tool",
+            "session_id": "ingest-session",
+            "content": "password = [LCM sensitive redaction: name=password_assignment; chars=9; bytes=9]\nend",
+            "persisted_output_source_path": "/tmp/hermes-results/call.txt",
+            "persisted_output_expected_chars": 128,
+            "persisted_output_preview_sha256": existing_raw_preview_sha256,
+            "persisted_output_preview_prefix": "password = OLDSECRET\nend",
+            "persisted_output_markers": [
+                {
+                    "source_path": "/tmp/hermes-results/call.txt",
+                    "expected_chars": 128,
+                    "preview_sha256": existing_raw_preview_sha256,
+                    "preview_prefix": "password = OLDSECRET\nend",
+                }
+            ],
+        }
+
+        assert _sanitize_persisted_output_marker_metadata(payload) is True
+        payload_text = json.dumps(payload, sort_keys=True)
+        assert "preview_prefix" not in payload_text
+        assert "OLDSECRET" not in payload_text
+        assert "preview_sha256" not in payload_text
+        assert "persisted_output_preview_sha256" not in payload
+
+    def test_replay_distinguishes_same_path_retry_with_backdated_mtime(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(tmp_path)
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        shared_prefix = "SAME_RETRY_PREFIX:" + ("p" * 64)
+        old_result = shared_prefix + ("a" * 1000)
+        new_result = shared_prefix + ("b" * 1000)
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_retry_backdated.txt"
+        persisted_path.write_text(old_result, encoding="utf-8")
+        old_stat = persisted_path.stat()
+        marker = (
+            "<persisted-output>\n"
+            f"This tool result was too large ({len(old_result):,} characters, 1.0 KB).\n"
+            f"Full output saved to: {persisted_path}\n"
+            "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+            "Preview (first 30 chars):\n"
+            f"{old_result[:30]}\n...\n"
+            "</persisted-output>"
+        )
+        messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        os.utime(persisted_path, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns))
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "ingest-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(messages)
+
+        assert replay._store.get_session_count("ingest-session") == 4
+        payloads = [json.loads(path.read_text())["content"] for path in output_dir.glob("*.json")]
+        assert old_result in payloads
+        assert new_result in payloads
+
     def test_ingest_preserves_recoverable_marker_when_externalization_disabled(self, tmp_path, monkeypatch):
         import tempfile
         from hermes_lcm.engine import LCMEngine
@@ -4733,7 +5426,9 @@ class TestIngestExternalization:
 
         engine._ingest_messages(messages)
         stored = engine._store.get_session_messages("ingest-session")
-        assert stored[0]["content"] == marker
+        assert stored[0]["content"].startswith(marker.removesuffix("</persisted-output>"))
+        assert "[LCM persisted-output file generation:" in stored[0]["content"]
+        assert stored[0]["content"].endswith("</persisted-output>")
         assert not output_dir.exists()
 
         replay_with_file = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
@@ -4741,7 +5436,16 @@ class TestIngestExternalization:
         replay_with_file._ingest_cursor_needs_reconcile = True
         replay_with_file._ingest_messages(messages)
 
-        assert replay_with_file._store.get_session_count("ingest-session") == 1
+        assert replay_with_file._store.get_session_count("ingest-session") == 2
+
+        from dataclasses import replace
+        enabled_config = replace(engine._config, large_output_externalization_enabled=True)
+        replay_enabled_with_file = LCMEngine(config=enabled_config, hermes_home=str(tmp_path / "hermes"))
+        replay_enabled_with_file._session_id = "ingest-session"
+        replay_enabled_with_file._ingest_cursor_needs_reconcile = True
+        replay_enabled_with_file._ingest_messages(messages)
+
+        assert replay_enabled_with_file._store.get_session_count("ingest-session") == 3
 
         persisted_path.unlink()
         replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
@@ -4749,7 +5453,7 @@ class TestIngestExternalization:
         replay._ingest_cursor_needs_reconcile = True
         replay._ingest_messages(messages)
 
-        assert replay._store.get_session_count("ingest-session") == 1
+        assert replay._store.get_session_count("ingest-session") == 4
 
     def test_replay_reconciles_redacted_inline_persisted_marker_when_externalization_disabled(self, tmp_path, monkeypatch):
         import tempfile
@@ -4785,13 +5489,80 @@ class TestIngestExternalization:
         assert "[LCM sensitive redaction:" in stored[0]["content"]
         assert not output_dir.exists()
 
+        replay_with_file = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_with_file._session_id = "ingest-session"
+        replay_with_file._ingest_cursor_needs_reconcile = True
+        replay_with_file._ingest_messages(messages)
+        assert replay_with_file._store.get_session_count("ingest-session") == 2
+
         persisted_path.unlink()
         replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
         replay._session_id = "ingest-session"
         replay._ingest_cursor_needs_reconcile = True
         replay._ingest_messages(messages)
 
-        assert replay._store.get_session_count("ingest-session") == 1
+        assert replay._store.get_session_count("ingest-session") == 3
+
+    def test_replay_appends_externalization_disabled_retry_that_only_differs_inside_lossy_redaction(self, tmp_path, monkeypatch):
+        import os
+        import tempfile
+        import time
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        engine, output_dir = self._engine(
+            tmp_path,
+            large_output_externalization_enabled=False,
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["password_assignment"],
+        )
+        host_storage = tmp_path / "hermes-results"
+        host_storage.mkdir()
+        suffix = "\n" + ("z" * 1000)
+        old_result = "password = OLDSECRET" + suffix
+        new_result = "password = NEWSECRET" + suffix
+        assert len(new_result) == len(old_result)
+        persisted_path = host_storage / "call_disabled_password_retry.txt"
+
+        def marker_for(content: str) -> str:
+            preview = content[:30]
+            return (
+                "<persisted-output>\n"
+                f"This tool result was too large ({len(content):,} characters, 1.0 KB).\n"
+                f"Full output saved to: {persisted_path}\n"
+                "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
+                "Preview (first 30 chars):\n"
+                f"{preview}\n...\n"
+                "</persisted-output>"
+            )
+
+        persisted_path.write_text(old_result, encoding="utf-8")
+        original_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(old_result)},
+        ]
+        engine._ingest_messages(original_messages)
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        replay_same = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_same._session_id = "ingest-session"
+        replay_same._ingest_cursor_needs_reconcile = True
+        replay_same._ingest_messages(original_messages)
+        assert replay_same._store.get_session_count("ingest-session") == 4
+
+        persisted_path.write_text(new_result, encoding="utf-8")
+        future_mtime = time.time() + 5
+        os.utime(persisted_path, (future_mtime, future_mtime))
+        retry_messages = [
+            {"role": "assistant", "content": "Calling", "tool_calls": [{"id": "call_retry", "function": {"name": "dump", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_retry", "content": marker_for(new_result)},
+        ]
+        replay_retry = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay_retry._session_id = "ingest-session"
+        replay_retry._ingest_cursor_needs_reconcile = True
+        replay_retry._ingest_messages(retry_messages)
+        assert replay_retry._store.get_session_count("ingest-session") == 6
+        assert not output_dir.exists()
 
     def test_ingest_recovers_persisted_output_with_crlf_newlines(self, tmp_path, monkeypatch):
         import tempfile


### PR DESCRIPTION
## Summary
- Adds strict persisted-output replay identity for Hermes tool-output markers.
- Requires live-file/stat-backed proof before a recovered persisted-output marker can satisfy durable replay identity.
- Treats missing or unrecoverable raw persisted-output markers as append-worthy instead of replay-proof, even when path/preview/length or inline-looking metadata matches.
- Preserves safe file-generation metadata for recovered persisted-output payloads while avoiding raw content hashes and lossy preview digest leaks.
- Expands regression coverage for forged inline metadata, stale durable payloads, externalization-disabled fallback, legacy preview-prefix handling, and lossy redaction retries.

## Why
- Persisted-output markers are only trustworthy while the backing Hermes temp file can be safely recovered and matched.
- Inline marker text is untrusted preview content; treating it as proof after the file is gone can silently drop legitimate retried tool results.
- The safer replay contract is: dedupe only with real proof, otherwise append rather than lose data.

## Validation
- `python -m pytest tests/test_lcm_core.py::TestIngestExternalization -q -o addopts=` → `49 passed`
- `python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` → `927 passed`
- `python -m pytest -q -o addopts=` → `1400 passed, 12 xfailed`
- `python -m compileall -q engine.py externalize.py ingest_protection.py tests/test_lcm_core.py && git diff --check origin/main...HEAD && git diff --check` → clean
- Static scan of `engine.py`, `externalize.py`, and `ingest_protection.py` for `persisted_output_content_sha256` / `content_sha256` → `STATIC_SCAN_CLEAN`
- Local Codex CLI review with `model_reasoning_effort="xhigh"` on the final branch diff → `No blockers found.`

## Risk / impact
- Replay behavior is intentionally stricter for persisted-output markers whose backing file is missing or unrecoverable: these markers append instead of deduping, to avoid silent data loss.
- This can create duplicates in ambiguous replay cases, but only where the branch cannot prove identity safely.
- Recovered persisted-output payload metadata now carries file generation fields (`size`, `mtime_ns`, `ctime_ns`) for non-content identity checks.
- No schema migration or config change is required.
- The implementation avoids raw full-content hashes and avoids preview-derived digests for lossy redaction cases.

## Scope boundaries
- Does not change Hermes host-side tool result persistence.
- Does not introduce provenance-signed inline trailers; inline marker text remains untrusted.
- Does not try to dedupe missing-file persisted-output markers without live-file proof.
- Does not change unrelated compaction, summarization, or tool APIs.

## Screenshots / before-after
- Not applicable (non-UI change).

## Rollout / operator notes
- No migration steps required.
- Existing externalized payloads remain compatible.
- Legacy preview-prefix metadata is still handled where safe, but lossy redaction cases avoid deriving replay identity from raw legacy preview text.
- Operators should expect safer append behavior for ambiguous missing-file persisted-output replays.

## Reviewer focus
- Please focus on the replay gates around persisted-output markers in `engine.py`.
- Check that missing/unrecoverable temp files cannot become replay-proof through forged inline marker identity/generation text.
- Check that live-file proof, file-generation metadata, redaction handling, and legacy preview-prefix compatibility stay aligned across `ingest_protection.py`, `externalize.py`, and the regression tests.
