### PR TITLE
fix(search): keep natural-language queries on the FTS5 path instead of crashing to the LIKE fallback

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -42,6 +42,7 @@ from .search_query import (
     normalize_search_sort,
     requires_like_fallback,
     sanitize_fts5_query,
+    sanitize_like_terms_query,
     should_apply_directness_rank_adjustment,
 )
 from .store import _normalize_source_value, _UNKNOWN_SOURCE, _legacy_blank_source_clause
@@ -501,7 +502,9 @@ class SummaryDAG:
     def _search_like(self, query: str, session_id: str | None = None,
                      limit: int = 20, sort: str | None = None,
                      source: str | None = None) -> List[SummaryNode]:
-        safe_query = sanitize_fts5_query(query)
+        # LIKE matches raw stored content, so keep characters the FTS5
+        # sanitizer would strip (apostrophes, emoji, CJK punctuation, ...).
+        safe_query = sanitize_like_terms_query(query)
         terms = extract_search_terms(safe_query)
         phrases = extract_quoted_phrases(safe_query)
         if not terms:

--- a/search_query.py
+++ b/search_query.py
@@ -26,16 +26,28 @@ _BOOLEAN_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
 _RISKY_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9][\-:/][A-Za-z0-9]")
 _SPLIT_PUNCT_RE = re.compile(r"[-:/]+")
 _STRIP_EDGE_PUNCT = "\"'()[]{}.,;"
-# Characters that are special in FTS5 query syntax
+# Characters that are special in FTS5 query syntax. This set is kept for the
+# risky-token checks and the LIKE-fallback cleanup, but FTS sanitization no
+# longer relies on it alone: outside quoted phrases, ANY non-word character
+# is a potential FTS5 syntax error (a bare apostrophe or comma each produce
+# "fts5: syntax error near ..."), and the unicode61 tokenizer treats every
+# one of them as a separator when indexing — so replacing them with spaces
+# matches the index instead of crashing the whole query into the LIKE
+# fallback.
 _FTS5_SPECIAL_CHARS = frozenset('"()*^-:{}.')
 
 
-def _sanitize_unquoted_fts5_fragment(text: str) -> str:
-    return "".join(" " if char in _FTS5_SPECIAL_CHARS else char for char in text)
+def _fts5_bareword_safe(char: str) -> bool:
+    return char.isalnum() or char == "_" or char.isspace()
 
 
-def sanitize_fts5_query(query: str) -> str:
-    """Strip FTS5 syntax operators while preserving balanced phrase quotes."""
+def _like_term_safe(char: str) -> bool:
+    return char not in _FTS5_SPECIAL_CHARS
+
+
+def _sanitize_query(query: str, is_safe) -> str:
+    """Replace unsafe characters with spaces while preserving balanced
+    phrase quotes (quoted phrase contents pass through verbatim)."""
     if not query:
         return ""
 
@@ -59,10 +71,24 @@ def sanitize_fts5_query(query: str) -> str:
         if in_quote:
             quote_buffer.append(char)
             continue
-        result.append(" " if char in _FTS5_SPECIAL_CHARS else char)
+        result.append(char if is_safe(char) else " ")
     if in_quote and quote_buffer:
-        result.extend(_sanitize_unquoted_fts5_fragment("".join(quote_buffer)))
+        result.extend(char if is_safe(char) else " " for char in quote_buffer)
     return "".join(result).strip()
+
+
+def sanitize_fts5_query(query: str) -> str:
+    """Sanitize a query for FTS5 MATCH: outside quoted phrases keep only
+    bareword-safe characters (alnum/underscore/whitespace) — exactly what
+    the unicode61 tokenizer indexed. Quoted phrases pass through unchanged."""
+    return _sanitize_query(query, _fts5_bareword_safe)
+
+
+def sanitize_like_terms_query(query: str) -> str:
+    """Lighter cleanup for LIKE-fallback term extraction: only strip FTS5
+    operator characters. LIKE matches raw stored content, so apostrophes,
+    emoji, CJK, etc. must survive for the fallback to find them."""
+    return _sanitize_query(query, _like_term_safe)
 
 
 _WORD_RE = re.compile(r"[\w-]+", re.UNICODE)

--- a/store.py
+++ b/store.py
@@ -41,6 +41,7 @@ from .search_query import (
     normalize_search_sort,
     requires_like_fallback,
     sanitize_fts5_query,
+    sanitize_like_terms_query,
     AGE_DECAY_RATE,
     should_apply_directness_rank_adjustment,
 )
@@ -1046,7 +1047,9 @@ class MessageStore:
                      role: str | None = None,
                      time_from: float | None = None,
                      time_to: float | None = None) -> List[Dict[str, Any]]:
-        safe_query = sanitize_fts5_query(query)
+        # LIKE matches raw stored content, so keep characters the FTS5
+        # sanitizer would strip (apostrophes, emoji, CJK punctuation, ...).
+        safe_query = sanitize_like_terms_query(query)
         terms = extract_search_terms(safe_query)
         phrases = extract_quoted_phrases(safe_query)
         if not terms:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3,6 +3,7 @@
 import copy
 import hashlib
 import json
+import logging
 import re
 import sqlite3
 import sys
@@ -1692,6 +1693,41 @@ class TestMessageStore:
 
         assert results == []
 
+    def test_search_apostrophe_query_stays_on_fts_path(self, store, caplog):
+        store.append("sess1", {"role": "user", "content": "no, don't reschedule the meeting"})
+
+        with caplog.at_level(logging.WARNING):
+            results = store.search("don't", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "no, don't reschedule the meeting"
+        assert "falling back to LIKE" not in caplog.text
+
+    def test_search_conversational_query_does_not_crash_fts(self, store, caplog):
+        store.append(
+            "sess1",
+            {"role": "user", "content": "what did I tell you, don't you remember?"},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            results = store.search(
+                "what did I tell you, don't you remember?", session_id="sess1"
+            )
+
+        assert len(results) == 1
+        assert "falling back to LIKE" not in caplog.text
+
+    def test_search_quoted_phrase_with_conversational_punctuation(self, store, caplog):
+        store.append("sess1", {"role": "user", "content": "the vendoring external plan, remember?"})
+        store.append("sess1", {"role": "user", "content": "external vendoring is different"})
+
+        with caplog.at_level(logging.WARNING):
+            results = store.search('"vendoring external", remember?', session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0]["content"] == "the vendoring external plan, remember?"
+        assert "falling back to LIKE" not in caplog.text
+
     def test_init_low_disk_degrades_without_leaving_broken_message_fts_triggers(self, tmp_path, monkeypatch):
         db_path = tmp_path / "low-disk-broken-message-fts.db"
         conn = sqlite3.connect(db_path)
@@ -2994,6 +3030,22 @@ class TestDbBootstrapGuards:
         assert sanitize_fts5_query("v2.21") == "v2 21"
         assert sanitize_fts5_query("api.v2") == "api v2"
         assert sanitize_fts5_query("hermes.lcm") == "hermes lcm"
+
+    def test_sanitize_fts5_query_neutralizes_apostrophes_and_commas(self):
+        # An unquoted apostrophe or comma is an FTS5 syntax error; the
+        # unicode61 tokenizer indexed them as separators, so spaces match
+        # the index instead of crashing the query into the LIKE fallback.
+        assert sanitize_fts5_query("don't") == "don t"
+        assert (
+            sanitize_fts5_query("what did I tell you, don't you remember?")
+            == "what did I tell you  don t you remember"
+        )
+
+    def test_sanitize_fts5_query_keeps_quoted_phrases_verbatim(self):
+        assert (
+            sanitize_fts5_query('"plugin-only support" yes, really')
+            == '"plugin-only support" yes  really'
+        )
 
     def test_ensure_external_content_fts_skips_rebuild_when_disk_is_low(self, tmp_path, monkeypatch):
         conn = sqlite3.connect(tmp_path / "low-disk.db")


### PR DESCRIPTION
## Problem

Any conversational search query containing an apostrophe, comma, question mark, or most other punctuation (for example `don't`) is a syntax error to FTS5. `store.search` catches the error and silently degrades to the LIKE fallback, so in practice nearly every natural-language query runs on the slow, unranked fallback path instead of the FTS index.

## Mechanism

`sanitize_fts5_query` (`search_query.py:47`) only replaces the fixed operator set `_FTS5_SPECIAL_CHARS` (`search_query.py:36`), leaving apostrophes, commas, and question marks in the unquoted query text. `store.search` (`store.py:931`) passes the result to `messages_fts MATCH`, FTS5 raises `fts5: syntax error near "'"`, and the handler at `store.py:997` logs "FTS message search failed, falling back to LIKE" and degrades. `dag.py:427` has the same path for summary search.

## Fix

Outside quoted phrases, keep only bareword-safe characters (alphanumerics, underscore, whitespace) and replace everything else with spaces. That is exactly the token alphabet the unicode61 tokenizer indexed, so the sanitized query matches the index instead of erroring; `don't` becomes `don t`, which matches rows containing `don't`. Quoted phrases pass through verbatim, as before.

The LIKE fallback must not use that strict sanitization: it matches raw stored content, so apostrophes, emoji, and CJK punctuation have to survive for the fallback to find them (an emoji-only query would otherwise produce zero terms and return nothing). The helper is therefore split in two: `sanitize_fts5_query` (strict, used by the FTS MATCH paths) and `sanitize_like_terms_query` (the previous operator-stripping behavior, used by `_search_like` in `store.py` and `dag.py`).

## Verification

New tests cover: `don't` returning its row on the FTS path with no fallback warning, a full conversational sentence (`what did I tell you, don't you remember?`) searching without any `OperationalError` or fallback, quoted phrases with trailing conversational punctuation still matching as phrases, and sanitizer unit cases. On unpatched main the new tests fail with the exact production error (`fts5: syntax error near ","`). The full `tests/test_lcm_core.py` suite passes (288 tests), including the existing emoji and LIKE-fallback regression tests.

## Incident evidence

One live store logged the FTS-to-LIKE fallback warning over 300 times, meaning nearly every conversational search had been silently running on the degraded fallback path.
