### PR TITLE
Add compaction telemetry (per-conversation snapshot)

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -525,6 +525,8 @@ class LCMEngine(ContextEngine):
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
         self.compression_count = 0
+        # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
+        self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
         self.protect_first_n = 3
         self.protect_last_n = self._config.fresh_tail_count
@@ -987,12 +989,97 @@ class LCMEngine(ContextEngine):
         self.last_cache_read_tokens = int(usage.get("cache_read_tokens", 0) or 0)
         self.last_cache_write_tokens = int(usage.get("cache_write_tokens", 0) or 0)
         self.last_reasoning_tokens = int(usage.get("reasoning_tokens", 0) or 0)
+        self._record_turn_compaction_telemetry()
 
     @property
     def cache_read_ratio(self) -> float:
         if self.last_prompt_tokens <= 0:
             return 0.0
         return self.last_cache_read_tokens / self.last_prompt_tokens
+
+    def _record_turn_compaction_telemetry(self) -> None:
+        """Persist a per-conversation compaction-telemetry snapshot for this turn.
+
+        Best-effort and diagnostic only: any failure is logged at debug and never
+        affects the turn. Turns with no token or cache signal are skipped so idle
+        turns do not churn the record. The since-compaction accumulators reset off
+        the monotonic ``compression_count`` (which also drops to 0 on a session
+        reset) rather than instrumenting the compaction hot path.
+        """
+        conversation_id = self._conversation_id
+        if not conversation_id:
+            return
+        prompt_tokens = self.last_prompt_tokens
+        cache_read = self.last_cache_read_tokens
+        cache_write = self.last_cache_write_tokens
+        if (
+            prompt_tokens <= 0
+            and cache_read <= 0
+            and cache_write <= 0
+            and not self.cache_metrics_available
+        ):
+            return
+        try:
+            existing = self._store.read_compaction_telemetry(conversation_id) or {}
+
+            if cache_read > 0 or cache_write > 0:
+                cache_state = "hot"
+            elif self.cache_metrics_available:
+                cache_state = "cold"
+            else:
+                cache_state = "unknown"
+            cold_streak = int(existing.get("consecutive_cold_observations", 0) or 0)
+            if cache_state == "hot":
+                cold_streak = 0
+            elif cache_state == "cold":
+                cold_streak += 1
+
+            prev_count = int(existing.get("compression_count_at_record", 0) or 0)
+            compacted = self.compression_count > prev_count
+            rebaselined = self.compression_count != prev_count  # compaction or session reset
+            if rebaselined:
+                turns_since = 0
+                peak_tokens_since = prompt_tokens
+            else:
+                turns_since = int(existing.get("turns_since_leaf_compaction", 0) or 0) + 1
+                peak_tokens_since = max(
+                    int(existing.get("peak_prompt_tokens_since_leaf_compaction", 0) or 0),
+                    prompt_tokens,
+                )
+            total_compactions = int(existing.get("total_compactions", 0) or 0)
+            if compacted:
+                total_compactions += self.compression_count - prev_count
+                last_leaf_compaction_at = time.time()
+                last_compaction_duration_ms = round(self._last_compaction_duration_ms, 3)
+            else:
+                last_leaf_compaction_at = existing.get("last_leaf_compaction_at")
+                last_compaction_duration_ms = existing.get("last_compaction_duration_ms")
+
+            record = dict(existing)
+            record.update({
+                "conversation_id": conversation_id,
+                "last_observed_prompt_tokens": prompt_tokens,
+                "last_observed_cache_read": cache_read,
+                "last_observed_cache_write": cache_write,
+                "cache_state": cache_state,
+                "consecutive_cold_observations": cold_streak,
+                "turns_since_leaf_compaction": turns_since,
+                "peak_prompt_tokens_since_leaf_compaction": peak_tokens_since,
+                # Reserved carry-forward field; no live 'medium'/'high' computation yet.
+                "activity_band": existing.get("activity_band", "low"),
+                "provider": self.provider or existing.get("provider"),
+                "model": self.model or existing.get("model"),
+                "last_api_call_at": time.time(),
+                "last_leaf_compaction_at": last_leaf_compaction_at,
+                "last_compaction_duration_ms": last_compaction_duration_ms,
+                "total_compactions": total_compactions,
+                "compression_count_at_record": self.compression_count,
+            })
+            if cache_state == "hot":
+                record["last_cache_hit_at"] = time.time()
+            self._store.write_compaction_telemetry(conversation_id, record)
+        except Exception:
+            logger.debug("LCM compaction telemetry update failed", exc_info=True)
 
     def _compression_boundary_cooldown_active(self) -> bool:
         """Return true while a boundary skip is in its short no-compress window."""
@@ -1891,6 +1978,7 @@ class LCMEngine(ContextEngine):
 
         self._last_compression_status = "running"
         self._last_compression_noop_reason = ""
+        _compress_started = time.perf_counter()
 
         if self._bypasses_lcm_context_management():
             return self._compress_lcm_bypassed_session(
@@ -2299,6 +2387,10 @@ class LCMEngine(ContextEngine):
         finally:
             self._pending_context_anchor_messages = None
         self.compression_count += 1
+        self._last_compaction_duration_ms = (time.perf_counter() - _compress_started) * 1000.0
+        logger.info(
+            "LCM leaf compaction finished in %.1fms", self._last_compaction_duration_ms
+        )
         self._last_compression_status = "compacted"
         self._last_compression_noop_reason = ""
         if recovery_assembly_cap is None:
@@ -4425,6 +4517,35 @@ class LCMEngine(ContextEngine):
                     "last_rollover_at": lifecycle_state.last_rollover_at,
                     "last_reset_at": lifecycle_state.last_reset_at,
                     "updated_at": lifecycle_state.updated_at,
+                }
+            try:
+                telemetry = self._store.read_compaction_telemetry(conversation_id)
+            except Exception:
+                telemetry = None
+            if telemetry:
+                status["compaction_telemetry"] = {
+                    "cache_state": telemetry.get("cache_state", "unknown"),
+                    "consecutive_cold_observations": telemetry.get(
+                        "consecutive_cold_observations", 0
+                    ),
+                    "turns_since_leaf_compaction": telemetry.get(
+                        "turns_since_leaf_compaction", 0
+                    ),
+                    "peak_prompt_tokens_since_leaf_compaction": telemetry.get(
+                        "peak_prompt_tokens_since_leaf_compaction", 0
+                    ),
+                    "last_observed_prompt_tokens": telemetry.get(
+                        "last_observed_prompt_tokens", 0
+                    ),
+                    "last_observed_cache_read": telemetry.get("last_observed_cache_read", 0),
+                    "last_observed_cache_write": telemetry.get("last_observed_cache_write", 0),
+                    "activity_band": telemetry.get("activity_band", "low"),
+                    "total_compactions": telemetry.get("total_compactions", 0),
+                    "last_leaf_compaction_at": telemetry.get("last_leaf_compaction_at"),
+                    "last_compaction_duration_ms": telemetry.get("last_compaction_duration_ms"),
+                    "provider": telemetry.get("provider"),
+                    "model": telemetry.get("model"),
+                    "last_api_call_at": telemetry.get("last_api_call_at"),
                 }
         return status
 

--- a/store.py
+++ b/store.py
@@ -729,6 +729,67 @@ class MessageStore:
             return None, None
         return row[0], row[1]
 
+    # -- Compaction telemetry ------------------------------------------------
+
+    @staticmethod
+    def _compaction_telemetry_key(conversation_id: str) -> str:
+        return f"compaction_telemetry:{conversation_id}"
+
+    def read_compaction_telemetry(self, conversation_id: str) -> Optional[Dict[str, Any]]:
+        """Return the persisted per-conversation compaction-telemetry record, or None.
+
+        Best-effort: a closed connection, missing/empty row, or malformed JSON all
+        yield None. Telemetry is diagnostic and must never block a turn. Reads are
+        unlocked, matching the store's other read paths.
+        """
+        if not conversation_id:
+            return None
+        conn = self._conn
+        if conn is None:
+            return None
+        row = conn.execute(
+            "SELECT value FROM metadata WHERE key = ?",
+            (self._compaction_telemetry_key(conversation_id),),
+        ).fetchone()
+        if not row or not row[0]:
+            return None
+        try:
+            data = json.loads(str(row[0]))
+        except (ValueError, TypeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def write_compaction_telemetry(self, conversation_id: str, record: Dict[str, Any]) -> None:
+        """Upsert the per-conversation compaction-telemetry record.
+
+        Stored as a single JSON row in the existing metadata table (no dedicated
+        schema, no version bump) under the store write lock. The write -- and its
+        commit -- is skipped when the serialized payload is unchanged so idle
+        turns do not churn the row.
+        """
+        if not conversation_id:
+            return
+        conn = self._conn
+        if conn is None:
+            return
+        serialized = json.dumps(record, sort_keys=True)
+        key = self._compaction_telemetry_key(conversation_id)
+        with self._write_lock:
+            existing = conn.execute(
+                "SELECT value FROM metadata WHERE key = ?", (key,)
+            ).fetchone()
+            if existing is not None and existing[0] == serialized:
+                return
+            conn.execute(
+                """
+                INSERT INTO metadata(key, value)
+                VALUES(?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                (key, serialized),
+            )
+            conn.commit()
+
     # -- Search -------------------------------------------------------------
 
     def search(self, query: str, session_id: str | None = None,

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,0 +1,131 @@
+"""Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.store import MessageStore
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_test.db")
+    e = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    e._session_id = "test-session"
+    e._conversation_id = "conv-1"
+    e.update_model("gpt-test", 200000, provider="openai-codex", api_mode="responses")
+    return e
+
+
+def _hot_usage(prompt=1000, read=400, write=50):
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": 100,
+        "total_tokens": prompt + 100,
+        "input_tokens": prompt - read - write,
+        "cache_read_tokens": read,
+        "cache_write_tokens": write,
+    }
+
+
+def _cold_usage(prompt=1000):
+    # Cache keys present (so cache_metrics_available) but both zero -> cold.
+    return {"prompt_tokens": prompt, "cache_read_tokens": 0, "cache_write_tokens": 0}
+
+
+def _telemetry(engine):
+    return engine.get_status().get("compaction_telemetry")
+
+
+def test_records_per_turn_snapshot(engine):
+    engine.update_from_response(_hot_usage(prompt=1050, read=400, write=50))
+    t = _telemetry(engine)
+    assert t is not None
+    assert t["cache_state"] == "hot"
+    assert t["consecutive_cold_observations"] == 0
+    assert t["turns_since_leaf_compaction"] == 1
+    assert t["last_observed_prompt_tokens"] == 1050
+    assert t["last_observed_cache_read"] == 400
+    assert t["last_observed_cache_write"] == 50
+    assert t["peak_prompt_tokens_since_leaf_compaction"] == 1050
+    assert t["provider"] == "openai-codex"
+    assert t["model"] == "gpt-test"
+    assert t["activity_band"] == "low"
+
+
+def test_turns_since_increments_and_peak_is_max(engine):
+    engine.update_from_response(_hot_usage(prompt=1000))
+    engine.update_from_response(_hot_usage(prompt=600))
+    t = _telemetry(engine)
+    assert t["turns_since_leaf_compaction"] == 2
+    assert t["peak_prompt_tokens_since_leaf_compaction"] == 1000  # max across turns
+
+
+def test_cold_streak_counts_and_hot_resets(engine):
+    engine.update_from_response(_cold_usage())
+    engine.update_from_response(_cold_usage())
+    assert _telemetry(engine)["cache_state"] == "cold"
+    assert _telemetry(engine)["consecutive_cold_observations"] == 2
+    engine.update_from_response(_hot_usage())
+    assert _telemetry(engine)["cache_state"] == "hot"
+    assert _telemetry(engine)["consecutive_cold_observations"] == 0
+
+
+def test_idle_turn_is_skipped(engine):
+    engine.update_from_response(_hot_usage())
+    before = _telemetry(engine)["turns_since_leaf_compaction"]
+    # No prompt tokens and no cache keys at all -> no signal -> no write.
+    engine.update_from_response({"completion_tokens": 5})
+    assert _telemetry(engine)["turns_since_leaf_compaction"] == before
+
+
+def test_resets_on_compaction(engine):
+    engine.update_from_response(_hot_usage(prompt=1000))
+    engine.update_from_response(_hot_usage(prompt=1000))
+    assert _telemetry(engine)["turns_since_leaf_compaction"] == 2
+
+    # Simulate a leaf compaction happening between turns.
+    engine.compression_count += 1
+    engine._last_compaction_duration_ms = 12.5
+    engine.update_from_response(_hot_usage(prompt=400))
+
+    t = _telemetry(engine)
+    assert t["turns_since_leaf_compaction"] == 0
+    assert t["total_compactions"] == 1
+    assert t["last_leaf_compaction_at"] is not None
+    assert t["last_compaction_duration_ms"] == 12.5
+    assert t["peak_prompt_tokens_since_leaf_compaction"] == 400  # reset to current
+
+
+def test_no_conversation_records_nothing(engine):
+    engine._conversation_id = ""
+    engine.update_from_response(_hot_usage())
+    assert _telemetry(engine) is None
+
+
+def test_unknown_cache_state_when_no_cache_signal(engine):
+    # Prompt tokens but no cache keys -> still recorded, state unknown.
+    engine.update_from_response({"prompt_tokens": 800})
+    t = _telemetry(engine)
+    assert t is not None
+    assert t["cache_state"] == "unknown"
+
+
+def test_store_roundtrip_and_skip_unchanged(tmp_path):
+    store = MessageStore(tmp_path / "t.db")
+    assert store.read_compaction_telemetry("c1") is None
+    record = {"conversation_id": "c1", "cache_state": "hot", "turns_since_leaf_compaction": 3}
+    store.write_compaction_telemetry("c1", record)
+    assert store.read_compaction_telemetry("c1") == record
+
+    # Unchanged payload must not rewrite the row.
+    key = store._compaction_telemetry_key("c1")
+    store.write_compaction_telemetry("c1", dict(record))
+    row = store._conn.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+
+    # Empty conversation id is a no-op.
+    store.write_compaction_telemetry("", {"x": 1})
+    assert store.read_compaction_telemetry("") is None
+    store.close()


### PR DESCRIPTION
## Summary
- Persist a lightweight **per-conversation compaction-telemetry** record and surface it under `get_status()["compaction_telemetry"]`.
- Stored as a single JSON row in the **existing metadata table** — no new table, no `SCHEMA_VERSION` bump, no client lockout.
- Recorded once per turn (in `update_from_response`): last prompt / cache-read / cache-write tokens; `cache_state` (hot|cold|unknown) + consecutive-cold streak; `turns_since_leaf_compaction`; `peak_prompt_tokens_since_leaf_compaction`; `total_compactions`; `last_leaf_compaction_at`; `last_compaction_duration_ms`; provider/model; `last_api_call_at`; `activity_band` (reserved, carried forward as `"low"`).
- `compress()` logs the leaf-compaction wall-clock at INFO (log-only; durations/queue-wait are not persisted).
- New `MessageStore.read_compaction_telemetry` / `write_compaction_telemetry` keep the engine out of the store's private connection/lock.

## Why
- Operators currently have no persisted view of cache behaviour or compaction cadence. This adds one cheaply and additively.
- Modelled on the TS reference (`compaction-telemetry` in `martian-engineering/lossless-claw`), but deliberately scoped down: the reference uses a dedicated table + migration; here a single metadata JSON row avoids a schema-version bump entirely.
- The since-compaction accumulators reset off the monotonic `compression_count` (which also drops to 0 on a session reset) rather than instrumenting the `compress()` hot path — one comparison in the per-turn recorder, no invasive pipeline change.

## Validation
- [x] Focused validation:
  - [x] `PYTHONPATH="<stub>:." python3 -m pytest tests/test_compaction_telemetry.py -q` -> `8 passed` (per-turn snapshot, turns/peak accumulation, cold streak + hot reset, idle-turn skip, reset-on-compaction, no-conversation no-op, unknown state, store roundtrip + skip-unchanged)
- [x] Default validation:
  - [x] `PYTHONPATH="<stub>:." python3 -m pytest tests -q` -> `1393 passed, 12 xfailed`
  - [x] `python3 -m compileall -q .`
  - [x] `python3 -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check origin/main...HEAD` -> clean
- [x] Workflow validation: not applicable; no workflows changed.
- [x] Added-line private/secret hygiene scan -> `0` hits.

## Notes
- Best-effort and non-blocking by design: turns with no token/cache signal are skipped so idle turns never churn the row; the write is skipped when the serialized payload is unchanged; every read/write is guarded so telemetry can never break a turn. Missing cache signals degrade to `cache_state="unknown"` with the cold streak carried.
- `activity_band` is a reserved carry-forward field (matches the reference, which has no live `medium`/`high` computation yet).
- Purely additive (+313 lines, no deletions). The two new store methods are purpose-named and independent of the generic `read_metadata_json`/`write_metadata_json` helpers proposed in a separate PR; they can be unified later if that lands.
- Validation used a minimal local `agent.context_engine` stub because this plugin repository is tested standalone outside the Hermes host package.