### PR TITLE
Encapsulate MessageStore connection behind a public accessor

### DIFF
--- a/command.py
+++ b/command.py
@@ -221,7 +221,7 @@ def _status_text(engine) -> str:
 
 
 def _scan_clean_candidates(engine) -> dict[str, Any]:
-    conn = engine._store._conn
+    conn = engine._store.connection
     try:
         rows = conn.execute(
             """
@@ -306,7 +306,7 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
 
 
 def _scan_retention_candidates(engine) -> dict[str, Any]:
-    conn = engine._store._conn
+    conn = engine._store.connection
     now = datetime.now().timestamp()
     # SQL is scoped to the foreground session so /lcm doctor retention
     # reports the operator's real conversation rather than whatever side
@@ -467,7 +467,7 @@ def _flush_engine_connections(engine) -> None:
     ``_rotate_backup_database`` (rolling backup) so the connection-flush
     contract stays in one place.
     """
-    engine._store._conn.commit()
+    engine._store.commit()
     engine._dag._conn.commit()
     lifecycle_conn = getattr(getattr(engine, "_lifecycle", None), "_conn", None)
     if lifecycle_conn is not None:
@@ -493,7 +493,7 @@ def _backup_database(engine) -> dict[str, Any]:
 
         dest = sqlite3.connect(str(backup_path))
         try:
-            engine._store._conn.backup(dest)
+            engine._store.backup(dest)
         finally:
             dest.close()
     except (OSError, sqlite3.Error) as exc:
@@ -539,7 +539,7 @@ def _rotate_backup_database(engine) -> dict[str, Any]:
             tmp_path.unlink()
         dest = sqlite3.connect(str(tmp_path))
         try:
-            engine._store._conn.backup(dest)
+            engine._store.backup(dest)
         finally:
             dest.close()
         # Atomic replace so the rolling slot is never half-written.
@@ -692,7 +692,7 @@ def _scan_fts_repair(engine) -> dict[str, Any]:
         "messages_fts": build_message_fts_spec(),
         "nodes_fts": build_nodes_fts_spec(),
     }
-    conn = engine._store._conn
+    conn = engine._store.connection
     for label, spec in specs.items():
         try:
             structural_needs_repair = external_content_fts_needs_repair(conn, spec)
@@ -763,7 +763,7 @@ def _doctor_repair_apply_text(engine) -> str:
             "note: repair apply aborted before any FTS tables were repaired",
         ])
 
-    conn = engine._store._conn
+    conn = engine._store.connection
     try:
         messages_result = repair_external_content_fts(conn, build_message_fts_spec())
         nodes_result = repair_external_content_fts(conn, build_nodes_fts_spec())
@@ -896,7 +896,7 @@ def _doctor_source_apply_text(engine) -> str:
 def _doctor_text(engine) -> str:
     db_path = Path(engine._store.db_path)
     runtime_identity = engine.get_runtime_identity()
-    store_conn = engine._store._conn
+    store_conn = engine._store.connection
     dag_conn = engine._dag._conn
 
     issues: list[str] = []
@@ -1421,7 +1421,7 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
     apply is destructive, so do the coordinated deletes on one connection to
     avoid half-cleaned state if a later table delete fails.
     """
-    conn = engine._store._conn
+    conn = engine._store.connection
     # Protect the actively-bound session id, not current_session_id. While a
     # cron tick has rebound the engine, _session_id is the row the engine is
     # actively writing to via lifecycle hooks; deleting it during cleanup

--- a/store.py
+++ b/store.py
@@ -1230,6 +1230,38 @@ class MessageStore:
             msg["name"] = stored["tool_name"]
         return msg
 
+    # -- Connection access --------------------------------------------------
+
+    @property
+    def connection(self) -> sqlite3.Connection | None:
+        """The live SQLite connection, or ``None`` once :meth:`close` has run.
+
+        Exposed for read-oriented diagnostics and inspection -- integrity /
+        quick checks, FTS sync counts, schema health -- that need ad-hoc
+        queries the store does not wrap in a purpose-built method. Callers must
+        treat it as read-only and tolerate ``None``; writes still go through the
+        store's own methods so the ``_write_lock`` contract stays in one place.
+        """
+        return self._conn
+
+    def commit(self) -> None:
+        """Commit pending writes on the store connection.
+
+        Used by the backup path's cross-connection flush so callers do not reach
+        the private connection. Requires a live connection: a closed store
+        raises, matching direct ``_conn.commit()`` use.
+        """
+        self._conn.commit()
+
+    def backup(self, dest: sqlite3.Connection) -> None:
+        """Copy the store's database into the already-open ``dest`` connection.
+
+        Thin wrapper over ``sqlite3.Connection.backup`` so callers snapshot the
+        store without reaching its private connection. Requires a live
+        connection, matching direct ``_conn.backup(dest)`` use.
+        """
+        self._conn.backup(dest)
+
     # -- Lifecycle ----------------------------------------------------------
 
     def close(self) -> None:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1200,6 +1200,10 @@ def test_lcm_doctor_repair_dry_run_works_with_read_only_database(tmp_path):
     class FakeStore:
         _conn = ro_conn
 
+        @property
+        def connection(self):
+            return self._conn
+
     class FakeEngine:
         _store = FakeStore()
 

--- a/tools.py
+++ b/tools.py
@@ -2182,7 +2182,7 @@ def lcm_inspect(args: Dict[str, Any], **kwargs) -> str:
     runtime_identity = full_status.get("runtime_identity") or engine.get_runtime_identity()
     lifecycle = _inspect_lifecycle_state(engine, session_id, conversation_id)
 
-    store_totals_row = engine._store._conn.execute(
+    store_totals_row = engine._store.connection.execute(
         """
         SELECT COUNT(*), MIN(store_id), MAX(store_id), COALESCE(SUM(token_estimate), 0)
         FROM messages
@@ -2459,7 +2459,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
 
     # 1. Database integrity
     try:
-        result = engine._store._conn.execute("PRAGMA integrity_check").fetchone()
+        result = engine._store.connection.execute("PRAGMA integrity_check").fetchone()
         ok = result and result[0] == "ok"
         checks.append({
             "check": "database_integrity",
@@ -2509,7 +2509,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     })
 
     try:
-        conn = engine._store._conn
+        conn = engine._store.connection
         if conn is None:
             raise RuntimeError("LCM store connection is not initialized")
         schema_health = inspect_lcm_schema_health(
@@ -2533,7 +2533,7 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
     # 1b. FTS5 integrity, separated from generic SQLite integrity so malformed
     # inverted indexes point at the exact table and repair path.
     for check_name, conn, spec in (
-        ("messages_fts_integrity", engine._store._conn, build_message_fts_spec()),
+        ("messages_fts_integrity", engine._store.connection, build_message_fts_spec()),
         ("nodes_fts_integrity", engine._dag._conn, build_nodes_fts_spec()),
     ):
         try:
@@ -2553,8 +2553,8 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
 
     # 2. SQLite storage posture and payload diagnostics
     try:
-        journal_mode_row = engine._store._conn.execute("PRAGMA journal_mode").fetchone()
-        quick_check_row = engine._store._conn.execute("PRAGMA quick_check").fetchone()
+        journal_mode_row = engine._store.connection.execute("PRAGMA journal_mode").fetchone()
+        quick_check_row = engine._store.connection.execute("PRAGMA quick_check").fetchone()
         db_path = Path(engine._store.db_path)
         wal_path = Path(str(db_path) + "-wal")
         checks.append({
@@ -2569,10 +2569,10 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
                 "wal_size_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
             },
         })
-        payload_risks = scan_sqlite_payload_risks(engine._store._conn)
+        payload_risks = scan_sqlite_payload_risks(engine._store.connection)
         externalized_stats = externalized_payload_stats(engine._config, hermes_home=engine._hermes_home)
         externalized_integrity = scan_externalized_payload_integrity(
-            engine._store._conn,
+            engine._store.connection,
             engine._config,
             hermes_home=engine._hermes_home,
         )
@@ -2621,10 +2621,10 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
 
     # 3. FTS index sync
     try:
-        msg_count = engine._store._conn.execute(
+        msg_count = engine._store.connection.execute(
             "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
         ).fetchone()[0]
-        fts_count = engine._store._conn.execute(
+        fts_count = engine._store.connection.execute(
             """
             SELECT COUNT(*)
             FROM messages_fts


### PR DESCRIPTION
## Summary
- Add a public `MessageStore.connection` property (read-oriented) plus `MessageStore.commit()` and `MessageStore.backup(dest)`.
- Route every remaining `engine._store._conn` reach-in in `command.py` and `tools.py` through the new public surface.
- Finishes the WS5 encapsulation started in #316 (metadata JSON read/write) for the store's raw connection.

## Why
After #316 moved the metadata JSON read/write onto `MessageStore`, the `/lcm`
command handlers and the inspect/doctor tools were the last callers still
poking the store's private `_conn`: ad-hoc diagnostic reads (integrity /
quick / journal-mode PRAGMAs, FTS sync counts, schema health, payload-risk
scans, inspect totals) and the backup path's flush + snapshot. That coupled
diagnostics and the CLI to the store's private field and its name. Giving the
store a documented public seam removes that coupling and keeps the None/closed
handling in one supported place, mirroring the already-public `db_path`.

## Validation
- `ruff check store.py command.py tools.py` → All checks passed
- `python -m pytest -q -o addopts=` (full suite) → 1545 passed, 12 xfailed
- `python -m pytest tests/test_lcm_command.py tests/test_lcm_inspect.py tests/test_tool_contracts.py tests/test_lcm_core.py -q -o addopts=` → 385 passed
- `scripts/validate_release.sh --full --keep-going --output <dir>` → PASS

## Notes
- Behaviour-preserving: `connection` returns the same object callers used
  before, so their existing `if conn is None` guards are unchanged; `commit`
  and `backup` are thin wrappers that keep the live-connection requirement (a
  closed store still raises, matching direct `_conn.commit()` / `_conn.backup()`
  use).
- Scope is deliberately the `MessageStore` connection only. The `_dag` and
  `_lifecycle` connections are separate classes with their own `_conn`; the
  backup flush in `_flush_engine_connections` still commits those directly.
- Trade-off, stated plainly: `connection` is a *read* seam for diagnostics, not
  full method-level encapsulation, so it does technically expose a handle a
  caller could write through outside `_write_lock`. That is enforced by
  convention (docstring) rather than the type system. It is not a new capability
  — callers already reached the same `_conn` directly — and writes in-tree still
  go through the store's locked methods. Happy to add per-check read methods
  instead if you'd prefer the connection stay private.
- `engine.py`'s two `_store._append_protected_batch(...)` calls are a private
  *method* on the append path, a different encapsulation question, and are left
  as-is.
- The one hand-rolled `FakeStore` test double gains a `connection` property to
  mirror the real store's public API; other tests set/read the real store's
  `_conn` field directly, which the property returns unchanged.

## Refs
- Follows #316 (metadata JSON on MessageStore); same WS5 encapsulation line.
