### PR TITLE
Fixup for #312: reject stale generationless auxiliary ends

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -577,6 +577,8 @@ class LCMEngine(ContextEngine):
         self._thread_context = threading.local()
         self._auxiliary_session_ids: set[str] = set()
         self._auxiliary_lineage_session_ids: set[str] = set()
+        self._auxiliary_last_prompt_tokens: dict[str, int] = {}
+        self._auxiliary_session_generations: dict[str, int] = {}
         self._lcm_bypass_lineage_session_ids: set[str] = set()
         self._lcm_bypass_lineage_platforms: dict[str, set[str]] = {}
         self._lcm_non_bypass_platforms: dict[str, set[str]] = {}
@@ -704,6 +706,8 @@ class LCMEngine(ContextEngine):
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.clear()
             self._auxiliary_lineage_session_ids.clear()
+            self._auxiliary_last_prompt_tokens.clear()
+            self._auxiliary_session_generations.clear()
             self._lcm_bypass_lineage_session_ids.clear()
             self._lcm_bypass_lineage_platforms.clear()
             self._lcm_non_bypass_platforms.clear()
@@ -973,6 +977,32 @@ class LCMEngine(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         if self._thread_context_stateless():
+            auxiliary_session_id = self._thread_context_session_id()
+            if auxiliary_session_id:
+                prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+                caller_generation = self._in_process_auxiliary_caller_generation(
+                    auxiliary_session_id
+                )
+                with self._auxiliary_session_lock:
+                    active_generation = self._auxiliary_session_generations.get(
+                        auxiliary_session_id
+                    )
+                    if active_generation is None and caller_generation:
+                        self._auxiliary_last_prompt_tokens.pop(auxiliary_session_id, None)
+                        self._auxiliary_session_generations[
+                            auxiliary_session_id
+                        ] = caller_generation
+                        active_generation = caller_generation
+                    generation_matches = (
+                        caller_generation == 0
+                        if active_generation is None
+                        else caller_generation == active_generation
+                    )
+                    if (
+                        auxiliary_session_id in self._auxiliary_session_ids
+                        and generation_matches
+                    ):
+                        self._auxiliary_last_prompt_tokens[auxiliary_session_id] = prompt_tokens
             return
         self.last_prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
         self.last_completion_tokens = int(usage.get("completion_tokens", 0) or 0)
@@ -1519,7 +1549,14 @@ class LCMEngine(ContextEngine):
         if self._bypasses_lcm_context_management():
             if self._compression_boundary_cooldown_active():
                 return False
-            tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+            if prompt_tokens is not None:
+                tokens = prompt_tokens
+            else:
+                auxiliary_session_id = self._thread_context_session_id()
+                if auxiliary_session_id:
+                    tokens = self._current_auxiliary_prompt_tokens(auxiliary_session_id)
+                else:
+                    tokens = self.last_prompt_tokens
             if self._should_force_overflow_recovery(observed_tokens=tokens):
                 return True
             if self.threshold_tokens <= 0:
@@ -1893,9 +1930,16 @@ class LCMEngine(ContextEngine):
         self._last_compression_noop_reason = ""
 
         if self._bypasses_lcm_context_management():
+            bypass_current_tokens = current_tokens
+            if bypass_current_tokens is None:
+                auxiliary_session_id = self._thread_context_session_id()
+                if auxiliary_session_id:
+                    bypass_current_tokens = self._current_auxiliary_prompt_tokens(
+                        auxiliary_session_id
+                    )
             return self._compress_lcm_bypassed_session(
                 messages,
-                current_tokens=current_tokens,
+                current_tokens=bypass_current_tokens,
                 focus_topic=focus_topic,
                 force=force,
             )
@@ -2438,6 +2482,23 @@ class LCMEngine(ContextEngine):
             return stack[-1]
         return ""
 
+    def _current_auxiliary_prompt_tokens(self, session_id: str) -> int:
+        if not session_id:
+            return 0
+        caller_generation = self._in_process_auxiliary_caller_generation(session_id)
+        with self._auxiliary_session_lock:
+            if session_id not in self._auxiliary_session_ids:
+                return 0
+            active_generation = self._auxiliary_session_generations.get(session_id)
+            generation_matches = (
+                caller_generation == 0
+                if active_generation is None
+                else caller_generation == active_generation
+            )
+            if not generation_matches:
+                return 0
+            return self._auxiliary_last_prompt_tokens.get(session_id, 0)
+
     def _thread_context_has_auxiliary_session(self, session_id: str) -> bool:
         with self._auxiliary_session_lock:
             return session_id in self._auxiliary_session_ids
@@ -2519,15 +2580,30 @@ class LCMEngine(ContextEngine):
         return bool(self._thread_context_session_id())
 
     def _register_auxiliary_session(self, session_id: str) -> None:
+        generation = self._in_process_auxiliary_caller_generation(session_id)
         with self._auxiliary_session_lock:
+            previous_generation = self._auxiliary_session_generations.get(session_id)
             self._auxiliary_session_ids.add(session_id)
             self._auxiliary_lineage_session_ids.add(session_id)
+            if generation:
+                if previous_generation != generation:
+                    self._auxiliary_last_prompt_tokens.pop(session_id, None)
+                self._auxiliary_session_generations[session_id] = generation
+            else:
+                self._auxiliary_last_prompt_tokens.pop(session_id, None)
+                self._auxiliary_session_generations.pop(session_id, None)
 
-    def _deactivate_auxiliary_session(self, session_id: str) -> None:
+    def _deactivate_auxiliary_session(self, session_id: str, *, generation: int = 0) -> bool:
         if not session_id:
-            return
+            return False
         with self._auxiliary_session_lock:
+            active_generation = self._auxiliary_session_generations.get(session_id)
+            if generation and active_generation and generation != active_generation:
+                return False
             self._auxiliary_session_ids.discard(session_id)
+            self._auxiliary_last_prompt_tokens.pop(session_id, None)
+            self._auxiliary_session_generations.pop(session_id, None)
+            return True
 
     def _mark_thread_context_stateless(self, session_id: str) -> None:
         self._register_auxiliary_session(session_id)
@@ -2545,13 +2621,20 @@ class LCMEngine(ContextEngine):
         self._sync_thread_context_current_auxiliary()
 
     def _handoff_auxiliary_session(self, old_session_id: str, new_session_id: str) -> None:
+        generation = self._in_process_auxiliary_caller_generation(new_session_id)
         with self._auxiliary_session_lock:
             if old_session_id:
+                self._auxiliary_last_prompt_tokens.pop(old_session_id, None)
+                self._auxiliary_session_generations.pop(old_session_id, None)
                 self._auxiliary_session_ids.discard(old_session_id)
                 self._auxiliary_lineage_session_ids.add(old_session_id)
             if new_session_id:
                 self._auxiliary_session_ids.add(new_session_id)
                 self._auxiliary_lineage_session_ids.add(new_session_id)
+                if generation:
+                    self._auxiliary_session_generations[new_session_id] = generation
+                else:
+                    self._auxiliary_session_generations.pop(new_session_id, None)
         stack = self._thread_context_auxiliary_stack()
         had_thread_marker = old_session_id in stack or new_session_id in stack
         stack[:] = [
@@ -2566,6 +2649,7 @@ class LCMEngine(ContextEngine):
     def _unmark_thread_context_auxiliary_session(self, session_id: str) -> None:
         with self._auxiliary_session_lock:
             self._auxiliary_session_ids.discard(session_id)
+            self._auxiliary_session_generations.pop(session_id, None)
         self._clear_thread_context_stateless(session_id)
 
     def _get_allowed_hermes_base(self) -> Path | None:
@@ -2619,6 +2703,25 @@ class LCMEngine(ContextEngine):
         if getattr(caller_self, "ephemeral_system_prompt", None) and log_prefix.startswith("[subagent-"):
             return True
         return False
+
+    def _in_process_auxiliary_caller_generation(self, session_id: str) -> int:
+        frame = inspect.currentframe()
+        try:
+            frame = frame.f_back if frame is not None else None
+            for _ in range(32):
+                if frame is None:
+                    return 0
+                caller_self = frame.f_locals.get("self")
+                if not self._caller_is_auxiliary_agent_frame(caller_self):
+                    frame = frame.f_back
+                    continue
+                caller_session = str(getattr(caller_self, "session_id", "") or "")
+                if not session_id or caller_session == session_id:
+                    return id(caller_self)
+                frame = frame.f_back
+        finally:
+            del frame
+        return 0
 
     def _in_process_parent_session_id(
         self,
@@ -3849,9 +3952,12 @@ class LCMEngine(ContextEngine):
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         if self._has_auxiliary_lineage_session(session_id) and session_id != self._session_id:
             current_thread_session_id = self._thread_context_session_id()
-            with self._auxiliary_session_lock:
-                self._auxiliary_session_ids.discard(session_id)
-            if current_thread_session_id == session_id:
+            ended_generation = self._in_process_auxiliary_caller_generation(session_id)
+            deactivated = self._deactivate_auxiliary_session(
+                session_id,
+                generation=ended_generation,
+            )
+            if deactivated and current_thread_session_id == session_id:
                 self._clear_thread_context_stateless(session_id)
             return
         current_session_bypasses = session_id == self._session_id and self._bypasses_lcm_context_management()

--- a/engine.py
+++ b/engine.py
@@ -2598,7 +2598,7 @@ class LCMEngine(ContextEngine):
             return False
         with self._auxiliary_session_lock:
             active_generation = self._auxiliary_session_generations.get(session_id)
-            if generation and active_generation and generation != active_generation:
+            if active_generation and generation != active_generation:
                 return False
             self._auxiliary_session_ids.discard(session_id)
             self._auxiliary_last_prompt_tokens.pop(session_id, None)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2020,6 +2020,144 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_thread_context_stateless_no_arg_should_compress_uses_auxiliary_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-no-arg-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+
+            assert instance.last_prompt_tokens == 0
+            assert instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+
+            instance._clear_thread_context_stateless("auxiliary:session")
+            assert not instance.should_compress()
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_compress_uses_auxiliary_usage_when_no_arg(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        calls = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+
+            def on_session_start(self, bound_session_id, **kwargs):
+                pass
+
+            def update_model(self, **kwargs):
+                pass
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                calls.append((list(messages), current_tokens, focus_topic, force))
+                self.compression_count += 1
+                return [{"role": "system", "content": "native compacted"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-no-arg-compress.db"))
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "short"}]
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+
+            assert count_messages_tokens(messages) < instance.threshold_tokens
+            assert instance.should_compress()
+            result = instance.compress(messages)
+
+            assert result == [{"role": "system", "content": "native compacted"}]
+            assert calls == [(messages, 25, None, False)]
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_session_end_clears_auxiliary_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-end-clears-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+
+            instance.on_session_end("auxiliary:session", [{"role": "user", "content": "done"}])
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_generationless_reregister_clears_usage(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-reregister-clears-usage.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert instance._auxiliary_last_prompt_tokens == {}
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_thread_context_stateless_adopting_generation_clears_generationless_usage(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-adopt-generation-clears.db"))
+        instance = LCMEngine(config=config)
+        try:
+            instance.on_session_start("foreground:session", platform="cli", context_length=1_000)
+            instance.threshold_tokens = 20
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance.update_from_response({"prompt_tokens": 25, "completion_tokens": 1, "total_tokens": 26})
+            assert instance.should_compress()
+            assert instance._auxiliary_session_generations == {}
+
+            monkeypatch.setattr(
+                instance,
+                "_in_process_auxiliary_caller_generation",
+                lambda session_id: 123 if session_id == "auxiliary:session" else 0,
+            )
+            instance._mark_thread_context_stateless("auxiliary:session")
+
+            assert instance._auxiliary_session_generations == {"auxiliary:session": 123}
+            assert instance._auxiliary_last_prompt_tokens == {}
+            assert not instance.should_compress()
+            assert instance._store.get_session_count("foreground:session") == 0
+            assert instance._store.get_session_count("auxiliary:session") == 0
+        finally:
+            instance.shutdown()
+
     @pytest.mark.parametrize(
         ("session_id", "config_kwargs"),
         [
@@ -11433,6 +11571,9 @@ class TestSessionRollover:
         def should_compress_preflight(self, engine: LCMEngine, messages):
             return engine.should_compress_preflight(messages)
 
+        def should_compress(self, engine: LCMEngine):
+            return engine.should_compress()
+
         def compress(self, engine: LCMEngine, messages):
             return engine.compress(messages)
 
@@ -14922,6 +15063,266 @@ class TestSessionRollover:
             {"role": "user", "content": "foreground followup persists after marker clear"},
         ])
         assert engine._store.get_session_count("foreground-followup-session") == 1
+
+    def test_same_thread_late_auxiliary_usage_after_end_is_not_reused(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_late_aux_usage_after_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert child.should_compress(engine)
+
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._auxiliary_last_prompt_tokens == {}
+
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {}
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert not replacement.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_late_auxiliary_usage_from_old_generation_does_not_pollute_reused_id(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_usage_generation_reuse.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.on_session_end(engine, [])
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert not replacement.should_compress(engine)
+
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not replacement.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_reused_generation_clears_usage_and_ignores_old_end(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generation_replace_before_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+        assert old_child.should_compress(engine)
+
+        replacement = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not replacement.should_compress(engine)
+
+        old_child.on_session_end(engine, [])
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not replacement.should_compress(engine)
+
+        replacement.update_from_response(engine, {"prompt_tokens": 25})
+        assert replacement.should_compress(engine)
+        old_messages = [{"role": "user", "content": "old frame short payload"}]
+        assert count_messages_tokens(old_messages) < engine.threshold_tokens
+        assert not old_child.should_compress(engine)
+        assert old_child.compress(engine, old_messages) == old_messages
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_no_arg_should_compress_without_usage_ignores_foreground_tokens(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_no_foreground_fallback.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        engine.update_from_response({"prompt_tokens": 25})
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        assert engine.last_prompt_tokens == 25
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not child.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_handoff_accepts_new_continuation_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 15})
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+        continuation = self.HostAgentFrame(
+            "background-review-continuation",
+            "background-review-session",
+            hermes_home,
+        )
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not continuation.should_compress(engine)
+
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-continuation": 25}
+        assert continuation.should_compress(engine)
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_auxiliary_usage_update_racing_session_end_does_not_restore_stale_tokens(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_usage_race.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        reached_active_probe = threading.Event()
+        continue_update = threading.Event()
+        original_active_auxiliary_session_ids = engine._active_auxiliary_session_ids
+
+        def delayed_active_auxiliary_session_ids():
+            if threading.current_thread() is thread:
+                reached_active_probe.set()
+                assert continue_update.wait(timeout=5)
+            return original_active_auxiliary_session_ids()
+
+        monkeypatch.setattr(
+            engine,
+            "_active_auxiliary_session_ids",
+            delayed_active_auxiliary_session_ids,
+        )
+        errors = []
+
+        def late_update():
+            try:
+                child.update_from_response(engine, {"prompt_tokens": 25})
+            except Exception as exc:  # pragma: no cover - assertion helper
+                errors.append(exc)
+
+        thread = threading.Thread(target=late_update)
+        thread.start()
+        assert reached_active_probe.wait(timeout=5)
+
+        child.on_session_end(engine, [])
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        continue_update.set()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
 
     def test_ended_auxiliary_marker_stays_stateless_until_next_normal_session_start(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2109,6 +2109,25 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_thread_context_stateless_stale_generationless_end_does_not_clear_replacement(self, tmp_path, monkeypatch):
+        config = LCMConfig(database_path=str(tmp_path / "thread-stateless-stale-end-generation.db"))
+        instance = LCMEngine(config=config)
+        try:
+            monkeypatch.setattr(
+                instance,
+                "_in_process_auxiliary_caller_generation",
+                lambda session_id: 123 if session_id == "auxiliary:session" else 0,
+            )
+            instance._mark_thread_context_stateless("auxiliary:session")
+            instance._auxiliary_last_prompt_tokens["auxiliary:session"] = 77
+
+            assert not instance._deactivate_auxiliary_session("auxiliary:session", generation=0)
+            assert instance._thread_context_has_auxiliary_session("auxiliary:session")
+            assert instance._auxiliary_session_generations == {"auxiliary:session": 123}
+            assert instance._auxiliary_last_prompt_tokens["auxiliary:session"] == 77
+        finally:
+            instance.shutdown()
+
     def test_thread_context_stateless_generationless_reregister_clears_usage(self, tmp_path):
         config = LCMConfig(database_path=str(tmp_path / "thread-stateless-reregister-clears-usage.db"))
         instance = LCMEngine(config=config)


### PR DESCRIPTION
Prevents an old generationless auxiliary session-end/deactivation from clearing a newer registered auxiliary generation.

Validation:
- `PYTHONPATH=/tmp/hermes-lcm-test-stubs python -m pytest tests/test_lcm_engine.py -k "stale_generationless_end or generationless_reregister_clears_usage or adopting_generation_clears_generationless_usage or session_end_clears_auxiliary_usage" -q`