### PR TITLE
fix: skip auxiliary replay on first ingest

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -944,6 +944,44 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         else:
             logger.warning(message, *args)
 
+    def _maybe_reclassify_current_session_as_auxiliary_at_ingest(self) -> bool:
+        """Defense-in-depth for host markers that arrive after session binding.
+
+        Older Hermes Agent background-review forks seed ``_memory_write_origin``
+        too late for ``on_session_start`` frame-walk detection. By first ingest
+        the marker is present on the running agent frame, so re-check only while
+        the bound session is still empty. That keeps normal foreground session
+        starts/resets writable and avoids reclassifying sessions after real data
+        has already been stored.
+        """
+        session_id = str(self._session_id or "")
+        if not session_id:
+            return False
+        if self._session_ignored or self._session_stateless or self._thread_context_stateless():
+            return False
+        if self._ingest_cursor > 0:
+            return False
+        try:
+            stored_count = self._store.get_session_count(session_id)
+        except Exception:
+            logger.debug("LCM first-ingest auxiliary recheck count probe failed", exc_info=True)
+            return False
+        if stored_count != 0:
+            return False
+        if not self._in_process_auxiliary_caller_generation(session_id):
+            return False
+
+        self._mark_thread_context_stateless(session_id)
+        if self._foreground_session_id == session_id:
+            self._foreground_session_id = ""
+            self._foreground_session_platform = ""
+            self._foreground_conversation_id = ""
+        logger.info(
+            "LCM reclassified session %s as auxiliary at first ingest after bind-time detection missed",
+            session_id,
+        )
+        return True
+
     def ingest(self, messages: List[Dict[str, Any]]) -> None:
         """Persist messages to the durable store every turn.
 
@@ -957,6 +995,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         compression runs later the same turn, already-ingested messages
         are skipped (no duplicates).
         """
+        if self._maybe_reclassify_current_session_as_auxiliary_at_ingest():
+            self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
+            return
         if self._bypasses_lcm_context_management():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
             return

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -1,0 +1,96 @@
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+class _FakeAgent:
+    def __init__(self, engine: LCMEngine, session_id: str, parent_session_id: str = ""):
+        self.engine = engine
+        self.session_id = session_id
+        self._parent_session_id = parent_session_id
+        self._memory_write_origin = "assistant_tool"
+        self._memory_write_context = "foreground"
+        self.log_prefix = ""
+        self.enabled_toolsets = {"terminal", "file", "web"}
+
+    def start_session(self) -> None:
+        self.engine.on_session_start(
+            self.session_id,
+            platform="cli",
+            conversation_id=f"conversation:{self.session_id}",
+        )
+
+    def ingest_history_after_background_marker(self, history):
+        self._memory_write_origin = "background_review"
+        self._memory_write_context = "background_review"
+        self.engine.ingest(history)
+
+    def ingest_history_as_foreground(self, history):
+        self.engine.ingest(history)
+
+
+class _ForegroundAgent(_FakeAgent):
+    pass
+
+
+def _engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm.db"))
+    return LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+
+
+def test_first_ingest_rechecks_background_review_marker_after_missed_bind_time(tmp_path):
+    engine = _engine(tmp_path)
+    agent = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+    history = [
+        {"role": "user", "content": "foreground question"},
+        {"role": "assistant", "content": "foreground answer"},
+    ]
+
+    try:
+        # Host bug shape: on_session_start fires while the agent still exposes
+        # the foreground default, so bind-time auxiliary detection misses.
+        agent.start_session()
+        assert engine._store.get_session_count("review-session") == 0
+
+        # By first post-LLM ingest the host has set the background-review marker.
+        # LCM must re-check before writing the replay snapshot as a new session.
+        agent.ingest_history_after_background_marker(history)
+
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine._thread_context_has_auxiliary_session("review-session")
+    finally:
+        engine.shutdown()
+
+
+def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
+    engine = _engine(tmp_path)
+    agent = _ForegroundAgent(engine, "foreground-session")
+    history = [{"role": "user", "content": "real foreground turn"}]
+
+    try:
+        agent.start_session()
+        agent.ingest_history_as_foreground(history)
+
+        assert engine._store.get_session_count("foreground-session") == 1
+        assert not engine._thread_context_has_auxiliary_session("foreground-session")
+    finally:
+        engine.shutdown()
+
+
+def test_first_ingest_recheck_does_not_poison_session_reset_foreground(tmp_path):
+    engine = _engine(tmp_path)
+    first = _ForegroundAgent(engine, "foreground-a")
+    second = _ForegroundAgent(engine, "foreground-b")
+
+    try:
+        first.start_session()
+        first.ingest_history_as_foreground([{"role": "user", "content": "before reset"}])
+        engine.on_session_reset()
+
+        second.start_session()
+        second.ingest_history_as_foreground([{"role": "user", "content": "after reset"}])
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 1
+        assert not engine._thread_context_has_auxiliary_session("foreground-b")
+    finally:
+        engine.shutdown()


### PR DESCRIPTION
## Summary
- Re-check the active session for late-arriving auxiliary/background-review markers before first ingest writes anything durable.
- Add regression coverage for missed bind-time detection, normal foreground ingest, and foreground session reset behavior.

## Why
- Fixes #356: older Hermes Agent background-review forks can expose the background marker only after `on_session_start`, which let the first replay snapshot create/pollute a durable LCM session.

## Validation
- [x] Focused validation: `python -m pytest tests/test_auxiliary_first_ingest.py tests/test_subagent_lineage.py tests/test_packaging_install.py::test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor tests/test_packaging_install.py::test_post_llm_hook_prefers_active_lcm_clone -q` -> `10 passed`
- [x] Focused validation: `python -m ruff check engine.py tests/test_auxiliary_first_ingest.py` -> `All checks passed!`
- [x] Focused validation: `git diff --check` -> passed
- [ ] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_lcm_rotate.py tests/test_lcm_inspect.py tests/test_lcm_command.py tests/test_ingest_protection.py -q` -> `1240 passed`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check` -> passed
- [ ] Workflow validation, if workflows changed: `actionlint` (not applicable; workflows unchanged)

## Notes
- Rebased onto `origin/main` after #341/#353. Conflict resolved by keeping the WS5 `BypassMixin` extraction on main and adding only the #356 first-ingest reclassification hook in `engine.py`.

Refs #356
