### PR TITLE
fix: make focus brief formatting brace-safe

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -283,12 +283,12 @@ def _build_l1_focus_brief(focus_topic: str) -> str:
         "\n"
         "Demote old / completed topics:\n"
         "If the summary contains tasks, questions, or remaining work that are no longer active in the latest turns,\n"
-        "mark them under one of these historical headings: {markers}.\n"
+        f"mark them under one of these historical headings: {markers}.\n"
         "Frame them as STALE context — the agent must NOT resume that work unless the latest user message\n"
         "explicitly asks for it. If fully resolved, reduce to a one-line bullet or omit.\n"
         "Exception: active blockers or handoff state should NOT be demoted even if they are absent from the\n"
         "latest turns. Keep blockers and pending handoffs outside historical headings so the agent can still act on them.\n"
-    ).format(markers=markers)
+    )
 
 
 def _build_l2_focus_brief(focus_topic: str) -> str:
@@ -308,12 +308,12 @@ def _build_l2_focus_brief(focus_topic: str) -> str:
         "Keep other active tasks only when they are current blockers or handoff state.\n"
         "\n"
         "Demote old / completed topics:\n"
-        "Place non-current work under: {markers}.\n"
+        f"Place non-current work under: {markers}.\n"
         "These sections are STALE — the agent must not act on them unless the latest user message explicitly\n"
         "requests it. Reduce resolved topics to one-liners or drop.\n"
         "Exception: active blockers and pending handoff state should NOT be demoted even when absent from recent\n"
         "turns. Keep them outside historical headings so the agent retains awareness of unresolved constraints.\n"
-    ).format(markers=markers)
+    )
 
 
 def _summary_model_chain(primary_model: str = "", fallback_models: list[str] | tuple[str, ...] | None = None) -> list[str]:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -17,7 +17,11 @@ from hermes_lcm.config import LCMConfig
 from hermes_lcm.tokens import count_tokens, count_message_tokens, count_messages_tokens
 from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG, SummaryNode
-from hermes_lcm.escalation import _deterministic_truncate
+from hermes_lcm.escalation import (
+    _build_l1_focus_brief,
+    _build_l2_focus_brief,
+    _deterministic_truncate,
+)
 from hermes_lcm.lifecycle_state import LifecycleStateStore
 from hermes_lcm.db_bootstrap import ExternalContentFtsSpec, ensure_external_content_fts
 from hermes_lcm.search_query import sanitize_fts5_query
@@ -32,6 +36,27 @@ from hermes_lcm.message_patterns import (
     compile_message_patterns,
     matches_message_pattern,
 )
+
+
+class TestFocusBriefFormatting:
+    def test_l1_focus_brief_preserves_literal_braces_in_focus_topic(self):
+        topic = 'Investigate JSON payload {"mode": "force", "items": [1, 2]} and placeholder {0}'
+
+        brief = _build_l1_focus_brief(topic)
+
+        assert topic in brief
+        assert "Replacement index" not in brief
+        assert "## Historical Task Snapshot" in brief
+        assert "mark them under one of these historical headings:" in brief
+
+    def test_l2_focus_brief_preserves_literal_braces_in_focus_topic(self):
+        topic = "Reconcile tool output with braces: {'force': true, 'topic': '{markers}'}"
+
+        brief = _build_l2_focus_brief(topic)
+
+        assert topic in brief
+        assert "## Historical Remaining Work" in brief
+        assert "Place non-current work under:" in brief
 
 
 class TestModelRouting:


### PR DESCRIPTION
## Summary
- make L1/L2 focus brief construction safe when the focus topic contains literal braces such as JSON snippets or `{0}` placeholders
- add regression coverage for both focus brief builders

## Why
- focus topics are derived from recent user turns, which can include logs, JSON, markdown, or placeholders with `{}`
- the previous builders formatted the whole assembled prompt with `.format(markers=...)`, so braces from the user-derived topic were parsed as format fields and could crash compression before summarization
- this keeps marker interpolation explicit without reparsing the rest of the prompt text

## Validation
- [x] Focused validation: `python3 -m pytest tests/test_lcm_core.py::TestFocusBriefFormatting -q` -> `2 passed`
- [x] Focused validation: `python3 -m pytest tests/test_lcm_core.py -q` -> `290 passed`
- [x] Focused validation: `ruff check escalation.py tests/test_lcm_core.py` -> `All checks passed!`
- [x] GitHub CI: `workflow-lint`, `lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`, `test (3.14)` -> passed on `282e498`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-focus-brief`
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Risk / impact
- Low-risk string-construction change only.
- Affects compression prompt construction; intended impact is avoiding crashes when derived focus text contains braces.

## Scope boundaries
- Does not change summarization policy, routing, token budgets, persistence, or DAG behavior.
- Does not change release metadata.

## Rollout / operator notes
- No migration required.
- A running Hermes process still needs to load a plugin version containing this patch before it can benefit from the fix.

## Reviewer focus
- Please check that literal braces from `focus_topic` can no longer be parsed as `.format()` fields.
- Please check whether this should supersede or be folded into #294.

## Notes
- Related to #294, which covers the same crash class but was still open/unmerged when this branch was created.
