### PR TITLE
Lift /lcm doctor session-stat scans into MessageStore (WS5.5)

### DIFF
--- a/command.py
+++ b/command.py
@@ -221,37 +221,8 @@ def _status_text(engine) -> str:
 
 
 def _scan_clean_candidates(engine) -> dict[str, Any]:
-    conn = engine._store.connection
     try:
-        rows = conn.execute(
-            """
-            WITH session_ids AS (
-                SELECT session_id FROM messages
-                UNION
-                SELECT session_id FROM summary_nodes
-            ),
-            message_stats AS (
-                SELECT session_id,
-                       COUNT(*) AS message_count,
-                       COALESCE(SUM(token_estimate), 0) AS token_total
-                FROM messages
-                GROUP BY session_id
-            ),
-            node_stats AS (
-                SELECT session_id, COUNT(*) AS node_count
-                FROM summary_nodes
-                GROUP BY session_id
-            )
-            SELECT s.session_id,
-                   COALESCE(m.message_count, 0) AS message_count,
-                   COALESCE(m.token_total, 0) AS token_total,
-                   COALESCE(n.node_count, 0) AS node_count
-            FROM session_ids s
-            LEFT JOIN message_stats m ON m.session_id = s.session_id
-            LEFT JOIN node_stats n ON n.session_id = s.session_id
-            ORDER BY s.session_id
-            """
-        ).fetchall()
+        rows = engine._store.scan_session_cleanup_stats()
     except Exception as exc:  # pragma: no cover - defensive
         return {
             "error": str(exc),
@@ -306,7 +277,6 @@ def _scan_clean_candidates(engine) -> dict[str, Any]:
 
 
 def _scan_retention_candidates(engine) -> dict[str, Any]:
-    conn = engine._store.connection
     now = datetime.now().timestamp()
     # SQL is scoped to the foreground session so /lcm doctor retention
     # reports the operator's real conversation rather than whatever side
@@ -327,48 +297,7 @@ def _scan_retention_candidates(engine) -> dict[str, Any]:
             "protected_count": 0,
         }
     try:
-        rows = conn.execute(
-            """
-            WITH session_ids AS (
-                SELECT session_id FROM messages
-                UNION
-                SELECT session_id FROM summary_nodes
-            ),
-            message_stats AS (
-                SELECT session_id,
-                       COUNT(*) AS message_count,
-                       COALESCE(SUM(token_estimate), 0) AS token_total,
-                       MIN(timestamp) AS first_message_at,
-                       MAX(timestamp) AS last_message_at
-                FROM messages
-                GROUP BY session_id
-            ),
-            node_stats AS (
-                SELECT session_id,
-                       COUNT(*) AS node_count,
-                       COALESCE(SUM(token_count), 0) AS node_token_total,
-                       MIN(COALESCE(earliest_at, created_at)) AS first_node_at,
-                       MAX(COALESCE(latest_at, created_at)) AS last_node_at
-                FROM summary_nodes
-                GROUP BY session_id
-            )
-            SELECT s.session_id,
-                   COALESCE(m.message_count, 0) AS message_count,
-                   COALESCE(m.token_total, 0) AS token_total,
-                   COALESCE(n.node_count, 0) AS node_count,
-                   COALESCE(n.node_token_total, 0) AS node_token_total,
-                   m.first_message_at,
-                   m.last_message_at,
-                   n.first_node_at,
-                   n.last_node_at
-            FROM session_ids s
-            LEFT JOIN message_stats m ON m.session_id = s.session_id
-            LEFT JOIN node_stats n ON n.session_id = s.session_id
-            WHERE s.session_id = ?
-            ORDER BY s.session_id
-            """,
-            (session_id,),
-        ).fetchall()
+        rows = engine._store.scan_session_retention_stats(session_id)
     except Exception as exc:  # pragma: no cover - defensive
         return {
             "error": str(exc),

--- a/store.py
+++ b/store.py
@@ -677,6 +677,87 @@ class MessageStore:
             "effective_unknown_messages": normalized_unknown + legacy_blank,
         }
 
+    def scan_session_cleanup_stats(self) -> List[tuple]:
+        """Per-session ``(session_id, message_count, token_total, node_count)``
+        rows across messages and summary nodes, for ``/lcm doctor clean``
+        candidate scanning. Callers own the pattern/protection policy."""
+        return self._conn.execute(
+            """
+            WITH session_ids AS (
+                SELECT session_id FROM messages
+                UNION
+                SELECT session_id FROM summary_nodes
+            ),
+            message_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS message_count,
+                       COALESCE(SUM(token_estimate), 0) AS token_total
+                FROM messages
+                GROUP BY session_id
+            ),
+            node_stats AS (
+                SELECT session_id, COUNT(*) AS node_count
+                FROM summary_nodes
+                GROUP BY session_id
+            )
+            SELECT s.session_id,
+                   COALESCE(m.message_count, 0) AS message_count,
+                   COALESCE(m.token_total, 0) AS token_total,
+                   COALESCE(n.node_count, 0) AS node_count
+            FROM session_ids s
+            LEFT JOIN message_stats m ON m.session_id = s.session_id
+            LEFT JOIN node_stats n ON n.session_id = s.session_id
+            ORDER BY s.session_id
+            """
+        ).fetchall()
+
+    def scan_session_retention_stats(self, session_id: str) -> List[tuple]:
+        """Per-session activity/token stats for one session (messages + summary
+        nodes), for ``/lcm doctor retention`` scanning. Callers own the
+        staleness/protection policy."""
+        return self._conn.execute(
+            """
+            WITH session_ids AS (
+                SELECT session_id FROM messages
+                UNION
+                SELECT session_id FROM summary_nodes
+            ),
+            message_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS message_count,
+                       COALESCE(SUM(token_estimate), 0) AS token_total,
+                       MIN(timestamp) AS first_message_at,
+                       MAX(timestamp) AS last_message_at
+                FROM messages
+                GROUP BY session_id
+            ),
+            node_stats AS (
+                SELECT session_id,
+                       COUNT(*) AS node_count,
+                       COALESCE(SUM(token_count), 0) AS node_token_total,
+                       MIN(COALESCE(earliest_at, created_at)) AS first_node_at,
+                       MAX(COALESCE(latest_at, created_at)) AS last_node_at
+                FROM summary_nodes
+                GROUP BY session_id
+            )
+            SELECT s.session_id,
+                   COALESCE(m.message_count, 0) AS message_count,
+                   COALESCE(m.token_total, 0) AS token_total,
+                   COALESCE(n.node_count, 0) AS node_count,
+                   COALESCE(n.node_token_total, 0) AS node_token_total,
+                   m.first_message_at,
+                   m.last_message_at,
+                   n.first_node_at,
+                   n.last_node_at
+            FROM session_ids s
+            LEFT JOIN message_stats m ON m.session_id = s.session_id
+            LEFT JOIN node_stats n ON n.session_id = s.session_id
+            WHERE s.session_id = ?
+            ORDER BY s.session_id
+            """,
+            (session_id,),
+        ).fetchall()
+
     def get_source_normalization_plan(self) -> Dict[str, Any]:
         """Return a dry-run plan for normalizing legacy blank source values."""
         stats_before = self.get_source_stats()


### PR DESCRIPTION
## Summary
- Add `MessageStore.scan_session_cleanup_stats()` and `scan_session_retention_stats(session_id)`.
- Move the two `/lcm doctor` session-stat SQL queries out of `command.py` into those methods.

## Why
First slice of WS5.5 (layer discipline). The `/lcm doctor` clean and retention
scanners ran their session-stat SQL directly against the store connection from
the command layer. This lifts those raw queries behind named store methods, so
the store owns its SQL and connection and the command layer keeps only the
pattern-match / staleness / protection policy.

## Validation
- `ruff check store.py command.py` → All checks passed
- `python -m pytest tests/test_lcm_command.py -q -o addopts= -k "clean or retention or doctor or scan"` → 52 passed
- `python -m pytest -q -o addopts=` (full suite) → 1545 passed, 12 xfailed (identical to base)
- `scripts/validate_release.sh --full --keep-going --output <dir>` → PASS

## Notes
- Behaviour-preserving: the SQL and its parameters are unchanged, and callers'
  error handling is unchanged — each method raises and the caller's existing
  `except` still catches it and returns the same error dict.
- Scope: just these two doctor scanners (a coherent unit). The broader WS5.5
  sweep (other raw command/tools queries → store/dag methods, a read-only engine
  facade for the `engine._*` accesses) is intentionally left for follow-ups so
  each PR stays small and reviewable.

## Stacking
Stacked on #323 (store-connection encapsulation) — these scanners previously
reached `engine._store.connection`, which #323 introduced. Please review/merge
#323 first; GitHub will then narrow this PR's diff to just the query lift.
Independent of #324 (touches different command.py functions).

## Refs
- Design: WS5 companion workstream WS5.5 (layer discipline).
