### PR TITLE
Add a ruff lint configuration and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,22 @@ jobs:
         run: |
           "$(go env GOPATH)"/bin/actionlint
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install ruff==0.15.13
+
+      - name: Lint with ruff
+        run: ruff check .
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/config.py
+++ b/config.py
@@ -397,7 +397,8 @@ class LCMConfig:
         c = cls()
         _int = _parse_int_env
         _float = _parse_float_env
-        _str = lambda key, default: os.environ.get(key, default)
+        def _str(key, default):
+            return os.environ.get(key, default)
         config_sources: dict[str, str] = {}
         config_source_warnings: list[str] = []
 

--- a/engine.py
+++ b/engine.py
@@ -54,7 +54,6 @@ from .ingest_protection import (
     _expected_persisted_output_chars,
     _has_inline_persisted_output_generation_metadata,
     _has_lossy_sensitive_redaction,
-    _inline_persisted_output_generation_metadata,
     _is_hermes_persisted_output_marker,
     _json_has_duplicate_object_keys,
     _persisted_output_inline_preview_sha256,
@@ -67,7 +66,6 @@ from .ingest_protection import (
     protect_inline_payloads_in_text,
     protect_messages_for_ingest,
     quarantine_suspicious_assistant_messages,
-    recover_hermes_persisted_output,
     recover_hermes_persisted_output_with_file_stat,
     redact_sensitive_text,
     redact_sensitive_value,
@@ -7061,7 +7059,6 @@ class LCMEngine(ContextEngine):
         for message in messages:
             redacted_message = dict(message)
             if "content" in redacted_message:
-                original_content = normalize_content_value(redacted_message.get("content")) or ""
                 redacted_content = redact_sensitive_value(
                     redacted_message.get("content"),
                     self._config,

--- a/presets.py
+++ b/presets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field as dataclass_field
 import os
 from typing import Any, Mapping
 
@@ -21,9 +21,9 @@ class LCMPreset:
     policy_path: str
     policy_version: str
     runtime_env: Mapping[str, Any]
-    unsupported_runtime_fields: Mapping[str, Any] = field(default_factory=dict)
+    unsupported_runtime_fields: Mapping[str, Any] = dataclass_field(default_factory=dict)
     applies_to: tuple[str, ...] = ()
-    provenance: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = dataclass_field(default_factory=dict)
     notes: str = ""
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+# Tooling configuration for the hermes-lcm plugin.
+#
+# This file exists only to pin lint settings so `ruff` behaves identically
+# locally and in CI. It intentionally declares no [build-system] or project
+# metadata: the plugin is installed via scripts/install.sh, not pip.
+
+[tool.ruff]
+# Match the oldest runtime CI exercises; keeps lint aligned with the 3.11 leg.
+target-version = "py311"
+
+[tool.ruff.lint]
+# Ruff's default rule set: pyflakes (F) plus a focused pycodestyle subset
+# (E4/E7/E9). We deliberately do not enable line-length (E501) or import
+# sorting (I) -- the codebase predates both and enforcing either would be a
+# large, purely cosmetic reformat with no behavioural benefit.
+select = ["E4", "E7", "E9", "F"]
+ignore = [
+    # module-import-not-at-top-of-file: several modules import after a
+    # sys.path / optional-dependency bootstrap, so imports legitimately
+    # follow executable statements.
+    "E402",
+]

--- a/store.py
+++ b/store.py
@@ -11,7 +11,6 @@ row identity (`store_id`) for DAG/source lookup.
 
 import json
 import logging
-import os
 import sqlite3
 import threading
 import time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ Patches the plugin modules so they can be imported both as a package
 (relative imports during plugin loading) and directly during testing.
 """
 import sys
-import types
 import importlib
 from pathlib import Path
 

--- a/tests/test_crash_safe_wal.py
+++ b/tests/test_crash_safe_wal.py
@@ -11,9 +11,7 @@ still depends on SQLite WAL recovery.
 
 from __future__ import annotations
 
-import os
 import sqlite3
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -2262,7 +2262,7 @@ class TestMessageStore:
         assert [result["store_id"] for result in results] == [direct_id]
 
     def test_search_recency_same_timestamp_pool_is_limit_stable(self, store):
-        ids = store.append_batch(
+        store.append_batch(
             "sess1",
             [
                 {

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -15468,7 +15468,7 @@ class TestSessionRollover:
             token_estimate=17,
             source="telegram",
         )
-        stale_host_store_id = engine._store.append(
+        engine._store.append(
             "old-hermes-session",
             {"role": "user", "content": "stale host context must stay"},
             token_estimate=11,
@@ -15595,7 +15595,7 @@ class TestSessionRollover:
             token_estimate=17,
             source="telegram",
         )
-        source_node_id = engine._dag.add_node(SummaryNode(
+        engine._dag.add_node(SummaryNode(
             session_id="lcm-source",
             depth=0,
             summary="parent mismatch summary",
@@ -15655,7 +15655,7 @@ class TestSessionRollover:
             token_estimate=11,
             source="telegram",
         )
-        source_node_id = engine._dag.add_node(SummaryNode(
+        engine._dag.add_node(SummaryNode(
             session_id="lcm-source",
             depth=0,
             summary="bound summary",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -16652,7 +16652,7 @@ class TestSessionRollover:
         engine.on_session_end("background-review-continuation", [])
         assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
 
-        next_child = self._start_host_child(
+        self._start_host_child(
             engine,
             hermes_home,
             "background-review-session-2",
@@ -16968,7 +16968,7 @@ class TestSessionRollover:
             "background-review-continuation",
             context_length=1_000,
         )
-        real_continuation = self.HostAgentFrame(
+        self.HostAgentFrame(
             "background-review-continuation",
             "background-review-session",
             hermes_home,

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -479,8 +479,6 @@ def test_git_runtime_identity_reports_untracked_files_as_dirty(tmp_path, monkeyp
     (checkout / ".git").mkdir(parents=True)
     (checkout / "untracked.txt").write_text("hi", encoding="utf-8")
 
-    called = []
-
     def fake_git(*args, **kwargs):
         cmd = args[0]
         if cmd[-2:] == ["status", "--porcelain"]:
@@ -509,7 +507,6 @@ def test_plugin_entrypoint_registration_is_repeatable_and_returns_lcm_engine():
 
 def test_register_gracefully_degrades_when_legacy_host_lacks_register_tool():
     """Guard regression: register() must not raise when ctx lacks register_tool."""
-    repo_root = Path(__file__).resolve().parent.parent
     module = _load_plugin_entrypoint_module("hermes_lcm_no_register_tool")
 
     class _CtxNoTool:
@@ -555,7 +552,6 @@ def test_registered_tool_handler_forwards_messages_to_engine_handle_tool_call(mo
     register_tool signatures will NOT have tools registered — they rely on
     the native context-engine path instead.
     """
-    repo_root = Path(__file__).resolve().parent.parent
     module = _load_plugin_entrypoint_module("hermes_lcm_handler_forward")
 
     registered = {}  # tool_name -> handler


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` pinning an explicit ruff rule set (default pyflakes `F` + pycodestyle `E4`/`E7`/`E9`; `E501` line-length and `I` import-sorting deliberately **off**; `E402` ignored for the intentional post-bootstrap imports).
- Add a `lint` job to `.github/workflows/ci.yml` that runs `ruff check .` on `ruff==0.15.13`, with the same pinned action SHAs as the existing jobs.
- Apply the behaviour-neutral cleanups the gate flagged so the tree passes:
  - `config.py`: assigned `lambda` -> nested `def` (E731).
  - `presets.py`: alias the `dataclasses.field` import so loop variables no longer shadow it (F402).
  - `store.py`, tests: drop unused imports (F401) and unused local assignments while keeping the side-effecting calls (F841).

## Why
- There is currently no lint gate, so style/dead-code regressions land silently. This adds one that behaves **identically locally and in CI**.
- The config is declared in-repo on purpose: without it, `ruff` picks up whatever machine-level config a contributor happens to have, so local results diverge from CI. Pinning it makes the gate reproducible.
- The rule set is intentionally minimal/additive: no reformatting, no import churn, no line-length enforcement. Only genuine dead code / shadowing was touched, all behaviour-preserving.

## Validation
- [x] Focused validation: `ruff check .` -> `All checks passed!`
- [x] Default validation:
  - [x] `PYTHONPATH="<stub>:." python3 -m pytest tests -q` -> `1385 passed, 12 xfailed, 22 warnings`
  - [x] `python3 -m compileall -q .`
  - [x] `python3 -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD` -> clean
- [x] Workflow validation: `.github/workflows/ci.yml` changed; the new `lint` job mirrors the existing jobs' pinned action SHAs. actionlint not run locally (not installed); the repo's `workflow-lint` job covers it.
- [x] Added-line private/secret hygiene scan -> `0` hits.

## Notes
- Validation used a minimal local `agent.context_engine` stub because this plugin repository is tested standalone outside the Hermes host package (same stub the existing CI `test` job creates).
- `pyproject.toml` intentionally declares no `[build-system]` or project metadata; it is a tooling-only file (the plugin installs via `scripts/install.sh`, not pip).
- Measured findings before the fixes: 34 total under the selected rules = 20 E402 (ignored by config) + 4 F401 + 7 F841 + 2 F402 + 1 E731.