### PR TITLE
Extract Codex OAuth route detection into codex_routing.py (WS5 seam)

### DIFF
--- a/codex_routing.py
+++ b/codex_routing.py
@@ -1,0 +1,71 @@
+"""Codex OAuth route detection and effective context-window caps.
+
+Isolated from ``engine.py`` (WS5 seam) so the Codex-specific routing policy —
+which model slugs are on the ChatGPT Codex OAuth route and what effective
+context window that route enforces — lives in one cohesive place. These are
+pure helpers with no engine state; ``engine.py`` imports them and keeps its own
+policy constants (for example the gpt-5.5 compaction threshold).
+"""
+
+from __future__ import annotations
+
+# ChatGPT Codex OAuth exposes provider-enforced context windows that can be
+# materially lower than the same model slug on direct OpenAI/OpenRouter routes.
+# Hermes Agent resolves these from chatgpt.com/backend-api/codex/models, with
+# this table as its fallback. LCM sees only the host-advertised context_length;
+# when that value was explicitly overridden above the real Codex OAuth window,
+# we still have to budget against the effective provider window or compaction
+# fires too late and provider requests can overflow.
+_CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
+    "gpt-5.1-codex-max": 272_000,
+    "gpt-5.1-codex-mini": 272_000,
+    "gpt-5.3-codex-spark": 128_000,
+    "gpt-5.3-codex": 272_000,
+    "gpt-5.2-codex": 272_000,
+    "gpt-5.4-mini": 272_000,
+    "gpt-5.5": 272_000,
+    "gpt-5.4": 272_000,
+    "gpt-5.2": 272_000,
+    "gpt-5": 272_000,
+}
+
+
+def _bare_model_slug(model: str | None) -> str:
+    return (model or "").strip().lower().rsplit("/", 1)[-1]
+
+
+def _is_openai_codex_route(provider: str | None) -> bool:
+    return (provider or "").strip().lower() == "openai-codex"
+
+
+def _codex_oauth_context_cap(model: str | None, provider: str | None) -> int | None:
+    """Return LCM's best-known Codex OAuth effective context cap.
+
+    This intentionally mirrors Hermes Agent's hardcoded fallback policy, not the
+    direct OpenAI model catalog. A host-provided context_length may be a user
+    override or stale cache entry; Codex OAuth still enforces these lower route
+    windows.
+    """
+    if not _is_openai_codex_route(provider):
+        return None
+    bare_model = _bare_model_slug(model)
+    if not bare_model:
+        return None
+    for slug, cap in sorted(
+        _CODEX_OAUTH_CONTEXT_CAPS.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        if slug in bare_model:
+            return cap
+    return None
+
+
+def _is_codex_gpt55_route(model: str | None, provider: str | None) -> bool:
+    """Return True for gpt-5.5 on ChatGPT Codex OAuth, mirroring Hermes core."""
+    if not _is_openai_codex_route(provider):
+        return False
+    bare_model = _bare_model_slug(model)
+    return (
+        bare_model == "gpt-5.5"
+        or bare_model.startswith("gpt-5.5-")
+        or bare_model.startswith("gpt-5.5.")
+    )

--- a/engine.py
+++ b/engine.py
@@ -23,6 +23,10 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from agent.context_engine import ContextEngine
 
+from .codex_routing import (
+    _codex_oauth_context_cap,
+    _is_codex_gpt55_route,
+)
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
@@ -186,67 +190,7 @@ def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None
 _SESSION_END_BUSY_TIMEOUT_MS = 50
-# ChatGPT Codex OAuth exposes provider-enforced context windows that can be
-# materially lower than the same model slug on direct OpenAI/OpenRouter routes.
-# Hermes Agent resolves these from chatgpt.com/backend-api/codex/models, with
-# this table as its fallback. LCM sees only the host-advertised context_length;
-# when that value was explicitly overridden above the real Codex OAuth window,
-# we still have to budget against the effective provider window or compaction
-# fires too late and provider requests can overflow.
-_CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
-    "gpt-5.1-codex-max": 272_000,
-    "gpt-5.1-codex-mini": 272_000,
-    "gpt-5.3-codex-spark": 128_000,
-    "gpt-5.3-codex": 272_000,
-    "gpt-5.2-codex": 272_000,
-    "gpt-5.4-mini": 272_000,
-    "gpt-5.5": 272_000,
-    "gpt-5.4": 272_000,
-    "gpt-5.2": 272_000,
-    "gpt-5": 272_000,
-}
 _CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
-
-
-def _bare_model_slug(model: str | None) -> str:
-    return (model or "").strip().lower().rsplit("/", 1)[-1]
-
-
-def _is_openai_codex_route(provider: str | None) -> bool:
-    return (provider or "").strip().lower() == "openai-codex"
-
-
-def _codex_oauth_context_cap(model: str | None, provider: str | None) -> int | None:
-    """Return LCM's best-known Codex OAuth effective context cap.
-
-    This intentionally mirrors Hermes Agent's hardcoded fallback policy, not the
-    direct OpenAI model catalog. A host-provided context_length may be a user
-    override or stale cache entry; Codex OAuth still enforces these lower route
-    windows.
-    """
-    if not _is_openai_codex_route(provider):
-        return None
-    bare_model = _bare_model_slug(model)
-    if not bare_model:
-        return None
-    for slug, cap in sorted(
-        _CODEX_OAUTH_CONTEXT_CAPS.items(), key=lambda item: len(item[0]), reverse=True
-    ):
-        if slug in bare_model:
-            return cap
-    return None
-
-
-def _is_codex_gpt55_route(model: str | None, provider: str | None) -> bool:
-    """Return True for gpt-5.5 on ChatGPT Codex OAuth, mirroring Hermes core."""
-    if not _is_openai_codex_route(provider):
-        return False
-    bare_model = _bare_model_slug(model)
-    return (
-        bare_model == "gpt-5.5"
-        or bare_model.startswith("gpt-5.5-")
-        or bare_model.startswith("gpt-5.5.")
-    )
 
 # Auto-focus topic derivation: infer a compact focus hint from the most recent
 # real user turns so that summarization can prioritise current user intent.


### PR DESCRIPTION
## Summary
- Move the four Codex-route helpers and their context-cap table out of `engine.py` into a new `codex_routing.py`: `_bare_model_slug`, `_is_openai_codex_route`, `_codex_oauth_context_cap`, `_is_codex_gpt55_route`, and `_CODEX_OAUTH_CONTEXT_CAPS`.
- `engine.py` imports the two helpers it actually calls (`_codex_oauth_context_cap`, `_is_codex_gpt55_route`); the two internal helpers and the caps table travel with them.
- Keep `_CODEX_GPT55_COMPACTION_THRESHOLD` in `engine.py` — it is engine-side compaction policy, not route detection.

## Why
WS5 engine decomposition. `engine.py` is ~9k lines; the Codex OAuth route logic (which model slugs are on the ChatGPT Codex OAuth route and what effective context window that route enforces) is a cohesive, pure, self-contained concern with no engine state. Isolating it into its own module — alongside the existing `model_routing.py` split — makes the route policy discoverable in one place and shrinks the monolith, with zero behaviour change.

## Validation
- `ruff check codex_routing.py engine.py` → All checks passed
- **Equivalence harness** (byte-identical proof): reconstructs the four helpers + caps dict from `git show main:engine.py` and compares against `codex_routing.py` across an exhaustive `(model, provider)` grid — 11 provider variants × 134 model variants (bare/prefixed slugs, whitespace, case, near-miss versions like `gpt-5.55`/`gpt-5.5.1`). Result: **1474 scenarios, 0 differing**, caps dict identical.
- `python -m pytest -q -o addopts=` (full suite) → **1570 passed, 12 xfailed**
- `scripts/validate_release.sh --full --keep-going --output <dir>` → **PASS**

## Notes
- Behaviour-preserving; the moved code is byte-identical to its pre-move form.
- Import surface unchanged for callers: `engine.py` keeps calling `_codex_oauth_context_cap` / `_is_codex_gpt55_route` at the same call sites (`_effective_context_length`, `_runtime_context_threshold`). The two remaining helpers (`_bare_model_slug`, `_is_openai_codex_route`) are only used internally by the moved functions, so they are not re-imported into `engine.py` (no unused import).
- No import cycle: `codex_routing` imports nothing from the package; `engine` imports `codex_routing`.
- Existing Codex-cap tests in `tests/test_lcm_engine.py` continue to exercise the moved code through the engine methods.
- Independent of the other WS5 seams (touches only `engine.py` + new `codex_routing.py`).

## Refs
- Design: WS5 engine decomposition, companion to `model_routing.py` / `sanitize.py` / `maintenance.py` seams (#323–#327).