### PR TITLE
chore: prepare v0.19.0 release candidate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Version and branch
       description: hermes-lcm version, branch, commit, or release tag.
-      placeholder: v0.18.1, main, or commit SHA
+      placeholder: v0.19.0, main, or commit SHA
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 ## Unreleased
 
-- Began a behaviour-preserving decomposition of the ~9k-line `engine.py` into cohesive modules: stateful method clusters became `*Mixin` classes (`compaction.py`, `reconcile.py`, `aux_session.py`, `placeholder_ledger.py`) mixed back into `LCMEngine`, and pure/helper groups became plain modules (`engine_registry.py`, `codex_routing.py`, `sqlite_util.py`, `runtime_identity.py`, `message_analysis.py`). No behaviour or public-surface change; documented in `docs/architecture.md`.
+## v0.19.0 - 2026-07-07
+
+Release focus: data-safety hardening, operator diagnostics, import tooling, benchmarking, and the WS5 engine decomposition.
+
+- Hardened lossless storage and replay boundaries: GC tombstones preserve surrounding text, ingest failures surface in status/doctor, ignored-message drops are counted, persisted Hermes tool outputs and redacted durable retries replay losslessly, and auxiliary bypass/session fallback edge cases are covered. (#298, #308, #310, #312, #313)
+- Strengthened storage and downgrade safety with serialized lifecycle/DAG writes, monotonic frontiers, path-contained externalized payloads, ReDoS-safe redaction, wrapped-base64 handling, a summary spend guard, and a schema-too-new open guard. (#300, #301, #302)
+- Added operator and migration surfaces: read-only `lcm_inspect`, JSONL session export import, compression no-op status, compaction telemetry, benchmark-backed preset validation, and steady-state hot-path benchmarks. (#295, #303, #306, #307, #309, #320)
+- Added CI-backed ruff linting and release/validation-friendly tooling updates, including follow-up JSONL import hardening and metadata JSON access through `MessageStore`. (#314, #315, #316)
+- Began and documented the behaviour-preserving WS5 decomposition of the ~9k-line `engine.py`: stateful method clusters became `*Mixin` classes (`compaction.py`, `reconcile.py`, `aux_session.py`, `placeholder_ledger.py`) mixed back into `LCMEngine`, and pure/helper groups became plain modules (`engine_registry.py`, `codex_routing.py`, `sqlite_util.py`, `runtime_identity.py`, `message_analysis.py`). (#323, #324, #325, #326, #327, #328, #329, #330, #331, #332, #333, #334, #335, #336, #337, #338, #339)
 
 ## v0.18.1 - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.18.1 (8 tools)
+  ✓ hermes-lcm v0.19.0 (8 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -92,7 +92,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.18.1 (8 tools)
+  ✓ hermes-lcm v0.19.0 (8 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.18.1
+version: 0.19.0
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -416,7 +416,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.18.1" in result
+    assert "plugin_version: 0.19.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -456,7 +456,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.18.1" in result
+    assert "plugin_version: 0.19.0" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
     assert "triage_guidance:\n- none" in result

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -999,7 +999,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.18.1"
+    assert identity["plugin_version"] == "0.19.0"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -1025,11 +1025,11 @@ def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
 
     initial = identity_mod._plugin_metadata()
     assert initial["name"] == "hermes-lcm"
-    assert initial["version"] == "0.18.1"
+    assert initial["version"] == "0.19.0"
 
-    updated = original.replace('version: "0.18.1"', 'version: "9.9.9-test"')
+    updated = original.replace('version: "0.19.0"', 'version: "9.9.9-test"')
     if updated == original:
-        updated = original.replace('version: 0.18.1', 'version: 9.9.9-test')
+        updated = original.replace('version: 0.19.0', 'version: 9.9.9-test')
     assert updated != original
 
     try:
@@ -1067,7 +1067,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.18.1"
+    assert payload["runtime_identity"]["plugin_version"] == "0.19.0"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -250,7 +250,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.18.1"
+    assert identity["plugin_version"] == "0.19.0"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]


### PR DESCRIPTION
## Summary
- Prepare hermes-lcm v0.19.0 release metadata and changelog.
- Update the plugin manifest version plus docs/test expectations that display the plugin version/tool count.
- Preserve the curated GitHub release body draft prepared at `/home/w0lf/.hermes/profiles/turing/release-drafts/hermes-lcm-v0.19.0.md`.

## Why
- WS5 code/docs work has landed and main CI is green.
- The repo is ready for a minor release candidate before tagging/publishing v0.19.0.

## Validation
- `ruff check .` passed.
- `scripts/validate_release.sh --full --keep-going` passed.
- Full pytest passed: `1575 passed, 12 xfailed, 37 warnings in 56.60s`.
- Low-fd pytest passed: `1575 passed, 12 xfailed, 37 warnings in 52.80s`.
- Reviewer gate `t_d5072482` passed local RC review against commit `f29f3f43971a9b18fab9bb20de7a69b0055ff2e9`.
- Full validation checklist: `/tmp/hermes-lcm-release-validation-20260707-025946/validation-checklist.md`.

## Notes
- This PR does not create or push the `v0.19.0` tag.
- Publishing/editing the GitHub release remains a separate approval gate after this PR lands and main CI is green.

Refs #
