### PR TITLE
fix: prevent LCM scaffold recursion and preflight skips

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -4893,10 +4893,10 @@ class LCMEngine(CompactionMixin, ReconcileMixin, AuxiliarySessionMixin, Placehol
         emitted inside the summary block so restart reconciliation ignores it
         instead of ingesting a duplicate non-contiguous user message.
 
-        If a previous compaction already emitted the preserved-objective
-        scaffold and no newer real user turn exists, carry that scaffold forward
-        as the next anchor source so repeated compaction does not summarize the
-        active objective away one compression later.
+        Previous preserved-objective scaffolds are derived context, not real
+        user turns, so they are not eligible as the next anchor source. Once a
+        reverse scan reaches one, older user turns are stale relative to that
+        synthetic continuity marker and must not be promoted as current intent.
         """
         selected_tail_messages = [msg for msg in selected_tail if isinstance(msg, dict)]
         for message in reversed(messages):
@@ -4913,14 +4913,8 @@ class LCMEngine(CompactionMixin, ReconcileMixin, AuxiliarySessionMixin, Placehol
                 or self._is_ignored_active_replay_placeholder(message, content_text)
             ):
                 continue
-            sanitized_preserved_objective = self._sanitized_preserved_objective_context_content(message)
-            if sanitized_preserved_objective:
-                if any(
-                    self._sanitized_preserved_objective_context_content(selected) == sanitized_preserved_objective
-                    for selected in selected_tail_messages
-                ):
-                    return None
-                return sanitized_preserved_objective
+            if self._preserved_objective_context_content(message):
+                return None
             if message.get("role") != "user":
                 continue
             if self._is_preserved_todo_context_message(message):

--- a/engine.py
+++ b/engine.py
@@ -555,6 +555,22 @@ class LCMEngine(CompactionMixin, ReconcileMixin, AuxiliarySessionMixin, Placehol
             )
         return raw_context_length, None, ""
 
+    def _effective_threshold_tokens(self, context_threshold_tokens: int) -> int:
+        """Return the host-visible preflight trigger token count.
+
+        Hermes core uses ``threshold_tokens`` as a cheap gate before it pays for
+        the full request estimate that includes system prompt and tool schemas.
+        LCM can enforce a stricter active-context assembly cap than the normal
+        context-threshold value, so expose the stricter cap here; otherwise a
+        tool/schema-heavy request can skip host preflight entirely.
+        """
+        assembly_cap = self._effective_assembly_token_cap()
+        if assembly_cap is not None and assembly_cap > 0:
+            if context_threshold_tokens > 0:
+                return min(context_threshold_tokens, assembly_cap)
+            return assembly_cap
+        return context_threshold_tokens
+
     def _set_context_length(
         self,
         context_length: Any,
@@ -599,8 +615,11 @@ class LCMEngine(CompactionMixin, ReconcileMixin, AuxiliarySessionMixin, Placehol
             self._runtime_context_threshold(model=model, provider=provider)
         )
         self.threshold_percent = self.context_threshold
-        self.threshold_tokens = int(
+        context_threshold_tokens = int(
             effective_context_length * self.context_threshold
+        )
+        self.threshold_tokens = self._effective_threshold_tokens(
+            context_threshold_tokens
         )
         return True
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -465,6 +465,52 @@ def test_codex_oauth_context_cap_constrains_reserve_based_assembly_cap(tmp_path)
 
         assert engine.context_length == 272_000
         assert engine._effective_assembly_token_cap() == 248_000
+        assert engine.threshold_tokens == int(272_000 * 0.85)
+    finally:
+        engine.shutdown()
+
+
+def test_threshold_tokens_respects_lower_max_assembly_cap_for_host_preflight(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.75,
+        database_path=str(tmp_path / "codex-low-assembly-cap.db"),
+        max_assembly_tokens=96_000,
+    )
+    config.config_sources["context_threshold"] = "env:LCM_CONTEXT_THRESHOLD"
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.5",
+            provider="openai-codex",
+            context_length=400_000,
+        )
+
+        assert engine.context_length == 272_000
+        assert int(272_000 * 0.75) == 204_000
+        assert engine._effective_assembly_token_cap() == 96_000
+        assert engine.threshold_tokens == 96_000
+        assert engine.should_compress(96_000)
+    finally:
+        engine.shutdown()
+
+
+def test_threshold_tokens_respects_lower_reserve_based_cap_for_host_preflight(tmp_path):
+    config = LCMConfig(
+        context_threshold=0.90,
+        database_path=str(tmp_path / "reserve-low-assembly-cap.db"),
+        reserve_tokens_floor=30_000,
+    )
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-test",
+            provider="openai",
+            context_length=100_000,
+        )
+
+        assert engine._effective_assembly_token_cap() == 70_000
+        assert engine.threshold_tokens == 70_000
+        assert engine.should_compress(70_000)
     finally:
         engine.shutdown()
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5466,7 +5466,7 @@ class TestMessageFiltering:
         assert "SECRET" not in result_text
         assert "Current user objective preserved" not in result_text
 
-    def test_preserved_objective_survives_ignored_backlog_filtering(self, tmp_path):
+    def test_preserved_objective_scaffold_does_not_survive_ignored_backlog_filtering(self, tmp_path):
         engine = self._make_engine(
             tmp_path,
             "lcm_msg_ignore_preserved_scaffold.db",
@@ -5480,14 +5480,14 @@ class TestMessageFiltering:
                 "content": "[Current user objective preserved from compacted history]\ncarry this objective forward",
             },
             {"role": "user", "content": "SECRET ignored objective must not be preserved"},
-            {"role": "assistant", "content": "fresh tail response"},
+            {"role": "user", "content": "fresh visible request"},
         ]
 
         result = engine.compress(messages, current_tokens=count_messages_tokens(messages))
         result_text = "\n".join(str(msg.get("content", "")) for msg in result)
 
-        assert "carry this objective forward" in result_text
-        assert "fresh tail response" in result_text
+        assert "carry this objective forward" not in result_text
+        assert "fresh visible request" in result_text
         assert "SECRET" not in result_text
 
     def test_original_ignore_decision_survives_sensitive_active_redaction(self, tmp_path, monkeypatch):
@@ -10593,7 +10593,7 @@ class TestEngineCompress:
         assert secret not in node_text
         assert trailing_request in node_text
 
-    def test_compress_sanitizes_carried_preserved_objective_anchor(self, tmp_path, monkeypatch):
+    def test_compress_does_not_reanchor_carried_preserved_objective_scaffold(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=4,
             leaf_chunk_tokens=1,
@@ -10628,8 +10628,8 @@ class TestEngineCompress:
 
         result_text = "\n".join(str(msg.get("content", "")) for msg in result)
 
-        assert "[Current user objective preserved from compacted history]" in result_text
-        assert trailing_request in result_text
+        assert "[Current user objective preserved from compacted history]" not in result_text
+        assert trailing_request not in result_text
         assert secret not in result_text
         assert "active_memory" not in result_text
         assert "Untrusted context" not in result_text
@@ -10676,7 +10676,7 @@ class TestEngineCompress:
         assert "active_memory" not in result_text
         assert "Untrusted context" not in result_text
 
-    def test_compress_carries_preserved_user_request_across_repeated_compaction(self, tmp_path, monkeypatch):
+    def test_compress_does_not_reanchor_preserved_user_request_across_repeated_compaction(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=4,
             leaf_chunk_tokens=1,
@@ -10713,8 +10713,8 @@ class TestEngineCompress:
             {"role": "tool", "tool_call_id": "call_4", "content": "out4"},
         ])
         second_serialized = "\n".join(str(msg.get("content", "")) for msg in second)
-        assert latest_request in second_serialized
-        assert second_serialized.count("[Current user objective preserved from compacted history]") == 1
+        assert latest_request not in second_serialized
+        assert "[Current user objective preserved from compacted history]" not in second_serialized
 
     def test_compress_preserves_system_and_tail(self, engine):
         """Compression should always keep system prompt and fresh tail."""


### PR DESCRIPTION
## Summary
- Stop treating previously emitted preserved-objective scaffolds as eligible latest-user anchor sources.
- Expose LCM's effective active-context assembly cap as the host-visible `threshold_tokens` preflight trigger.
- Add regressions for lower `max_assembly_tokens` and reserve-based assembly caps so Hermes core does not skip preflight when LCM's real assembly budget is lower than the normal context-threshold value.

## Why
- Preserved-objective scaffolds are derived continuity metadata, not human turns. Reusing a prior scaffold as the next latest-user anchor can recursively preserve stale/synthetic context and grow active context pressure.
- Hermes core uses a compressor's `threshold_tokens` as a cheap gate before it pays for the full request estimate that includes system prompt and tool schemas.
- LCM can enforce a stricter active-context budget than `context_length * context_threshold` via `LCM_MAX_ASSEMBLY_TOKENS` or `LCM_RESERVE_TOKENS_FLOOR`. If LCM advertises only the larger context threshold, Hermes can skip preflight and then send a request that exceeds the real active-context budget.
- New invariant: when an assembly cap is active, LCM exposes `min(context_threshold_tokens, effective_assembly_cap)` as `threshold_tokens`.

## Validation
- [x] Focused validation: `python3 -m pytest -q tests/test_lcm_engine.py::test_threshold_tokens_respects_lower_max_assembly_cap_for_host_preflight tests/test_lcm_engine.py::test_threshold_tokens_respects_lower_reserve_based_cap_for_host_preflight tests/test_lcm_engine.py::test_codex_oauth_context_cap_constrains_reserve_based_assembly_cap` -> `3 passed`
- [x] Engine validation: `python3 -m pytest -q tests/test_lcm_engine.py` -> `698 passed`
- [x] Lint: `python3 -m ruff check engine.py tests/test_lcm_engine.py` -> `All checks passed!`
- [x] Diff check: `git diff --check` -> exit 0 before commit
- [x] GitHub CI on `dddc80c5ff6b769d1602d4dfbee81e2e4b40c8bc` -> `workflow-lint`, `lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`, and `test (3.14)` passed
- [ ] Broader local adjacent validation: `python3 -m pytest -q tests/test_lcm_engine.py tests/test_ingest_protection.py` -> `828 passed, 2 failed`; both failures are the existing `import_lossless_claw` legacy data-URI externalization assertions and reproduce on pristine `origin/main` with the two focused failing tests.

