### PR TITLE
Extract active-engine registry into engine_registry.py (WS5 seam)

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -26,6 +26,13 @@ from agent.context_engine import ContextEngine
 from .config import LCMConfig
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
+from .engine_registry import (
+    _ACTIVE_ENGINE_REGISTRY_LOCK,
+    _ACTIVE_ENGINES_BY_CONVERSATION_ID,
+    _ACTIVE_ENGINES_BY_SESSION_ID,
+    _remove_registry_entries_for_engine,
+    resolve_active_lcm_engine,  # noqa: F401  (re-exported: hosts import it from .engine)
+)
 from .escalation import (
     SummaryCircuitBreaker,
     SummarySpendGuard,
@@ -103,85 +110,6 @@ from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
 logger = logging.getLogger(__name__)
-
-_ACTIVE_ENGINE_REGISTRY_LOCK = threading.RLock()
-_ACTIVE_ENGINES_BY_SESSION_ID = weakref.WeakValueDictionary()
-_ACTIVE_ENGINES_BY_CONVERSATION_ID = weakref.WeakValueDictionary()
-
-
-def _is_usable_lcm_engine(engine: Any) -> bool:
-    return bool(
-        engine is not None
-        and getattr(engine, "name", None) == "lcm"
-        and hasattr(engine, "ingest")
-    )
-
-
-def _engine_matches_session_binding(engine: Any, session_id: str) -> bool:
-    return bool(
-        _is_usable_lcm_engine(engine)
-        and session_id
-        and str(getattr(engine, "_session_id", "") or "") == session_id
-    )
-
-
-def _engine_matches_conversation_binding(engine: Any, conversation_id: str) -> bool:
-    return bool(
-        _is_usable_lcm_engine(engine)
-        and conversation_id
-        and str(getattr(engine, "_conversation_id", "") or "") == conversation_id
-    )
-
-
-def _remove_registry_entries_for_engine(
-    engine: Any,
-    *,
-    keep_session_id: str = "",
-    keep_conversation_id: str = "",
-) -> None:
-    for registered_session_id, registered_engine in list(_ACTIVE_ENGINES_BY_SESSION_ID.items()):
-        if registered_engine is engine and registered_session_id != keep_session_id:
-            _ACTIVE_ENGINES_BY_SESSION_ID.pop(registered_session_id, None)
-    for registered_conversation_id, registered_engine in list(
-        _ACTIVE_ENGINES_BY_CONVERSATION_ID.items()
-    ):
-        if registered_engine is engine and registered_conversation_id != keep_conversation_id:
-            _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(registered_conversation_id, None)
-
-
-def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -> Any:
-    """Return the LCM runtime clone most recently bound to a session/lane.
-
-    Newer Hermes Agent hosts pass the active per-agent context engine directly
-    to ``post_llm_call`` hooks. Older hosts may only pass session/lane ids. LCM
-    clones register their own session binding when ``on_session_start`` runs so
-    post-turn ingest can still follow the active clone instead of rebinding the
-    process-wide plugin singleton.
-    """
-    session_id = str(session_id or "")
-    conversation_id = str(conversation_id or "")
-    with _ACTIVE_ENGINE_REGISTRY_LOCK:
-        if session_id:
-            engine = _ACTIVE_ENGINES_BY_SESSION_ID.get(session_id)
-            if _engine_matches_session_binding(engine, session_id):
-                return engine
-            if engine is not None:
-                _ACTIVE_ENGINES_BY_SESSION_ID.pop(session_id, None)
-        if conversation_id:
-            engine = _ACTIVE_ENGINES_BY_CONVERSATION_ID.get(conversation_id)
-            conversation_matches = _engine_matches_conversation_binding(
-                engine,
-                conversation_id,
-            )
-            session_matches = not session_id or _engine_matches_session_binding(
-                engine,
-                session_id,
-            )
-            if conversation_matches and session_matches:
-                return engine
-            if engine is not None and not conversation_matches:
-                _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
-    return None
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent
 _PLUGIN_METADATA: dict[str, str] | None = None

--- a/engine_registry.py
+++ b/engine_registry.py
@@ -1,0 +1,95 @@
+"""Process-wide registry of active LCM runtime clones by session/lane.
+
+Isolated from ``engine.py`` (WS5 seam): LCM clones register their own
+session/conversation binding so post-turn ingest can follow the active clone
+instead of the process-wide plugin singleton. The lock and the two weak
+registries live here alongside the pure resolver/matcher helpers that read
+them. ``engine.py`` imports the shared lock, the two registries, the removal
+helper, and the public ``resolve_active_lcm_engine`` entry point; the binding
+methods on ``LCMEngine`` mutate the same shared objects by reference.
+"""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import Any
+
+_ACTIVE_ENGINE_REGISTRY_LOCK = threading.RLock()
+_ACTIVE_ENGINES_BY_SESSION_ID = weakref.WeakValueDictionary()
+_ACTIVE_ENGINES_BY_CONVERSATION_ID = weakref.WeakValueDictionary()
+
+
+def _is_usable_lcm_engine(engine: Any) -> bool:
+    return bool(
+        engine is not None
+        and getattr(engine, "name", None) == "lcm"
+        and hasattr(engine, "ingest")
+    )
+
+
+def _engine_matches_session_binding(engine: Any, session_id: str) -> bool:
+    return bool(
+        _is_usable_lcm_engine(engine)
+        and session_id
+        and str(getattr(engine, "_session_id", "") or "") == session_id
+    )
+
+
+def _engine_matches_conversation_binding(engine: Any, conversation_id: str) -> bool:
+    return bool(
+        _is_usable_lcm_engine(engine)
+        and conversation_id
+        and str(getattr(engine, "_conversation_id", "") or "") == conversation_id
+    )
+
+
+def _remove_registry_entries_for_engine(
+    engine: Any,
+    *,
+    keep_session_id: str = "",
+    keep_conversation_id: str = "",
+) -> None:
+    for registered_session_id, registered_engine in list(_ACTIVE_ENGINES_BY_SESSION_ID.items()):
+        if registered_engine is engine and registered_session_id != keep_session_id:
+            _ACTIVE_ENGINES_BY_SESSION_ID.pop(registered_session_id, None)
+    for registered_conversation_id, registered_engine in list(
+        _ACTIVE_ENGINES_BY_CONVERSATION_ID.items()
+    ):
+        if registered_engine is engine and registered_conversation_id != keep_conversation_id:
+            _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(registered_conversation_id, None)
+
+
+def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -> Any:
+    """Return the LCM runtime clone most recently bound to a session/lane.
+
+    Newer Hermes Agent hosts pass the active per-agent context engine directly
+    to ``post_llm_call`` hooks. Older hosts may only pass session/lane ids. LCM
+    clones register their own session binding when ``on_session_start`` runs so
+    post-turn ingest can still follow the active clone instead of rebinding the
+    process-wide plugin singleton.
+    """
+    session_id = str(session_id or "")
+    conversation_id = str(conversation_id or "")
+    with _ACTIVE_ENGINE_REGISTRY_LOCK:
+        if session_id:
+            engine = _ACTIVE_ENGINES_BY_SESSION_ID.get(session_id)
+            if _engine_matches_session_binding(engine, session_id):
+                return engine
+            if engine is not None:
+                _ACTIVE_ENGINES_BY_SESSION_ID.pop(session_id, None)
+        if conversation_id:
+            engine = _ACTIVE_ENGINES_BY_CONVERSATION_ID.get(conversation_id)
+            conversation_matches = _engine_matches_conversation_binding(
+                engine,
+                conversation_id,
+            )
+            session_matches = not session_id or _engine_matches_session_binding(
+                engine,
+                session_id,
+            )
+            if conversation_matches and session_matches:
+                return engine
+            if engine is not None and not conversation_matches:
+                _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
+    return None


### PR DESCRIPTION
## Summary
- Move the process-wide active-LCM-clone registry out of `engine.py` into a new `engine_registry.py`: the registry `RLock`, the two `WeakValueDictionary` registries (by session id / conversation id), the resolver/matcher helpers, the removal helper, and the public `resolve_active_lcm_engine`.
- `engine.py` imports the shared lock, the two registries, `_remove_registry_entries_for_engine`, and `resolve_active_lcm_engine`. The matcher helpers (`_is_usable_lcm_engine`, `_engine_matches_session_binding`, `_engine_matches_conversation_binding`) stay internal to the module.

## Why
WS5 engine decomposition. `engine.py` is ~9k lines; the process-wide registry that lets post-turn ingest follow the active per-agent LCM clone (instead of the plugin singleton) is a cohesive concern with its own lock and weak maps. Isolating it shrinks the monolith with no behaviour change, alongside the earlier `sanitize.py` / `maintenance.py` / `codex_routing.py` / `sqlite_util.py` / `runtime_identity.py` / `message_analysis.py` splits.

## Validation
- `ruff check engine_registry.py engine.py` → All checks passed
- **Equivalence harness**: reconstructs the five helpers from `git show main:engine.py` (AST slice) and proves (1) the moved source is **byte-identical** (5/5 functions), and (2) behavioural parity old-vs-new by driving two independent registries through an 18-step register/resolve/remove sequence (session/conversation collisions, non-usable engines, missing-ingest engines, session-id reuse across engines) and comparing both the resolved engine and the full registry key→engine structure at every step. Result: **0 differing**.
- `python -m pytest -q -o addopts=` (full suite) → **1570 passed, 12 xfailed**
- `scripts/validate_release.sh --full --keep-going --output <dir>` → **PASS**

## Notes
- Behaviour-preserving; the moved code is byte-identical to its pre-move form.
- The `LCMEngine` binding methods (`_register_active_engine_binding` / `_unregister_active_engine_binding`) keep their bodies verbatim: the lock and the two registries are shared mutable objects, so mutating them through the imported names (`_ACTIVE_ENGINES_BY_SESSION_ID[sid] = self`, `with _ACTIVE_ENGINE_REGISTRY_LOCK:`) hits the same objects the resolver reads.
- `resolve_active_lcm_engine` is re-exported from `engine.py` (`# noqa: F401`) so any host importing it from `hermes_lcm.engine` keeps working; it is also importable from `hermes_lcm.engine_registry`.
- No import cycle: `engine_registry` imports only the stdlib; `engine` imports `engine_registry`.
- Independent of the other WS5 seams (touches only `engine.py` + the new module).

## Refs
- Design: WS5 engine decomposition, companion to the earlier seams (#323–#331).