### PR TITLE
fix(escalation): never str.format() the auto-derived focus topic

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -283,12 +283,12 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
         "\n"
         "Demote old / completed topics:\n"
         "If the summary contains tasks, questions, or remaining work that are no longer active in the latest turns,\n"
-        "mark them under one of these historical headings: {markers}.\n"
+        f"mark them under one of these historical headings: {markers}.\n"
         "Frame them as STALE context — the agent must NOT resume that work unless the latest user message\n"
         "explicitly asks for it. If fully resolved, reduce to a one-line bullet or omit.\n"
         "Exception: active blockers or handoff state should NOT be demoted even if they are absent from the\n"
         "latest turns. Keep blockers and pending handoffs outside historical headings so the agent can still act on them.\n"
-    ).format(markers=markers)
+    )
 
 
 def _build_l2_focus_brief(focus_topic: str) -> str:
@@ -308,12 +308,12 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         "Keep other active tasks only when they are current blockers or handoff state.\n"
         "\n"
         "Demote old / completed topics:\n"
-        "Place non-current work under: {markers}.\n"
+        f"Place non-current work under: {markers}.\n"
         "These sections are STALE — the agent must not act on them unless the latest user message explicitly\n"
         "requests it. Reduce resolved topics to one-liners or drop.\n"
         "Exception: active blockers and pending handoff state should NOT be demoted even when absent from recent\n"
         "turns. Keep them outside historical headings so the agent retains awareness of unresolved constraints.\n"
-    ).format(markers=markers)
+    )
 
 
 def _summary_model_chain(primary_model: str = "", fallback_models: list[str] | tuple[str, ...] | None = None) -> list[str]:

--- a/tests/test_focus_brief_brace_safe.py
+++ b/tests/test_focus_brief_brace_safe.py
@@ -1,0 +1,51 @@
+"""Regression tests: focus-brief builders must not treat the focus topic as a
+format template.
+
+The auto-derived focus topic is built from raw user message text
+(``LCMEngine._derive_auto_focus_topic``). That text can contain literal curly
+braces — brace-dense JSON payloads, code snippets, or even a single stray ``{``.
+
+``_build_l1_focus_brief`` / ``_build_l2_focus_brief`` must embed that text
+verbatim without ever running ``str.format()`` over it. Running ``.format()``
+over untrusted content raises ``ValueError: unmatched '{' in format spec`` (or
+``KeyError`` / ``Single '}' encountered`` depending on the brace shape), which
+aborts compression and drops the whole turn.
+"""
+
+import pytest
+
+from hermes_lcm import escalation
+
+
+# Brace shapes that all break str.format() when used as the template string.
+BRACY_TOPICS = [
+    "rate is 3{ per unit",                 # lone open brace
+    "rate is 3} per unit",                 # lone close brace
+    'data {"k": "v"}',                     # balanced braces
+    "plan {tier: {gold",                   # nested/colon -> "unmatched '{' in format spec"
+    '[IMPORTANT] {"rule": {"id": "quo-maint-line"}}',  # brace-dense wakeup-style JSON
+]
+
+
+@pytest.mark.parametrize("builder", [
+    escalation._build_l1_focus_brief,
+    escalation._build_l2_focus_brief,
+])
+@pytest.mark.parametrize("topic", BRACY_TOPICS)
+def test_focus_brief_survives_braces(builder, topic):
+    # Must not raise regardless of braces in the focus topic.
+    out = builder(topic)
+    # The historical-heading markers must still be substituted (the sole real
+    # placeholder), and the topic text must survive verbatim.
+    assert "## Historical Task Snapshot" in out
+    assert "{markers}" not in out  # placeholder actually got filled
+    assert topic in out            # focus topic embedded literally, braces intact
+
+
+@pytest.mark.parametrize("builder", [
+    escalation._build_l1_focus_brief,
+    escalation._build_l2_focus_brief,
+])
+def test_focus_brief_empty_topic_returns_blank(builder):
+    assert builder("") == ""
+    assert builder("   ") == ""


### PR DESCRIPTION
## Summary

`_build_l1_focus_brief` / `_build_l2_focus_brief` run `str.format()` over a string
that already embeds the **auto-derived focus topic**, which comes from raw user
message text. When that text contains literal curly braces, `.format()` parses
them as replacement fields and raises — aborting compaction and dropping the whole
turn.

## Root cause

Both builders assemble the guidance string from adjacent literals, one of which is
an **f-string** that interpolates the untrusted topic, and then call `.format()`
over the *entire* assembled string:

```python
markers = " / ".join(...)              # compile-time constant
return (
    "Focus brief:\n"
    f"Primary focus: {topic}\n"        # <-- untrusted topic embedded here
    ...
    "mark them under one of these historical headings: {markers}.\n"
    ...
).format(markers=markers)              # <-- .format() re-parses the whole string, incl. topic's braces
```

`topic` is produced by `LCMEngine._derive_auto_focus_topic`, which pulls the raw
text of the latest user turns (whitespace-collapsed / redacted / truncated only —
braces preserved; the truncation can even slice a JSON object mid-brace). So any
brace in recent user content flows into `.format()`:

- `unmatched '{' in format spec` (e.g. `plan {tier: {gold`, or JSON sliced mid-object)
- `Single '}' encountered in format string` (a lone `}`)
- `KeyError` / `IndexError` (`{"k": "v"}`, `{0}` …)

We hit this in production when the latest user message was a brace-dense JSON
payload: every compaction on that session failed with
`ValueError: unmatched '{' in format spec`, before any summarizer model call, and
the turn was lost.

Traceback tail:

```
escalation.py:_build_l1_prompt -> _build_l1_focus_brief(focus_topic)
    ).format(markers=markers)
ValueError: unmatched '{' in format spec
```

## Fix

`{markers}` is the only real placeholder and it is a compile-time constant, so
there is no reason to run `.format()` over the assembled string. Make the
`{markers}` line an f-string segment and drop `.format()` entirely. The untrusted
topic is then only ever embedded via f-string interpolation, which does **not**
re-parse the interpolated value for braces.

Applied to both `_build_l1_focus_brief` and `_build_l2_focus_brief` (4 lines).

## Tests

Adds `tests/test_focus_brief_brace_safe.py`: parametrized over both builders and
over lone `{`, lone `}`, balanced `{}`, nested `{x:{y`, and a brace-dense JSON
focus topic — asserts no exception, the historical-heading markers still render,
and the topic text is embedded verbatim (braces intact). Also covers the
empty-topic `""` path. Fails on `main` (10/12), passes with this change (12/12).
