### PR TITLE
Extract SQLite lock-contention helpers into sqlite_util.py (WS5 seam)

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -17,9 +17,8 @@ import subprocess
 import threading
 import time
 import weakref
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agent.context_engine import ContextEngine
 
@@ -97,6 +96,10 @@ from .message_content import (
     normalize_content_value,
     stored_text_content_for_pattern_matching,
     text_content_for_pattern_matching,
+)
+from .sqlite_util import (
+    _is_sqlite_locked_error,
+    _temporary_sqlite_busy_timeout,
 )
 from .store import MessageStore
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
@@ -326,45 +329,6 @@ def _git_runtime_identity(root: Path) -> dict[str, Any]:
         "plugin_git_dirty": None if dirty_output is None else bool(dirty_output),
         "plugin_git_remote": _git("config", "--get", "remote.origin.url") or "",
     }
-
-
-def _is_sqlite_locked_error(exc: BaseException) -> bool:
-    """Return True when an exception chain represents SQLite lock contention."""
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        message = str(current).lower()
-        if isinstance(current, sqlite3.Error) and "locked" in message:
-            return True
-        current = current.__cause__ or current.__context__
-    return False
-
-
-def _sqlite_busy_timeout_ms(conn: sqlite3.Connection) -> int:
-    row = conn.execute("PRAGMA busy_timeout").fetchone()
-    return int(row[0]) if row and row[0] is not None else 0
-
-
-@contextmanager
-def _temporary_sqlite_busy_timeout(
-    connections: List[sqlite3.Connection | None],
-    timeout_ms: int,
-) -> Iterator[None]:
-    """Temporarily bound SQLite lock waits for gateway-critical paths."""
-    bounded_timeout = max(0, int(timeout_ms))
-    originals: list[tuple[sqlite3.Connection, int]] = []
-    for conn in connections:
-        if conn is None:
-            continue
-        original = _sqlite_busy_timeout_ms(conn)
-        conn.execute(f"PRAGMA busy_timeout={bounded_timeout}")
-        originals.append((conn, original))
-    try:
-        yield
-    finally:
-        for conn, original in reversed(originals):
-            conn.execute(f"PRAGMA busy_timeout={original}")
 
 
 _SYNTHETIC_ASSISTANT_NOISE = {

--- a/sqlite_util.py
+++ b/sqlite_util.py
@@ -1,0 +1,53 @@
+"""SQLite lock-contention helpers shared by the LCM engine.
+
+Isolated from ``engine.py`` (WS5 seam): detecting SQLite lock-contention error
+chains and temporarily bounding ``busy_timeout`` on gateway-critical paths are a
+cohesive, pure SQLite concern with no engine state. ``engine.py`` imports the
+two entry points it calls; the busy-timeout probe travels with them. Callers
+keep their own policy constants (for example the session-end timeout budget).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from typing import Iterator, List
+
+
+def _is_sqlite_locked_error(exc: BaseException) -> bool:
+    """Return True when an exception chain represents SQLite lock contention."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if isinstance(current, sqlite3.Error) and "locked" in message:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _sqlite_busy_timeout_ms(conn: sqlite3.Connection) -> int:
+    row = conn.execute("PRAGMA busy_timeout").fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+@contextmanager
+def _temporary_sqlite_busy_timeout(
+    connections: List[sqlite3.Connection | None],
+    timeout_ms: int,
+) -> Iterator[None]:
+    """Temporarily bound SQLite lock waits for gateway-critical paths."""
+    bounded_timeout = max(0, int(timeout_ms))
+    originals: list[tuple[sqlite3.Connection, int]] = []
+    for conn in connections:
+        if conn is None:
+            continue
+        original = _sqlite_busy_timeout_ms(conn)
+        conn.execute(f"PRAGMA busy_timeout={bounded_timeout}")
+        originals.append((conn, original))
+    try:
+        yield
+    finally:
+        for conn, original in reversed(originals):
+            conn.execute(f"PRAGMA busy_timeout={original}")


### PR DESCRIPTION
## Summary
- Move the SQLite busy/lock utilities out of `engine.py` into a new `sqlite_util.py`: `_is_sqlite_locked_error` (exception-chain lock detection), `_sqlite_busy_timeout_ms` (PRAGMA probe), and the `_temporary_sqlite_busy_timeout` context manager.
- `engine.py` imports the two entry points it calls (`_is_sqlite_locked_error`, `_temporary_sqlite_busy_timeout`); the busy-timeout probe is internal and travels with them.
- Drop the now-unused `contextlib.contextmanager` and `typing.Iterator` imports from `engine.py`.

## Why
WS5 engine decomposition. `engine.py` is ~9k lines; detecting SQLite lock-contention error chains and temporarily bounding `busy_timeout` on gateway-critical paths are a cohesive, pure SQLite concern with no engine state. Isolating them into their own module shrinks the monolith with zero behaviour change, alongside the earlier `sanitize.py` / `maintenance.py` / `codex_routing.py` splits.

## Validation
- `ruff check sqlite_util.py engine.py` → All checks passed
- **Equivalence harness**: reconstructs the three helpers from `git show main:engine.py` (AST slice) and proves (1) the moved source is **byte-identical** (3/3 functions), and (2) behavioural parity old-vs-new across 38 scenarios — exception chains (nested `__cause__`/`__context__`, non-sqlite, non-locked, `IntegrityError` carrying "locked", a cyclic `__context__` loop) and a `busy_timeout` base×timeout grid (set/restore across multiple connections plus `None`). Result: **0 differing**.
- `python -m pytest -q -o addopts=` (full suite) → **1570 passed, 12 xfailed**
- `scripts/validate_release.sh --full --keep-going --output <dir>` → **PASS**

## Notes
- Behaviour-preserving; the moved code is byte-identical to its pre-move form.
- `_SESSION_END_BUSY_TIMEOUT_MS` stays in `engine.py` — it is the caller-side timeout budget passed into `_temporary_sqlite_busy_timeout`, not a SQLite primitive.
- Call sites unchanged: `_is_sqlite_locked_error` (3 sites in the SQLite retry paths) and `_temporary_sqlite_busy_timeout` (session-end path) call the same names. `_sqlite_busy_timeout_ms` is only used internally by the context manager, so it is not re-imported into `engine.py` (no unused import).
- No import cycle: `sqlite_util` imports only the stdlib; `engine` imports `sqlite_util`.
- No tests reference these helpers by name; they remain covered through the engine SQLite retry/session-end paths.
- Independent of the other WS5 seams (touches only `engine.py` + new `sqlite_util.py`).

## Refs
- Design: WS5 engine decomposition, companion to the `sanitize.py` / `maintenance.py` / `codex_routing.py` seams (#323–#328).