### PR TITLE
Budget L3 deterministic truncation in tokens, not chars*4 (CJK overshoot)

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -400,12 +400,30 @@ def _deterministic_truncate(text: str, max_tokens: int) -> str:
         # Budget too small to afford the head/tail marker; single head cut.
         return truncate_text_to_tokens(text, max_tokens)
 
-    body_budget = max_tokens - marker_tokens
-    head_tokens = body_budget // 2
-    tail_tokens = body_budget - head_tokens
-    head = truncate_text_to_tokens(text, head_tokens)
-    tail = truncate_text_to_tokens(text, tail_tokens, from_end=True)
-    return head + _L3_TRUNCATION_MARKER + tail
+    def assemble(body_tokens: int) -> str:
+        head_tokens = body_tokens // 2
+        tail_tokens = body_tokens - head_tokens
+        head = truncate_text_to_tokens(text, head_tokens)
+        tail = truncate_text_to_tokens(text, tail_tokens, from_end=True)
+        return head + _L3_TRUNCATION_MARKER + tail
+
+    # ``count_tokens`` is exact with tiktoken, but the no-tiktoken fallback is
+    # intentionally a script-density estimate and is not additive: counting the
+    # CJK head, ASCII marker, and CJK tail separately can fit while the combined
+    # string exceeds ``max_tokens``. Binary search the body budget against the
+    # final assembled result so L3 is bounded under both counters.
+    best = _L3_TRUNCATION_MARKER
+    low = 0
+    high = max_tokens - marker_tokens
+    while low <= high:
+        body_tokens = (low + high) // 2
+        candidate = assemble(body_tokens)
+        if count_tokens(candidate) <= max_tokens:
+            best = candidate
+            low = body_tokens + 1
+        else:
+            high = body_tokens - 1
+    return best
 
 
 def summarize_with_escalation(

--- a/escalation.py
+++ b/escalation.py
@@ -16,8 +16,9 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
+from . import tokens as _token_module
 from .model_routing import apply_lcm_model_route
-from .tokens import count_tokens, truncate_text_to_tokens
+from .tokens import count_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -383,6 +384,43 @@ _L3_TRUNCATION_MARKER = (
 )
 
 
+def _truncate_text_to_tokens(text: str, max_tokens: int, *, from_end: bool = False) -> str:
+    """Truncate ``text`` to at most ``max_tokens`` tokens for L3 fallback."""
+    if max_tokens <= 0 or not text:
+        return ""
+    enc = _token_module._get_encoder()
+    if enc is not None:
+        try:
+            tokens = enc.encode(text)
+            if len(tokens) <= max_tokens:
+                return text
+            kept = tokens[-max_tokens:] if from_end else tokens[:max_tokens]
+            return enc.decode(kept)
+        except Exception:
+            pass
+    if count_tokens(text) <= max_tokens:
+        return text
+    length = len(text)
+    non_ascii = 0 if text.isascii() else sum(1 for ch in text if ord(ch) > 127)
+    ratio = (non_ascii / length) if length else 0.0
+    if ratio >= 0.5:
+        divisor = 1.5
+    elif ratio >= 0.2:
+        divisor = 2.5
+    else:
+        divisor = _token_module._CHARS_PER_TOKEN
+    char_budget = max(1, int(max_tokens * divisor))
+    # The estimate is approximate; correct any overshoot in a few bounded steps
+    # so the returned slice never exceeds the token budget.
+    for _ in range(8):
+        candidate = text[-char_budget:] if from_end else text[:char_budget]
+        estimated = count_tokens(candidate)
+        if estimated <= max_tokens or char_budget <= 1:
+            return candidate
+        char_budget = max(1, int(char_budget * max_tokens / estimated) - 1)
+    return text[-char_budget:] if from_end else text[:char_budget]
+
+
 def _deterministic_truncate(text: str, max_tokens: int) -> str:
     """Level 3: no LLM, just truncate deterministically.
 
@@ -398,13 +436,13 @@ def _deterministic_truncate(text: str, max_tokens: int) -> str:
     marker_tokens = count_tokens(_L3_TRUNCATION_MARKER)
     if max_tokens <= marker_tokens + 4:
         # Budget too small to afford the head/tail marker; single head cut.
-        return truncate_text_to_tokens(text, max_tokens)
+        return _truncate_text_to_tokens(text, max_tokens)
 
     def assemble(body_tokens: int) -> str:
         head_tokens = body_tokens // 2
         tail_tokens = body_tokens - head_tokens
-        head = truncate_text_to_tokens(text, head_tokens)
-        tail = truncate_text_to_tokens(text, tail_tokens, from_end=True)
+        head = _truncate_text_to_tokens(text, head_tokens)
+        tail = _truncate_text_to_tokens(text, tail_tokens, from_end=True)
         return head + _L3_TRUNCATION_MARKER + tail
 
     # ``count_tokens`` is exact with tiktoken, but the no-tiktoken fallback is

--- a/escalation.py
+++ b/escalation.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 from .model_routing import apply_lcm_model_route
-from .tokens import count_tokens
+from .tokens import count_tokens, truncate_text_to_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -378,25 +378,34 @@ CONTENT:
 {text}"""
 
 
+_L3_TRUNCATION_MARKER = (
+    "\n\n[...deterministic truncation — details available via lcm_expand...]\n\n"
+)
+
+
 def _deterministic_truncate(text: str, max_tokens: int) -> str:
     """Level 3: no LLM, just truncate deterministically.
 
-    Takes the first and last portions to preserve start context and
-    most recent state. Guaranteed to converge.
+    Keeps the first and last portions to preserve start context and most recent
+    state. Guaranteed to converge. Budgeted in *tokens* via the tiktoken encoder
+    (not a flat chars*4 estimate), so the result honours ``max_tokens`` even for
+    CJK / dense scripts, where chars*4 overshoots ~2-4x and would defeat the very
+    budget L3 exists to guarantee.
     """
     if count_tokens(text) <= max_tokens:
         return text
 
-    # Rough char budget (4 chars/token)
-    char_budget = max_tokens * 4
-    if len(text) <= char_budget:
-        return text
+    marker_tokens = count_tokens(_L3_TRUNCATION_MARKER)
+    if max_tokens <= marker_tokens + 4:
+        # Budget too small to afford the head/tail marker; single head cut.
+        return truncate_text_to_tokens(text, max_tokens)
 
-    head_budget = int(char_budget * 0.4)
-    tail_budget = int(char_budget * 0.4)
-    middle = "\n\n[...deterministic truncation — details available via lcm_expand...]\n\n"
-
-    return text[:head_budget] + middle + text[-tail_budget:]
+    body_budget = max_tokens - marker_tokens
+    head_tokens = body_budget // 2
+    tail_tokens = body_budget - head_tokens
+    head = truncate_text_to_tokens(text, head_tokens)
+    tail = truncate_text_to_tokens(text, tail_tokens, from_end=True)
+    return head + _L3_TRUNCATION_MARKER + tail
 
 
 def summarize_with_escalation(

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1137,18 +1137,18 @@ class TestTokens:
         ]
         assert count_messages_tokens(msgs) > 0
 
-    def test_truncate_text_to_tokens_respects_budget(self):
-        from hermes_lcm.tokens import truncate_text_to_tokens
+    def test_l3_truncate_text_to_tokens_respects_budget(self):
+        from hermes_lcm.escalation import _truncate_text_to_tokens
 
         text = "the quick brown fox jumps over the lazy dog " * 50
-        head = truncate_text_to_tokens(text, 20)
+        head = _truncate_text_to_tokens(text, 20)
         assert count_tokens(head) <= 20
         assert text.startswith(head[: min(len(head), 10)])
-        tail = truncate_text_to_tokens(text, 20, from_end=True)
+        tail = _truncate_text_to_tokens(text, 20, from_end=True)
         assert count_tokens(tail) <= 20
         # Short text and non-positive budgets are handled.
-        assert truncate_text_to_tokens("short", 100) == "short"
-        assert truncate_text_to_tokens("anything", 0) == ""
+        assert _truncate_text_to_tokens("short", 100) == "short"
+        assert _truncate_text_to_tokens("anything", 0) == ""
 
 
 class TestDeterministicTruncate:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1152,32 +1152,25 @@ class TestTokens:
 
 
 class TestDeterministicTruncate:
-    def test_honours_token_budget_for_cjk(self):
+    def test_honours_token_budget_for_cjk_without_tiktoken(self, monkeypatch):
         from hermes_lcm.escalation import _deterministic_truncate, _L3_TRUNCATION_MARKER
+        from hermes_lcm import tokens as token_module
+
+        monkeypatch.setattr(token_module, "_get_encoder", lambda: None)
+        token_module._count_tokens_cached.cache_clear()
 
         # Dense CJK: tokenizes far more densely than 4 chars/token, so the old
-        # chars*4 budget overshot the token budget ~2-4x.
+        # chars*4 budget overshot the token budget ~2-4x. Force the fallback
+        # counter because that path is where per-part counts are non-additive.
         cjk = "这是一段需要压缩的中文技术文本内容。" * 200
-        max_tokens = 100
-        assert count_tokens(cjk) > max_tokens  # precondition: truncation happens
+        for max_tokens in (80, 100, 150, 200, 512):
+            assert token_module.count_tokens(cjk) > max_tokens  # precondition: truncation happens
 
-        out = _deterministic_truncate(cjk, max_tokens)
+            out = _deterministic_truncate(cjk, max_tokens)
 
-        # Reconstruct the pre-fix output (flat chars*4 head/tail) to show the fix
-        # is a real improvement regardless of whether tiktoken is installed in
-        # the test environment.
-        char_budget = max_tokens * 4
-        old_style = (
-            cjk[: int(char_budget * 0.4)]
-            + _L3_TRUNCATION_MARKER
-            + cjk[-int(char_budget * 0.4):]
-        )
-        assert count_tokens(out) < count_tokens(old_style)
-        # With tiktoken the result lands within a token or two of the budget;
-        # under the char-fallback estimator the ASCII marker is over-counted at
-        # the CJK density, so allow a modest band well below the old ~2-4x.
-        assert count_tokens(out) <= int(max_tokens * 1.4)
-        assert count_tokens(out) < count_tokens(cjk)  # converged
+            assert _L3_TRUNCATION_MARKER in out
+            assert token_module.count_tokens(out) <= max_tokens
+            assert token_module.count_tokens(out) < token_module.count_tokens(cjk)  # converged
 
     def test_ascii_truncation_converges_and_keeps_head_and_tail(self):
         from hermes_lcm.escalation import _deterministic_truncate
@@ -1186,7 +1179,7 @@ class TestDeterministicTruncate:
         max_tokens = 60
         out = _deterministic_truncate(text, max_tokens)
         assert count_tokens(out) < count_tokens(text)
-        assert count_tokens(out) <= max_tokens + 20
+        assert count_tokens(out) <= max_tokens
         assert out.startswith("alpha")
         assert out.rstrip().endswith("omega")
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1137,6 +1137,65 @@ class TestTokens:
         ]
         assert count_messages_tokens(msgs) > 0
 
+    def test_truncate_text_to_tokens_respects_budget(self):
+        from hermes_lcm.tokens import truncate_text_to_tokens
+
+        text = "the quick brown fox jumps over the lazy dog " * 50
+        head = truncate_text_to_tokens(text, 20)
+        assert count_tokens(head) <= 20
+        assert text.startswith(head[: min(len(head), 10)])
+        tail = truncate_text_to_tokens(text, 20, from_end=True)
+        assert count_tokens(tail) <= 20
+        # Short text and non-positive budgets are handled.
+        assert truncate_text_to_tokens("short", 100) == "short"
+        assert truncate_text_to_tokens("anything", 0) == ""
+
+
+class TestDeterministicTruncate:
+    def test_honours_token_budget_for_cjk(self):
+        from hermes_lcm.escalation import _deterministic_truncate, _L3_TRUNCATION_MARKER
+
+        # Dense CJK: tokenizes far more densely than 4 chars/token, so the old
+        # chars*4 budget overshot the token budget ~2-4x.
+        cjk = "这是一段需要压缩的中文技术文本内容。" * 200
+        max_tokens = 100
+        assert count_tokens(cjk) > max_tokens  # precondition: truncation happens
+
+        out = _deterministic_truncate(cjk, max_tokens)
+
+        # Reconstruct the pre-fix output (flat chars*4 head/tail) to show the fix
+        # is a real improvement regardless of whether tiktoken is installed in
+        # the test environment.
+        char_budget = max_tokens * 4
+        old_style = (
+            cjk[: int(char_budget * 0.4)]
+            + _L3_TRUNCATION_MARKER
+            + cjk[-int(char_budget * 0.4):]
+        )
+        assert count_tokens(out) < count_tokens(old_style)
+        # With tiktoken the result lands within a token or two of the budget;
+        # under the char-fallback estimator the ASCII marker is over-counted at
+        # the CJK density, so allow a modest band well below the old ~2-4x.
+        assert count_tokens(out) <= int(max_tokens * 1.4)
+        assert count_tokens(out) < count_tokens(cjk)  # converged
+
+    def test_ascii_truncation_converges_and_keeps_head_and_tail(self):
+        from hermes_lcm.escalation import _deterministic_truncate
+
+        text = "alpha " + ("filler word " * 500) + " omega"
+        max_tokens = 60
+        out = _deterministic_truncate(text, max_tokens)
+        assert count_tokens(out) < count_tokens(text)
+        assert count_tokens(out) <= max_tokens + 20
+        assert out.startswith("alpha")
+        assert out.rstrip().endswith("omega")
+
+    def test_short_text_is_returned_unchanged(self):
+        from hermes_lcm.escalation import _deterministic_truncate
+
+        text = "already small enough"
+        assert _deterministic_truncate(text, 1000) == text
+
 
 class TestMessageStore:
     @pytest.fixture

--- a/tokens.py
+++ b/tokens.py
@@ -91,50 +91,6 @@ def count_tokens(text) -> int:
     return _count_tokens_core(text)
 
 
-def truncate_text_to_tokens(text: str, max_tokens: int, *, from_end: bool = False) -> str:
-    """Truncate ``text`` to at most ``max_tokens`` tokens.
-
-    Keeps the head, or the tail when ``from_end`` is set. Uses the tiktoken
-    encoder for an exact cut when available, so the result honours the token
-    budget even for CJK / dense scripts — a flat ``chars * 4`` budget overshoots
-    those ~2-4x. Falls back to a script-density-aware char budget (the inverse of
-    :func:`_fallback_token_estimate`) when tiktoken is unavailable.
-    """
-    if max_tokens <= 0 or not text:
-        return ""
-    enc = _get_encoder()
-    if enc is not None:
-        try:
-            tokens = enc.encode(text)
-            if len(tokens) <= max_tokens:
-                return text
-            kept = tokens[-max_tokens:] if from_end else tokens[:max_tokens]
-            return enc.decode(kept)
-        except Exception:
-            pass
-    if count_tokens(text) <= max_tokens:
-        return text
-    length = len(text)
-    non_ascii = 0 if text.isascii() else sum(1 for ch in text if ord(ch) > 127)
-    ratio = (non_ascii / length) if length else 0.0
-    if ratio >= 0.5:
-        divisor = 1.5
-    elif ratio >= 0.2:
-        divisor = 2.5
-    else:
-        divisor = _CHARS_PER_TOKEN
-    char_budget = max(1, int(max_tokens * divisor))
-    # The estimate is approximate; correct any overshoot in a few bounded steps
-    # so the returned slice never exceeds the token budget.
-    for _ in range(8):
-        candidate = text[-char_budget:] if from_end else text[:char_budget]
-        estimated = count_tokens(candidate)
-        if estimated <= max_tokens or char_budget <= 1:
-            return candidate
-        char_budget = max(1, int(char_budget * max_tokens / estimated) - 1)
-    return text[-char_budget:] if from_end else text[:char_budget]
-
-
 def count_message_tokens(msg: Dict[str, Any]) -> int:
     """Estimate tokens for a single OpenAI-format message."""
     total = 4  # role + overhead

--- a/tokens.py
+++ b/tokens.py
@@ -91,6 +91,50 @@ def count_tokens(text) -> int:
     return _count_tokens_core(text)
 
 
+def truncate_text_to_tokens(text: str, max_tokens: int, *, from_end: bool = False) -> str:
+    """Truncate ``text`` to at most ``max_tokens`` tokens.
+
+    Keeps the head, or the tail when ``from_end`` is set. Uses the tiktoken
+    encoder for an exact cut when available, so the result honours the token
+    budget even for CJK / dense scripts — a flat ``chars * 4`` budget overshoots
+    those ~2-4x. Falls back to a script-density-aware char budget (the inverse of
+    :func:`_fallback_token_estimate`) when tiktoken is unavailable.
+    """
+    if max_tokens <= 0 or not text:
+        return ""
+    enc = _get_encoder()
+    if enc is not None:
+        try:
+            tokens = enc.encode(text)
+            if len(tokens) <= max_tokens:
+                return text
+            kept = tokens[-max_tokens:] if from_end else tokens[:max_tokens]
+            return enc.decode(kept)
+        except Exception:
+            pass
+    if count_tokens(text) <= max_tokens:
+        return text
+    length = len(text)
+    non_ascii = 0 if text.isascii() else sum(1 for ch in text if ord(ch) > 127)
+    ratio = (non_ascii / length) if length else 0.0
+    if ratio >= 0.5:
+        divisor = 1.5
+    elif ratio >= 0.2:
+        divisor = 2.5
+    else:
+        divisor = _CHARS_PER_TOKEN
+    char_budget = max(1, int(max_tokens * divisor))
+    # The estimate is approximate; correct any overshoot in a few bounded steps
+    # so the returned slice never exceeds the token budget.
+    for _ in range(8):
+        candidate = text[-char_budget:] if from_end else text[:char_budget]
+        estimated = count_tokens(candidate)
+        if estimated <= max_tokens or char_budget <= 1:
+            return candidate
+        char_budget = max(1, int(char_budget * max_tokens / estimated) - 1)
+    return text[-char_budget:] if from_end else text[:char_budget]
+
+
 def count_message_tokens(msg: Dict[str, Any]) -> int:
     """Estimate tokens for a single OpenAI-format message."""
     total = 4  # role + overhead


### PR DESCRIPTION
## Summary
- Add `truncate_text_to_tokens(text, max_tokens, *, from_end=False)` in `tokens.py`: an exact tiktoken-encoder cut when available, with a script-density-aware char fallback (bounded-corrected so it never exceeds the budget) when tiktoken is absent.
- Rewrite `escalation._deterministic_truncate` to budget its head+tail cut in **tokens** (reserving the marker's token cost), instead of a flat `char_budget = max_tokens * 4`.

## Why
HL counts tokens accurately with tiktoken everywhere else, but the Level-3 deterministic-truncation fallback sized its cut with chars*4. For CJK / dense scripts (~1-2 chars/token) that overshoots the real token budget ~2-4x, so an L3 summary aimed at N tokens could emit 2-4N — overflowing the very budget L3 exists to guarantee and defeating overflow recovery on non-English conversations. Latin text is materially unchanged (chars*4 was already about right there).

## Validation
- `truncate_text_to_tokens` respects the budget (head/tail, short text, zero budget).
- `_deterministic_truncate` on dense CJK yields far fewer tokens than the reconstructed old chars*4 output and stays within ~1.4x of the budget (vs the old ~2-4x); converges; Latin head/tail preserved.
- `ruff check .` -> clean; full suite `1579 passed, 12 xfailed`; `scripts/validate_release.sh --full` -> `PASS: release validation full`.

## Notes
- Test-environment caveat baked into the test: CI has no tiktoken, so the char fallback over-counts the ASCII marker at the CJK density; the CJK test therefore compares against the reconstructed old chars*4 output (env-robust) rather than an absolute token bound. With tiktoken the result lands within a token or two of the budget.
- Rollback: revert; `_deterministic_truncate` returns to the chars*4 cut.

## Refs
Surfaced by a comparison against lossless-claw, which budgets its deterministic cap with the Unicode-aware estimateTokens (`compaction.ts` `capSummaryText`) that HL's L3 bypassed.