### PR TITLE
fix: harden auxiliary lifecycle edge cases

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1047,18 +1047,27 @@ class LCMEngine(ContextEngine):
                                 auxiliary_session_id
                             )
                         self._auxiliary_last_prompt_tokens.pop(auxiliary_session_id, None)
+                        if self._host_fallback_session_id == auxiliary_session_id:
+                            self._end_host_fallback_compressor_for_session(
+                                auxiliary_session_id,
+                                [],
+                                current_session_bypasses=True,
+                            )
                         self._auxiliary_session_generations[
                             auxiliary_session_id
                         ] = caller_generation
-                        self._auxiliary_handoff_parent_session_ids.pop(
-                            auxiliary_session_id,
-                            None,
-                        )
                         active_generation = caller_generation
+                    stack = self._thread_context_auxiliary_stack()
+                    stack_marks_current_session = bool(
+                        active_generation is not None
+                        and caller_generation == 0
+                        and stack
+                        and stack[-1] == auxiliary_session_id
+                    )
                     generation_matches = (
                         caller_generation == 0
                         if active_generation is None
-                        else caller_generation == active_generation
+                        else caller_generation == active_generation or stack_marks_current_session
                     )
                     if generation_matches:
                         self._auxiliary_last_prompt_tokens[auxiliary_session_id] = prompt_tokens
@@ -2112,7 +2121,7 @@ class LCMEngine(ContextEngine):
 
         if self._bypasses_lcm_context_management():
             bypass_current_tokens = current_tokens
-            if bypass_current_tokens is None:
+            if bypass_current_tokens is None or bypass_current_tokens <= 0:
                 auxiliary_session_id = self._thread_context_session_id()
                 if auxiliary_session_id:
                     auxiliary_prompt_tokens = self._current_auxiliary_prompt_tokens(
@@ -2811,6 +2820,12 @@ class LCMEngine(ContextEngine):
                 if previous_generation != generation:
                     if previous_generation is not None:
                         self._retire_auxiliary_generation(session_id, previous_generation)
+                    if self._host_fallback_session_id == session_id:
+                        self._end_host_fallback_compressor_for_session(
+                            session_id,
+                            [],
+                            current_session_bypasses=True,
+                        )
                     if (
                         had_active_session
                         or had_cached_usage
@@ -2821,6 +2836,8 @@ class LCMEngine(ContextEngine):
                 self._auxiliary_session_generations[session_id] = generation
                 self._auxiliary_handoff_parent_session_ids.pop(session_id, None)
             else:
+                if previous_generation is not None and had_active_session:
+                    return True
                 if previous_generation is not None:
                     self._retire_auxiliary_generation(session_id, previous_generation)
                 self._auxiliary_last_prompt_tokens.pop(session_id, None)
@@ -2875,7 +2892,7 @@ class LCMEngine(ContextEngine):
                 has_cached_usage = session_id in self._auxiliary_last_prompt_tokens
                 if generation != 0 or (
                     session_id in self._auxiliary_direct_end_guard_session_ids
-                    and not (expected_parent and has_cached_usage)
+                    and not has_cached_usage
                 ):
                     return False
             self._auxiliary_session_ids.discard(session_id)
@@ -2919,9 +2936,15 @@ class LCMEngine(ContextEngine):
         preserve_old_foreground_marker: bool = False,
     ) -> None:
         generation = self._in_process_auxiliary_caller_generation(new_session_id)
+        if generation and self._auxiliary_generation_is_retired(new_session_id, generation):
+            with self._auxiliary_session_lock:
+                if new_session_id:
+                    self._auxiliary_lineage_session_ids.add(new_session_id)
+            return
         stack = self._thread_context_auxiliary_stack()
         handoff_from_active_thread_marker = old_session_id in stack
         with self._auxiliary_session_lock:
+            old_session_was_active = old_session_id in self._auxiliary_session_ids
             if old_session_id:
                 if not preserve_old_session:
                     self._auxiliary_last_prompt_tokens.pop(old_session_id, None)
@@ -2947,16 +2970,48 @@ class LCMEngine(ContextEngine):
                     or new_session_id in self._auxiliary_lineage_session_ids
                 )
                 had_direct_end_guard = new_session_id in self._auxiliary_direct_end_guard_session_ids
+                expected_new_parent = self._auxiliary_handoff_parent_session_ids.get(new_session_id)
+                stale_generationless_parent_handoff = bool(
+                    previous_new_generation is not None
+                    and not generation
+                    and old_session_id
+                    and not old_session_was_active
+                    and self._auxiliary_retired_session_generations.get(old_session_id)
+                    and old_session_id != expected_new_parent
+                )
+                if stale_generationless_parent_handoff:
+                    self._auxiliary_lineage_session_ids.add(new_session_id)
+                    return
                 new_generation_replaces_old = (
                     previous_new_generation is not None
                     and (
                         (bool(generation) and previous_new_generation != generation)
-                        or (not generation and had_direct_end_guard)
+                        or (
+                            not generation
+                            and had_direct_end_guard
+                            and (
+                                new_session_id not in self._auxiliary_last_prompt_tokens
+                                or not expected_new_parent
+                                or old_session_id == expected_new_parent
+                            )
+                        )
                     )
                 )
                 if had_new_session_state and new_generation_replaces_old:
                     self._retire_auxiliary_generation(new_session_id, previous_new_generation)
                 boundary_from_live_new_generation = bool(generation) and previous_new_generation == generation
+                if (
+                    previous_new_generation is not None
+                    and not generation
+                    and had_direct_end_guard
+                    and new_session_id in self._auxiliary_last_prompt_tokens
+                    and expected_new_parent
+                    and old_session_id
+                    and not old_session_was_active
+                    and old_session_id != expected_new_parent
+                ):
+                    self._auxiliary_lineage_session_ids.add(new_session_id)
+                    return
                 preserve_new_foreground_marker = (
                     new_session_id in self._auxiliary_foreground_reused_session_ids
                     and not boundary_from_live_new_generation
@@ -2991,10 +3046,46 @@ class LCMEngine(ContextEngine):
                     self._auxiliary_session_ids.add(new_session_id)
                     self._auxiliary_foreground_reused_session_ids.discard(new_session_id)
                     if generation:
+                        if previous_new_generation != generation and self._host_fallback_session_id == new_session_id:
+                            self._end_host_fallback_compressor_for_session(
+                                new_session_id,
+                                [],
+                                current_session_bypasses=True,
+                            )
                         self._auxiliary_session_generations[new_session_id] = generation
                         self._auxiliary_handoff_parent_session_ids.pop(new_session_id, None)
                     elif previous_new_generation is None or new_generation_replaces_old:
                         self._auxiliary_session_generations.pop(new_session_id, None)
+                elif generation:
+                    if previous_new_generation != generation:
+                        if previous_new_generation is not None:
+                            self._retire_auxiliary_generation(new_session_id, previous_new_generation)
+                        self._auxiliary_last_prompt_tokens.pop(new_session_id, None)
+                        self._auxiliary_direct_end_guard_session_ids.discard(new_session_id)
+                        if self._host_fallback_session_id == new_session_id:
+                            self._end_host_fallback_compressor_for_session(
+                                new_session_id,
+                                [],
+                                current_session_bypasses=True,
+                            )
+                    self._auxiliary_session_ids.add(new_session_id)
+                    self._auxiliary_session_generations[new_session_id] = generation
+                    self._auxiliary_handoff_parent_session_ids.pop(new_session_id, None)
+                else:
+                    if previous_new_generation is not None:
+                        self._retire_auxiliary_generation(new_session_id, previous_new_generation)
+                    self._auxiliary_last_prompt_tokens.pop(new_session_id, None)
+                    self._auxiliary_direct_end_guard_session_ids.discard(new_session_id)
+                    if self._host_fallback_session_id == new_session_id:
+                        self._end_host_fallback_compressor_for_session(
+                            new_session_id,
+                            [],
+                            current_session_bypasses=True,
+                        )
+                    self._auxiliary_session_ids.add(new_session_id)
+                    self._auxiliary_session_generations.pop(new_session_id, None)
+                    if old_session_id:
+                        self._auxiliary_handoff_parent_session_ids[new_session_id] = old_session_id
                 self._auxiliary_lineage_session_ids.add(new_session_id)
         stack = self._thread_context_auxiliary_stack()
         had_thread_marker = old_session_id in stack or new_session_id in stack
@@ -3287,14 +3378,21 @@ class LCMEngine(ContextEngine):
         active_auxiliary_ids = self._active_auxiliary_session_ids()
         known_auxiliary_ids = self._known_auxiliary_lineage_session_ids()
         known_auxiliary_parent_ids = self._known_auxiliary_parent_lineage_session_ids()
+        bypassed_auxiliary_ids = {
+            str(auxiliary_id or "")
+            for auxiliary_id in known_auxiliary_ids
+            if self._lcm_session_last_bypassed.get(str(auxiliary_id or ""))
+        }
         if child_parent_id in active_auxiliary_ids:
             return True
         if child_parent_id in known_auxiliary_parent_ids and child_parent_id != self._session_id:
             return True
+        if child_parent_id in bypassed_auxiliary_ids:
+            return True
         if child_parent_id != parent_session_id:
             return self._session_has_auxiliary_ancestor(
                 str(child_parent_id or ""),
-                known_auxiliary_parent_ids | active_auxiliary_ids,
+                known_auxiliary_parent_ids | active_auxiliary_ids | bypassed_auxiliary_ids,
                 path,
             )
         return False
@@ -3942,8 +4040,69 @@ class LCMEngine(ContextEngine):
         previous_session_id = self._session_id
         self._lcm_current_start_allows_bypass_lineage = False
         requested_platform = str(kwargs.get("platform") or self._session_platform or "")
+        pre_reset_preserve_ambiguous_no_frame_old_session = False
+        if boundary_reason == "compression" and old_session_id and old_session_id != session_id:
+            old_session_auxiliary_generation = self._in_process_auxiliary_caller_generation(
+                old_session_id
+            )
+            new_session_auxiliary_parent = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+            )
+            new_session_auxiliary_generation = self._in_process_auxiliary_caller_generation(session_id)
+            with self._auxiliary_session_lock:
+                active_old_auxiliary_generation = self._auxiliary_session_generations.get(
+                    old_session_id
+                )
+                old_session_auxiliary_generation_is_stale = bool(
+                    (
+                        old_session_auxiliary_generation
+                        and self._auxiliary_generation_is_retired(
+                            old_session_id,
+                            old_session_auxiliary_generation,
+                        )
+                    )
+                    or (
+                        new_session_auxiliary_generation
+                        and self._auxiliary_generation_is_retired(
+                            session_id,
+                            new_session_auxiliary_generation,
+                        )
+                    )
+                    or (
+                        active_old_auxiliary_generation is not None
+                        and (
+                            (
+                                old_session_auxiliary_generation
+                                and active_old_auxiliary_generation != old_session_auxiliary_generation
+                            )
+                        )
+                    )
+                )
+                old_session_has_retired_generation = bool(
+                    self._auxiliary_retired_session_generations.get(old_session_id)
+                )
+            if old_session_auxiliary_generation_is_stale:
+                logger.info(
+                    "LCM ignored stale auxiliary compression boundary from %s to %s",
+                    old_session_id,
+                    session_id,
+                )
+                return
+            pre_reset_preserve_ambiguous_no_frame_old_session = bool(
+                active_old_auxiliary_generation is not None
+                and not old_session_auxiliary_generation
+                and old_session_id != self._session_id
+                and old_session_has_retired_generation
+                and old_session_id not in self._auxiliary_direct_end_guard_session_ids
+                and new_session_auxiliary_parent != old_session_id
+            )
         if self._host_fallback_compressor is not None and (
             self._host_fallback_session_id != session_id or requested_platform != self._session_platform
+        ) and not (
+            pre_reset_preserve_ambiguous_no_frame_old_session
+            and self._host_fallback_session_id == old_session_id
         ):
             compressor = self._host_fallback_compressor
             fallback_session_id = self._host_fallback_session_id or previous_session_id
@@ -3973,9 +4132,63 @@ class LCMEngine(ContextEngine):
                 session_id=session_id,
                 include_explicit=False,
             )
+            new_session_auxiliary_generation = self._in_process_auxiliary_caller_generation(session_id)
+            with self._auxiliary_session_lock:
+                active_old_auxiliary_generation = self._auxiliary_session_generations.get(
+                    old_session_id
+                )
+                old_session_auxiliary_generation_is_stale = bool(
+                    (
+                        old_session_auxiliary_generation
+                        and self._auxiliary_generation_is_retired(
+                            old_session_id,
+                            old_session_auxiliary_generation,
+                        )
+                    )
+                    or (
+                        new_session_auxiliary_generation
+                        and self._auxiliary_generation_is_retired(
+                            session_id,
+                            new_session_auxiliary_generation,
+                        )
+                    )
+                    or (
+                        active_old_auxiliary_generation is not None
+                        and (
+                            (
+                                old_session_auxiliary_generation
+                                and active_old_auxiliary_generation != old_session_auxiliary_generation
+                            )
+                        )
+                    )
+                )
+                old_session_has_retired_generation = bool(
+                    self._auxiliary_retired_session_generations.get(old_session_id)
+                )
+            new_session_auxiliary_parent = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+            )
             new_session_is_auxiliary_continuation = new_session_auxiliary_parent == old_session_id
+            preserve_ambiguous_no_frame_old_session = bool(
+                active_old_auxiliary_generation is not None
+                and not old_session_auxiliary_generation
+                and old_session_id != self._session_id
+                and old_session_has_retired_generation
+                and old_session_id not in self._auxiliary_direct_end_guard_session_ids
+                and not new_session_is_auxiliary_continuation
+            )
+            if old_session_auxiliary_generation_is_stale:
+                logger.info(
+                    "LCM ignored stale auxiliary compression boundary from %s to %s",
+                    old_session_id,
+                    session_id,
+                )
+                return
             if (
                 self._has_auxiliary_lineage_session(old_session_id)
+                and not old_session_auxiliary_generation_is_stale
                 and (
                     old_session_id != self._session_id
                     or old_session_auxiliary_generation
@@ -3990,7 +4203,10 @@ class LCMEngine(ContextEngine):
                 self._handoff_auxiliary_session(
                     old_session_id,
                     session_id,
-                    preserve_old_session=old_session_id == self._session_id,
+                    preserve_old_session=(
+                        old_session_id == self._session_id
+                        or preserve_ambiguous_no_frame_old_session
+                    ),
                     preserve_old_foreground_marker=old_session_is_suppressed_foreground,
                 )
                 logger.info(
@@ -4036,12 +4252,16 @@ class LCMEngine(ContextEngine):
         if self._is_live_auxiliary_child_session(session_id, previous_session_id, kwargs):
             explicit_parent_id = str(kwargs.get("parent_session_id") or "")
             preserve_foreground_reuse_marker = bool(
-                explicit_parent_id
-                and self._lcm_session_last_bypassed.get(explicit_parent_id)
+                (
+                    explicit_parent_id
+                    and self._lcm_session_last_bypassed.get(explicit_parent_id)
+                )
+                or self._lcm_session_last_normal_conversation_id.get(session_id)
             )
             if preserve_foreground_reuse_marker:
                 if self._lcm_session_last_normal_conversation_id.get(session_id):
-                    self._auxiliary_foreground_reused_session_ids.add(session_id)
+                    with self._auxiliary_session_lock:
+                        self._auxiliary_foreground_reused_session_ids.add(session_id)
                 self._mark_thread_context_stateless(
                     session_id,
                     preserve_foreground_reuse_marker=True,
@@ -4443,14 +4663,20 @@ class LCMEngine(ContextEngine):
             )
         ):
             current_thread_session_id = self._thread_context_session_id()
-            if current_thread_session_id == session_id or active_auxiliary_end:
-                self._remember_lcm_bypass_message_prefix(session_id, messages)
             deactivated = self._deactivate_auxiliary_session(
                 session_id,
                 generation=ended_generation,
             )
-            if deactivated and current_thread_session_id == session_id:
-                self._clear_thread_context_stateless(session_id)
+            if deactivated:
+                if current_thread_session_id == session_id or active_auxiliary_end:
+                    self._remember_lcm_bypass_message_prefix(session_id, messages)
+                self._end_host_fallback_compressor_for_session(
+                    session_id,
+                    messages,
+                    current_session_bypasses=False,
+                )
+                if current_thread_session_id == session_id:
+                    self._clear_thread_context_stateless(session_id)
             return
         current_session_bypasses = session_id == self._session_id and self._bypasses_lcm_context_management()
         ended_session_directly_bypasses = self._ended_session_directly_bypasses_lcm(session_id)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -2624,6 +2624,38 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_auxiliary_native_fallback_resets_on_session_end(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        config = LCMConfig(database_path=str(tmp_path / "auxiliary-native-reset-on-end.db"))
+        instance = LCMEngine(config=config)
+        messages = [{"role": "user", "content": "auxiliary final messages"}]
+        compressor = FakeContextCompressor()
+        try:
+            instance.on_session_start("foreground-session", platform="cli", context_length=2_000)
+            instance._mark_thread_context_stateless("auxiliary-session")
+            instance._host_fallback_compressor = compressor
+            instance._host_fallback_session_id = "auxiliary-session"
+
+            instance.on_session_end("auxiliary-session", messages)
+
+            assert compressor.ended == [("auxiliary-session", messages)]
+            assert compressor.reset is True
+            assert instance._host_fallback_compressor is None
+            assert instance._host_fallback_session_id == ""
+            assert not instance._thread_context_has_auxiliary_session("auxiliary-session")
+        finally:
+            instance.shutdown()
+
     def test_bypassed_native_fallback_resets_when_same_session_id_rebinds_platform(self, tmp_path, monkeypatch):
         instances = []
 
@@ -11681,8 +11713,8 @@ class TestSessionRollover:
         def should_compress(self, engine: LCMEngine):
             return engine.should_compress()
 
-        def compress(self, engine: LCMEngine, messages):
-            return engine.compress(messages)
+        def compress(self, engine: LCMEngine, messages, **kwargs):
+            return engine.compress(messages, **kwargs)
 
         def update_from_response(self, engine: LCMEngine, usage: dict) -> None:
             engine.update_from_response(usage)
@@ -12735,6 +12767,44 @@ class TestSessionRollover:
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("foreground-branch-session") == 1
 
+    def test_active_auxiliary_reused_as_foreground_with_parent_metadata_rebinds(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_active_aux_reused_foreground.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+        )
+        aux_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "foreground-branch-session",
+            "foreground-session",
+        )
+        aux_child.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._thread_context_has_auxiliary_session("foreground-branch-session")
+
+        engine.on_session_start(
+            "foreground-branch-session",
+            hermes_home=str(hermes_home),
+            platform="tui",
+            context_length=200000,
+            parent_session_id="foreground-session",
+        )
+
+        assert engine._session_id == "foreground-branch-session"
+        assert engine._thread_context_session_id() == ""
+        assert not engine._thread_context_has_auxiliary_session("foreground-branch-session")
+        engine.should_compress_preflight([
+            {"role": "user", "content": "active aux id reused as foreground persists normally"},
+        ])
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("foreground-branch-session") == 1
+
     def test_explicit_parent_id_without_aux_frame_or_live_row_rebinds_foreground_branch(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -12989,7 +13059,7 @@ class TestSessionRollover:
         )
         replacement.update_from_response(engine, {"prompt_tokens": 25})
         engine.on_session_end("reused-parent", [])
-        assert engine._thread_context_has_auxiliary_session("reused-parent")
+        assert not engine._thread_context_has_auxiliary_session("reused-parent")
         assert not old_child.should_compress(engine)
 
         engine.on_session_start(
@@ -13340,6 +13410,110 @@ class TestSessionRollover:
             "reused child normal final",
         ]
 
+    def test_state_db_child_of_bypassed_reused_parent_stays_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('stateless-parent', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('state-db-child', 'stateless-parent', 3.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_state_db_bypassed_child.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine._auxiliary_lineage_session_ids.add("stateless-parent")
+        engine._auxiliary_foreground_reused_session_ids.add("stateless-parent")
+        engine._lcm_session_last_bypassed["stateless-parent"] = True
+
+        engine.on_session_start(
+            "state-db-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+
+        assert engine.current_session_id == "foreground-session"
+        assert engine._thread_context_has_auxiliary_session("state-db-child")
+        assert engine._store.get_session_count("state-db-child") == 0
+        assert engine.should_compress_preflight([
+            {"role": "user", "content": "state db child must stay stateless"},
+        ]) is False
+        assert engine._store.get_session_count("state-db-child") == 0
+
+    def test_state_db_grandchild_of_bypassed_reused_parent_stays_auxiliary(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        state_db = hermes_home / "state.db"
+        conn = sqlite3.connect(state_db)
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL
+            );
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('foreground-session', NULL, 1.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('stateless-parent', 'foreground-session', 2.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('intermediate-child', 'stateless-parent', 3.0, NULL);
+            INSERT INTO sessions(id, parent_session_id, started_at, ended_at)
+            VALUES ('state-db-grandchild', 'intermediate-child', 4.0, NULL);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_state_db_bypassed_grandchild.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine._auxiliary_lineage_session_ids.add("stateless-parent")
+        engine._auxiliary_foreground_reused_session_ids.add("stateless-parent")
+        engine._lcm_session_last_bypassed["stateless-parent"] = True
+
+        engine.on_session_start(
+            "state-db-grandchild",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+
+        assert engine.current_session_id == "foreground-session"
+        assert engine._thread_context_has_auxiliary_session("state-db-grandchild")
+        assert engine._store.get_session_count("state-db-grandchild") == 0
+        assert engine.should_compress_preflight([
+            {"role": "user", "content": "state db grandchild must stay stateless"},
+        ]) is False
+        assert engine._store.get_session_count("state-db-grandchild") == 0
+
     def test_side_channel_child_marks_prior_normal_id_as_foreground_reuse(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -13411,6 +13585,78 @@ class TestSessionRollover:
         assert [row["content"] for row in engine._store.get_range("prior-normal-child")] == [
             "prior normal child prefix",
             "prior normal child final",
+        ]
+
+    def test_inferred_side_channel_child_preserves_prior_normal_suffix(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_inferred_side_channel_child_prior_normal.db"),
+            stateless_session_patterns=["stateless"],
+        )
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stateless_parent = self._start_host_child(
+            engine,
+            hermes_home,
+            "stateless-parent",
+            "foreground-session",
+        )
+        stateless_parent.on_session_end(engine, [])
+        engine.on_session_start(
+            "stateless-parent",
+            hermes_home=str(hermes_home),
+            platform="stateless",
+            context_length=1_000,
+        )
+
+        engine.on_session_start(
+            "prior-normal-child",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            conversation_id="prior-normal-child-conversation",
+            context_length=1_000,
+        )
+        normal_prefix = [{"role": "user", "content": "inferred prior normal prefix"}]
+        engine.ingest(normal_prefix)
+        engine.on_session_start(
+            "foreground-2",
+            hermes_home=str(hermes_home),
+            platform="cli",
+            context_length=1_000,
+        )
+        side_channel_child = self.HostAgentFrame(
+            "prior-normal-child",
+            "stateless-parent",
+            hermes_home,
+        )
+        side_channel_child.on_session_start(engine)
+        assert engine._auxiliary_lineage_suppressed_as_foreground("prior-normal-child")
+        side_channel_child.on_session_end(
+            engine,
+            normal_prefix + [
+                {"role": "assistant", "content": "inferred side-channel final"},
+            ],
+        )
+        assert [row["content"] for row in engine._store.get_range("prior-normal-child")] == [
+            "inferred prior normal prefix",
+        ]
+
+        engine.on_session_end(
+            "prior-normal-child",
+            normal_prefix + [
+                {"role": "assistant", "content": "inferred prior normal final"},
+            ],
+        )
+        assert [row["content"] for row in engine._store.get_range("prior-normal-child")] == [
+            "inferred prior normal prefix",
+            "inferred prior normal final",
         ]
 
     def test_side_channel_prefix_only_end_fails_closed_for_ambiguous_suffix(self, tmp_path):
@@ -15258,7 +15504,7 @@ class TestSessionRollover:
         assert engine._session_id == "reused-session"
         assert engine._conversation_id == "normal-conversation"
         assert engine._thread_context_session_id() == ""
-        assert engine._thread_context_has_auxiliary_session("stale-continuation")
+        assert not engine._thread_context_has_auxiliary_session("stale-continuation")
         assert [
             node.node_id for node in engine._dag.get_session_nodes("reused-session")
         ] == [foreground_node_id]
@@ -16272,12 +16518,61 @@ class TestSessionRollover:
         replacement.update_from_response(engine, {"prompt_tokens": 25})
         assert replacement.should_compress(engine)
         engine.on_session_end("background-review-session", [])
-        assert engine._thread_context_has_auxiliary_session("background-review-session")
-        assert replacement.should_compress(engine)
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not replacement.should_compress(engine)
         old_messages = [{"role": "user", "content": "old frame short payload"}]
         assert count_messages_tokens(old_messages) < engine.threshold_tokens
         assert not old_child.should_compress(engine)
         assert old_child.compress(engine, old_messages) == old_messages
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_auxiliary_compress_zero_current_tokens_uses_cached_usage(self, tmp_path, monkeypatch):
+        native_calls = []
+
+        class FakeContextCompressor:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self._last_compress_aborted = False
+                self._last_summary_error = None
+
+            def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+                native_calls.append(current_tokens)
+                self.compression_count += 1
+                return [{"role": "user", "content": "native compacted auxiliary"}]
+
+        agent_module = sys.modules.get("agent") or ModuleType("agent")
+        if not hasattr(agent_module, "__path__"):
+            agent_module.__path__ = []
+        compressor_module = ModuleType("agent.context_compressor")
+        setattr(compressor_module, "ContextCompressor", FakeContextCompressor)
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+        monkeypatch.setitem(sys.modules, "agent.context_compressor", compressor_module)
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_zero_current_tokens.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        child.update_from_response(engine, {"prompt_tokens": 30})
+        messages = [{"role": "user", "content": "tiny"}]
+
+        result = child.compress(engine, messages, current_tokens=0)
+
+        assert native_calls == [30]
+        assert result == [{"role": "user", "content": "native compacted auxiliary"}]
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-session") == 0
 
@@ -16354,6 +16649,41 @@ class TestSessionRollover:
         assert engine.should_compress()
         assert engine.compress(messages) == messages
         assert calls == [(25, None, False)]
+        assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+
+    def test_stack_marked_auxiliary_update_uses_generation_usage_without_caller_frame(
+        self,
+        tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_stack_marked_update.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        assert engine._auxiliary_session_generations["background-review-session"]
+        stack = engine._thread_context_auxiliary_stack()
+        stack[:] = ["background-review-session"]
+        engine._thread_context.current_auxiliary_session_id = "background-review-session"
+        assert engine._thread_context_session_id() == "background-review-session"
+
+        engine.update_from_response({"prompt_tokens": 25})
+
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 25}
+        assert child.should_compress(engine)
         assert engine._store.get_session_count("foreground-session") == 0
         assert engine._store.get_session_count("background-review-session") == 0
 
@@ -16553,6 +16883,51 @@ class TestSessionRollover:
         assert engine._auxiliary_last_prompt_tokens == {}
         assert not stale_continuation.should_compress(engine)
         assert engine._store.get_session_count("foreground-session") == 0
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_retired_generation_boundary_does_not_reactivate_stale_continuation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_retired_generation_boundary_reject.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        stale_continuation = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-continuation",
+            "background-review-session",
+        )
+        stale_generation = engine._auxiliary_session_generations["background-review-continuation"]
+        stale_continuation.on_session_end(engine, [])
+        assert engine._auxiliary_generation_is_retired(
+            "background-review-continuation",
+            stale_generation,
+        )
+
+        stale_continuation.on_compression_boundary_from(
+            engine,
+            old_session_id="background-review-session",
+            context_length=1_000,
+        )
+        stale_continuation.update_from_response(engine, {"prompt_tokens": 99})
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not stale_continuation.should_compress(engine)
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._store.get_session_count("background-review-continuation") == 0
 
@@ -16864,6 +17239,320 @@ class TestSessionRollover:
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._store.get_session_count("background-review-continuation") == 0
 
+    def test_stale_auxiliary_end_does_not_reset_live_native_fallback(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_aux_end_fallback.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        live_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        live_child.update_from_response(engine, {"prompt_tokens": 25})
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "background-review-session"
+
+        stale_child.on_session_end(engine, [{"role": "user", "content": "stale final"}])
+
+        assert compressor.ended == []
+        assert compressor.reset is False
+        assert engine._host_fallback_compressor is compressor
+        assert engine._host_fallback_session_id == "background-review-session"
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert live_child.should_compress(engine)
+
+    def test_auxiliary_generation_replacement_resets_native_fallback(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_replacement_fallback_reset.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "background-review-session"
+
+        live_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+
+        assert compressor.ended == [("background-review-session", [])]
+        assert compressor.reset is True
+        assert engine._host_fallback_compressor is None
+        assert engine._host_fallback_session_id == ""
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 30}
+
+    def test_auxiliary_generation_adoption_resets_native_fallback(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_adoption_fallback_reset.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        child = self.HostAgentFrame(
+            "background-review-session",
+            "foreground-session",
+            hermes_home,
+        )
+        engine._mark_thread_context_stateless("background-review-session")
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "background-review-session"
+
+        child.update_from_response(engine, {"prompt_tokens": 30})
+
+        assert compressor.ended == [("background-review-session", [])]
+        assert compressor.reset is True
+        assert engine._host_fallback_compressor is None
+        assert engine._host_fallback_session_id == ""
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 30}
+        assert "background-review-session" in engine._auxiliary_session_generations
+
+    def test_auxiliary_handoff_generation_replacement_resets_native_fallback(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_replacement_fallback_reset.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(engine, hermes_home, "parent-session", "foreground-session")
+        first_continuation = self.HostAgentFrame(
+            "reused-continuation",
+            "parent-session",
+            hermes_home,
+        )
+        first_continuation.on_compression_boundary_from(
+            engine,
+            old_session_id="parent-session",
+            context_length=1_000,
+        )
+        first_generation = engine._auxiliary_session_generations["reused-continuation"]
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "reused-continuation"
+
+        second_continuation = self.HostAgentFrame(
+            "reused-continuation",
+            "parent-session",
+            hermes_home,
+        )
+        second_continuation.on_compression_boundary_from(
+            engine,
+            old_session_id="parent-session",
+            context_length=1_000,
+        )
+
+        assert engine._auxiliary_session_generations["reused-continuation"] != first_generation
+        assert compressor.ended == [("reused-continuation", [])]
+        assert compressor.reset is True
+        assert engine._host_fallback_compressor is None
+        assert engine._host_fallback_session_id == ""
+
+    def test_stale_auxiliary_boundary_does_not_reset_live_native_fallback(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_aux_boundary_fallback.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        live_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "background-review-session"
+
+        stale_child.on_compression_boundary(engine, "stale-continuation", context_length=1_000)
+
+        assert compressor.ended == []
+        assert compressor.reset is False
+        assert engine._host_fallback_compressor is compressor
+        assert engine._host_fallback_session_id == "background-review-session"
+        assert engine._thread_context_has_auxiliary_session("background-review-session")
+        assert not engine._thread_context_has_auxiliary_session("stale-continuation")
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 30}
+        engine.threshold_tokens = 20
+        assert live_child.should_compress(engine)
+
+    def test_direct_host_end_clears_guarded_replacement_with_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        config = LCMConfig(database_path=str(tmp_path / "lcm_guarded_replacement_direct_end.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        old_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        old_child.update_from_response(engine, {"prompt_tokens": 25})
+        replacement_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        replacement_child.update_from_response(engine, {"prompt_tokens": 30})
+        assert "background-review-session" in engine._auxiliary_direct_end_guard_session_ids
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 30}
+
+        engine.on_session_end("background-review-session", [])
+
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert "background-review-session" not in engine._auxiliary_direct_end_guard_session_ids
+        assert "background-review-session" not in engine._auxiliary_session_generations
+
+    def test_generationless_duplicate_start_preserves_live_auxiliary_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_duplicate_start_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        previous_generation = engine._auxiliary_session_generations["background-review-session"]
+
+        child.on_session_start(
+            engine,
+            parent_session_id="foreground-session",
+            context_length=1_000,
+        )
+
+        assert engine._auxiliary_session_generations == {
+            "background-review-session": previous_generation
+        }
+        assert engine._auxiliary_retired_session_generations == {}
+        child.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {"background-review-session": 25}
+        assert child.should_compress(engine)
+
     def test_auxiliary_handoff_reused_generationless_continuation_rejects_stale_parent(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -16924,6 +17613,426 @@ class TestSessionRollover:
         assert real_continuation.should_compress(engine)
         assert not stale_continuation.should_compress(engine)
 
+    def test_stale_generationless_boundary_preserves_live_continuation_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_stale_boundary_live_usage.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+
+        parent_one = self._start_host_child(engine, hermes_home, "parent-one", "foreground-session")
+        parent_one.on_compression_boundary(engine, "shared-continuation", context_length=1_000)
+        parent_two = self._start_host_child(engine, hermes_home, "parent-two", "foreground-session")
+        parent_two.on_compression_boundary(engine, "shared-continuation", context_length=1_000)
+        real_continuation = self.HostAgentFrame(
+            "shared-continuation",
+            "parent-two",
+            hermes_home,
+        )
+        real_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        assert real_continuation.should_compress(engine)
+
+        parent_one.on_compression_boundary(engine, "shared-continuation", context_length=1_000)
+
+        assert engine._auxiliary_last_prompt_tokens == {"shared-continuation": 30}
+        assert real_continuation.should_compress(engine)
+
+    def test_no_frame_stale_boundary_does_not_replace_live_auxiliary(self, tmp_path):
+        class FakeContextCompressor:
+            def __init__(self):
+                self.ended = []
+                self.reset = False
+
+            def on_session_end(self, session_id, messages):
+                self.ended.append((session_id, messages))
+
+            def on_session_reset(self):
+                self.reset = True
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_no_frame_stale_boundary_live_aux.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        stale_child = self._start_host_child(engine, hermes_home, "reused-child", "foreground-session")
+        stale_child.on_session_end(engine, [])
+        live_child = self._start_host_child(engine, hermes_home, "reused-child", "foreground-session")
+        live_generation = engine._auxiliary_session_generations["reused-child"]
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        compressor = FakeContextCompressor()
+        engine._host_fallback_compressor = compressor
+        engine._host_fallback_session_id = "reused-child"
+        assert live_child.should_compress(engine)
+
+        engine.on_session_start(
+            "stale-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="reused-child",
+            platform="telegram",
+            context_length=1_000,
+        )
+
+        assert engine._thread_context_has_auxiliary_session("reused-child")
+        assert engine._thread_context_has_auxiliary_session("stale-continuation")
+        assert engine._auxiliary_session_generations["reused-child"] == live_generation
+        assert engine._auxiliary_last_prompt_tokens == {"reused-child": 30}
+        assert engine._host_fallback_compressor is compressor
+        assert engine._host_fallback_session_id == "reused-child"
+        assert compressor.ended == []
+        assert compressor.reset is False
+        assert live_child.should_compress(engine)
+        assert engine._store.get_session_count("reused-child") == 0
+        assert engine._store.get_session_count("stale-continuation") == 0
+
+    def test_auxiliary_handoff_to_foreground_reused_id_stays_active(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_handoff_foreground_reused_id.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_aux = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-continuation",
+            "foreground-session",
+        )
+        old_aux.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(engine, hermes_home, "parent-session", "next-foreground-session")
+        continuation = self.HostAgentFrame("reused-continuation", "parent-session", hermes_home)
+        continuation.on_compression_boundary_from(engine, old_session_id="parent-session")
+
+        assert engine._thread_context_has_auxiliary_session("reused-continuation")
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+        assert engine._auxiliary_session_generations["reused-continuation"]
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 25}
+        engine.threshold_tokens = 20
+        engine._last_boundary_skip_time = 0
+        assert continuation.should_compress(engine)
+        assert engine._store.get_session_count("reused-continuation") == 0
+        assert engine._store.get_session_count("parent-session") == 0
+
+    def test_foreground_reused_handoff_replacement_clears_stale_usage(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_foreground_reused_handoff_replacement.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_aux = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-continuation",
+            "foreground-session",
+        )
+        old_aux.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(engine, hermes_home, "parent-a", "next-foreground-session")
+        first_continuation = self.HostAgentFrame("reused-continuation", "parent-a", hermes_home)
+        first_continuation.on_compression_boundary_from(engine, old_session_id="parent-a")
+        first_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        first_generation = engine._auxiliary_session_generations["reused-continuation"]
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 30}
+
+        self._start_host_child(engine, hermes_home, "parent-b", "next-foreground-session")
+        second_continuation = self.HostAgentFrame("reused-continuation", "parent-b", hermes_home)
+        second_continuation.on_compression_boundary_from(engine, old_session_id="parent-b")
+
+        assert engine._auxiliary_session_generations["reused-continuation"] != first_generation
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not second_continuation.should_compress(engine)
+        assert not first_continuation.should_compress(engine)
+        second_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 30}
+
+    def test_parent_handoff_to_foreground_reused_id_retires_displaced_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_parent_handoff_retires_reused_generation.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_aux = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-continuation",
+            "foreground-session",
+        )
+        old_aux.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(engine, hermes_home, "parent-a", "next-foreground-session")
+        first_continuation = self.HostAgentFrame("reused-continuation", "parent-a", hermes_home)
+        first_continuation.on_compression_boundary_from(engine, old_session_id="parent-a")
+        first_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        first_generation = engine._auxiliary_session_generations["reused-continuation"]
+
+        parent_b = self._start_host_child(engine, hermes_home, "parent-b", "next-foreground-session")
+        parent_b.on_compression_boundary(engine, "reused-continuation", context_length=1_000)
+
+        assert engine._auxiliary_generation_is_retired("reused-continuation", first_generation)
+        assert engine._auxiliary_last_prompt_tokens == {}
+        first_continuation.update_from_response(engine, {"prompt_tokens": 99})
+        assert engine._auxiliary_last_prompt_tokens == {}
+        assert not first_continuation.should_compress(engine)
+        assert engine._store.get_session_count("reused-continuation") == 0
+
+    def test_stale_parent_handoff_does_not_clobber_live_reused_continuation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_parent_handoff_live_reused.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.threshold_tokens = 20
+        old_aux = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-continuation",
+            "foreground-session",
+        )
+        old_aux.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        self._start_host_child(engine, hermes_home, "parent-a", "next-foreground-session")
+        first_continuation = self.HostAgentFrame("reused-continuation", "parent-a", hermes_home)
+        first_continuation.on_compression_boundary_from(engine, old_session_id="parent-a")
+        first_continuation.update_from_response(engine, {"prompt_tokens": 30})
+        self._start_host_child(engine, hermes_home, "parent-b", "next-foreground-session")
+        second_continuation = self.HostAgentFrame("reused-continuation", "parent-b", hermes_home)
+        second_continuation.on_compression_boundary_from(engine, old_session_id="parent-b")
+        second_continuation.update_from_response(engine, {"prompt_tokens": 40})
+        live_generation = engine._auxiliary_session_generations["reused-continuation"]
+        retired_parent_a_generations = engine._auxiliary_retired_session_generations["parent-a"]
+        assert retired_parent_a_generations
+        assert all(
+            engine._auxiliary_generation_is_retired("parent-a", generation)
+            for generation in retired_parent_a_generations
+        )
+
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="parent-a",
+            platform="telegram",
+            context_length=1_000,
+        )
+
+        assert engine._auxiliary_session_generations["reused-continuation"] == live_generation
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 40}
+        second_continuation.update_from_response(engine, {"prompt_tokens": 45})
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 45}
+        assert engine._store.get_session_count("reused-continuation") == 0
+
+    def test_generationless_parent_handoff_to_foreground_reused_id_stays_active(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_aux_generationless_handoff_foreground_reused_id.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        old_aux = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-continuation",
+            "foreground-session",
+        )
+        old_aux.update_from_response(engine, {"prompt_tokens": 25})
+        engine.on_session_start(
+            "reused-continuation",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+
+        engine.on_session_start(
+            "next-foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        parent = self._start_host_child(engine, hermes_home, "parent-session", "next-foreground-session")
+        parent.on_compression_boundary(engine, "reused-continuation", context_length=1_000)
+
+        assert engine._thread_context_has_auxiliary_session("reused-continuation")
+        assert "reused-continuation" in engine._auxiliary_foreground_reused_session_ids
+        assert "reused-continuation" not in engine._auxiliary_session_generations
+        continuation = self.HostAgentFrame("reused-continuation", "parent-session", hermes_home)
+        continuation.update_from_response(engine, {"prompt_tokens": 25})
+        assert engine._auxiliary_session_generations["reused-continuation"]
+        assert engine._auxiliary_last_prompt_tokens == {"reused-continuation": 25}
+        engine.threshold_tokens = 20
+        engine._last_boundary_skip_time = 0
+        assert continuation.should_compress(engine)
+
+    def test_stale_retired_auxiliary_boundary_does_not_clobber_live_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_stale_retired_aux_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-child",
+            "foreground-session",
+        )
+        stale_child.update_from_response(engine, {"prompt_tokens": 25})
+
+        live_child = self.HostAgentFrame("reused-child", "foreground-session", hermes_home)
+        live_child.on_session_start(engine, context_length=1_000)
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        live_generation = engine._auxiliary_session_generations["reused-child"]
+        assert live_generation != 0
+        assert engine._auxiliary_last_prompt_tokens == {"reused-child": 30}
+
+        stale_child.on_compression_boundary(engine, "stale-continuation", context_length=1_000)
+
+        assert engine._thread_context_has_auxiliary_session("reused-child")
+        assert engine._auxiliary_session_generations["reused-child"] == live_generation
+        assert engine._auxiliary_last_prompt_tokens == {"reused-child": 30}
+        assert live_child.thread_context_session_id(engine) == "reused-child"
+
+    def test_generationless_stale_auxiliary_boundary_does_not_clobber_live_generation(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_generationless_stale_aux_boundary.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        stale_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "reused-child",
+            "foreground-session",
+        )
+        stale_child.update_from_response(engine, {"prompt_tokens": 25})
+
+        live_child = self.HostAgentFrame("reused-child", "foreground-session", hermes_home)
+        live_child.on_session_start(engine, context_length=1_000)
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        live_generation = engine._auxiliary_session_generations["reused-child"]
+        assert live_generation != 0
+        assert engine._auxiliary_last_prompt_tokens == {"reused-child": 30}
+
+        stale_child.on_compression_boundary(
+            engine,
+            "stale-continuation",
+            context_length=1_000,
+        )
+
+        assert engine._thread_context_has_auxiliary_session("reused-child")
+        assert not engine._thread_context_has_auxiliary_session("stale-continuation")
+        assert engine._auxiliary_session_generations["reused-child"] == live_generation
+        assert engine._auxiliary_last_prompt_tokens == {"reused-child": 30}
+        engine.threshold_tokens = 20
+        assert live_child.should_compress(engine)
+
     def test_auxiliary_handoff_reused_clean_continuation_rejects_stale_generation(self, tmp_path):
         hermes_home = tmp_path / "hermes-home"
         hermes_home.mkdir()
@@ -16980,6 +18089,48 @@ class TestSessionRollover:
         assert not engine._thread_context_has_auxiliary_session("background-review-continuation")
         assert engine._auxiliary_last_prompt_tokens == {}
         assert engine._auxiliary_session_generations == {}
+        assert engine._store.get_session_count("background-review-session") == 0
+        assert engine._store.get_session_count("background-review-continuation") == 0
+
+    def test_live_guarded_auxiliary_boundary_without_frame_is_accepted(self, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm_live_guarded_boundary_no_frame.db"))
+        engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+        engine.on_session_start(
+            "foreground-session",
+            hermes_home=str(hermes_home),
+            platform="telegram",
+            context_length=1_000,
+        )
+        first_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        first_child.update_from_response(engine, {"prompt_tokens": 25})
+        live_child = self._start_host_child(
+            engine,
+            hermes_home,
+            "background-review-session",
+            "foreground-session",
+        )
+        live_child.update_from_response(engine, {"prompt_tokens": 30})
+        assert "background-review-session" in engine._auxiliary_direct_end_guard_session_ids
+
+        engine.on_session_start(
+            "background-review-continuation",
+            hermes_home=str(hermes_home),
+            boundary_reason="compression",
+            old_session_id="background-review-session",
+            platform="telegram",
+            context_length=1_000,
+        )
+
+        assert engine._thread_context_has_auxiliary_session("background-review-continuation")
+        assert not engine._thread_context_has_auxiliary_session("background-review-session")
         assert engine._store.get_session_count("background-review-session") == 0
         assert engine._store.get_session_count("background-review-continuation") == 0
 


### PR DESCRIPTION
## Summary
- harden auxiliary/thread-stateless lifecycle handling after PR #312
- preserve live auxiliary generations and native fallback state across stale/no-frame callbacks
- add regressions for reused IDs, retired generations, guarded handoffs, inferred side-channel children, and fallback reset edge cases

## Why
PR #312 is merged, but local adversarial review found more same-session-ID lifecycle edges where stale auxiliary callbacks could still clobber live usage/fallback state or drop normal suffix handling. This follow-up keeps the no-LCM-write contract for auxiliary/stateless side channels while making the host fallback path safer.

## Validation
- `python -m ruff check engine.py tests/test_lcm_engine.py`
- `python -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py -q -k "thread_context_stateless or auxiliary or bypass or stateless or ignored or host_fallback or native_fallback or session_end or compression_boundary or reused or stack_marked or state_db or foreground or zero" -o addopts=` → 289 passed, 690 deselected
- `python -m pytest -q -o addopts=` → 1570 passed, 12 xfailed
- `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-aux-lifecycle-followups5-20260706052133` → PASS
- local `codex review --base origin/main -c model_reasoning_effort='"'"'xhigh'"'"'` → no discrete introduced bug found

## Risk / impact
- Risk is limited to auxiliary/stateless lifecycle and host fallback paths.
- Normal LCM storage paths should remain unchanged.
- The new regressions are intentionally defensive around stale callback ordering and reused session IDs.
