### PR TITLE
Harden JSONL import follow-up edge cases

### DIFF
--- a/scripts/import_lossless_claw.py
+++ b/scripts/import_lossless_claw.py
@@ -47,6 +47,8 @@ from hermes_lcm.tokens import count_message_tokens  # noqa: E402
 
 VALID_SESSION_IDENTITIES = frozenset({"session_id", "session_key"})
 JSONL_OPENCLAW_TOOL_CALL_TYPES = frozenset({"toolCall", "tool_call", "toolUse", "tool_use"})
+JSONL_OPENCLAW_TOOL_RESULT_TYPES = frozenset({"toolResult", "tool_result"})
+JSONL_OPENCLAW_TOOL_ROW_TYPES = JSONL_OPENCLAW_TOOL_CALL_TYPES | JSONL_OPENCLAW_TOOL_RESULT_TYPES
 JSONL_RESPONSES_FUNCTION_CALL_TYPES = frozenset({"function_call"})
 JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES = frozenset({"function_call_output"})
 JSONL_RESPONSES_NATIVE_TYPES = JSONL_RESPONSES_FUNCTION_CALL_TYPES | JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES
@@ -68,6 +70,7 @@ class ImportCandidate:
     tool_name: str | None
     timestamp: float
     token_estimate: int
+    existing_source_key_aliases: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -75,6 +78,7 @@ class JsonlPendingFunctionCall:
     line_no: int
     row: dict[str, Any]
     row_id: str | None
+    parent_id: str | None
     timestamp_value: Any
     source_session: str
     tool_call: dict[str, Any]
@@ -393,7 +397,15 @@ def _message_from_parts(role: str, content: str, parts: list[sqlite3.Row]) -> tu
             "call_id",
             "id",
         )
-        candidate_tool_name = _part_value(part, "tool_name", "name", "toolName", "tool_name")
+        candidate_tool_name = _part_value(
+            part,
+            "tool_name",
+            "name",
+            "toolName",
+            "tool_name",
+            "tool_use_name",
+            "toolUseName",
+        )
 
         if role == "assistant":
             if candidate_tool_call_id or candidate_tool_name:
@@ -974,6 +986,12 @@ def _existing_source_message_keys(target_db: Path, import_id: str) -> set[str]:
         conn.close()
 
 
+def _candidate_matches_existing_source_key(candidate: ImportCandidate, existing_keys: set[str]) -> bool:
+    return candidate.source_message_key in existing_keys or any(
+        alias in existing_keys for alias in candidate.existing_source_key_aliases
+    )
+
+
 def _backup_target(target_db: Path) -> str | None:
     if not target_db.exists():
         return None
@@ -1078,7 +1096,7 @@ def _process_import_candidates(
     warnings = list(warnings or [])
     existing_keys = _existing_source_message_keys(target_path, import_id)
     to_import = [
-        candidate for candidate in candidates if candidate.source_message_key not in existing_keys
+        candidate for candidate in candidates if not _candidate_matches_existing_source_key(candidate, existing_keys)
     ]
     skipped_existing = len(candidates) - len(to_import)
 
@@ -1293,6 +1311,129 @@ def _jsonl_has_malformed_type(row: dict[str, Any]) -> bool:
     return row.get("type") is not None and _jsonl_row_type(row) is None
 
 
+def _jsonl_has_present_field(row: dict[str, Any], *keys: str) -> bool:
+    return any(key in row and row.get(key) is not None for key in keys)
+
+
+def _jsonl_present_message_field(message: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in message and message.get(key) is not None:
+            return message.get(key)
+    return None
+
+
+def _jsonl_bare_tool_role_allows(row: dict[str, Any], *roles: str) -> bool:
+    role = row.get("role")
+    return role in (None, "") or str(role) in roles
+
+
+def _jsonl_bare_tool_call_row_type(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) is not None or isinstance(row.get("message"), dict):
+        return None
+    if not _jsonl_bare_tool_role_allows(row, "assistant"):
+        return None
+
+    responses_call_id = _jsonl_message_field(row, "call_id", "callId")
+    if (
+        responses_call_id is not None
+        and _jsonl_message_field(row, "name") is not None
+        and _jsonl_has_present_field(row, "arguments", "input", "parameters")
+    ):
+        return "function_call"
+
+    openclaw_call_id = _jsonl_message_field(
+        row,
+        "tool_call_id",
+        "toolCallId",
+        "tool_use_id",
+        "toolUseId",
+    )
+    if (
+        openclaw_call_id is not None
+        and _jsonl_message_field(row, "tool_name", "toolName", "tool_use_name", "toolUseName", "name") is not None
+        and _jsonl_has_present_field(
+            row,
+            "tool_input",
+            "toolInput",
+            "tool_use_input",
+            "toolUseInput",
+            "input",
+            "parameters",
+        )
+    ):
+        if _jsonl_has_present_field(row, "tool_call_id", "toolCallId", "tool_input", "toolInput"):
+            return "toolCall"
+        return "toolUse"
+
+    return None
+
+
+def _jsonl_bare_tool_result_row_type(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) is not None or isinstance(row.get("message"), dict):
+        return None
+    if not _jsonl_bare_tool_role_allows(row, "tool", "toolResult", "tool_result"):
+        return None
+
+    if (
+        _jsonl_message_field(row, "call_id", "callId") is not None
+        and _jsonl_has_present_field(row, "content", "output", "result", "tool_output", "toolOutput")
+    ):
+        return "function_call_output"
+
+    if (
+        _jsonl_message_field(row, "tool_call_id", "toolCallId", "tool_use_id", "toolUseId") is not None
+        and _jsonl_has_present_field(row, "content", "tool_output", "toolOutput", "output", "result")
+        and not _jsonl_has_present_field(row, "tool_input", "toolInput", "tool_use_input", "toolUseInput")
+    ):
+        return "toolResult"
+
+    return None
+
+
+def _jsonl_bare_tool_row_type(row: dict[str, Any]) -> str | None:
+    return _jsonl_bare_tool_call_row_type(row) or _jsonl_bare_tool_result_row_type(row)
+
+
+def _jsonl_effective_row_type(row: dict[str, Any], message: dict[str, Any] | None = None) -> str | None:
+    row_type = _jsonl_row_type(row)
+    if row_type in {"message", "custom_message"} or (
+        row_type is None and isinstance(row.get("message"), dict)
+    ):
+        row_message = message if message is not None else _jsonl_row_message(row)
+        nested_type = _jsonl_string_type(row_message.get("type"))
+        if nested_type in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES:
+            return nested_type
+    if row_type is None:
+        return _jsonl_bare_tool_row_type(row)
+    return row_type
+
+
+def _jsonl_has_malformed_nested_message_type(row: dict[str, Any], message: dict[str, Any]) -> bool:
+    row_type = _jsonl_row_type(row)
+    if row_type not in {None, "message", "custom_message"}:
+        return False
+    if row_type is None and not isinstance(row.get("message"), dict):
+        return False
+    return message.get("type") is not None and _jsonl_string_type(message.get("type")) is None
+
+
+def _jsonl_wrapped_metadata_message(row: dict[str, Any], message: dict[str, Any]) -> bool:
+    row_type = _jsonl_row_type(row)
+    if row_type not in {None, "message", "custom_message"}:
+        return False
+    if not isinstance(row.get("message"), dict):
+        return False
+    nested_type = _jsonl_string_type(message.get("type"))
+    if nested_type in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES:
+        return False
+    if _jsonl_malformed_tool_call_array_types(message) or _jsonl_tool_calls(message):
+        return False
+    nested_content = _jsonl_message_field(message, "content")
+    if _jsonl_message_field(message, "role") is not None and normalize_content_value(nested_content):
+        return False
+    return nested_type is not None or not normalize_content_value(nested_content)
+
+
 def _jsonl_tool_call_shaped_content_item(item: dict[str, Any]) -> bool:
     has_tool_specific_field = (
         _jsonl_message_field(
@@ -1330,21 +1471,39 @@ def _jsonl_content_item_has_malformed_tool_call_type(item: dict[str, Any]) -> bo
     )
 
 
-def _jsonl_openai_tool_call(value: dict[str, Any]) -> dict[str, Any] | None:
+def _jsonl_tool_call_array_item_has_malformed_type(item: dict[str, Any]) -> bool:
+    if item.get("type") is not None and _jsonl_string_type(item.get("type")) is None:
+        return True
+    nested = item.get("toolCall")
+    return (
+        isinstance(nested, dict)
+        and nested.get("type") is not None
+        and _jsonl_string_type(nested.get("type")) is None
+    )
+
+
+def _jsonl_openai_tool_call(
+    value: dict[str, Any],
+    *,
+    allow_id_fallback: bool = False,
+) -> dict[str, Any] | None:
     nested = value.get("toolCall")
     raw = nested if isinstance(nested, dict) else value
-    raw_type = _jsonl_string_type(raw.get("type"))
-    call_id = _jsonl_message_field(
-        raw,
+    raw_type = _jsonl_string_type(raw.get("type")) or _jsonl_bare_tool_call_row_type(raw)
+    function_value = raw.get("function")
+    call_id_keys = [
         "call_id",
         "callId",
         "tool_call_id",
         "toolCallId",
         "tool_use_id",
         "toolUseId",
-        "id",
-    )
-    function_value = raw.get("function")
+    ]
+    if raw_type not in JSONL_OPENCLAW_TOOL_CALL_TYPES and (
+        allow_id_fallback or raw_type not in JSONL_RESPONSES_FUNCTION_CALL_TYPES
+    ):
+        call_id_keys.append("id")
+    call_id = _jsonl_message_field(raw, *call_id_keys)
     if isinstance(function_value, dict):
         name = _jsonl_message_field(function_value, "name") or _jsonl_message_field(
             raw,
@@ -1354,12 +1513,12 @@ def _jsonl_openai_tool_call(value: dict[str, Any]) -> dict[str, Any] | None:
             "tool_use_name",
             "toolUseName",
         )
-        arguments = _jsonl_message_field(function_value, "arguments")
+        arguments = _jsonl_present_message_field(function_value, "arguments")
     else:
         name = _jsonl_message_field(raw, "name", "tool_name", "toolName", "tool_use_name", "toolUseName")
         arguments = None
     if arguments is None:
-        arguments = _jsonl_message_field(
+        arguments = _jsonl_present_message_field(
             raw,
             "arguments",
             "tool_input",
@@ -1369,6 +1528,8 @@ def _jsonl_openai_tool_call(value: dict[str, Any]) -> dict[str, Any] | None:
             "input",
             "parameters",
         )
+    if raw_type in JSONL_OPENCLAW_TOOL_CALL_TYPES and arguments is None:
+        return None
     if call_id is None or name is None:
         return None
     return {
@@ -1419,20 +1580,60 @@ def _jsonl_has_malformed_tool_call_content(message: dict[str, Any]) -> bool:
     return bool(_jsonl_malformed_tool_call_content_types(message.get("content")))
 
 
-def _jsonl_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]] | None:
-    value = message.get("tool_calls", message.get("toolCalls"))
-    calls: list[dict[str, Any]] = []
-    if isinstance(value, list):
+def _jsonl_malformed_tool_call_array_types(message: dict[str, Any]) -> list[str]:
+    values = [message.get(key) for key in ("tool_calls", "toolCalls") if key in message]
+    if not values:
+        return []
+    malformed: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            malformed.append("non-list tool_calls")
+            continue
         for item in value:
             if not isinstance(item, dict):
+                malformed.append("tool_calls")
                 continue
-            calls.append(_jsonl_openai_tool_call(item) or item)
-    message_type = _jsonl_string_type(message.get("type")) or ""
+            if _jsonl_tool_call_array_item_has_malformed_type(item):
+                malformed.append("non-string tool_calls type")
+                continue
+            if _jsonl_openai_tool_call(item, allow_id_fallback=True) is None:
+                malformed.append(_jsonl_string_type(item.get("type")) or "tool_calls")
+    return malformed
+
+
+def _jsonl_has_malformed_tool_call_array(message: dict[str, Any]) -> bool:
+    return bool(_jsonl_malformed_tool_call_array_types(message))
+
+
+def _jsonl_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]] | None:
+    calls: list[dict[str, Any]] = []
+    seen_call_ids: set[str] = set()
+
+    def append_call(call: dict[str, Any]) -> None:
+        call_id = str(call.get("id", ""))
+        if call_id in seen_call_ids:
+            return
+        seen_call_ids.add(call_id)
+        calls.append(call)
+
+    for key in ("tool_calls", "toolCalls"):
+        value = message.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                call = _jsonl_openai_tool_call(item, allow_id_fallback=True)
+                if call is not None:
+                    append_call(call)
+    message_type = _jsonl_string_type(message.get("type")) or _jsonl_bare_tool_call_row_type(message) or ""
     if message_type in JSONL_TOOL_CALL_TYPES or "toolCall" in message:
         call = _jsonl_openai_tool_call(message)
         if call is not None:
-            calls.append(call)
-    calls.extend(_jsonl_tool_calls_from_content(message.get("content")))
+            append_call(call)
+    for call in _jsonl_tool_calls_from_content(message.get("content")):
+        append_call(call)
     return calls or None
 
 
@@ -1446,10 +1647,13 @@ def _jsonl_message_field(message: dict[str, Any], *keys: str) -> Any:
 
 def _jsonl_role(message: dict[str, Any], row_type: Any) -> str:
     row_type = _jsonl_string_type(row_type)
-    role = message.get("role")
-    if role in (None, "") and row_type in (
-        {"toolResult", "tool_result"} | JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES
+    nested_type = _jsonl_string_type(message.get("type"))
+    if row_type in {None, "message", "custom_message"} and (
+        nested_type in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES
     ):
+        row_type = nested_type
+    role = message.get("role")
+    if role in (None, "") and row_type in (JSONL_OPENCLAW_TOOL_RESULT_TYPES | JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES):
         role = "toolResult"
     if role in (None, "") and row_type in JSONL_TOOL_CALL_TYPES:
         role = "assistant"
@@ -1469,6 +1673,18 @@ def _jsonl_content(message: dict[str, Any], role: str) -> Any:
 
 
 def _jsonl_row_id(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) is None:
+        value = _jsonl_message_field(row, "id")
+        if value is None:
+            value = _jsonl_message_field(_jsonl_row_message(row), "id")
+        return str(value) if value is not None else None
+
+    if _jsonl_row_type(row) in {"message", "custom_message"}:
+        value = _jsonl_message_field(_jsonl_row_message(row), "id")
+        if value is None:
+            value = _jsonl_message_field(row, "id")
+        return str(value) if value is not None else None
+
     value = _jsonl_message_field(_jsonl_row_message(row), "id")
     if value is None:
         value = _jsonl_message_field(row, "id")
@@ -1476,55 +1692,261 @@ def _jsonl_row_id(row: dict[str, Any]) -> str | None:
 
 
 def _jsonl_parent_id(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) is None:
+        value = _jsonl_message_field(row, "parent_id", "parentId")
+        if value is None:
+            value = _jsonl_message_field(_jsonl_row_message(row), "parent_id", "parentId")
+        return str(value) if value is not None else None
+
     value = _jsonl_message_field(_jsonl_row_message(row), "parent_id", "parentId")
     if value is None:
         value = _jsonl_message_field(row, "parent_id", "parentId")
     return str(value) if value is not None else None
 
 
+def _jsonl_untyped_message_nested_id(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) is not None:
+        return None
+    message = row.get("message")
+    if not isinstance(message, dict):
+        return None
+    if _jsonl_effective_row_type(row, message) in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES:
+        return None
+    value = _jsonl_message_field(message, "id")
+    return str(value) if value is not None else None
+
+
+def _jsonl_wrapped_message_nested_id(row: dict[str, Any]) -> str | None:
+    if _jsonl_row_type(row) not in {None, "message", "custom_message"}:
+        return None
+    message = row.get("message")
+    if not isinstance(message, dict):
+        return None
+    value = _jsonl_message_field(message, "id")
+    return str(value) if value is not None else None
+
+
+def _jsonl_untyped_nested_id_overrides(rows: list[tuple[int, dict[str, Any]]]) -> dict[int, str]:
+    line_nested_ids: dict[int, str] = {}
+    nested_ids: set[str] = set()
+    nested_parent_refs: set[str] = set()
+
+    for line_no, row in rows:
+        if not _jsonl_valid_importable_row(row):
+            continue
+        nested_id = _jsonl_untyped_message_nested_id(row)
+        envelope_id = _jsonl_message_field(row, "id")
+        if nested_id is None or envelope_id is None:
+            continue
+        line_nested_ids[line_no] = nested_id
+        nested_ids.add(nested_id)
+
+        nested_parent_id = _jsonl_message_field(_jsonl_row_message(row), "parent_id", "parentId")
+        if nested_parent_id is not None:
+            nested_parent_refs.add(str(nested_parent_id))
+
+    if nested_parent_refs.intersection(nested_ids):
+        return line_nested_ids
+    return {}
+
+
+def _jsonl_row_id_for_line(
+    row: dict[str, Any],
+    line_no: int,
+    row_id_overrides: dict[int, str] | None,
+) -> str | None:
+    if row_id_overrides is not None and line_no in row_id_overrides:
+        return row_id_overrides[line_no]
+    return _jsonl_row_id(row)
+
+
+def _jsonl_traversal_ids(row: dict[str, Any], row_id: str | None) -> list[str]:
+    ids: list[str] = []
+    if row_id is not None:
+        ids.append(row_id)
+    raw_message = row.get("message")
+    top_level_message_with_metadata = (
+        isinstance(raw_message, dict)
+        and ("role" in row or "content" in row)
+        and _jsonl_wrapped_metadata_message(row, raw_message)
+    )
+    nested_id = None if top_level_message_with_metadata else _jsonl_wrapped_message_nested_id(row)
+    if nested_id is not None and nested_id not in ids:
+        ids.append(nested_id)
+    if _jsonl_row_type(row) in {None, "message", "custom_message"} and isinstance(row.get("message"), dict):
+        envelope_id = _jsonl_message_field(row, "id")
+        if envelope_id is not None and str(envelope_id) not in ids:
+            ids.append(str(envelope_id))
+    return ids
+
+
+def _jsonl_wrapped_tool_envelope_row_id(row: dict[str, Any], message: dict[str, Any]) -> str | None:
+    row_type = _jsonl_row_type(row)
+    if row_type not in {None, "message", "custom_message"}:
+        return None
+    if row_type is None and not isinstance(row.get("message"), dict):
+        return None
+    if _jsonl_effective_row_type(row, message) not in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES:
+        return None
+    if row_type in {"message", "custom_message"} and _jsonl_wrapped_message_nested_id(row) is not None:
+        return None
+    envelope_id = _jsonl_message_field(row, "id")
+    return str(envelope_id) if envelope_id is not None else None
+
+
+def _jsonl_alias_canonical_ids(
+    rows: list[tuple[int, dict[str, Any]]],
+    *,
+    row_id_overrides: dict[int, str] | None = None,
+) -> dict[str, str]:
+    canonical_by_id: dict[str, str] = {}
+    members_by_canonical: dict[str, set[str]] = {}
+
+    for line_no, row in rows:
+        if _jsonl_row_type(row) == "session":
+            continue
+        row_id = _jsonl_row_id_for_line(row, line_no, row_id_overrides)
+        if row_id is None:
+            continue
+        traversal_ids = _jsonl_traversal_ids(row, row_id)
+        if not traversal_ids:
+            continue
+
+        known_canonicals = {
+            canonical_by_id[traversal_id]
+            for traversal_id in traversal_ids
+            if traversal_id in canonical_by_id
+        }
+        canonical = next(
+            (
+                canonical_by_id[traversal_id]
+                for traversal_id in traversal_ids
+                if traversal_id in canonical_by_id
+            ),
+            traversal_ids[0],
+        )
+        members = set(traversal_ids)
+        for known_canonical in known_canonicals:
+            members.update(members_by_canonical.get(known_canonical, {known_canonical}))
+        for known_canonical in known_canonicals:
+            if known_canonical != canonical:
+                members_by_canonical.pop(known_canonical, None)
+
+        canonical_members = members_by_canonical.setdefault(canonical, set())
+        canonical_members.update(members)
+        for member in canonical_members:
+            canonical_by_id[member] = canonical
+
+    return canonical_by_id
+
+
+def _jsonl_canonical_id(value: str | None, canonical_by_id: dict[str, str]) -> str | None:
+    if value is None:
+        return None
+    return canonical_by_id.get(value, value)
+
+
 def _jsonl_importable_row(row: dict[str, Any]) -> bool:
     if _jsonl_has_malformed_type(row):
         return False
+    message = _jsonl_row_message(row)
+    if _jsonl_wrapped_metadata_message(row, message):
+        return False
     row_type = _jsonl_row_type(row)
+    effective_row_type = _jsonl_effective_row_type(row, message)
+    if effective_row_type in JSONL_OPENCLAW_TOOL_ROW_TYPES | JSONL_RESPONSES_NATIVE_TYPES:
+        return True
     if row_type in (
         {"message", "custom_message", "toolResult", "tool_result"}
         | JSONL_RESPONSES_NATIVE_TYPES
         | JSONL_OPENCLAW_TOOL_CALL_TYPES
     ):
         return True
-    return row_type is None and ("role" in row or "content" in row)
+    return row_type is None and (
+        isinstance(row.get("message"), dict) or "role" in row or "content" in row
+    )
 
 
 def _jsonl_valid_importable_row(row: dict[str, Any]) -> bool:
     if _jsonl_has_malformed_type(row):
         return False
     row_type = _jsonl_row_type(row)
+    message = _jsonl_row_message(row)
+    if _jsonl_has_malformed_nested_message_type(row, message):
+        return False
+    if _jsonl_wrapped_metadata_message(row, message):
+        return False
+    effective_row_type = _jsonl_effective_row_type(row)
+    if effective_row_type in JSONL_TOOL_CALL_TYPES:
+        return _jsonl_openai_tool_call(message) is not None
+    if (
+        row_type in {"message", "custom_message"}
+        or (row_type is None and isinstance(row.get("message"), dict))
+    ) and effective_row_type in JSONL_TOOL_CALL_TYPES:
+        return _jsonl_openai_tool_call(message) is not None
+    if (
+        row_type in {"message", "custom_message"}
+        or (row_type is None and isinstance(row.get("message"), dict))
+    ):
+        nested_type = _jsonl_string_type(message.get("type"))
+        if (
+            nested_type is not None
+            and effective_row_type == row_type
+            and _jsonl_message_field(message, "role") is None
+            and "content" not in message
+            and not _jsonl_tool_calls(message)
+        ):
+            return False
     if row_type in JSONL_TOOL_CALL_TYPES:
         return _jsonl_openai_tool_call(row) is not None
     if row_type == "message":
         if not (isinstance(row.get("message"), dict) or "role" in row or "content" in row):
             return False
-        return not _jsonl_has_malformed_tool_call_content(_jsonl_row_message(row))
+        row_message = _jsonl_row_message(row)
+        return not (
+            _jsonl_has_malformed_tool_call_content(row_message)
+            or _jsonl_has_malformed_tool_call_array(row_message)
+        )
     if row_type == "custom_message":
         if not (isinstance(row.get("message"), dict) or "role" in row or "content" in row):
             return False
-        return not _jsonl_has_malformed_tool_call_content(_jsonl_row_message(row))
-    if row_type is None and ("role" in row or "content" in row):
-        return not _jsonl_has_malformed_tool_call_content(row)
+        row_message = _jsonl_row_message(row)
+        return not (
+            _jsonl_has_malformed_tool_call_content(row_message)
+            or _jsonl_has_malformed_tool_call_array(row_message)
+        )
+    if row_type is None and (
+        isinstance(row.get("message"), dict) or "role" in row or "content" in row
+    ):
+        row_message = _jsonl_row_message(row)
+        return not (
+            _jsonl_has_malformed_tool_call_content(row_message)
+            or _jsonl_has_malformed_tool_call_array(row_message)
+        )
     return _jsonl_importable_row(row)
 
 
 def _jsonl_row_message(row: dict[str, Any]) -> dict[str, Any]:
     raw_message = row.get("message")
+    if (
+        _jsonl_row_type(row) in {None, "message", "custom_message"}
+        and isinstance(raw_message, dict)
+        and ("role" in row or "content" in row)
+        and _jsonl_wrapped_metadata_message(row, raw_message)
+    ):
+        return row
+    if _jsonl_row_type(row) is None and ("role" in row or "content" in row):
+        return row
     return raw_message if isinstance(raw_message, dict) else row
 
 
 def _jsonl_row_role(row: dict[str, Any]) -> str:
-    return _jsonl_role(_jsonl_row_message(row), _jsonl_row_type(row))
+    message = _jsonl_row_message(row)
+    return _jsonl_role(message, _jsonl_effective_row_type(row, message))
 
 
 def _jsonl_valid_tool_call_row(row: dict[str, Any]) -> bool:
-    return _jsonl_row_type(row) in JSONL_TOOL_CALL_TYPES and _jsonl_valid_importable_row(row)
+    return _jsonl_effective_row_type(row) in JSONL_TOOL_CALL_TYPES and _jsonl_valid_importable_row(row)
 
 
 def _jsonl_responses_function_call_message(row: dict[str, Any]) -> dict[str, Any]:
@@ -1551,23 +1973,53 @@ def _jsonl_responses_function_output_message(row: dict[str, Any]) -> dict[str, A
     )
     if tool_call_id is not None:
         message["tool_call_id"] = tool_call_id
-    tool_name = _jsonl_message_field(row, "tool_name", "toolName", "name")
+    tool_name = _jsonl_message_field(row, "tool_name", "toolName", "tool_use_name", "toolUseName", "name")
     if tool_name is not None:
         message["tool_name"] = tool_name
     return message
 
 
-def _jsonl_active_leaf_lines(rows: list[tuple[int, dict[str, Any]]]) -> set[int] | None:
+def _jsonl_tool_result_call_id(message: dict[str, Any]) -> Any:
+    return _jsonl_message_field(
+        message,
+        "tool_call_id",
+        "toolCallId",
+        "tool_use_id",
+        "toolUseId",
+        "call_id",
+        "callId",
+    )
+
+
+def _jsonl_result_row_type(row: dict[str, Any], message: dict[str, Any]) -> str | None:
+    row_type = _jsonl_effective_row_type(row, message)
+    if row_type in JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES:
+        return "function_call_output"
+    if row_type in JSONL_OPENCLAW_TOOL_RESULT_TYPES:
+        return "tool_result"
+    if _jsonl_role(message, row_type) == "tool" and _jsonl_tool_result_call_id(message) is not None:
+        return "tool_result"
+    return None
+
+
+def _jsonl_active_leaf_lines(
+    rows: list[tuple[int, dict[str, Any]]],
+    *,
+    row_id_overrides: dict[int, str] | None = None,
+) -> set[int] | None:
     row_by_line = dict(rows)
+    canonical_by_id = _jsonl_alias_canonical_ids(rows, row_id_overrides=row_id_overrides)
     line_by_id: dict[str, int] = {}
     parent_by_id: dict[str, str | None] = {}
+    traversal_ids_by_line: dict[int, set[str]] = {}
     last_message_id: str | None = None
     idless_importable_lines: set[int] = set()
+    idless_importable_lines_by_parent: dict[str, list[int]] = {}
     has_parent_edges = False
     for line_no, row in rows:
         if _jsonl_row_type(row) == "session":
             continue
-        row_id = _jsonl_row_id(row)
+        row_id = _jsonl_row_id_for_line(row, line_no, row_id_overrides)
         valid_importable = _jsonl_valid_importable_row(row)
         if row_id is None:
             if valid_importable:
@@ -1583,40 +2035,72 @@ def _jsonl_active_leaf_lines(rows: list[tuple[int, dict[str, Any]]]) -> set[int]
                     "callId",
                 )
                 if role != "tool" or tool_call_id is None:
-                    idless_importable_lines.add(line_no)
+                    parent_id = _jsonl_parent_id(row)
+                    if parent_id is None:
+                        idless_importable_lines.add(line_no)
+                    else:
+                        parent_key = _jsonl_canonical_id(parent_id, canonical_by_id)
+                        if parent_key is not None:
+                            idless_importable_lines_by_parent.setdefault(parent_key, []).append(line_no)
             continue
-        if _jsonl_importable_row(row) and not valid_importable:
-            if row_id not in line_by_id:
-                line_by_id[row_id] = line_no
-                parent_by_id[row_id] = _jsonl_parent_id(row)
-            continue
-        line_by_id[row_id] = line_no
         parent_id = _jsonl_parent_id(row)
-        parent_by_id[row_id] = parent_id
+        parent_key = _jsonl_canonical_id(parent_id, canonical_by_id)
+        traversal_ids = _jsonl_traversal_ids(row, row_id)
+        traversal_ids_by_line.setdefault(line_no, set()).update(traversal_ids)
         if not valid_importable:
+            for traversal_id in traversal_ids:
+                if traversal_id not in line_by_id:
+                    line_by_id[traversal_id] = line_no
+                    parent_by_id[traversal_id] = parent_key
             continue
-        if parent_id is not None and _jsonl_row_role(row) != "tool":
+        for traversal_id in traversal_ids:
+            line_by_id[traversal_id] = line_no
+            parent_by_id[traversal_id] = parent_key
+        if parent_key is not None and _jsonl_row_role(row) != "tool":
             has_parent_edges = True
         if _jsonl_row_role(row) != "tool":
-            last_message_id = row_id
+            last_message_id = _jsonl_canonical_id(row_id, canonical_by_id)
     if not has_parent_edges or last_message_id is None:
         return None
 
     active_lines: set[int] = set()
     seen_ids: set[str] = set()
     current: str | None = last_message_id
-    while current is not None and current not in seen_ids:
+    while current is not None:
+        if current in seen_ids:
+            return None
         seen_ids.add(current)
         line_no = line_by_id.get(current)
         if line_no is None:
-            break
+            return None
         active_lines.add(line_no)
-        current = parent_by_id.get(current)
+        current = _jsonl_canonical_id(parent_by_id.get(current), canonical_by_id)
 
     active_importable_lines = {
         line_no for line_no in active_lines if _jsonl_valid_importable_row(row_by_line.get(line_no, {}))
     }
     active_importable_lines.update(idless_importable_lines)
+    active_traversal_ids = set(seen_ids)
+    for line_no in active_lines:
+        for traversal_id in traversal_ids_by_line.get(line_no, set()):
+            active_traversal_ids.add(traversal_id)
+            canonical_id = _jsonl_canonical_id(traversal_id, canonical_by_id)
+            if canonical_id is not None:
+                active_traversal_ids.add(canonical_id)
+    for parent_id, line_numbers in idless_importable_lines_by_parent.items():
+        if parent_id in active_traversal_ids:
+            active_importable_lines.update(line_numbers)
+
+    active_tool_call_lines_by_parent: dict[str, list[int]] = {}
+    for line_no, row in rows:
+        if not _jsonl_valid_tool_call_row(row):
+            continue
+        parent_key = _jsonl_canonical_id(_jsonl_parent_id(row), canonical_by_id)
+        if parent_key is not None:
+            active_tool_call_lines_by_parent.setdefault(parent_key, []).append(line_no)
+    for sibling_lines in active_tool_call_lines_by_parent.values():
+        if active_importable_lines.intersection(sibling_lines):
+            active_importable_lines.update(sibling_lines)
 
     active_tool_call_run: list[int] = []
     active_tool_call_parent: str | None = None
@@ -1631,12 +2115,12 @@ def _jsonl_active_leaf_lines(rows: list[tuple[int, dict[str, Any]]]) -> set[int]
             active_tool_call_run = []
             active_tool_call_parent = None
             continue
-        parent_id = _jsonl_parent_id(row)
-        if active_tool_call_run and parent_id != active_tool_call_parent:
+        parent_key = _jsonl_canonical_id(_jsonl_parent_id(row), canonical_by_id)
+        if active_tool_call_run and parent_key != active_tool_call_parent:
             flush_active_tool_call_run()
             active_tool_call_run = []
         active_tool_call_run.append(line_no)
-        active_tool_call_parent = parent_id
+        active_tool_call_parent = parent_key
     flush_active_tool_call_run()
 
     active_tool_call_ids: set[str] = set()
@@ -1691,7 +2175,10 @@ def _jsonl_active_leaf_lines_by_session(
     active_lines: set[int] = set()
     pruning_enabled = False
     for session_rows in grouped.values():
-        session_active = _jsonl_active_leaf_lines(session_rows)
+        session_active = _jsonl_active_leaf_lines(
+            session_rows,
+            row_id_overrides=_jsonl_untyped_nested_id_overrides(session_rows),
+        )
         if session_active is None:
             active_lines.update(line_no for line_no, row in session_rows if _jsonl_importable_row(row))
         else:
@@ -1700,7 +2187,29 @@ def _jsonl_active_leaf_lines_by_session(
     return active_lines if pruning_enabled else None
 
 
-def _jsonl_session_value(row: dict[str, Any], message: dict[str, Any], fallback: str) -> str:
+def _jsonl_row_id_overrides_by_session(
+    rows: list[tuple[int, dict[str, Any]]],
+    *,
+    fallback_session: str,
+) -> dict[int, str]:
+    grouped: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    current_session = fallback_session
+    for line_no, row in rows:
+        if _jsonl_row_type(row) == "session":
+            session_id = _safe_segment(row.get("id"), current_session)
+            if session_id:
+                current_session = session_id
+            continue
+        session = _jsonl_session_value(row, _jsonl_row_message(row), current_session)
+        grouped.setdefault(session, []).append((line_no, row))
+
+    overrides: dict[int, str] = {}
+    for session_rows in grouped.values():
+        overrides.update(_jsonl_untyped_nested_id_overrides(session_rows))
+    return overrides
+
+
+def _jsonl_explicit_session_value(row: dict[str, Any], message: dict[str, Any]) -> str | None:
     value = _jsonl_message_field(
         row,
         "session_id",
@@ -1720,7 +2229,33 @@ def _jsonl_session_value(row: dict[str, Any], message: dict[str, Any], fallback:
             "conversation_id",
             "conversationId",
         )
-    return _safe_segment(value, fallback)
+    return str(value) if value is not None else None
+
+
+def _jsonl_session_value(row: dict[str, Any], message: dict[str, Any], fallback: str) -> str:
+    return _safe_segment(_jsonl_explicit_session_value(row, message), fallback)
+
+
+def _jsonl_resolve_tool_output_source_session(
+    *,
+    tool_call_id: Any,
+    source_session: str,
+    source_session_is_explicit: bool,
+    seen_tool_call_ids_by_session: dict[str, set[str]],
+) -> str | None:
+    if tool_call_id is None:
+        return None
+    call_id = str(tool_call_id)
+    if call_id in seen_tool_call_ids_by_session.get(source_session, set()):
+        return source_session
+    if source_session_is_explicit:
+        return None
+    matching_sessions = [
+        session
+        for session, call_ids in seen_tool_call_ids_by_session.items()
+        if call_id in call_ids
+    ]
+    return matching_sessions[0] if len(matching_sessions) == 1 else None
 
 
 def _jsonl_warning(path: Path, line_no: int, message: str) -> str:
@@ -1731,12 +2266,236 @@ def _jsonl_source_message_key(source_session: str, source_row_id: str) -> str:
     return json.dumps([source_session, source_row_id], separators=(",", ":"), ensure_ascii=False)
 
 
+def _jsonl_normalized_tool_arguments(value: Any) -> str:
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+        normalized = normalize_content_value(decoded)
+    else:
+        normalized = normalize_content_value(value)
+    return normalized or ""
+
+
+def _jsonl_tool_call_source_row_id(
+    row: dict[str, Any],
+    message: dict[str, Any],
+    tool_calls: list[dict[str, Any]] | None,
+) -> str | None:
+    call_type = _jsonl_effective_row_type(row, message)
+    if call_type not in JSONL_TOOL_CALL_TYPES or not tool_calls:
+        return None
+
+    semantic_calls: list[list[str]] = []
+    for tool_call in tool_calls:
+        function_value = tool_call.get("function")
+        if not isinstance(function_value, dict):
+            return None
+        call_id = _jsonl_message_field(tool_call, "id", "tool_call_id", "toolCallId")
+        tool_name = _jsonl_message_field(function_value, "name")
+        if call_id is None or tool_name is None:
+            return None
+        arguments = _jsonl_normalized_tool_arguments(function_value.get("arguments"))
+        arguments_hash = hashlib.sha256(arguments.encode("utf-8")).hexdigest()
+        semantic_calls.append([str(call_type), str(call_id), str(tool_name), arguments_hash])
+
+    prefix = "tool_call:" if len(semantic_calls) == 1 else "tool_calls:"
+    value: Any = semantic_calls[0] if len(semantic_calls) == 1 else semantic_calls
+    return prefix + _jsonl_compact_json(value)
+
+
+def _jsonl_result_source_row_id(
+    row: dict[str, Any],
+    message: dict[str, Any],
+    normalized_content: str | None,
+) -> str | None:
+    result_type = _jsonl_result_row_type(row, message)
+    if result_type is None:
+        return None
+
+    tool_call_id = _jsonl_tool_result_call_id(message)
+    if tool_call_id is None:
+        return None
+    content_hash = hashlib.sha256((normalized_content or "").encode("utf-8")).hexdigest()
+    return "result:" + _jsonl_compact_json([result_type, str(tool_call_id), content_hash])
+
+
+def _existing_tool_call_ids_by_source_session(target_db: Path, import_id: str) -> dict[str, set[str]]:
+    if not target_db.exists():
+        return {}
+    conn = sqlite3.connect(target_db)
+    try:
+        if not _target_has_import_table(conn) or not _table_exists(conn, "messages"):
+            return {}
+        import_columns = _table_columns(conn, "lcm_imported_messages")
+        message_columns = _table_columns(conn, "messages")
+        if not {"source_session", "target_store_id"}.issubset(import_columns):
+            return {}
+        if not {"store_id", "tool_calls"}.issubset(message_columns):
+            return {}
+        rows = conn.execute(
+            """SELECT im.source_session, m.tool_calls
+               FROM lcm_imported_messages im
+               JOIN messages m ON m.store_id = im.target_store_id
+               WHERE im.import_id = ?
+                 AND m.tool_calls IS NOT NULL
+                 AND m.tool_calls != ''""",
+            (import_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_session: dict[str, set[str]] = {}
+    for source_session, raw_tool_calls in rows:
+        try:
+            tool_calls = json.loads(raw_tool_calls)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(tool_calls, list):
+            continue
+        session_ids = by_session.setdefault(str(source_session), set())
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            call_id = _jsonl_message_field(tool_call, "id", "tool_call_id", "toolCallId")
+            if call_id is not None:
+                session_ids.add(str(call_id))
+    return by_session
+
+
+def _merge_tool_call_ids_by_session(
+    target: dict[str, set[str]],
+    source: dict[str, set[str]],
+) -> None:
+    for source_session, call_ids in source.items():
+        target.setdefault(source_session, set()).update(call_ids)
+
+
+def _jsonl_active_tool_call_ids_by_source_session(files: Iterable[Path]) -> dict[str, set[str]]:
+    by_session: dict[str, set[str]] = {}
+    for path in files:
+        fallback_session = _jsonl_file_session_fallback(path)
+        current_session = fallback_session
+        if not path.is_file():
+            raise FileNotFoundError(f"{path}: source JSONL file not found")
+        try:
+            handle = path.open("r", encoding="utf-8")
+        except OSError as exc:
+            raise OSError(f"{path}: could not read source JSONL file: {exc}") from exc
+        valid_rows: list[tuple[int, dict[str, Any]]] = []
+        with handle:
+            for line_no, line in enumerate(handle, start=1):
+                text = line.strip()
+                if not text:
+                    continue
+                try:
+                    decoded = json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(decoded, dict):
+                    valid_rows.append((line_no, decoded))
+
+        active_leaf_lines = _jsonl_active_leaf_lines_by_session(
+            valid_rows,
+            fallback_session=fallback_session,
+        )
+        for line_no, row in valid_rows:
+            if _jsonl_row_type(row) == "session":
+                session_id = _safe_segment(row.get("id"), current_session)
+                if session_id:
+                    current_session = session_id
+                continue
+            if active_leaf_lines is not None and _jsonl_valid_importable_row(row) and line_no not in active_leaf_lines:
+                continue
+            if not _jsonl_valid_importable_row(row):
+                continue
+            message = _jsonl_row_message(row)
+            tool_calls = _jsonl_tool_calls(message)
+            if not tool_calls:
+                continue
+            source_session = _jsonl_session_value(row, message, current_session)
+            session_call_ids = by_session.setdefault(source_session, set())
+            for tool_call in tool_calls:
+                call_id = _jsonl_message_field(tool_call, "id", "tool_call_id", "toolCallId")
+                if call_id is not None:
+                    session_call_ids.add(str(call_id))
+    return by_session
+
+
+def _jsonl_candidate_tool_call_keys(candidate: ImportCandidate) -> set[tuple[str, str]]:
+    if not candidate.tool_calls:
+        return set()
+    keys: set[tuple[str, str]] = set()
+    for tool_call in candidate.tool_calls:
+        call_id = _jsonl_message_field(tool_call, "id", "tool_call_id", "toolCallId")
+        if call_id is not None:
+            keys.add((candidate.source_session, str(call_id)))
+    return keys
+
+
+def _jsonl_tool_call_ids_by_source_session(
+    candidates: Iterable[ImportCandidate],
+    *,
+    excluded_source_keys: set[str] | None = None,
+) -> dict[str, set[str]]:
+    excluded_source_keys = excluded_source_keys or set()
+    by_session: dict[str, set[str]] = {}
+    for candidate in candidates:
+        if _candidate_matches_existing_source_key(candidate, excluded_source_keys):
+            continue
+        for source_session, call_id in _jsonl_candidate_tool_call_keys(candidate):
+            by_session.setdefault(source_session, set()).add(call_id)
+    return by_session
+
+
+def _jsonl_order_candidates_by_tool_dependencies(
+    candidates: list[ImportCandidate],
+) -> list[ImportCandidate]:
+    current_run_call_keys: set[tuple[str, str]] = set()
+    for candidate in candidates:
+        current_run_call_keys.update(_jsonl_candidate_tool_call_keys(candidate))
+    if not current_run_call_keys:
+        return candidates
+
+    ordered: list[ImportCandidate] = []
+    pending_tool_results: list[tuple[tuple[str, str], ImportCandidate]] = []
+    emitted_call_keys: set[tuple[str, str]] = set()
+
+    def flush_pending_tool_results() -> None:
+        remaining: list[tuple[tuple[str, str], ImportCandidate]] = []
+        for key, pending_candidate in pending_tool_results:
+            if key in emitted_call_keys:
+                ordered.append(pending_candidate)
+            else:
+                remaining.append((key, pending_candidate))
+        pending_tool_results[:] = remaining
+
+    for candidate in candidates:
+        if candidate.role == "tool" and candidate.tool_call_id is not None:
+            result_key = (candidate.source_session, candidate.tool_call_id)
+            if result_key in current_run_call_keys and result_key not in emitted_call_keys:
+                pending_tool_results.append((result_key, candidate))
+                continue
+
+        ordered.append(candidate)
+        emitted_call_keys.update(_jsonl_candidate_tool_call_keys(candidate))
+        flush_pending_tool_results()
+
+    ordered.extend(candidate for _, candidate in pending_tool_results)
+    return ordered
+
+
 def _collect_jsonl_candidates(
     files: Iterable[Path],
     *,
     namespace: str,
     agent: str,
+    existing_tool_call_ids_by_session: dict[str, set[str]] | None = None,
+    current_run_tool_call_ids_by_session: dict[str, set[str]] | None = None,
+    existing_source_keys: set[str] | None = None,
 ) -> tuple[list[ImportCandidate], int, int, int, int, list[str]]:
+    source_files = [Path(path) for path in files]
     candidates: list[ImportCandidate] = []
     warnings: list[str] = []
     scanned = 0
@@ -1744,10 +2503,18 @@ def _collect_jsonl_candidates(
     invalid_rows = 0
     source_sessions: set[str] = set()
     seen_keys: set[str] = set()
+    existing_source_keys = existing_source_keys or set()
+    known_tool_call_ids_by_session: dict[str, set[str]] = {
+        session: set(call_ids)
+        for session, call_ids in (existing_tool_call_ids_by_session or {}).items()
+    }
+    _merge_tool_call_ids_by_session(known_tool_call_ids_by_session, current_run_tool_call_ids_by_session or {})
     now = time.time()
 
-    for path in files:
-        current_session = _jsonl_file_session_fallback(path)
+    for path in source_files:
+        fallback_session = _jsonl_file_session_fallback(path)
+        current_session = fallback_session
+        current_session_from_header = False
         if not path.is_file():
             raise FileNotFoundError(f"{path}: source JSONL file not found")
         try:
@@ -1774,8 +2541,11 @@ def _collect_jsonl_candidates(
 
         active_leaf_lines = _jsonl_active_leaf_lines_by_session(
             valid_rows,
-            fallback_session=_jsonl_file_session_fallback(path),
+            fallback_session=fallback_session,
         )
+        # Source keys must stay row-local; nested aliases are only for branch traversal.
+        line_row_id_overrides: dict[int, str] | None = None
+        parent_canonical_by_id = _jsonl_alias_canonical_ids(valid_rows)
         pending_native_function_calls: list[JsonlPendingFunctionCall] = []
 
         def append_jsonl_candidate(
@@ -1787,10 +2557,29 @@ def _collect_jsonl_candidates(
             timestamp_value: Any,
             source_row_id_override: str | None = None,
             source_session_override: str | None = None,
+            source_key_aliases_override: tuple[str, ...] = (),
         ) -> None:
             nonlocal invalid_rows, skipped_empty
 
-            role = _jsonl_role(message, row.get("type"))
+            row_type = _jsonl_row_type(row)
+            effective_row_type = _jsonl_effective_row_type(row, message)
+            if (
+                row_type not in JSONL_OPENCLAW_TOOL_CALL_TYPES
+                and effective_row_type in JSONL_OPENCLAW_TOOL_CALL_TYPES
+                and _jsonl_openai_tool_call(message) is None
+                and not _jsonl_tool_calls(message)
+            ):
+                invalid_rows += 1
+                warnings.append(
+                    _jsonl_warning(
+                        path,
+                        line_no,
+                        f"{effective_row_type} row missing tool call id or name, or input/arguments",
+                    )
+                )
+                return
+
+            role = _jsonl_role(message, effective_row_type)
             content = _jsonl_content(message, role)
             if _jsonl_malformed_tool_call_content_types(content):
                 invalid_rows += 1
@@ -1798,7 +2587,25 @@ def _collect_jsonl_candidates(
                     _jsonl_warning(
                         path,
                         line_no,
-                        "message content tool call item missing tool call id or name, or has non-string type",
+                        "message content tool call item missing tool call id or name, "
+                        "or input/arguments, or has non-string type",
+                    )
+                )
+                return
+
+            malformed_tool_call_array_types = _jsonl_malformed_tool_call_array_types(message)
+            if malformed_tool_call_array_types:
+                invalid_rows += 1
+                warning_message = (
+                    "message tool_calls must be a list"
+                    if "non-list tool_calls" in malformed_tool_call_array_types
+                    else "message tool_calls item missing tool call id or name, or input/arguments"
+                )
+                warnings.append(
+                    _jsonl_warning(
+                        path,
+                        line_no,
+                        warning_message,
                     )
                 )
                 return
@@ -1810,9 +2617,34 @@ def _collect_jsonl_candidates(
                 return
 
             source_session = source_session_override or _jsonl_session_value(row, message, current_session)
+            if source_session_override is None and _jsonl_result_row_type(row, message) is not None:
+                resolved_source_session = _jsonl_resolve_tool_output_source_session(
+                    tool_call_id=_jsonl_tool_result_call_id(message),
+                    source_session=source_session,
+                    source_session_is_explicit=(
+                        current_session_from_header
+                        or _jsonl_explicit_session_value(row, message) is not None
+                    ),
+                    seen_tool_call_ids_by_session=known_tool_call_ids_by_session,
+                )
+                if resolved_source_session is None:
+                    return
+                source_session = resolved_source_session
             source = _target_source(namespace, agent, source_session)
-            source_row_id = source_row_id_override or _safe_segment(row_id, f"line:{line_no}")
+            source_row_id = source_row_id_override
+            if source_row_id is None:
+                source_row_id = _jsonl_wrapped_tool_envelope_row_id(row, message)
+            if source_row_id is None and row_id is None:
+                source_row_id = _jsonl_tool_call_source_row_id(row, message, tool_calls)
+            if source_row_id is None and row_id is None:
+                source_row_id = _jsonl_result_source_row_id(row, message, normalized_content)
+            source_row_id = source_row_id or _safe_segment(row_id, f"line:{line_no}")
             source_message_key = _jsonl_source_message_key(source_session, source_row_id)
+            existing_source_key_aliases = source_key_aliases_override
+            if not existing_source_key_aliases and row_id is None and not source_row_id.startswith("line:"):
+                legacy_line_key = _jsonl_source_message_key(source_session, f"line:{line_no}")
+                if legacy_line_key in existing_source_keys:
+                    existing_source_key_aliases = (legacy_line_key,)
             if source_message_key in seen_keys:
                 invalid_rows += 1
                 warnings.append(
@@ -1829,16 +2661,19 @@ def _collect_jsonl_candidates(
             msg_for_tokens: dict[str, Any] = {"role": role, "content": content}
             if tool_calls:
                 msg_for_tokens["tool_calls"] = tool_calls
-            tool_call_id = _jsonl_message_field(
-                message,
-                "tool_call_id",
-                "toolCallId",
-                "tool_use_id",
-                "toolUseId",
-                "call_id",
-                "callId",
-            )
-            tool_name = _jsonl_message_field(message, "tool_name", "toolName", "name")
+            tool_call_id = None
+            tool_name = None
+            if role == "tool":
+                tool_call_id = _jsonl_message_field(
+                    message,
+                    "tool_call_id",
+                    "toolCallId",
+                    "tool_use_id",
+                    "toolUseId",
+                    "call_id",
+                    "callId",
+                )
+                tool_name = _jsonl_message_field(message, "tool_name", "toolName", "tool_use_name", "toolUseName", "name")
             candidates.append(
                 ImportCandidate(
                     source_message_id=_stable_positive_int(source_message_key),
@@ -1854,45 +2689,144 @@ def _collect_jsonl_candidates(
                     tool_name=str(tool_name) if tool_name is not None else None,
                     timestamp=_parse_timestamp(timestamp_value, now),
                     token_estimate=count_message_tokens(msg_for_tokens),
+                    existing_source_key_aliases=existing_source_key_aliases,
                 )
             )
+            if (
+                tool_calls
+                and source_message_key not in existing_source_keys
+                and not existing_source_key_aliases
+            ):
+                known_tool_call_ids = known_tool_call_ids_by_session.setdefault(source_session, set())
+                for tool_call in tool_calls:
+                    call_id = _jsonl_message_field(tool_call, "id", "tool_call_id", "toolCallId")
+                    if call_id is not None:
+                        known_tool_call_ids.add(str(call_id))
 
-        def flush_pending_native_function_calls() -> None:
-            if not pending_native_function_calls:
-                return
-            first = pending_native_function_calls[0]
-            row_ids = [
-                _safe_segment(pending.row_id, f"line:{pending.line_no}")
-                for pending in pending_native_function_calls
-            ]
-            source_row_id = (
-                row_ids[0]
-                if len(row_ids) == 1
-                else "function_calls:" + _jsonl_compact_json(row_ids)
+        def pending_function_call_source_row_id(pending: JsonlPendingFunctionCall) -> str:
+            if pending.row_id is not None:
+                return _safe_segment(pending.row_id, f"line:{pending.line_no}")
+            message = _jsonl_row_message(pending.row)
+            return (
+                _jsonl_tool_call_source_row_id(pending.row, message, [pending.tool_call])
+                or f"line:{pending.line_no}"
             )
+
+        def pending_function_call_legacy_source_key(pending: JsonlPendingFunctionCall) -> str | None:
+            if pending.row_id is not None:
+                return None
+            legacy_source_key = _jsonl_source_message_key(pending.source_session, f"line:{pending.line_no}")
+            return legacy_source_key if legacy_source_key in existing_source_keys else None
+
+        def function_call_group_source_row_id(row_ids: list[str]) -> str:
+            return row_ids[0] if len(row_ids) == 1 else "function_calls:" + _jsonl_compact_json(row_ids)
+
+        def pending_function_call_legacy_group_source_key(
+            group: list[JsonlPendingFunctionCall],
+        ) -> str | None:
+            if len(group) < 2 or any(pending.row_id is not None for pending in group):
+                return None
+            source_session = group[0].source_session
+            legacy_row_ids = [f"line:{pending.line_no}" for pending in group]
+            legacy_source_row_id = function_call_group_source_row_id(legacy_row_ids)
+            legacy_source_key = _jsonl_source_message_key(source_session, legacy_source_row_id)
+            return legacy_source_key if legacy_source_key in existing_source_keys else None
+
+        def existing_function_call_group_end(row_ids: list[str], start: int) -> int | None:
+            source_session = pending_native_function_calls[start].source_session
+            for end in range(len(row_ids), start, -1):
+                source_row_id = function_call_group_source_row_id(row_ids[start:end])
+                source_message_key = _jsonl_source_message_key(source_session, source_row_id)
+                if source_message_key in existing_source_keys:
+                    return end
+                if pending_function_call_legacy_group_source_key(
+                    pending_native_function_calls[start:end]
+                ):
+                    return end
+                if end == start + 1 and pending_function_call_legacy_source_key(
+                    pending_native_function_calls[start]
+                ):
+                    return end
+            return None
+
+        def append_pending_native_function_call_group(group: list[JsonlPendingFunctionCall]) -> None:
+            first = group[0]
+            row_ids: list[str] = []
+            for pending in group:
+                row_ids.append(pending_function_call_source_row_id(pending))
+            source_row_id = function_call_group_source_row_id(row_ids)
+            existing_source_key_aliases_list: list[str] = []
+            if legacy_group_alias := pending_function_call_legacy_group_source_key(group):
+                existing_source_key_aliases_list.append(legacy_group_alias)
+            existing_source_key_aliases_list.extend(
+                alias
+                for pending in group
+                if (alias := pending_function_call_legacy_source_key(pending)) is not None
+            )
+            existing_source_key_aliases = tuple(existing_source_key_aliases_list)
             append_jsonl_candidate(
                 line_no=first.line_no,
                 row=first.row,
                 message={
                     "role": "assistant",
                     "content": None,
-                    "tool_calls": [pending.tool_call for pending in pending_native_function_calls],
+                    "tool_calls": [pending.tool_call for pending in group],
                 },
                 row_id=first.row_id,
                 timestamp_value=first.timestamp_value,
                 source_row_id_override=source_row_id,
                 source_session_override=first.source_session,
+                source_key_aliases_override=existing_source_key_aliases,
             )
+
+        def flush_pending_native_function_calls() -> None:
+            if not pending_native_function_calls:
+                return
+            row_ids = [
+                pending_function_call_source_row_id(pending)
+                for pending in pending_native_function_calls
+            ]
+            existing_span_ends = {
+                index: span_end
+                for index in range(len(row_ids))
+                if (span_end := existing_function_call_group_end(row_ids, index)) is not None
+            }
+            if not existing_span_ends:
+                append_pending_native_function_call_group(pending_native_function_calls)
+                pending_native_function_calls.clear()
+                return
+
+            index = 0
+            while index < len(pending_native_function_calls):
+                existing_span_end = existing_span_ends.get(index)
+                if existing_span_end is not None:
+                    append_pending_native_function_call_group(
+                        pending_native_function_calls[index:existing_span_end]
+                    )
+                    index = existing_span_end
+                    continue
+                append_pending_native_function_call_group(
+                    pending_native_function_calls[index : index + 1]
+                )
+                index += 1
             pending_native_function_calls.clear()
+
+        def pending_native_function_call_context_differs(source_session: str, parent_id: str | None) -> bool:
+            parent_key = _jsonl_canonical_id(parent_id, parent_canonical_by_id)
+            return bool(pending_native_function_calls) and (
+                pending_native_function_calls[-1].source_session != source_session
+                or pending_native_function_calls[-1].parent_id != parent_key
+            )
 
         for line_no, row, row_error in parsed_rows:
             if row_error is not None:
-                flush_pending_native_function_calls()
                 scanned += 1
                 invalid_rows += 1
                 warnings.append(_jsonl_warning(path, line_no, row_error))
                 continue
             assert row is not None
+            candidate_source_session_override: str | None = None
+            candidate_source_row_id_override: str | None = None
             if active_leaf_lines is not None and _jsonl_valid_importable_row(row) and line_no not in active_leaf_lines:
                 flush_pending_native_function_calls()
                 scanned += 1
@@ -1904,27 +2838,212 @@ def _collect_jsonl_candidates(
                 session_id = _safe_segment(row.get("id"), current_session)
                 if session_id:
                     current_session = session_id
+                    current_session_from_header = True
                 else:
                     warnings.append(_jsonl_warning(path, line_no, "session header missing id"))
                 continue
+            effective_row_type = _jsonl_effective_row_type(row)
+            wrapped_message: dict[str, Any] | None = None
+            if row_type in {"message", "custom_message"}:
+                raw_message = row.get("message")
+                if isinstance(raw_message, dict):
+                    if ("role" in row or "content" in row) and _jsonl_wrapped_metadata_message(row, raw_message):
+                        wrapped_message = row
+                    else:
+                        wrapped_message = raw_message
+                elif "role" in row or "content" in row:
+                    wrapped_message = row
+            elif row_type is None and isinstance(row.get("message"), dict) and not (
+                "role" in row or "content" in row
+            ):
+                wrapped_message = row["message"]
+
+            wrapped_effective_row_type = (
+                _jsonl_effective_row_type(row, wrapped_message)
+                if wrapped_message is not None
+                else row_type
+            )
+            if wrapped_message is not None and _jsonl_has_malformed_nested_message_type(row, wrapped_message):
+                scanned += 1
+                invalid_rows += 1
+                warnings.append(_jsonl_warning(path, line_no, "message row has non-string nested type"))
+                continue
+
+            if wrapped_message is not None and _jsonl_wrapped_metadata_message(row, wrapped_message):
+                scanned += 1
+                skipped_empty += 1
+                continue
+
             if row_type is not None and not _jsonl_importable_row(row):
-                flush_pending_native_function_calls()
                 scanned += 1
                 continue
 
-            if row_type in {"message", "custom_message"}:
+            if (
+                wrapped_message is not None
+                and wrapped_effective_row_type in JSONL_RESPONSES_FUNCTION_CALL_TYPES
+                and row_type not in JSONL_RESPONSES_FUNCTION_CALL_TYPES
+            ):
+                scanned += 1
+                if not _jsonl_valid_importable_row(row):
+                    flush_pending_native_function_calls()
+                    invalid_rows += 1
+                    warnings.append(
+                        _jsonl_warning(
+                            path,
+                            line_no,
+                            f"{wrapped_effective_row_type} row missing tool call id or name",
+                        )
+                    )
+                    continue
+                message = wrapped_message
+                row_id = _jsonl_wrapped_tool_envelope_row_id(row, message) or _jsonl_row_id_for_line(
+                    row,
+                    line_no,
+                    line_row_id_overrides,
+                )
+                timestamp_value = row.get("timestamp", message.get("timestamp"))
+                tool_calls = _jsonl_tool_calls(message)
+                if not tool_calls:
+                    flush_pending_native_function_calls()
+                    skipped_empty += 1
+                    continue
+                source_session = _jsonl_session_value(row, message, current_session)
+                parent_id = _jsonl_parent_id(row)
+                parent_key = _jsonl_canonical_id(parent_id, parent_canonical_by_id)
+                if pending_native_function_call_context_differs(source_session, parent_id):
+                    flush_pending_native_function_calls()
+                pending_native_function_calls.append(
+                    JsonlPendingFunctionCall(
+                        line_no=line_no,
+                        row=row,
+                        row_id=row_id,
+                        parent_id=parent_key,
+                        timestamp_value=timestamp_value,
+                        source_session=source_session,
+                        tool_call=tool_calls[0],
+                    )
+                )
+                continue
+
+            if (
+                wrapped_message is not None
+                and wrapped_effective_row_type in JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES
+                and row_type not in JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES
+            ):
+                flush_pending_native_function_calls()
+                scanned += 1
+                message = wrapped_message
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp", message.get("timestamp"))
+                candidate_source_row_id_override = _jsonl_wrapped_tool_envelope_row_id(row, message)
+            elif (
+                row_type is None
+                and wrapped_message is None
+                and effective_row_type in JSONL_RESPONSES_FUNCTION_CALL_TYPES
+            ):
+                scanned += 1
+                if not _jsonl_valid_importable_row(row):
+                    flush_pending_native_function_calls()
+                    invalid_rows += 1
+                    warnings.append(
+                        _jsonl_warning(path, line_no, f"{effective_row_type} row missing tool call id or name")
+                    )
+                    continue
+                message = _jsonl_responses_function_call_message(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp")
+                tool_calls = _jsonl_tool_calls(message)
+                if not tool_calls:
+                    flush_pending_native_function_calls()
+                    skipped_empty += 1
+                    continue
+                source_session = _jsonl_session_value(row, message, current_session)
+                parent_id = _jsonl_parent_id(row)
+                parent_key = _jsonl_canonical_id(parent_id, parent_canonical_by_id)
+                if pending_native_function_call_context_differs(source_session, parent_id):
+                    flush_pending_native_function_calls()
+                pending_native_function_calls.append(
+                    JsonlPendingFunctionCall(
+                        line_no=line_no,
+                        row=row,
+                        row_id=row_id,
+                        parent_id=parent_key,
+                        timestamp_value=timestamp_value,
+                        source_session=source_session,
+                        tool_call=tool_calls[0],
+                    )
+                )
+                continue
+            elif (
+                row_type is None
+                and wrapped_message is None
+                and effective_row_type in JSONL_OPENCLAW_TOOL_CALL_TYPES
+            ):
+                flush_pending_native_function_calls()
+                scanned += 1
+                if not _jsonl_valid_importable_row(row):
+                    invalid_rows += 1
+                    warnings.append(
+                        _jsonl_warning(
+                            path,
+                            line_no,
+                            f"{effective_row_type} row missing tool call id or name, or input/arguments",
+                        )
+                    )
+                    continue
+                message = _jsonl_responses_function_call_message(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp")
+            elif (
+                row_type is None
+                and wrapped_message is None
+                and effective_row_type in JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES
+            ):
+                flush_pending_native_function_calls()
+                scanned += 1
+                message = _jsonl_responses_function_output_message(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp")
+                tool_call_id = _jsonl_message_field(message, "tool_call_id", "toolCallId", "call_id", "callId")
+                source_session = _jsonl_session_value(row, message, current_session)
+                resolved_source_session = _jsonl_resolve_tool_output_source_session(
+                    tool_call_id=tool_call_id,
+                    source_session=source_session,
+                    source_session_is_explicit=(
+                        current_session_from_header
+                        or _jsonl_explicit_session_value(row, message) is not None
+                    ),
+                    seen_tool_call_ids_by_session=known_tool_call_ids_by_session,
+                )
+                if resolved_source_session is None:
+                    continue
+                candidate_source_session_override = resolved_source_session
+            elif (
+                row_type is None
+                and wrapped_message is None
+                and effective_row_type in JSONL_OPENCLAW_TOOL_RESULT_TYPES
+            ):
+                flush_pending_native_function_calls()
+                scanned += 1
+                message = row
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp")
+            elif row_type in {"message", "custom_message"}:
                 flush_pending_native_function_calls()
                 scanned += 1
                 raw_message = row.get("message")
                 if isinstance(raw_message, dict):
-                    message = raw_message
+                    if ("role" in row or "content" in row) and _jsonl_wrapped_metadata_message(row, raw_message):
+                        message = row
+                    else:
+                        message = raw_message
                 elif "role" in row or "content" in row:
                     message = row
                 else:
                     invalid_rows += 1
                     warnings.append(_jsonl_warning(path, line_no, "message row missing message object"))
                     continue
-                row_id = _jsonl_row_id(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
                 timestamp_value = row.get("timestamp", message.get("timestamp"))
             elif row_type in JSONL_RESPONSES_FUNCTION_CALL_TYPES:
                 scanned += 1
@@ -1934,7 +3053,7 @@ def _collect_jsonl_candidates(
                     warnings.append(_jsonl_warning(path, line_no, f"{row_type} row missing tool call id or name"))
                     continue
                 message = _jsonl_responses_function_call_message(row)
-                row_id = _jsonl_row_id(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
                 timestamp_value = row.get("timestamp")
                 tool_calls = _jsonl_tool_calls(message)
                 if not tool_calls:
@@ -1942,16 +3061,16 @@ def _collect_jsonl_candidates(
                     skipped_empty += 1
                     continue
                 source_session = _jsonl_session_value(row, message, current_session)
-                if (
-                    pending_native_function_calls
-                    and pending_native_function_calls[-1].source_session != source_session
-                ):
+                parent_id = _jsonl_parent_id(row)
+                parent_key = _jsonl_canonical_id(parent_id, parent_canonical_by_id)
+                if pending_native_function_call_context_differs(source_session, parent_id):
                     flush_pending_native_function_calls()
                 pending_native_function_calls.append(
                     JsonlPendingFunctionCall(
                         line_no=line_no,
                         row=row,
                         row_id=row_id,
+                        parent_id=parent_key,
                         timestamp_value=timestamp_value,
                         source_session=source_session,
                         tool_call=tool_calls[0],
@@ -1963,31 +3082,52 @@ def _collect_jsonl_candidates(
                 scanned += 1
                 if not _jsonl_valid_importable_row(row):
                     invalid_rows += 1
-                    warnings.append(_jsonl_warning(path, line_no, f"{row_type} row missing tool call id or name"))
+                    warnings.append(
+                        _jsonl_warning(
+                            path,
+                            line_no,
+                            f"{row_type} row missing tool call id or name, or input/arguments",
+                        )
+                    )
                     continue
                 message = _jsonl_responses_function_call_message(row)
-                row_id = _jsonl_row_id(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
                 timestamp_value = row.get("timestamp")
             elif row_type in JSONL_RESPONSES_FUNCTION_OUTPUT_TYPES:
                 flush_pending_native_function_calls()
                 scanned += 1
                 message = _jsonl_responses_function_output_message(row)
-                row_id = _jsonl_row_id(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
                 timestamp_value = row.get("timestamp")
+                tool_call_id = _jsonl_message_field(message, "tool_call_id", "toolCallId", "call_id", "callId")
+                source_session = _jsonl_session_value(row, message, current_session)
+                resolved_source_session = _jsonl_resolve_tool_output_source_session(
+                    tool_call_id=tool_call_id,
+                    source_session=source_session,
+                    source_session_is_explicit=(
+                        current_session_from_header
+                        or _jsonl_explicit_session_value(row, message) is not None
+                    ),
+                    seen_tool_call_ids_by_session=known_tool_call_ids_by_session,
+                )
+                if resolved_source_session is None:
+                    continue
+                candidate_source_session_override = resolved_source_session
             elif row_type in {"toolResult", "tool_result"}:
                 flush_pending_native_function_calls()
                 scanned += 1
                 message = row
-                row_id = _jsonl_row_id(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
                 timestamp_value = row.get("timestamp")
-            elif row.get("type") is None and ("role" in row or "content" in row):
+            elif row.get("type") is None and (
+                isinstance(row.get("message"), dict) or "role" in row or "content" in row
+            ):
                 flush_pending_native_function_calls()
                 scanned += 1
-                message = row
-                row_id = _jsonl_row_id(row)
-                timestamp_value = row.get("timestamp")
+                message = _jsonl_row_message(row)
+                row_id = _jsonl_row_id_for_line(row, line_no, line_row_id_overrides)
+                timestamp_value = row.get("timestamp", message.get("timestamp"))
             else:
-                flush_pending_native_function_calls()
                 scanned += 1
                 invalid_rows += 1
                 warnings.append(_jsonl_warning(path, line_no, "unsupported row shape"))
@@ -1999,9 +3139,12 @@ def _collect_jsonl_candidates(
                 message=message,
                 row_id=row_id,
                 timestamp_value=timestamp_value,
+                source_row_id_override=candidate_source_row_id_override,
+                source_session_override=candidate_source_session_override,
             )
         flush_pending_native_function_calls()
 
+    candidates = _jsonl_order_candidates_by_tool_dependencies(candidates)
     return candidates, scanned, skipped_empty, len(source_sessions), invalid_rows, warnings
 
 
@@ -2017,10 +3160,29 @@ def import_jsonl_sessions(
     source_files = [Path(path) for path in files]
     target_path = Path(target_db)
     resolved_import_id = import_id or _default_jsonl_import_id(source_files)
+    existing_tool_call_ids = _existing_tool_call_ids_by_source_session(
+        target_path,
+        resolved_import_id,
+    )
+    existing_source_keys = _existing_source_message_keys(target_path, resolved_import_id)
+    prepass_candidates, _, _, _, _, _ = _collect_jsonl_candidates(
+        source_files,
+        namespace=namespace,
+        agent=agent,
+        existing_tool_call_ids_by_session=existing_tool_call_ids,
+        existing_source_keys=existing_source_keys,
+    )
+    current_run_tool_call_ids = _jsonl_tool_call_ids_by_source_session(
+        prepass_candidates,
+        excluded_source_keys=existing_source_keys,
+    )
     candidates, scanned, skipped_empty, conversations, invalid_rows, warnings = _collect_jsonl_candidates(
         source_files,
         namespace=namespace,
         agent=agent,
+        existing_tool_call_ids_by_session=existing_tool_call_ids,
+        current_run_tool_call_ids_by_session=current_run_tool_call_ids,
+        existing_source_keys=existing_source_keys,
     )
     return _process_import_candidates(
         source_label=",".join(str(path) for path in source_files),

--- a/tests/test_import_lossless_claw.py
+++ b/tests/test_import_lossless_claw.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import sqlite3
@@ -857,6 +858,46 @@ def jsonl_key(session_id: str, row_id: str) -> str:
     return json.dumps([session_id, row_id], separators=(",", ":"), ensure_ascii=False)
 
 
+def jsonl_result_row_id(result_type: str, tool_call_id: str, content: object) -> str:
+    if content is None:
+        normalized_content = None
+    elif isinstance(content, str):
+        normalized_content = content
+    else:
+        normalized_content = json.dumps(content, ensure_ascii=False, sort_keys=True)
+    content_hash = hashlib.sha256((normalized_content or "").encode("utf-8")).hexdigest()
+    return "result:" + json.dumps(
+        [result_type, tool_call_id, content_hash],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def jsonl_tool_call_row_id(call_type: str, tool_call_id: str, tool_name: str, arguments: object) -> str:
+    if isinstance(arguments, str):
+        try:
+            decoded_arguments = json.loads(arguments)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            normalized_arguments = arguments
+        else:
+            if decoded_arguments is None:
+                normalized_arguments = ""
+            elif isinstance(decoded_arguments, str):
+                normalized_arguments = decoded_arguments
+            else:
+                normalized_arguments = json.dumps(decoded_arguments, ensure_ascii=False, sort_keys=True)
+    elif arguments is None:
+        normalized_arguments = ""
+    else:
+        normalized_arguments = json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+    arguments_hash = hashlib.sha256(normalized_arguments.encode("utf-8")).hexdigest()
+    return "tool_call:" + json.dumps(
+        [call_type, tool_call_id, tool_name, arguments_hash],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
 def jsonl_message(
     entry_id: str,
     role: str,
@@ -1069,6 +1110,69 @@ def test_jsonl_import_reports_non_string_type_rows_without_aborting(tmp_path: Pa
     assert rows == [("user", "root"), ("assistant", "current")]
 
 
+def test_jsonl_import_wrapped_metadata_message_does_not_drive_leaf_pruning(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-metadata-tail.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("probe"),
+            jsonl_message("m1", "user", "root"),
+            jsonl_message("m2", "assistant", "current", parent_id="m1"),
+            {"id": "meta", "parentId": "m1", "message": {"type": "reasoning", "content": "tail metadata"}},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="wrapped-metadata-tail", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    assert result.skipped_empty == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+    assert rows == [("user", "root"), ("assistant", "current")]
+
+
+def test_jsonl_import_untyped_envelope_metadata_without_content_does_not_drive_leaf_pruning(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope-metadata-tail.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+            {
+                "type": "message",
+                "id": "leaf",
+                "parentId": "root",
+                "message": {"role": "assistant", "content": "current"},
+            },
+            {"id": "meta", "parentId": "root", "message": {"summary": "tail metadata"}},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="untyped-envelope-metadata-tail", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    assert result.skipped_empty == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+    assert rows == [("user", "root"), ("assistant", "current")]
+
+
 def test_jsonl_import_maps_openclaw_tool_call_and_tool_result_entries(tmp_path: Path):
     importer = load_importer_module()
     session_file = tmp_path / "session-a.jsonl"
@@ -1188,6 +1292,325 @@ def test_jsonl_import_prefers_responses_function_call_call_id_over_item_id(tmp_p
     assert tool == ("tool", "found it", "call_lookup_memory", "lookup_memory")
 
 
+def test_jsonl_import_rejects_nested_responses_function_call_without_call_id(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-function-call-missing-call-id.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-function-call-missing-call-id"),
+            {
+                "type": "message",
+                "id": "assistant-tool-call",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "function_call",
+                            "id": "fc_1",
+                            "name": "lookup",
+                            "arguments": "{}",
+                        },
+                    ],
+                },
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-function-call-missing-call-id",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("message content tool call item missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+@pytest.mark.parametrize("row_shape", ["top-level", "wrapped"])
+def test_jsonl_import_rejects_responses_function_object_without_call_id(
+    tmp_path: Path,
+    row_shape: str,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / f"responses-function-object-missing-call-id-{row_shape}.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    function_call = {
+        "type": "function_call",
+        "id": "fc_1",
+        "function": {"name": "lookup", "arguments": "{}"},
+    }
+    row = (
+        {"type": "message", "id": "fc-envelope", "message": function_call}
+        if row_shape == "wrapped"
+        else function_call
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header(f"responses-function-object-missing-call-id-{row_shape}"),
+            row,
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=f"responses-function-object-missing-call-id-{row_shape}",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("function_call row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+@pytest.mark.parametrize("tool_calls_key", ["tool_calls", "toolCalls"])
+def test_jsonl_import_rejects_malformed_message_tool_calls_array(
+    tmp_path: Path,
+    tool_calls_key: str,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / f"malformed-{tool_calls_key}.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("bad-tool-calls"),
+            jsonl_message(
+                "m1",
+                "assistant",
+                None,
+                **{
+                    tool_calls_key: [
+                        {"type": "function", "function": {"name": "lookup", "arguments": "{}"}},
+                    ],
+                },
+            ),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=f"malformed-{tool_calls_key}", apply=True
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert result.skipped_empty == 0
+    assert any("message tool_calls item missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_reads_tool_calls_when_both_array_spellings_are_present(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "both-tool-call-array-spellings.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("both-tool-call-array-spellings"),
+            jsonl_message(
+                "m1",
+                "assistant",
+                None,
+                tool_calls=[],
+                toolCalls=[
+                    {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}},
+                ],
+            ),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="both-tool-call-array-spellings",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.imported == 1
+    assert result.invalid_rows == 0
+    assert result.skipped_empty == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+
+
+def test_jsonl_import_deduplicates_same_tool_call_from_both_array_spellings(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "duplicate-tool-call-array-spellings.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    call = {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("duplicate-tool-call-array-spellings"),
+            jsonl_message("m1", "assistant", None, tool_calls=[call], toolCalls=[call]),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="duplicate-tool-call-array-spellings",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.imported == 1
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+
+
+def test_jsonl_import_rejects_malformed_tool_calls_when_both_array_spellings_are_present(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "both-tool-call-array-spellings-malformed.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("both-tool-call-array-spellings-malformed"),
+            jsonl_message(
+                "m1",
+                "assistant",
+                None,
+                tool_calls=[],
+                toolCalls=[
+                    {"id": "call_1", "type": ["function"], "function": {"name": "lookup", "arguments": "{}"}},
+                ],
+            ),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="both-tool-call-array-spellings-malformed",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert result.skipped_empty == 0
+    assert any("message tool_calls item missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_rejects_non_string_message_tool_call_type_and_skips_output(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "non-string-tool-call-type.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "message",
+                "id": "bad",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_bad",
+                            "type": ["function"],
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        },
+                    ],
+                },
+            },
+            {"type": "function_call_output", "call_id": "call_bad", "output": "orphan"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="non-string-tool-call-type",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert result.skipped_empty == 0
+    assert any("message tool_calls item missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_rejects_non_list_message_tool_calls(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "non-list-tool-calls.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("non-list-tool-calls"),
+            {
+                "type": "message",
+                "id": "m1",
+                "message": {
+                    "role": "assistant",
+                    "content": "text",
+                    "tool_calls": {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    },
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="non-list-tool-calls",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert result.skipped_empty == 0
+    assert any("message tool_calls must be a list" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
 def test_jsonl_import_maps_native_responses_function_call_and_output_items(tmp_path: Path):
     importer = load_importer_module()
     session_file = tmp_path / "responses-native-items.jsonl"
@@ -1233,7 +1656,1377 @@ def test_jsonl_import_maps_native_responses_function_call_and_output_items(tmp_p
     assert rows[1] == ("tool", "result", "call_1", None, None)
     assert import_keys == [
         (jsonl_key("responses-native-items", "fc_1"),),
-        (jsonl_key("responses-native-items", "line:3"),),
+        (
+            jsonl_key(
+                "responses-native-items",
+                jsonl_result_row_id("function_call_output", "call_1", "result"),
+            ),
+        ),
+    ]
+
+
+def test_jsonl_import_maps_bare_untyped_responses_function_call_and_output_items(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-bare-items.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-bare-items"),
+            {"call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="responses-bare-items", apply=True
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="responses-bare-items", apply=True
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+
+
+def test_jsonl_import_maps_bare_content_responses_function_output_item(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-bare-content-output.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("s"),
+            {"type": "function_call", "id": "fc", "call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"call_id": "call_1", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-bare-content-output",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "fc"),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_1", "result")),),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+def test_jsonl_import_maps_typed_wrapped_responses_function_call_and_output_items(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-responses.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("wrapped-responses"),
+            {
+                "type": "message",
+                "id": "fc-env",
+                "message": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": {"q": "x"},
+                },
+            },
+            {
+                "type": "custom_message",
+                "id": "out-env",
+                "message": {"type": "function_call_output", "id": "out_1", "call_id": "call_1", "output": "result"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="wrapped-responses", apply=True
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": '{"q":"x"}'}}
+    ]
+    assert rows[0][4] is None
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("wrapped-responses", "fc_1"),),
+        (jsonl_key("wrapped-responses", "out_1"),),
+    ]
+
+
+def test_jsonl_import_maps_untyped_wrapped_responses_function_call_and_output_items(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-wrapped-responses.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("untyped-wrapped-responses"),
+            {
+                "id": "fc-env",
+                "message": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": {"q": "x"},
+                },
+            },
+            {
+                "id": "out-env",
+                "message": {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="untyped-wrapped-responses", apply=True
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": '{"q":"x"}'}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("untyped-wrapped-responses", "fc-env"),),
+        (jsonl_key("untyped-wrapped-responses", "out-env"),),
+    ]
+
+
+def test_jsonl_import_preserves_untyped_top_level_message_with_nested_metadata(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-top-level-with-message-metadata.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("untyped-top-level-with-message-metadata"),
+            {
+                "id": "m1",
+                "role": "user",
+                "content": "visible top-level content",
+                "message": {"type": "reasoning", "summary": "auxiliary metadata"},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-top-level-with-message-metadata",
+        apply=True,
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-top-level-with-message-metadata",
+        apply=True,
+    )
+
+    assert first.scanned == 1
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert first.invalid_rows == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("user", "visible top-level content")]
+    assert import_keys == [(jsonl_key("untyped-top-level-with-message-metadata", "m1"),)]
+
+
+@pytest.mark.parametrize("wrapper_type", ["message", "custom_message"])
+def test_jsonl_import_preserves_typed_top_level_message_with_nested_metadata(
+    tmp_path: Path,
+    wrapper_type: str,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / f"{wrapper_type}-top-level-with-message-metadata.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": wrapper_type,
+                "id": "m1",
+                "role": "user",
+                "content": "visible top-level content",
+                "message": {"type": "reasoning", "summary": "auxiliary metadata"},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=f"{wrapper_type}-top-level-with-message-metadata",
+        apply=True,
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=f"{wrapper_type}-top-level-with-message-metadata",
+        apply=True,
+    )
+
+    assert first.scanned == 1
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert first.invalid_rows == 0
+    assert first.skipped_empty == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("user", "visible top-level content")]
+    assert import_keys == [(jsonl_key("s", "m1"),)]
+
+
+@pytest.mark.parametrize("wrapper_type", ["message", "custom_message"])
+def test_jsonl_import_preserves_typed_top_level_message_when_nested_role_metadata_has_no_content(
+    tmp_path: Path,
+    wrapper_type: str,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / f"{wrapper_type}-top-level-with-role-metadata.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": wrapper_type,
+                "id": "m1",
+                "role": "user",
+                "content": "visible top-level content",
+                "message": {"role": "user", "metadata": {"aux": True}},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=f"{wrapper_type}-top-level-with-role-metadata",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.imported == 1
+    assert result.skipped_empty == 0
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+
+    assert rows == [("user", "visible top-level content")]
+
+
+def test_jsonl_import_does_not_alias_nested_metadata_id_over_top_level_message(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "typed-top-level-metadata-id-collision.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "message",
+                "id": "m1",
+                "role": "user",
+                "content": "root",
+                "message": {"id": "m2", "type": "reasoning", "summary": "aux"},
+            },
+            {
+                "type": "message",
+                "id": "env2",
+                "message": {"id": "m2", "parentId": "m1", "role": "assistant", "content": "leaf"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="typed-top-level-metadata-id-collision",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("user", "root"), ("assistant", "leaf")]
+    assert import_keys == [(jsonl_key("s", "m1"),), (jsonl_key("s", "m2"),)]
+
+
+@pytest.mark.parametrize("tool_calls_key", ["tool_calls", "toolCalls"])
+def test_jsonl_import_empty_tool_calls_metadata_does_not_prune_real_leaf(
+    tmp_path: Path,
+    tool_calls_key: str,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / f"empty-{tool_calls_key}-metadata-branch.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "message", "id": "m1", "message": {"role": "user", "content": "root"}},
+            {
+                "type": "message",
+                "id": "m2",
+                "parentId": "m1",
+                "message": {"role": "assistant", "content": "current"},
+            },
+            {
+                "type": "message",
+                "id": "meta",
+                "parentId": "m1",
+                "message": {"type": "reasoning", "content": "tail metadata", tool_calls_key: []},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=f"empty-{tool_calls_key}-metadata-branch",
+        apply=True,
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.skipped_empty == 1
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("user", "root"), ("assistant", "current")]
+    assert import_keys == [(jsonl_key("s", "m1"),), (jsonl_key("s", "m2"),)]
+
+
+def test_jsonl_import_prunes_untyped_wrapped_native_call_branch_by_nested_parent(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-wrapped-native-call-branch.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+            {
+                "id": "env-old",
+                "message": {"id": "old", "parentId": "root", "role": "assistant", "content": "old branch"},
+            },
+            {
+                "id": "env-call",
+                "message": {
+                    "id": "nested-call",
+                    "type": "function_call",
+                    "parentId": "root",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": {},
+                },
+            },
+            {
+                "id": "env-final",
+                "message": {"id": "final", "parentId": "nested-call", "role": "assistant", "content": "final"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-wrapped-native-call-branch",
+        apply=True,
+    )
+
+    assert result.scanned == 4
+    assert result.eligible == 3
+    assert result.imported == 3
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_calls FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None)
+    assert rows[1][0:2] == ("assistant", None)
+    assert json.loads(rows[1][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[2] == ("assistant", "final", None)
+    assert import_keys == [
+        (jsonl_key("s", "env-root"),),
+        (jsonl_key("s", "env-call"),),
+        (jsonl_key("s", "env-final"),),
+    ]
+
+
+def test_jsonl_import_rejects_non_string_nested_message_type(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "nested-nonstring.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("nested-nonstring"),
+            {
+                "type": "message",
+                "id": "bad-result",
+                "message": {"type": ["toolResult"], "toolCallId": "call_1", "content": "result"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="nested-nonstring", apply=True
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("nested-nonstring.jsonl:2" in warning for warning in result.warnings)
+    assert any("non-string nested type" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_imports_responses_function_output_from_later_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    first_file = tmp_path / "responses-catchup-1.jsonl"
+    second_file = tmp_path / "responses-catchup-2.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        first_file,
+        [
+            jsonl_header("responses-catchup"),
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[first_file],
+        target_db=target_db,
+        import_id="responses-catchup",
+        apply=True,
+    )
+    write_jsonl_session(
+        second_file,
+        [
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[second_file],
+        target_db=target_db,
+        import_id="responses-catchup",
+        apply=True,
+    )
+
+    assert first.imported == 1
+    assert second.scanned == 1
+    assert second.eligible == 1
+    assert second.imported == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("responses-catchup", "fc_1"),),
+        (
+            jsonl_key(
+                "responses-catchup",
+                jsonl_result_row_id("function_call_output", "call_1", "result"),
+            ),
+        ),
+    ]
+
+
+def test_jsonl_import_resolves_responses_output_before_call_file_in_same_run(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    output_file = tmp_path / "a-output.jsonl"
+    call_file = tmp_path / "b-call.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        output_file,
+        [{"type": "function_call_output", "call_id": "call_1", "output": "result"}],
+    )
+    write_jsonl_session(
+        call_file,
+        [
+            jsonl_header("catchup-order"),
+            {
+                "type": "function_call",
+                "id": "fc1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": {},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[output_file, call_file],
+        target_db=target_db,
+        import_id="responses-catchup-order",
+        apply=True,
+    )
+    second = importer.import_jsonl_sessions(
+        files=[output_file, call_file],
+        target_db=target_db,
+        import_id="responses-catchup-order",
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_rows = conn.execute(
+        """SELECT source_session, source_message_key
+           FROM lcm_imported_messages
+           ORDER BY source_message_key"""
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_rows == [
+        ("catchup-order", jsonl_key("catchup-order", "fc1")),
+        (
+            "catchup-order",
+            jsonl_key(
+                "catchup-order",
+                jsonl_result_row_id("function_call_output", "call_1", "result"),
+            ),
+        ),
+    ]
+
+
+def test_jsonl_import_idless_native_function_output_key_survives_line_shift(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-line-shift.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-native-line-shift"),
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-native-line-shift",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-native-line-shift"),
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+            {"type": "reasoning", "id": "rs_1", "summary": "inserted metadata"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-native-line-shift",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    message_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    conn.close()
+
+    assert message_count == 2
+    assert import_keys == [
+        (jsonl_key("responses-native-line-shift", "fc_1"),),
+        (
+            jsonl_key(
+                "responses-native-line-shift",
+                jsonl_result_row_id("function_call_output", "call_1", "result"),
+            ),
+        ),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+def test_jsonl_import_idless_responses_function_call_key_survives_line_shift(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-idless-call-line-shift.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-idless-call-line-shift"),
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-idless-call-line-shift",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-idless-call-line-shift"),
+            {"type": "reasoning", "id": "rs_1", "summary": "inserted metadata"},
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-idless-call-line-shift",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (
+            jsonl_key(
+                "responses-idless-call-line-shift",
+                jsonl_tool_call_row_id("function_call", "call_1", "lookup", {}),
+            ),
+        ),
+        (
+            jsonl_key(
+                "responses-idless-call-line-shift",
+                jsonl_result_row_id("function_call_output", "call_1", "result"),
+            ),
+        ),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+def test_jsonl_import_idless_responses_function_call_skips_legacy_line_key_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-idless-call-legacy-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-idless-call-legacy-catchup"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    conn = sqlite3.connect(target_db)
+    target_store_ids = [
+        store_id
+        for (store_id,) in conn.execute(
+            "SELECT target_store_id FROM lcm_imported_messages ORDER BY target_store_id"
+        ).fetchall()
+    ]
+    for target_store_id, row_id in zip(target_store_ids, ["line:2", "line:3"], strict=True):
+        source_message_key = jsonl_key("s", row_id)
+        conn.execute(
+            """UPDATE lcm_imported_messages
+               SET source_message_id = ?, source_message_key = ?
+               WHERE import_id = ? AND target_store_id = ?""",
+            (
+                importer._stable_positive_int(source_message_key),
+                source_message_key,
+                import_id,
+                target_store_id,
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 2
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    message_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+    assert message_count == 2
+    assert import_keys == [(jsonl_key("s", "line:2"),), (jsonl_key("s", "line:3"),)]
+
+
+def test_jsonl_import_idless_responses_function_call_skips_legacy_grouped_line_key_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-idless-grouped-call-legacy-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-idless-grouped-call-legacy-catchup"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": {}},
+            {"type": "function_call", "call_id": "call_2", "name": "search", "arguments": {}},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    legacy_grouped_row_id = "function_calls:" + json.dumps(
+        ["line:2", "line:3"],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    legacy_grouped_key = jsonl_key("s", legacy_grouped_row_id)
+    conn = sqlite3.connect(target_db)
+    target_store_id = conn.execute(
+        "SELECT target_store_id FROM lcm_imported_messages WHERE import_id = ?",
+        (import_id,),
+    ).fetchone()[0]
+    conn.execute(
+        """UPDATE lcm_imported_messages
+           SET source_message_id = ?, source_message_key = ?
+           WHERE import_id = ? AND target_store_id = ?""",
+        (
+            importer._stable_positive_int(legacy_grouped_key),
+            legacy_grouped_key,
+            import_id,
+            target_store_id,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert second.scanned == 2
+    assert second.eligible == 1
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [(legacy_grouped_key,)]
+
+
+def test_jsonl_import_appended_responses_function_call_does_not_reimport_existing_sibling(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-appended-sibling.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-appended-sibling"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "lookup", "arguments": {}},
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows,
+            {"type": "function_call", "id": "fc_2", "call_id": "call_2", "name": "search", "arguments": {}},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 1
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert second.scanned == 2
+    assert second.eligible == 2
+    assert second.imported == 1
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1][0:2] == ("assistant", None)
+    assert json.loads(rows[1][2]) == [
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}}
+    ]
+    assert import_keys == [(jsonl_key("s", "fc_1"),), (jsonl_key("s", "fc_2"),)]
+
+
+def test_jsonl_import_malformed_row_does_not_split_existing_responses_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-malformed-row-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-malformed-row-catchup"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "lookup", "arguments": {}},
+        {"type": "function_call", "id": "fc_2", "call_id": "call_2", "name": "search", "arguments": {}},
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows[:2],
+            "{bad json",
+            first_rows[2],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert first.invalid_rows == 0
+    assert second.scanned == 3
+    assert second.eligible == 1
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 1
+    assert any("responses-native-malformed-row-catchup.jsonl:3: invalid JSON" in warning for warning in second.warnings)
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [(jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),)]
+
+
+def test_jsonl_import_malformed_json_object_does_not_split_existing_responses_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-malformed-object-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-malformed-object-catchup"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "lookup", "arguments": {}},
+        {"type": "function_call", "id": "fc_2", "call_id": "call_2", "name": "search", "arguments": {}},
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows[:2],
+            {"type": ["reasoning"], "id": "bad"},
+            first_rows[2],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert first.invalid_rows == 0
+    assert second.scanned == 3
+    assert second.eligible == 1
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 1
+    assert any(
+        "responses-native-malformed-object-catchup.jsonl:3: unsupported row shape" in warning
+        for warning in second.warnings
+    )
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [(jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),)]
+
+
+def test_jsonl_import_nested_non_string_type_does_not_split_existing_responses_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-nested-nonstring-type-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-nested-nonstring-type-catchup"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "lookup", "arguments": {}},
+        {"type": "function_call", "id": "fc_2", "call_id": "call_2", "name": "search", "arguments": {}},
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows[:2],
+            {"type": "message", "id": "bad", "message": {"type": ["reasoning"]}},
+            first_rows[2],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 1
+    assert first.imported == 1
+    assert first.invalid_rows == 0
+    assert second.scanned == 3
+    assert second.eligible == 1
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 1
+    assert any(
+        "responses-native-nested-nonstring-type-catchup.jsonl:3: message row has non-string nested type" in warning
+        for warning in second.warnings
+    )
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0:2] == ("assistant", None)
+    assert json.loads(rows[0][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [(jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),)]
+
+
+def test_jsonl_import_unsupported_metadata_does_not_split_existing_responses_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-unsupported-metadata-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-unsupported-metadata-catchup"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "parentId": "root",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": {},
+        },
+        {
+            "type": "function_call",
+            "id": "fc_2",
+            "parentId": "root",
+            "call_id": "call_2",
+            "name": "search",
+            "arguments": {},
+        },
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows[:3],
+            {"type": "reasoning", "id": "meta", "parentId": "other", "summary": "m"},
+            first_rows[3],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 3
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.scanned == 4
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 2
+    assert rows[0] == ("user", "root", None)
+    assert rows[1][0:2] == ("assistant", None)
+    assert json.loads(rows[1][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [
+        (jsonl_key("s", "root"),),
+        (jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),),
+    ]
+
+
+def test_jsonl_import_wrapped_metadata_does_not_split_existing_responses_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-wrapped-metadata-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "responses-native-wrapped-metadata-catchup"
+    first_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "parentId": "root",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": {},
+        },
+        {
+            "type": "function_call",
+            "id": "fc_2",
+            "parentId": "root",
+            "call_id": "call_2",
+            "name": "search",
+            "arguments": {},
+        },
+    ]
+    write_jsonl_session(session_file, first_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *first_rows[:3],
+            {"type": "message", "id": "meta", "parentId": "other", "message": {"type": "reasoning", "summary": "m"}},
+            first_rows[3],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id=import_id,
+        apply=True,
+    )
+
+    assert first.scanned == 3
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.scanned == 4
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    assert second.skipped_empty == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content, tool_calls FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 2
+    assert rows[0] == ("user", "root", None)
+    assert rows[1][0:2] == ("assistant", None)
+    assert json.loads(rows[1][2]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert import_keys == [
+        (jsonl_key("s", "root"),),
+        (jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),),
     ]
 
 
@@ -1299,8 +3092,18 @@ def test_jsonl_import_groups_consecutive_native_responses_function_calls(tmp_pat
     assert rows[2] == ("tool", "search result", "call_2", None, None)
     assert import_keys == [
         (jsonl_key("responses-native-parallel", 'function_calls:["fc_1","fc_2"]'),),
-        (jsonl_key("responses-native-parallel", "line:4"),),
-        (jsonl_key("responses-native-parallel", "line:5"),),
+        (
+            jsonl_key(
+                "responses-native-parallel",
+                jsonl_result_row_id("function_call_output", "call_1", "lookup result"),
+            ),
+        ),
+        (
+            jsonl_key(
+                "responses-native-parallel",
+                jsonl_result_row_id("function_call_output", "call_2", "search result"),
+            ),
+        ),
     ]
 
 
@@ -1371,8 +3174,545 @@ def test_jsonl_import_keeps_parent_linked_parallel_native_function_calls(tmp_pat
     assert import_keys == [
         (jsonl_key("responses-native-parent-parallel", "m1"),),
         (jsonl_key("responses-native-parent-parallel", 'function_calls:["fc_1","fc_2"]'),),
-        (jsonl_key("responses-native-parent-parallel", "line:5"),),
-        (jsonl_key("responses-native-parent-parallel", "line:6"),),
+        (
+            jsonl_key(
+                "responses-native-parent-parallel",
+                jsonl_result_row_id("function_call_output", "call_1", "lookup result"),
+            ),
+        ),
+        (
+            jsonl_key(
+                "responses-native-parent-parallel",
+                jsonl_result_row_id("function_call_output", "call_2", "search result"),
+            ),
+        ),
+    ]
+
+
+def test_jsonl_import_keeps_responses_siblings_with_alias_equivalent_parents(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-alias-parent-parallel.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "parentId": "root",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": {},
+            },
+            {
+                "type": "function_call",
+                "id": "fc_2",
+                "parentId": "env-root",
+                "call_id": "call_2",
+                "name": "search",
+                "arguments": {},
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "r1"},
+            {"type": "function_call_output", "call_id": "call_2", "output": "r2"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-native-alias-parent-parallel",
+        apply=True,
+    )
+
+    assert result.scanned == 5
+    assert result.eligible == 4
+    assert result.imported == 4
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1][0:3] == ("assistant", None, None)
+    assert json.loads(rows[1][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert rows[1][4] is None
+    assert rows[2] == ("tool", "r1", "call_1", None, None)
+    assert rows[3] == ("tool", "r2", "call_2", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "env-root"),),
+        (jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_1", "r1")),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_2", "r2")),),
+    ]
+
+
+@pytest.mark.parametrize("function_call_shape", ["top-level", "wrapped", "bare"])
+def test_jsonl_import_splits_pending_responses_function_calls_on_parent_change(
+    tmp_path: Path,
+    function_call_shape: str,
+):
+    importer = load_importer_module()
+    test_id = f"responses-parent-split-{function_call_shape}"
+    session_file = tmp_path / f"{test_id}.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+
+    def function_call_row(parent_id: str, call_id: str, name: str) -> dict[str, object]:
+        message = {
+            "type": "function_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": {},
+        }
+        if function_call_shape == "wrapped":
+            return {"type": "message", "parentId": parent_id, "message": message}
+        if function_call_shape == "bare":
+            return {
+                "parentId": parent_id,
+                "call_id": call_id,
+                "name": name,
+                "arguments": {},
+            }
+        return {"type": "function_call", "parentId": parent_id, **message}
+
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header(test_id),
+            jsonl_message("root", "user", "root"),
+            jsonl_message("mid", "assistant", "mid", parent_id="root"),
+            function_call_row("root", "call_1", "lookup"),
+            function_call_row("mid", "call_2", "search"),
+            {"type": "function_call_output", "call_id": "call_1", "output": "r1"},
+            {"type": "function_call_output", "call_id": "call_2", "output": "r2"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=test_id, apply=True
+    )
+
+    assert result.scanned == 6
+    assert result.eligible == 6
+    assert result.imported == 6
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1] == ("assistant", "mid", None, None, None)
+    assert rows[2][0:3] == ("assistant", None, None)
+    assert json.loads(rows[2][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[3][0:3] == ("assistant", None, None)
+    assert json.loads(rows[3][3]) == [
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}}
+    ]
+    assert rows[4] == ("tool", "r1", "call_1", None, None)
+    assert rows[5] == ("tool", "r2", "call_2", None, None)
+
+
+@pytest.mark.parametrize(
+    ("wrapper_type", "metadata_message"),
+    [
+        ("message", {"type": "reasoning", "summary": "meta"}),
+        ("custom_message", {"type": "reasoning", "summary": "meta"}),
+        (None, {"type": "reasoning", "summary": "meta"}),
+        ("message", {"summary": "meta"}),
+        ("custom_message", {"summary": "meta"}),
+        (None, {"summary": "meta"}),
+    ],
+    ids=[
+        "message-reasoning",
+        "custom-message-reasoning",
+        "untyped-reasoning",
+        "message-metadata",
+        "custom-message-metadata",
+        "untyped-metadata",
+    ],
+)
+def test_jsonl_import_metadata_wrappers_do_not_split_responses_group_on_catchup(
+    tmp_path: Path,
+    wrapper_type: str | None,
+    metadata_message: dict[str, object],
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-metadata-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = f"responses-metadata-catchup-{wrapper_type or 'untyped'}-{len(metadata_message)}"
+    initial_rows: list[dict[str, object]] = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "m1", "message": {"role": "user", "content": "root"}},
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "parentId": "m1",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": {},
+        },
+        {
+            "type": "function_call",
+            "id": "fc_2",
+            "parentId": "m1",
+            "call_id": "call_2",
+            "name": "search",
+            "arguments": {},
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "r1"},
+        {"type": "function_call_output", "call_id": "call_2", "output": "r2"},
+    ]
+    metadata_row: dict[str, object] = {
+        "id": "meta",
+        "parentId": "m1",
+        "message": {**metadata_message},
+    }
+    if wrapper_type is not None:
+        metadata_row["type"] = wrapper_type
+
+    write_jsonl_session(session_file, initial_rows)
+    first = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=import_id, apply=True
+    )
+    write_jsonl_session(session_file, initial_rows[:3] + [metadata_row] + initial_rows[3:])
+    second = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=import_id, apply=True
+    )
+
+    assert first.imported == 4
+    assert first.invalid_rows == 0
+    assert second.scanned == 6
+    assert second.eligible == 4
+    assert second.imported == 0
+    assert second.skipped_existing == 4
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1][0:3] == ("assistant", None, None)
+    assert json.loads(rows[1][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert rows[2] == ("tool", "r1", "call_1", None, None)
+    assert rows[3] == ("tool", "r2", "call_2", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "m1"),),
+        (jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_1", "r1")),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_2", "r2")),),
+    ]
+
+
+def test_jsonl_import_metadata_parented_to_previous_function_call_does_not_split_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-metadata-previous-call-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    initial_rows: list[dict[str, object]] = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "parentId": "root",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": {},
+        },
+        {
+            "type": "function_call",
+            "id": "fc_2",
+            "parentId": "root",
+            "call_id": "call_2",
+            "name": "search",
+            "arguments": {},
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "r1"},
+        {"type": "function_call_output", "call_id": "call_2", "output": "r2"},
+    ]
+
+    write_jsonl_session(session_file, initial_rows)
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-metadata-previous-call-catchup",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *initial_rows[:3],
+            {"type": "message", "id": "meta", "parentId": "fc_1", "message": {"type": "reasoning", "summary": "meta"}},
+            *initial_rows[3:],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-metadata-previous-call-catchup",
+        apply=True,
+    )
+
+    assert first.imported == 4
+    assert first.invalid_rows == 0
+    assert second.scanned == 6
+    assert second.eligible == 4
+    assert second.imported == 0
+    assert second.skipped_existing == 4
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1][0:3] == ("assistant", None, None)
+    assert json.loads(rows[1][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert rows[2] == ("tool", "r1", "call_1", None, None)
+    assert rows[3] == ("tool", "r2", "call_2", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "root"),),
+        (jsonl_key("s", 'function_calls:["fc_1","fc_2"]'),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_1", "r1")),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_2", "r2")),),
+    ]
+
+
+def test_jsonl_import_bare_metadata_parented_to_call_id_does_not_split_group_on_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-bare-metadata-call-id-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    initial_rows: list[dict[str, object]] = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+        {"parentId": "root", "call_id": "call_1", "name": "lookup", "arguments": {}},
+        {"parentId": "root", "call_id": "call_2", "name": "search", "arguments": {}},
+        {"type": "function_call_output", "call_id": "call_1", "output": "r1"},
+        {"type": "function_call_output", "call_id": "call_2", "output": "r2"},
+    ]
+
+    write_jsonl_session(session_file, initial_rows)
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-bare-metadata-call-id-catchup",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *initial_rows[:3],
+            {"id": "meta", "parentId": "call_1", "message": {"type": "reasoning", "summary": "m"}},
+            *initial_rows[3:],
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-bare-metadata-call-id-catchup",
+        apply=True,
+    )
+
+    assert first.imported == 4
+    assert first.invalid_rows == 0
+    assert second.scanned == 6
+    assert second.eligible == 4
+    assert second.imported == 0
+    assert second.skipped_existing == 4
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1][0:3] == ("assistant", None, None)
+    assert json.loads(rows[1][3]) == [
+        {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}},
+        {"id": "call_2", "type": "function_call", "function": {"name": "search", "arguments": "{}"}},
+    ]
+    assert rows[2] == ("tool", "r1", "call_1", None, None)
+    assert rows[3] == ("tool", "r2", "call_2", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "root"),),
+        (
+            jsonl_key(
+                "s",
+                "function_calls:"
+                + json.dumps(
+                    [
+                        jsonl_tool_call_row_id("function_call", "call_1", "lookup", {}),
+                        jsonl_tool_call_row_id("function_call", "call_2", "search", {}),
+                    ],
+                    separators=(",", ":"),
+                ),
+            ),
+        ),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_1", "r1")),),
+        (jsonl_key("s", jsonl_result_row_id("function_call_output", "call_2", "r2")),),
+    ]
+
+
+def test_jsonl_import_keeps_parent_linked_native_function_call_siblings_across_reasoning_row(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-native-parent-parallel-reasoning.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-native-parent-parallel-reasoning"),
+            jsonl_message("m1", "user", "root"),
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "parentId": "m1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": {"query": "sammy"},
+            },
+            {
+                "type": "function_call",
+                "id": "fc_2",
+                "parentId": "m1",
+                "call_id": "call_2",
+                "name": "search",
+                "arguments": {"query": "memory"},
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "lookup result"},
+            {"type": "function_call_output", "call_id": "call_2", "output": "search result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-native-parent-parallel-reasoning",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-native-parent-parallel-reasoning"),
+            jsonl_message("m1", "user", "root"),
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "parentId": "m1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": {"query": "sammy"},
+            },
+            {"id": "rs_1", "parentId": "m1", "message": {"type": "reasoning", "summary": "interleaved"}},
+            {
+                "type": "function_call",
+                "id": "fc_2",
+                "parentId": "m1",
+                "call_id": "call_2",
+                "name": "search",
+                "arguments": {"query": "memory"},
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "lookup result"},
+            {"type": "function_call_output", "call_id": "call_2", "output": "search result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-native-parent-parallel-reasoning",
+        apply=True,
+    )
+
+    assert first.scanned == 5
+    assert first.eligible == 4
+    assert first.imported == 4
+    assert first.invalid_rows == 0
+    assert second.scanned == 6
+    assert second.eligible == 4
+    assert second.imported == 0
+    assert second.skipped_existing == 4
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("user", "root", None, None, None)
+    assert rows[1][0:3] == ("assistant", None, None)
+    assert json.loads(rows[1][3]) == [
+        {
+            "id": "call_1",
+            "type": "function_call",
+            "function": {"name": "lookup", "arguments": '{"query":"sammy"}'},
+        },
+        {
+            "id": "call_2",
+            "type": "function_call",
+            "function": {"name": "search", "arguments": '{"query":"memory"}'},
+        },
+    ]
+    assert rows[2] == ("tool", "lookup result", "call_1", None, None)
+    assert rows[3] == ("tool", "search result", "call_2", None, None)
+    assert import_keys == [
+        (jsonl_key("responses-native-parent-parallel-reasoning", "m1"),),
+        (
+            jsonl_key(
+                "responses-native-parent-parallel-reasoning",
+                'function_calls:["fc_1","fc_2"]',
+            ),
+        ),
+        (
+            jsonl_key(
+                "responses-native-parent-parallel-reasoning",
+                jsonl_result_row_id("function_call_output", "call_1", "lookup result"),
+            ),
+        ),
+        (
+            jsonl_key(
+                "responses-native-parent-parallel-reasoning",
+                jsonl_result_row_id("function_call_output", "call_2", "search result"),
+            ),
+        ),
     ]
 
 
@@ -1439,6 +3779,1047 @@ def test_jsonl_import_maps_top_level_openclaw_tool_call_rows(
     ]
     assert rows[0][4] is None
     assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+
+
+def test_jsonl_import_maps_top_level_tool_use_name_on_result_rows(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "top-level-tool-use-name.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("top-level-tool-use-name"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+            {"type": "toolResult", "id": "tr1", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="top-level-tool-use-name", apply=True
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"query":"sammy"}'}}
+    ]
+    assert rows[0][4] is None
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+
+
+def test_jsonl_import_accepts_openclaw_tool_use_with_empty_string_input(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "openclaw-tool-use-empty-string-input.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": "",
+            },
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-tool-use-empty-string-input",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    assert result.skipped_empty == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": ""}}
+    ]
+    assert rows[0][4] is None
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+
+
+def test_jsonl_import_rejects_openclaw_tool_use_without_input(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "openclaw-tool-use-missing-input.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "toolUse", "id": "tu1", "toolUseId": "call_1", "toolUseName": "lookup"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-tool-use-missing-input",
+        apply=True,
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert result.skipped_empty == 0
+    assert any(
+        "toolUse row missing tool call id or name, or input/arguments" in warning
+        for warning in result.warnings
+    )
+    assert not target_db.exists()
+
+
+def test_jsonl_import_maps_bare_untyped_openclaw_tool_use_and_result_rows(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "bare-openclaw-tool-use-result.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("bare-openclaw-tool-use-result"),
+            {"toolUseId": "call_1", "toolUseName": "lookup", "toolUseInput": {}},
+            {"toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="bare-openclaw-tool-use-result",
+        apply=True,
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="bare-openclaw-tool-use-result",
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+
+
+def test_jsonl_import_maps_bare_openclaw_tool_use_with_generic_name_and_input_aliases(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "bare-openclaw-generic-alias-tool-use-result.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("bare-openclaw-generic-alias-tool-use-result"),
+            {"toolUseId": "call_1", "name": "lookup", "input": {"q": "x"}},
+            {"toolUseId": "call_1", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="bare-openclaw-generic-alias-tool-use-result",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"q":"x"}'}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+
+
+def test_jsonl_import_maps_bare_content_openclaw_tool_result_without_name(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "bare-openclaw-content-result.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("s"),
+            {"type": "toolUse", "id": "tu", "toolUseId": "call_1", "toolUseName": "lookup", "toolUseInput": {}},
+            {"toolUseId": "call_1", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="bare-openclaw-content-result",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("s", "tu"),),
+        (jsonl_key("s", jsonl_result_row_id("tool_result", "call_1", "result")),),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+def test_jsonl_import_maps_wrapped_openclaw_tool_use_and_result_rows(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-openclaw-tool-use-result.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("wrapped-openclaw-tool-use-result"),
+            {
+                "type": "message",
+                "id": "w-call",
+                "message": {
+                    "id": "nested-call-row",
+                    "type": "toolUse",
+                    "toolUseId": "call_1",
+                    "toolUseName": "lookup",
+                    "toolUseInput": {"q": "x"},
+                },
+            },
+            {
+                "type": "message",
+                "id": "w-result",
+                "message": {
+                    "id": "nested-result-row",
+                    "type": "toolResult",
+                    "toolUseId": "call_1",
+                    "toolUseName": "lookup",
+                    "content": "result",
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="wrapped-openclaw-tool-use-result",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"q":"x"}'}}
+    ]
+    assert rows[0][4] is None
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_keys == [
+        (jsonl_key("wrapped-openclaw-tool-use-result", "nested-call-row"),),
+        (jsonl_key("wrapped-openclaw-tool-use-result", "nested-result-row"),),
+    ]
+
+
+def test_jsonl_import_skips_wrapped_openclaw_tool_result_for_malformed_wrapped_tool_use(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-openclaw-tool-result-orphan.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("wrapped-openclaw-tool-result-orphan"),
+            {
+                "type": "message",
+                "id": "bad-call",
+                "message": {
+                    "type": "toolUse",
+                    "toolUseId": "call_bad",
+                    "toolUseInput": {"q": "x"},
+                },
+            },
+            {
+                "type": "message",
+                "id": "orphan-result",
+                "message": {
+                    "type": "toolResult",
+                    "toolUseId": "call_bad",
+                    "toolUseName": "lookup",
+                    "content": "orphan",
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="wrapped-openclaw-tool-result-orphan",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("toolUse row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_rejects_wrapped_openclaw_tool_use_without_call_id_and_skips_result(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-openclaw-tool-use-missing-call-id.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "message",
+                "id": "call-envelope",
+                "message": {
+                    "id": "message-row",
+                    "type": "toolUse",
+                    "toolUseName": "lookup",
+                    "toolUseInput": {},
+                },
+            },
+            {
+                "type": "message",
+                "id": "result-envelope",
+                "message": {
+                    "type": "toolResult",
+                    "toolUseId": "call_1",
+                    "toolUseName": "lookup",
+                    "content": "result",
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="wrapped-openclaw-tool-use-missing-call-id",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("toolUse row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_maps_untyped_wrapped_openclaw_tool_use_and_result_rows(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-wrapped-openclaw-tool-use-result.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "untyped-wrapped-tool"},
+            {
+                "id": "env-call",
+                "message": {
+                    "type": "toolUse",
+                    "toolUseId": "call_1",
+                    "toolUseName": "lookup",
+                    "toolUseInput": {"q": "x"},
+                },
+            },
+            {
+                "id": "env-result",
+                "message": {
+                    "type": "toolResult",
+                    "toolUseId": "call_1",
+                    "toolUseName": "lookup",
+                    "content": "result",
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-wrapped-openclaw-tool-use-result",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"q":"x"}'}}
+    ]
+    assert rows[0][4] is None
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_keys == [
+        (jsonl_key("untyped-wrapped-tool", "env-call"),),
+        (jsonl_key("untyped-wrapped-tool", "env-result"),),
+    ]
+
+
+def test_jsonl_import_skips_untyped_wrapped_openclaw_tool_result_for_malformed_tool_use(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-wrapped-openclaw-tool-result-orphan.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "untyped-wrapped-openclaw-tool-result-orphan"},
+            {
+                "id": "bad-call",
+                "message": {
+                    "type": "toolUse",
+                    "toolUseId": "call_bad",
+                    "toolUseInput": {"q": "x"},
+                },
+            },
+            {
+                "id": "orphan-result",
+                "message": {
+                    "type": "toolResult",
+                    "toolUseId": "call_bad",
+                    "toolUseName": "lookup",
+                    "content": "orphan",
+                },
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-wrapped-openclaw-tool-result-orphan",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("toolUse row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_idless_openclaw_tool_result_key_survives_line_shift(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "top-level-tool-result-line-shift.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("top-level-tool-result-line-shift"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="top-level-tool-result-line-shift",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("top-level-tool-result-line-shift"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+            {"type": "reasoning", "id": "rs_1", "summary": "inserted metadata"},
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="top-level-tool-result-line-shift",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_keys == [
+        (jsonl_key("top-level-tool-result-line-shift", "tu1"),),
+        (
+            jsonl_key(
+                "top-level-tool-result-line-shift",
+                jsonl_result_row_id("tool_result", "call_1", "result"),
+            ),
+        ),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+def test_jsonl_import_idless_openclaw_tool_use_key_survives_line_shift(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "openclaw-idless-tool-use-line-shift.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("openclaw-idless-tool-use-line-shift"),
+            {"type": "toolUse", "toolUseId": "call_1", "toolUseName": "lookup", "toolUseInput": {}},
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-idless-tool-use-line-shift",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("openclaw-idless-tool-use-line-shift"),
+            {"type": "reasoning", "id": "rs_1", "summary": "inserted metadata"},
+            {"type": "toolUse", "toolUseId": "call_1", "toolUseName": "lookup", "toolUseInput": {}},
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-idless-tool-use-line-shift",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_keys == [
+        (
+            jsonl_key(
+                "openclaw-idless-tool-use-line-shift",
+                jsonl_tool_call_row_id("toolUse", "call_1", "lookup", {}),
+            ),
+        ),
+        (
+            jsonl_key(
+                "openclaw-idless-tool-use-line-shift",
+                jsonl_result_row_id("tool_result", "call_1", "result"),
+            ),
+        ),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
+
+
+@pytest.mark.parametrize(
+    ("result_type", "result_fields"),
+    [
+        ("toolResult", {"toolUseId": "call_1", "toolUseName": "lookup"}),
+        ("tool_result", {"tool_use_id": "call_1", "tool_use_name": "lookup"}),
+    ],
+)
+def test_jsonl_import_imports_openclaw_tool_result_from_later_catchup(
+    tmp_path: Path,
+    result_type: str,
+    result_fields: dict[str, object],
+):
+    importer = load_importer_module()
+    test_id = result_type.replace("_", "-")
+    first_file = tmp_path / f"openclaw-tool-catchup-{test_id}-1.jsonl"
+    second_file = tmp_path / f"openclaw-tool-catchup-{test_id}-2.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        first_file,
+        [
+            jsonl_header(f"openclaw-tool-catchup-{test_id}"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[first_file],
+        target_db=target_db,
+        import_id=f"openclaw-tool-catchup-{test_id}",
+        apply=True,
+    )
+    write_jsonl_session(
+        second_file,
+        [
+            {"type": result_type, "content": "result", **result_fields},
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[second_file],
+        target_db=target_db,
+        import_id=f"openclaw-tool-catchup-{test_id}",
+        apply=True,
+    )
+
+    assert first.imported == 1
+    assert second.scanned == 1
+    assert second.eligible == 1
+    assert second.imported == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_rows = conn.execute(
+        """SELECT source_session, source_message_key
+           FROM lcm_imported_messages
+           ORDER BY target_store_id"""
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": '{"query":"sammy"}'}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_rows == [
+        (
+            f"openclaw-tool-catchup-{test_id}",
+            jsonl_key(f"openclaw-tool-catchup-{test_id}", "tu1"),
+        ),
+        (
+            f"openclaw-tool-catchup-{test_id}",
+            jsonl_key(
+                f"openclaw-tool-catchup-{test_id}",
+                jsonl_result_row_id("tool_result", "call_1", "result"),
+            ),
+        ),
+    ]
+
+
+def test_jsonl_import_resolves_openclaw_tool_result_before_call_file_in_same_run(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    output_file = tmp_path / "a-output.jsonl"
+    call_file = tmp_path / "b-call.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        output_file,
+        [
+            {
+                "type": "toolResult",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "content": "result",
+            },
+        ],
+    )
+    write_jsonl_session(
+        call_file,
+        [
+            jsonl_header("openclaw-catchup-order"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[output_file, call_file],
+        target_db=target_db,
+        import_id="openclaw-catchup-order",
+        apply=True,
+    )
+    second = importer.import_jsonl_sessions(
+        files=[output_file, call_file],
+        target_db=target_db,
+        import_id="openclaw-catchup-order",
+        apply=True,
+    )
+
+    assert first.scanned == 2
+    assert first.eligible == 2
+    assert first.imported == 2
+    assert first.invalid_rows == 0
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_rows = conn.execute(
+        """SELECT source_session, source_message_key
+           FROM lcm_imported_messages
+           ORDER BY source_message_key"""
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[1] == ("tool", "result", "call_1", None, "lookup")
+    assert import_rows == [
+        (
+            "openclaw-catchup-order",
+            jsonl_key(
+                "openclaw-catchup-order",
+                jsonl_result_row_id("tool_result", "call_1", "result"),
+            ),
+        ),
+        ("openclaw-catchup-order", jsonl_key("openclaw-catchup-order", "tu1")),
+    ]
+
+
+def test_jsonl_import_skipped_changed_openclaw_tool_use_does_not_authorize_result(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "changed-openclaw-tool-use.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "toolUse",
+                "id": "tu",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="changed-openclaw-tool-use",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {
+                "type": "toolUse",
+                "id": "tu",
+                "toolUseId": "call_bad",
+                "toolUseName": "bad",
+                "toolUseInput": {},
+            },
+            {
+                "type": "toolResult",
+                "toolUseId": "call_bad",
+                "toolUseName": "bad",
+                "content": "orphan",
+            },
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="changed-openclaw-tool-use",
+        apply=True,
+    )
+
+    assert first.imported == 1
+    assert second.scanned == 2
+    assert second.eligible == 1
+    assert second.imported == 0
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert json.loads(rows[0][3]) == [
+        {"id": "call_1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+    ]
+    assert rows[0][4] is None
+    assert keys == [(jsonl_key("s", "tu"),)]
+
+
+def test_jsonl_import_skips_openclaw_tool_result_for_malformed_tool_use(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "openclaw-tool-result-orphan.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("openclaw-tool-result-orphan"),
+            {"type": "toolUse", "id": "bad", "toolUseId": "call_bad", "toolUseInput": {}},
+            {"type": "toolResult", "toolUseId": "call_bad", "toolUseName": "lookup", "content": "orphan"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-tool-result-orphan",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("toolUse row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_rejects_top_level_openclaw_tool_use_without_call_id_and_skips_result(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "openclaw-tool-use-missing-call-id.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "toolUse", "id": "row1", "toolUseName": "lookup", "toolUseInput": {}},
+            {"type": "toolResult", "toolUseId": "call_1", "toolUseName": "lookup", "content": "result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="openclaw-tool-use-missing-call-id",
+        apply=True,
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 0
+    assert result.imported == 0
+    assert result.invalid_rows == 1
+    assert any("toolUse row missing tool call id or name" in warning for warning in result.warnings)
+    assert not target_db.exists()
+
+
+def test_jsonl_import_idless_wrapped_tool_result_key_survives_line_shift(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-tool-result-line-shift.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("wrapped-tool-result-line-shift"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+            {
+                "type": "message",
+                "message": {"role": "toolResult", "toolCallId": "call_1", "content": "result"},
+            },
+        ],
+    )
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="wrapped-tool-result-line-shift",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("wrapped-tool-result-line-shift"),
+            {
+                "type": "toolUse",
+                "id": "tu1",
+                "toolUseId": "call_1",
+                "toolUseName": "lookup",
+                "toolUseInput": {"query": "sammy"},
+            },
+            {"type": "reasoning", "id": "rs_1", "summary": "inserted metadata"},
+            {
+                "type": "message",
+                "message": {"role": "toolResult", "toolCallId": "call_1", "content": "result"},
+            },
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="wrapped-tool-result-line-shift",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0:3] == ("assistant", None, None)
+    assert rows[1] == ("tool", "result", "call_1", None, None)
+    assert import_keys == [
+        (jsonl_key("wrapped-tool-result-line-shift", "tu1"),),
+        (
+            jsonl_key(
+                "wrapped-tool-result-line-shift",
+                jsonl_result_row_id("tool_result", "call_1", "result"),
+            ),
+        ),
+    ]
+    assert all("line:" not in key for (key,) in import_keys)
 
 
 def test_jsonl_import_keeps_parent_linked_top_level_tool_use_siblings(tmp_path: Path):
@@ -1527,6 +4908,171 @@ def test_jsonl_import_follows_active_leaf_path_for_branched_exports(tmp_path: Pa
     conn.close()
     assert rows == [("root message",), ("current branch",)]
     assert import_keys == [(jsonl_key("branched", "root"),), (jsonl_key("branched", "leaf"),)]
+
+
+def test_jsonl_import_prunes_untyped_envelope_branch_with_nested_parent_ids(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope-nested-parents.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+            {
+                "id": "env-old",
+                "message": {"id": "old", "parentId": "root", "role": "assistant", "content": "old"},
+            },
+            {
+                "id": "env-leaf",
+                "message": {"id": "leaf", "parentId": "root", "role": "assistant", "content": "current"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="untyped-envelope-nested-parents", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+    assert rows == [("root",), ("current",)]
+    assert import_keys == [(jsonl_key("s", "env-root"),), (jsonl_key("s", "env-leaf"),)]
+
+
+def test_jsonl_import_prunes_untyped_envelope_branch_with_mixed_parent_aliases(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope-mixed-parents.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+            {
+                "id": "env-old",
+                "message": {"id": "old", "parentId": "root", "role": "assistant", "content": "old"},
+            },
+            {
+                "id": "env-leaf",
+                "parentId": "env-root",
+                "message": {"id": "leaf", "role": "assistant", "content": "current"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="untyped-envelope-mixed-parents", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+    assert rows == [("root",), ("current",)]
+    assert import_keys == [(jsonl_key("s", "env-root"),), (jsonl_key("s", "env-leaf"),)]
+
+
+def test_jsonl_import_metadata_id_does_not_overwrite_importable_leaf_parent(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "metadata-id-collision.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "message", "id": "root", "message": {"role": "user", "content": "root"}},
+            {
+                "type": "message",
+                "id": "leaf",
+                "parentId": "root",
+                "message": {"role": "assistant", "content": "leaf"},
+            },
+            {"type": "reasoning", "id": "root", "summary": "metadata"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="metadata-id-collision", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+    assert rows == [("root",), ("leaf",)]
+
+
+def test_jsonl_import_falls_back_to_no_pruning_for_dangling_parent_chain(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "dangling-parent.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("dangling-parent"),
+            jsonl_message("old", "user", "valid old row"),
+            jsonl_message("child", "assistant", "child with missing parent", parent_id="missing"),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="dangling-parent", apply=True
+    )
+
+    assert result.scanned == 2
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+    assert rows == [("valid old row",), ("child with missing parent",)]
+
+
+def test_jsonl_import_falls_back_to_no_pruning_for_parent_cycle(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "parent-cycle.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("parent-cycle"),
+            jsonl_message("old", "user", "valid old row"),
+            jsonl_message("m1", "assistant", "cycle first", parent_id="m2"),
+            jsonl_message("m2", "user", "cycle second", parent_id="m1"),
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="parent-cycle", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 3
+    assert result.imported == 3
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    conn.close()
+    assert rows == [("valid old row",), ("cycle first",), ("cycle second",)]
 
 
 def test_jsonl_import_malformed_message_rows_do_not_drive_leaf_pruning(tmp_path: Path):
@@ -1798,6 +5344,72 @@ def test_jsonl_import_keeps_idless_bare_rows_when_pruning_leaf_paths(tmp_path: P
     assert rows == [("user", "root"), ("system", "legacy/idless context"), ("assistant", "current")]
 
 
+def test_jsonl_import_preserves_bare_generic_tool_role_without_call_id(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "bare-legacy-tool-role.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("s"),
+            {"role": "tool", "content": "standalone legacy payload"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="bare-legacy-tool-role", apply=True
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.imported == 1
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+
+    assert rows == [("tool", "standalone legacy payload", None, None, None)]
+    assert keys == [(jsonl_key("s", "line:2"),)]
+
+
+def test_jsonl_import_preserves_wrapped_generic_tool_role_without_call_id(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "wrapped-legacy-tool-role.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("s"),
+            {
+                "type": "message",
+                "id": "m1",
+                "message": {"role": "tool", "content": "standalone legacy payload"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="wrapped-legacy-tool-role", apply=True
+    )
+
+    assert result.scanned == 1
+    assert result.eligible == 1
+    assert result.imported == 1
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+
+    assert rows == [("tool", "standalone legacy payload", None, None, None)]
+    assert keys == [(jsonl_key("s", "m1"),)]
+
+
 def test_jsonl_import_leaf_path_traverses_non_message_metadata_nodes(tmp_path: Path):
     importer = load_importer_module()
     session_file = tmp_path / "metadata-chain.jsonl"
@@ -1992,6 +5604,51 @@ def test_jsonl_import_keeps_native_responses_function_call_output_with_leaf_path
         {"id": "call_1", "type": "function_call", "function": {"name": "lookup", "arguments": "{}"}}
     ]
     assert rows[2] == ("tool", "result", "call_1", None, None)
+
+
+def test_jsonl_import_prunes_idless_native_function_call_on_abandoned_branch(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "responses-idless-native-abandoned-branch.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("responses-idless-native-abandoned-branch"),
+            jsonl_message("root", "user", "root"),
+            jsonl_message("old", "assistant", "old branch", parent_id="root"),
+            {"type": "function_call", "parentId": "old", "call_id": "call_old", "name": "lookup", "arguments": {}},
+            jsonl_message("leaf", "assistant", "current branch", parent_id="root"),
+            {"type": "function_call_output", "call_id": "call_old", "output": "old result"},
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="responses-idless-native-abandoned-branch",
+        apply=True,
+    )
+
+    assert result.scanned == 5
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute(
+        "SELECT role, content, tool_call_id, tool_calls, tool_name FROM messages ORDER BY store_id"
+    ).fetchall()
+    import_keys = conn.execute(
+        "SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("user", "root", None, None, None),
+        ("assistant", "current branch", None, None, None),
+    ]
+    assert import_keys == [
+        (jsonl_key("responses-idless-native-abandoned-branch", "root"),),
+        (jsonl_key("responses-idless-native-abandoned-branch", "leaf"),),
+    ]
 
 
 def test_jsonl_import_keeps_active_nested_tool_result_with_leaf_path(tmp_path: Path):
@@ -2211,7 +5868,7 @@ def test_jsonl_import_leaf_path_uses_nested_message_ids(tmp_path: Path):
     assert keys == [(jsonl_key("nested-id-branch", "root"),), (jsonl_key("nested-id-branch", "leaf"),)]
 
 
-def test_jsonl_import_leaf_path_prefers_nested_message_id_namespace(tmp_path: Path):
+def test_jsonl_import_leaf_path_aliases_typed_wrapper_ids_and_preserves_nested_keys(tmp_path: Path):
     importer = load_importer_module()
     session_file = tmp_path / "mixed-id-namespace.jsonl"
     target_db = tmp_path / "target-lcm.db"
@@ -2245,7 +5902,237 @@ def test_jsonl_import_leaf_path_prefers_nested_message_id_namespace(tmp_path: Pa
     keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
     conn.close()
     assert rows == [("root",), ("current",)]
-    assert keys == [(jsonl_key("mixed-id-namespace", "msg-root"),), (jsonl_key("mixed-id-namespace", "msg-leaf"),)]
+    assert keys == [
+        (jsonl_key("mixed-id-namespace", "msg-root"),),
+        (jsonl_key("mixed-id-namespace", "msg-leaf"),),
+    ]
+
+
+def test_jsonl_import_prunes_typed_wrapper_branch_with_mixed_parent_aliases(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "typed-wrapper-mixed-parents.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            {"type": "session", "id": "s"},
+            {"type": "message", "id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+            {
+                "type": "message",
+                "id": "env-old",
+                "message": {"id": "old", "parentId": "root", "role": "assistant", "content": "old branch"},
+            },
+            {
+                "type": "message",
+                "id": "env-leaf",
+                "parentId": "env-root",
+                "message": {"id": "leaf", "role": "assistant", "content": "current"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="typed-wrapper-mixed-parents", apply=True
+    )
+
+    assert result.scanned == 3
+    assert result.eligible == 2
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+    assert rows == [("root",), ("current",)]
+    assert keys == [(jsonl_key("s", "root"),), (jsonl_key("s", "leaf"),)]
+
+
+def test_jsonl_import_typed_wrapper_catchup_respects_origin_main_nested_source_keys(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "typed-wrapper-origin-main-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    import_id = "typed-wrapper-origin-main-catchup"
+    initial_rows = [
+        {"type": "session", "id": "s"},
+        {"type": "message", "id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+        {
+            "type": "message",
+            "id": "env-old",
+            "message": {"id": "old", "parentId": "root", "role": "assistant", "content": "old"},
+        },
+    ]
+    write_jsonl_session(session_file, initial_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=import_id, apply=True
+    )
+    conn = sqlite3.connect(target_db)
+    for target_store_id, row_id in [(1, "root"), (2, "old")]:
+        source_message_key = jsonl_key("s", row_id)
+        conn.execute(
+            """UPDATE lcm_imported_messages
+               SET source_message_id = ?, source_message_key = ?
+               WHERE import_id = ? AND target_store_id = ?""",
+            (
+                importer._stable_positive_int(source_message_key),
+                source_message_key,
+                import_id,
+                target_store_id,
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+    write_jsonl_session(
+        session_file,
+        [
+            *initial_rows,
+            {
+                "type": "message",
+                "id": "env-new",
+                "parentId": "env-root",
+                "message": {"id": "new", "role": "assistant", "content": "new"},
+            },
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id=import_id, apply=True
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 1
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+    assert rows == [("root",), ("old",), ("new",)]
+    assert keys == [
+        (jsonl_key("s", "root"),),
+        (jsonl_key("s", "old"),),
+        (jsonl_key("s", "new"),),
+    ]
+
+
+def test_jsonl_import_untyped_envelope_keys_survive_envelope_parent_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    initial_rows = [
+        {"type": "session", "id": "s"},
+        {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+        {
+            "id": "env-leaf",
+            "message": {"id": "leaf", "parentId": "root", "role": "assistant", "content": "leaf"},
+        },
+    ]
+    write_jsonl_session(session_file, initial_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-envelope-catchup",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *initial_rows,
+            {
+                "id": "env-new",
+                "parentId": "env-root",
+                "message": {"id": "new", "role": "assistant", "content": "new"},
+            },
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-envelope-catchup",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 1
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+    assert rows == [("root",), ("leaf",), ("new",)]
+    assert keys == [
+        (jsonl_key("s", "env-root"),),
+        (jsonl_key("s", "env-leaf"),),
+        (jsonl_key("s", "env-new"),),
+    ]
+
+
+def test_jsonl_import_untyped_envelope_keys_survive_nested_parent_catchup(
+    tmp_path: Path,
+):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope-nested-catchup.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    initial_rows = [
+        {"type": "session", "id": "s"},
+        {"id": "env-root", "message": {"id": "root", "role": "user", "content": "root"}},
+        {
+            "id": "env-leaf",
+            "parentId": "env-root",
+            "message": {"id": "leaf", "role": "assistant", "content": "leaf"},
+        },
+    ]
+    write_jsonl_session(session_file, initial_rows)
+
+    first = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-envelope-nested-catchup",
+        apply=True,
+    )
+    write_jsonl_session(
+        session_file,
+        [
+            *initial_rows,
+            {
+                "id": "env-new",
+                "message": {"id": "new", "parentId": "root", "role": "assistant", "content": "new"},
+            },
+        ],
+    )
+    second = importer.import_jsonl_sessions(
+        files=[session_file],
+        target_db=target_db,
+        import_id="untyped-envelope-nested-catchup",
+        apply=True,
+    )
+
+    assert first.imported == 2
+    assert second.scanned == 3
+    assert second.eligible == 2
+    assert second.imported == 1
+    assert second.skipped_existing == 1
+    assert second.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT content FROM messages ORDER BY store_id").fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+    assert rows == [("root",), ("leaf",), ("new",)]
+    assert keys == [
+        (jsonl_key("s", "env-root"),),
+        (jsonl_key("s", "env-leaf"),),
+        (jsonl_key("s", "env-new"),),
+    ]
 
 
 def test_jsonl_import_uses_nested_message_id_when_top_level_id_is_missing(tmp_path: Path):
@@ -2367,6 +6254,40 @@ def test_jsonl_import_accepts_top_level_typed_message_rows(tmp_path: Path):
         ("openclaw-jsonl:agent:unknown:typed-session", "top level typed content")
     ]
     conn.close()
+
+
+def test_jsonl_import_accepts_untyped_envelope_message_rows(tmp_path: Path):
+    importer = load_importer_module()
+    session_file = tmp_path / "untyped-envelope.jsonl"
+    target_db = tmp_path / "target-lcm.db"
+    write_jsonl_session(
+        session_file,
+        [
+            jsonl_header("untyped-envelope"),
+            {"id": "env-1", "message": {"id": "nested-1", "role": "user", "content": "hi"}},
+            {
+                "id": "env-2",
+                "parentId": "env-1",
+                "message": {"id": "nested-2", "role": "assistant", "content": "hello"},
+            },
+        ],
+    )
+
+    result = importer.import_jsonl_sessions(
+        files=[session_file], target_db=target_db, import_id="untyped-envelope", apply=True
+    )
+
+    assert result.imported == 2
+    assert result.invalid_rows == 0
+    conn = sqlite3.connect(target_db)
+    rows = conn.execute("SELECT role, content FROM messages ORDER BY store_id").fetchall()
+    keys = conn.execute("SELECT source_message_key FROM lcm_imported_messages ORDER BY target_store_id").fetchall()
+    conn.close()
+    assert rows == [("user", "hi"), ("assistant", "hello")]
+    assert keys == [
+        (jsonl_key("untyped-envelope", "env-1"),),
+        (jsonl_key("untyped-envelope", "env-2"),),
+    ]
 
 
 def test_jsonl_cli_directory_default_import_id_is_stable_for_catchup(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary
- Harden JSONL session import handling for follow-up edge cases found after PR #306 merged.
- Preserve catch-up idempotency across semantic source-key upgrades, including legacy `line:N` and grouped `function_calls:[...]` keys.
- Keep typed wrapper source keys compatible with existing nested `message.id` imports while still using envelope/nested aliases for pruning.
- Treat malformed or metadata-only rows as transparent for pending Responses function-call grouping so they do not duplicate existing grouped calls.
- Preserve top-level transcript content when nested `message` is auxiliary metadata, and normalize `tool_calls`/`toolCalls` alias handling without duplicate tool calls.
- Add regression coverage for idless tool rows, wrapper aliases, output-before-call ordering, orphan guards, malformed metadata cases, and mixed tool-call array spellings.

## Why
- PR #306 added JSONL/session-export imports, but local and public Codex follow-up review found additional P2-class edge cases around catch-up imports, parent aliases, malformed wrapper rows, native tool-call grouping, and metadata wrappers.
- The main risk was duplicate imports, dropped transcript rows, or corrupted tool-call/result rows when re-importing evolving OpenClaw/Responses JSONL exports.

## Validation
- `python -m pytest tests/test_import_lossless_claw.py -q -o addopts=` → `145 passed`
- `python -m py_compile scripts/import_lossless_claw.py && git diff --check` → passed
- duplicate pytest function scan → `test_count=129`, `duplicates=none`
- `python -m pytest -q -o addopts=` → `1469 passed, 12 xfailed`
- Internal local Codex CLI blocker review after the latest fix → `NO BLOCKERS`

## Risk / impact
- This touches the JSONL import path and idempotency/provenance logic for imported messages.
- Existing SQLite import behavior is intended to stay unchanged; the shared write path remains the same.
- The compatibility aliases are only used for existing source keys, so fresh imports keep the newer semantic source-key behavior while older imports avoid duplication on catch-up.
- Main residual risk is around unusual third-party JSONL export shapes not covered by the expanded regression set.

## Scope boundaries
- This PR does not change the SQLite source importer or summary import behavior.
- This PR does not add new CLI flags or change the dry-run/apply contract.
- This PR intentionally focuses on follow-up correctness hardening for the JSONL importer only.

## Screenshots / before-after
- Not applicable (non-UI change).

## Rollout / operator notes
- No migration or configuration change required.
- Existing JSONL imports can be rerun with the same `--import-id`; compatibility aliases prevent known old-key catch-up duplicates.
- Dry-run remains the default, and apply mode still backs up the target DB before writes.

## Reviewer focus
- Source-key compatibility between old `line:N` imports and new semantic source keys.
- Active-leaf pruning when envelope IDs and nested `message.id` / `parentId` aliases mix.
- Pending Responses function-call grouping around malformed, unsupported, or metadata-only rows.
- Top-level transcript rows that include nested auxiliary `message` metadata.
- `tool_calls` / `toolCalls` alias parsing, malformed-array rejection, and duplicate call-id dedupe.
- Tool-call/tool-result pairing and orphan protection across file-order catch-up.