### PR TITLE
Make schema-column migrations idempotent under concurrent startup

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 
 from .db_bootstrap import (
     ExternalContentFtsSpec,
+    add_column_if_missing,
     configure_connection,
     ensure_external_content_fts,
     refuse_schema_version_too_new,
@@ -211,10 +212,14 @@ class SummaryDAG:
         columns = {
             row[1] for row in self._conn.execute("PRAGMA table_info(summary_nodes)").fetchall()
         }
-        if "earliest_at" not in columns:
-            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL")
-        if "latest_at" not in columns:
-            self._conn.execute("ALTER TABLE summary_nodes ADD COLUMN latest_at REAL")
+        add_column_if_missing(
+            self._conn, columns, "earliest_at",
+            "ALTER TABLE summary_nodes ADD COLUMN earliest_at REAL",
+        )
+        add_column_if_missing(
+            self._conn, columns, "latest_at",
+            "ALTER TABLE summary_nodes ADD COLUMN latest_at REAL",
+        )
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
         )

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -98,6 +98,33 @@ def configure_connection(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA mmap_size=268435456")
 
 
+def add_column_if_missing(
+    conn: sqlite3.Connection,
+    existing_columns: set[str],
+    column: str,
+    alter_sql: str,
+) -> None:
+    """Idempotently add a column, tolerating a concurrent process that won the race.
+
+    In the multi-agent deployment (gateway + CLI sessions + sub-agents) every
+    process opens its own connection to the same ``lcm.db`` and runs startup
+    migrations concurrently.  A plain check-``PRAGMA table_info``-then-``ALTER``
+    races: two processes both observe the column as absent (each within its own
+    connection snapshot) and both issue ``ALTER TABLE ... ADD COLUMN``.  The loser
+    then raised ``sqlite3.OperationalError: duplicate column name``, which
+    propagated out of ``_init_db`` and crashed store construction.  Swallowing
+    exactly that error makes the migration idempotent under concurrency; any other
+    OperationalError still propagates.
+    """
+    if column in existing_columns:
+        return
+    try:
+        conn.execute(alter_sql)
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+
+
 def ensure_metadata_table(conn: sqlite3.Connection) -> None:
     conn.execute(
         """
@@ -198,22 +225,30 @@ def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
     columns = {
         row[1] for row in conn.execute("PRAGMA table_info(lcm_lifecycle_state)").fetchall()
     }
-    if "debt_kind" not in columns:
-        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_kind TEXT")
-    if "debt_size_estimate" not in columns:
-        conn.execute(
-            "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_size_estimate INTEGER NOT NULL DEFAULT 0"
-        )
-    if "debt_updated_at" not in columns:
-        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_updated_at REAL")
-    if "last_maintenance_attempt_at" not in columns:
-        conn.execute(
-            "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_maintenance_attempt_at REAL"
-        )
-    if "last_rollover_at" not in columns:
-        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_rollover_at REAL")
-    if "last_reset_at" not in columns:
-        conn.execute("ALTER TABLE lcm_lifecycle_state ADD COLUMN last_reset_at REAL")
+    add_column_if_missing(
+        conn, columns, "debt_kind",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_kind TEXT",
+    )
+    add_column_if_missing(
+        conn, columns, "debt_size_estimate",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_size_estimate INTEGER NOT NULL DEFAULT 0",
+    )
+    add_column_if_missing(
+        conn, columns, "debt_updated_at",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN debt_updated_at REAL",
+    )
+    add_column_if_missing(
+        conn, columns, "last_maintenance_attempt_at",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_maintenance_attempt_at REAL",
+    )
+    add_column_if_missing(
+        conn, columns, "last_rollover_at",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_rollover_at REAL",
+    )
+    add_column_if_missing(
+        conn, columns, "last_reset_at",
+        "ALTER TABLE lcm_lifecycle_state ADD COLUMN last_reset_at REAL",
+    )
 
 
 def ensure_message_origin_columns(conn: sqlite3.Connection) -> None:
@@ -225,8 +260,10 @@ def ensure_message_origin_columns(conn: sqlite3.Connection) -> None:
     columns = {
         row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()
     }
-    if "conversation_id" not in columns:
-        conn.execute("ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''")
+    add_column_if_missing(
+        conn, columns, "conversation_id",
+        "ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''",
+    )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_msg_conversation_session ON messages(conversation_id, session_id, store_id)"
     )

--- a/store.py
+++ b/store.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional
 
 from .db_bootstrap import (
     ExternalContentFtsSpec,
+    add_column_if_missing,
     configure_connection,
     ensure_external_content_fts,
     refuse_schema_version_too_new,
@@ -285,8 +286,10 @@ class MessageStore:
         columns = {
             row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
         }
-        if "source" not in columns:
-            self._conn.execute("ALTER TABLE messages ADD COLUMN source TEXT DEFAULT ''")
+        add_column_if_missing(
+            self._conn, columns, "source",
+            "ALTER TABLE messages ADD COLUMN source TEXT DEFAULT ''",
+        )
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_msg_source_session ON messages(source, session_id, store_id)"
         )
@@ -295,8 +298,10 @@ class MessageStore:
         columns = {
             row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
         }
-        if "conversation_id" not in columns:
-            self._conn.execute("ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''")
+        add_column_if_missing(
+            self._conn, columns, "conversation_id",
+            "ALTER TABLE messages ADD COLUMN conversation_id TEXT DEFAULT ''",
+        )
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_msg_conversation_session ON messages(conversation_id, session_id, store_id)"
         )

--- a/tests/test_crash_safe_wal.py
+++ b/tests/test_crash_safe_wal.py
@@ -12,11 +12,15 @@ still depends on SQLite WAL recovery.
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
 
-from hermes_lcm.db_bootstrap import configure_connection
+from hermes_lcm.db_bootstrap import (
+    configure_connection,
+    ensure_message_origin_columns,
+)
 from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG
 from hermes_lcm.lifecycle_state import LifecycleStateStore
@@ -174,3 +178,80 @@ class TestGracefulClose:
         lc = LifecycleStateStore(db)
         lc._conn = None
         lc.close()  # should not raise
+
+
+# --------------------------------------------------------------------------- #
+#  Concurrent-startup migration race (idempotent ADD COLUMN)
+# --------------------------------------------------------------------------- #
+
+
+def _seed_pre_conversation_id_messages(path: Path) -> None:
+    """Create a ``messages`` table as a pre-v5 build left it: without the
+    ``conversation_id`` column the column migration later adds. Scoped to the
+    column DDL only (no FTS), so the test isolates the ADD COLUMN race."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestConcurrentStartupMigration:
+    """Concurrent process startup must not crash on duplicate-column ALTERs.
+
+    Regression for the pre-fix race: gateway + CLI + sub-agents open independent
+    connections to one ``lcm.db`` after an upgrade and all run the column
+    migrations; the loser hit ``sqlite3.OperationalError: duplicate column name``
+    and crashed store construction. ``add_column_if_missing`` makes the ALTER
+    idempotent so every process migrates successfully.
+    """
+
+    def test_concurrent_column_migration_is_idempotent(self, tmp_path: Path):
+        db_path = tmp_path / "concurrent.db"
+        _seed_pre_conversation_id_messages(db_path)
+
+        thread_count = 8
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(thread_count)
+
+        def migrate() -> None:
+            # Each thread is a stand-in for a separate process: its own
+            # connection to the same file, its own busy_timeout, racing the same
+            # ``ALTER TABLE messages ADD COLUMN conversation_id``.
+            conn = sqlite3.connect(str(db_path), timeout=30.0)
+            try:
+                configure_connection(conn)
+                barrier.wait()  # maximise overlap on the migration DDL
+                ensure_message_origin_columns(conn)
+                conn.commit()
+            except BaseException as exc:  # noqa: BLE001 - re-asserted below
+                with lock:
+                    errors.append(exc)
+            finally:
+                conn.close()
+
+        threads = [threading.Thread(target=migrate) for _ in range(thread_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent column migration raised: {errors!r}"
+        conn = sqlite3.connect(str(db_path))
+        columns = [
+            row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()
+        ]
+        conn.close()
+        assert columns.count("conversation_id") == 1


### PR DESCRIPTION
## Summary
- Add `add_column_if_missing(conn, existing_columns, column, alter_sql)` in `db_bootstrap.py` and route all column migrations through it. It keeps the existing "skip if already present" check and additionally swallows exactly the `duplicate column name` `OperationalError` (any other error still propagates), making each `ALTER TABLE ... ADD COLUMN` idempotent under concurrency.
- Converted call sites: `ensure_lifecycle_state_columns` / `ensure_message_origin_columns` (db_bootstrap.py), `MessageStore._ensure_source_column` / `_ensure_conversation_id_column` (store.py), `SummaryDAG._ensure_source_window_columns` (dag.py).

## Why
In the multi-agent deployment (gateway + CLI sessions + sub-agents) every process opens its own connection to the same `lcm.db` and runs the startup migrations concurrently. Each column migration did check-`PRAGMA table_info`-then-`ALTER` in autocommit with no guard, so two processes could both observe a column as absent and both issue the ALTER. The loser raised `sqlite3.OperationalError: duplicate column name`, which propagated out of `_init_db` and **crashed store construction**. This bites precisely at an upgrade boundary, when many processes restart together.

Behaviour is unchanged on the non-racing path (same check, same ALTERs); only the concurrent loser now skips instead of crashing.

## Validation
- New regression test `TestConcurrentStartupMigration` (tests/test_crash_safe_wal.py) races `ensure_message_origin_columns` from 8 threads, each with its own connection to one seeded pre-v5 DB (FTS-free, to isolate the column DDL). Without the guard 7/8 threads raise `duplicate column name: conversation_id`; with it every thread migrates and the column exists exactly once.
- `ruff check .` -> clean.
- `PYTHONPATH=<hermes-agent> python -m pytest -q -o addopts=` -> `1576 passed, 12 xfailed`.
- `scripts/validate_release.sh --full` -> `PASS: release validation full` (all 12 gates, incl. low-fd).

## Notes
- Out of scope / follow-up: the FTS structural rebuild (`repair_external_content_fts`) has a separate concurrency window on a different trigger (missing shadow tables / corruption, not column upgrades — a column migration does not change row counts, so it does not enter that path). Left for a focused follow-up so this PR stays scoped to the verified crash.
- Rollback: revert the commit; migrations return to the prior unguarded check-then-ALTER.

## Refs
Surfaced by a comparison against the more mature lossless-claw, whose `runLcmMigrations` serializes migrations under `BEGIN EXCLUSIVE`.