### PR TITLE
Discard reasoning-only summaries instead of persisting them (unclosed <think>)

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -35,6 +35,24 @@ _THINK_BLOCK_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# Matches the *start* of a reasoning block with no required close. Applied to
+# text after closed <think>...</think> pairs have been stripped: if what
+# remains still begins with a reasoning marker, the model emitted an *unclosed*
+# block (typically because it ran into max_tokens before the closing tag), and
+# the leftover raw reasoning must not be persisted as the summary. Covers the
+# angle-tag family plus pipe-delimited (<|think|>), bracket ([think]), and
+# prose-header (``Thinking Process:`` / ``Chain of thought:``) shapes.
+_REASONING_START_RE = re.compile(
+    r"^\s*(?:"
+    r"<\s*(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)(?:\s[^>]*)?>"
+    r"|<\|\s*(?:start_of_)?(?:think|thinking|reasoning|thought)\s*\|>"
+    r"|\[\s*(?:think|thinking|reasoning|thought)\s*\]"
+    r"|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:"
+    r"|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:"
+    r")",
+    re.IGNORECASE,
+)
+
 _DEFAULT_ROUTE_KEY = "<task-default>"
 
 
@@ -151,6 +169,28 @@ def _strip_reasoning_blocks(text: str) -> str:
     return _THINK_BLOCK_RE.sub("", text)
 
 
+def _sanitize_reasoning_summary(text: str) -> str:
+    """Return a summary safe to persist, or ``""`` when the model returned only
+    reasoning.
+
+    ``_strip_reasoning_blocks`` removes *closed* ``<think>...</think>`` pairs,
+    but a reasoning model that runs into ``max_tokens`` before emitting the
+    closing tag leaves an *unclosed* block the paired-tag regex cannot match.
+    The leftover raw reasoning — which often quotes the summarizer system prompt
+    verbatim — would then be accepted as the summary purely because it is shorter
+    than the source. When the stripped remainder is empty, or still begins with
+    an (unclosed) reasoning marker, treat the result as unusable and return
+    ``""`` so the caller escalates to the next model / L2 / deterministic
+    fallback instead of persisting reasoning as the summary.
+    """
+    if not isinstance(text, str):
+        return ""
+    stripped = _strip_reasoning_blocks(text).strip()
+    if not stripped or _REASONING_START_RE.match(stripped):
+        return ""
+    return stripped
+
+
 def _call_llm_for_summary(prompt: str, max_tokens: int,
                            model: str = "", timeout: float | None = None) -> Optional[str]:
     """Call the Hermes auxiliary LLM for summarization."""
@@ -169,7 +209,13 @@ def _call_llm_for_summary(prompt: str, max_tokens: int,
         content = response.choices[0].message.content
         if not isinstance(content, str):
             content = str(content) if content else ""
-        return _strip_reasoning_blocks(content).strip()
+        sanitized = _sanitize_reasoning_summary(content)
+        if content.strip() and not sanitized:
+            logger.warning(
+                "LCM summary discarded reasoning-only output (model=%s); escalating",
+                model or "<default>",
+            )
+        return sanitized
     except Exception as e:
         logger.warning("LLM summarization failed: %s", e)
         return None

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -341,6 +341,36 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert level == 1
         assert calls == ["primary-model", "fallback-model"]
 
+    def test_summary_fallback_chain_escalates_past_reasoning_only_primary(self, monkeypatch):
+        """A reasoning-only primary output is sanitized to "" by
+        _call_llm_for_summary; summarize_with_escalation must escalate to the
+        next model rather than accept the empty result."""
+        from hermes_lcm import escalation
+
+        calls = []
+
+        def fake_summary_call(prompt, max_tokens, model="", timeout=None):
+            calls.append(model)
+            if model == "primary-model":
+                # What _call_llm_for_summary now returns for an unclosed
+                # <think> block / reasoning-only response.
+                return ""
+            return "clean fallback summary"
+
+        monkeypatch.setattr(escalation, "_call_llm_for_summary", fake_summary_call)
+
+        summary, level = escalation.summarize_with_escalation(
+            "source text " * 80,
+            source_tokens=200,
+            token_budget=50,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+        )
+
+        assert summary == "clean fallback summary"
+        assert level == 1
+        assert calls == ["primary-model", "fallback-model"]
+
 
     def test_summary_circuit_breaker_skips_temporarily_open_route(self, monkeypatch):
         from hermes_lcm import escalation

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1246,6 +1246,58 @@ class TestEscalationStripReasoning:
         assert "</think>" not in result
         assert "Summary: docker rollout completed" in result
 
+    def test_sanitize_reasoning_summary_discards_unclosed_and_reasoning_only(self):
+        from hermes_lcm.escalation import _sanitize_reasoning_summary
+
+        # Clean summaries pass through (closed blocks already stripped).
+        assert _sanitize_reasoning_summary("<think>plan</think>real summary") == "real summary"
+        assert _sanitize_reasoning_summary("just a summary") == "just a summary"
+        # Unclosed reasoning block (model ran into max_tokens) -> discarded.
+        assert _sanitize_reasoning_summary("<think>reasoning that never closes ...") == ""
+        # Non-tag reasoning shapes -> discarded.
+        assert _sanitize_reasoning_summary("Thinking Process:\n1. figure out ...") == ""
+        assert _sanitize_reasoning_summary("<|start_of_think|> deliberating") == ""
+        assert _sanitize_reasoning_summary("[thinking] weighing options") == ""
+        # Empty after stripping a closed block -> discarded.
+        assert _sanitize_reasoning_summary("<think>only reasoning</think>   ") == ""
+        assert _sanitize_reasoning_summary("") == ""
+
+    def test_call_llm_for_summary_discards_unclosed_reasoning(self, monkeypatch):
+        """An unclosed <think> block (model hit max_tokens before the closing
+        tag) must not be persisted as the summary; _call_llm_for_summary returns
+        "" so the caller escalates to the next model / L2 / L3."""
+        import hermes_lcm.escalation as esc
+
+        class _FakeMessage:
+            def __init__(self, content):
+                self.content = content
+
+        class _FakeChoice:
+            def __init__(self, content):
+                self.message = _FakeMessage(content)
+
+        class _FakeResponse:
+            def __init__(self, content):
+                self.choices = [_FakeChoice(content)]
+
+        unclosed = (
+            "<think>The user wants a compression. Let me restate the system "
+            "prompt: You are a summarizer that extracts decisions, files, errors"
+        )
+
+        def fake_call_llm(**kwargs):
+            return _FakeResponse(unclosed)
+
+        self._install_fake_auxiliary_client(monkeypatch, fake_call_llm)
+
+        result = esc._call_llm_for_summary(
+            prompt="please summarize",
+            max_tokens=200,
+            model="any",
+            timeout=10.0,
+        )
+
+        assert result == "", f"expected reasoning-only output discarded, got {result!r}"
 
     def test_synthesize_expansion_answer_strips_reasoning_from_response(self, monkeypatch):
         """Integration: lcm_expand_query routes through


### PR DESCRIPTION
## Summary
- Add `_sanitize_reasoning_summary(text)` in `escalation.py` and route `_call_llm_for_summary`'s return through it, so a reasoning-only summarizer response is discarded (returns `""`) instead of being persisted as the summary.
- Add `_REASONING_START_RE`, which matches an *unclosed* leading reasoning marker — including non-tag shapes: `<|think|>` / `<|start_of_think|>`, `[think]`, and prose headers `Thinking Process:` / `Chain of thought:`.

## Why
`_strip_reasoning_blocks` only removes *closed* `<think>...</think>` pairs (backreferenced regex). A reasoning model (Qwen/QwQ/DeepSeek-R1, GLM, MiniMax) that runs into `max_tokens` before emitting the closing tag leaves an **unclosed** block the regex cannot match. The leftover raw reasoning — which, per the existing module comment, often quotes the summarizer system prompt verbatim — was then accepted as the summary purely because `count_tokens(result) < source_tokens`, persisted as a `SummaryNode`, and replayed into the model as context (and re-fed by `lcm_expand_query`). That is both a summary-quality bug and a system-prompt leak.

With the fix, a reasoning-only response is falsy, so the existing escalation path advances to the next model / L2 / deterministic L3 truncation of the real source text. Behaviour is unchanged for normal summaries and already-handled closed blocks.

## Validation
- `_sanitize_reasoning_summary` unit test: closed->clean, unclosed->"", pipe/bracket/prose shapes->"", empty->"".
- `_call_llm_for_summary` integration: an unclosed `<think>` response returns `""` (without the fix it returns the raw reasoning blob — proven by temporarily reverting the wire-in).
- Escalation test: a reasoning-only primary escalates to the fallback model instead of accepting the empty result.
- `ruff check .` -> clean; full suite `1578 passed, 12 xfailed`; `scripts/validate_release.sh --full` -> `PASS: release validation full`.

## Notes
- The same closed-tag-only strip is used in `extraction.py`, `tools.py`, and `sanitize.py`; those non-summary paths are left for a focused follow-up so this PR stays scoped to the persisted-summary leak.
- Rollback: revert the commit; `_call_llm_for_summary` returns to `_strip_reasoning_blocks(content).strip()`.

## Refs
Mirrors lossless-claw `sanitizeReasoningSummaryText` (src/summarize.ts), which forces the empty-summary path on `reasoningOnly` output.