### PR TITLE
Extract bypass-lineage tracking into a mixin (WS5 seam)

### DIFF
--- a/bypass_lineage.py
+++ b/bypass_lineage.py
@@ -1,0 +1,74 @@
+"""LCM bypass-lineage session tracking.
+
+Extracted verbatim from :mod:`hermes_lcm.engine` as ``BypassLineageMixin``
+(WS5 seam). The methods record and hand off which sessions descend from an
+LCM-bypassed session so later turns can recognise the lineage. State stays on
+the engine (accessed via ``self``, including the shared auxiliary-session
+lock); mixing this in leaves every call site and ``self._*`` reference
+unchanged.
+"""
+
+from typing import Optional
+
+
+class BypassLineageMixin:
+    def _has_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> bool:
+        with self._auxiliary_session_lock:
+            if session_id not in self._lcm_bypass_lineage_session_ids:
+                return False
+            if platform is None:
+                return True
+            platforms = self._lcm_bypass_lineage_platforms.get(session_id) or set()
+            return not platforms or platform in platforms
+
+    def _mark_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> None:
+        if not session_id:
+            return
+        platform = self._session_platform if platform is None else str(platform or "")
+        with self._auxiliary_session_lock:
+            self._lcm_bypass_lineage_session_ids.add(session_id)
+            self._lcm_bypass_lineage_platforms.setdefault(session_id, set()).add(platform)
+            self._lcm_session_last_platform[session_id] = platform
+            self._lcm_session_last_bypassed[session_id] = True
+
+    def _unmark_lcm_bypass_lineage_session(self, session_id: str) -> None:
+        if not session_id:
+            return
+        with self._auxiliary_session_lock:
+            self._lcm_bypass_lineage_session_ids.discard(session_id)
+            self._lcm_bypass_lineage_platforms.pop(session_id, None)
+
+    def _handoff_lcm_bypass_lineage(
+        self,
+        old_session_id: str,
+        new_session_id: str,
+        *,
+        new_platform: str = "",
+    ) -> None:
+        with self._auxiliary_session_lock:
+            if old_session_id:
+                self._lcm_bypass_lineage_session_ids.add(old_session_id)
+            if new_session_id:
+                new_platform = str(new_platform or "")
+                self._lcm_bypass_lineage_session_ids.add(new_session_id)
+                self._lcm_bypass_lineage_platforms.setdefault(new_session_id, set()).add(new_platform)
+                self._lcm_session_last_platform[new_session_id] = new_platform
+                self._lcm_session_last_bypassed[new_session_id] = True
+
+    def _compression_boundary_from_lcm_bypassed_session(self, old_session_id: str) -> bool:
+        if not old_session_id:
+            return False
+        if old_session_id in self._lcm_session_last_bypassed:
+            return bool(self._lcm_session_last_bypassed.get(old_session_id))
+        if old_session_id == self._session_id:
+            return bool(
+                self._bypasses_lcm_context_management()
+                or self._session_id_matches_lcm_bypass_filters(
+                    old_session_id,
+                    platform=self._session_platform,
+                )
+            )
+        return bool(
+            self._has_lcm_bypass_lineage_session(old_session_id)
+            or self._session_id_matches_lcm_bypass_filters(old_session_id)
+        )

--- a/engine.py
+++ b/engine.py
@@ -116,6 +116,7 @@ from .reconcile import ReconcileMixin, _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
 from .compaction import CompactionMixin
 from .reset_state import ResetStateMixin
 from .bypass import BypassMixin
+from .bypass_lineage import BypassLineageMixin
 from .lifecycle_state import LifecycleStateStore
 from .message_content import (
     normalize_content_value,
@@ -146,7 +147,16 @@ _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across co
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
 
 
-class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
+class LCMEngine(
+    CompactionMixin,
+    ResetStateMixin,
+    BypassLineageMixin,
+    ReconcileMixin,
+    AuxiliarySessionMixin,
+    PlaceholderLedgerMixin,
+    BypassMixin,
+    ContextEngine,
+):
     """Lossless Context Management engine.
 
     Automatic LCM compaction is routine background maintenance. Hosts that
@@ -1446,67 +1456,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._conversation_id,
             self._session_id,
             self._last_compacted_store_id,
-        )
-
-    def _has_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> bool:
-        with self._auxiliary_session_lock:
-            if session_id not in self._lcm_bypass_lineage_session_ids:
-                return False
-            if platform is None:
-                return True
-            platforms = self._lcm_bypass_lineage_platforms.get(session_id) or set()
-            return not platforms or platform in platforms
-
-    def _mark_lcm_bypass_lineage_session(self, session_id: str, *, platform: Optional[str] = None) -> None:
-        if not session_id:
-            return
-        platform = self._session_platform if platform is None else str(platform or "")
-        with self._auxiliary_session_lock:
-            self._lcm_bypass_lineage_session_ids.add(session_id)
-            self._lcm_bypass_lineage_platforms.setdefault(session_id, set()).add(platform)
-            self._lcm_session_last_platform[session_id] = platform
-            self._lcm_session_last_bypassed[session_id] = True
-
-    def _unmark_lcm_bypass_lineage_session(self, session_id: str) -> None:
-        if not session_id:
-            return
-        with self._auxiliary_session_lock:
-            self._lcm_bypass_lineage_session_ids.discard(session_id)
-            self._lcm_bypass_lineage_platforms.pop(session_id, None)
-
-    def _handoff_lcm_bypass_lineage(
-        self,
-        old_session_id: str,
-        new_session_id: str,
-        *,
-        new_platform: str = "",
-    ) -> None:
-        with self._auxiliary_session_lock:
-            if old_session_id:
-                self._lcm_bypass_lineage_session_ids.add(old_session_id)
-            if new_session_id:
-                new_platform = str(new_platform or "")
-                self._lcm_bypass_lineage_session_ids.add(new_session_id)
-                self._lcm_bypass_lineage_platforms.setdefault(new_session_id, set()).add(new_platform)
-                self._lcm_session_last_platform[new_session_id] = new_platform
-                self._lcm_session_last_bypassed[new_session_id] = True
-
-    def _compression_boundary_from_lcm_bypassed_session(self, old_session_id: str) -> bool:
-        if not old_session_id:
-            return False
-        if old_session_id in self._lcm_session_last_bypassed:
-            return bool(self._lcm_session_last_bypassed.get(old_session_id))
-        if old_session_id == self._session_id:
-            return bool(
-                self._bypasses_lcm_context_management()
-                or self._session_id_matches_lcm_bypass_filters(
-                    old_session_id,
-                    platform=self._session_platform,
-                )
-            )
-        return bool(
-            self._has_lcm_bypass_lineage_session(old_session_id)
-            or self._session_id_matches_lcm_bypass_filters(old_session_id)
         )
 
     def _get_allowed_hermes_base(self) -> Path | None:


### PR DESCRIPTION
## Summary
- Move the 5 methods that record and hand off which sessions descend from an LCM-bypassed session (`_has_lcm_bypass_lineage_session`, `_mark_lcm_bypass_lineage_session`, `_unmark_lcm_bypass_lineage_session`, `_handoff_lcm_bypass_lineage`, `_compression_boundary_from_lcm_bypassed_session`) out of `engine.py` into a new `BypassLineageMixin` in `bypass_lineage.py`.
- `LCMEngine` mixes it in before `ContextEngine`, so `self` still resolves every reference -- including the shared auxiliary-session lock and lineage dicts; call sites, shared state, and method names are unchanged.

## Why
- Continues the WS5 engine decomposition. Small, self-contained cluster: no external call sites, no `LCMEngine.` statics, no module-level constants (only `typing.Optional`).

## Validation
- `ruff check .` -> `All checks passed!`
- Byte-identity: the extracted method bodies are byte-for-byte identical to `git show main:engine.py` (AST-slice compare, 0 diffs).
- `PYTHONPATH=<hermes-agent> python -m pytest -q -o addopts=` -> `1575 passed, 12 xfailed` (unchanged from the v0.19.0 baseline).
- `scripts/validate_release.sh --full` -> `PASS: release validation full` (all 12 gates).

## Notes
- Behaviour-neutral, mechanical move only. No logic changes.
- Mixin ordering follows the established WS5 convention: `CompactionMixin` stays first (it overrides the compaction protocol); `BypassLineageMixin` overrides no protocol method, so its position before `ContextEngine` is arbitrary and safe under any merge order.

## Refs
Follows the WS5 module/mixin decomposition (#333, #334, #335, #337, #341, #342, #343).