### PR TITLE
Fix foreground recovery after late auxiliary reclassification

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,37 @@ def _host_forwards_registered_tool_messages(ctx) -> bool:
     return bool(capability)
 
 
+def _engine_bound_session_id(engine) -> str:
+    """Return the lifecycle/ingest session bound on an LCM engine.
+
+    ``current_session_id`` is an operator-facing foreground view and can differ
+    from the bound ingest session while an auxiliary side channel is active.
+    Post-turn ingest rebinding must use the bound id or it can append a resumed
+    foreground turn to a stale auxiliary child.
+    """
+    return str(
+        getattr(engine, "bound_session_id", "")
+        or getattr(engine, "_session_id", "")
+        or ""
+    )
+
+
+def _ensure_engine_bound_to_session(
+    active_engine,
+    session_id: str,
+    *,
+    platform: str = "",
+    conversation_id: str = "",
+) -> None:
+    session_id = str(session_id or "")
+    if session_id and _engine_bound_session_id(active_engine) != session_id:
+        active_engine.on_session_start(
+            session_id,
+            platform=platform,
+            conversation_id=conversation_id or None,
+        )
+
+
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
@@ -205,15 +236,12 @@ def register(ctx):
                 # can deliver stale lane metadata alongside the correct active
                 # session id; rebinding a clone on conversation_id mismatch
                 # alone would move it away from the runtime it is serving.
-                if (
-                    session_id
-                    and str(getattr(active_engine, "current_session_id", "") or "") != session_id
-                ):
-                    active_engine.on_session_start(
-                        session_id,
-                        platform=platform,
-                        conversation_id=conversation_id or None,
-                    )
+                _ensure_engine_bound_to_session(
+                    active_engine,
+                    session_id,
+                    platform=platform,
+                    conversation_id=conversation_id,
+                )
                 active_engine.ingest(history)
             except Exception as exc:
                 logger.debug("LCM post_llm_call ingest error: %s", exc)

--- a/aux_session.py
+++ b/aux_session.py
@@ -586,6 +586,7 @@ class AuxiliarySessionMixin:
         kwargs: Dict[str, Any],
         session_id: str = "",
         include_explicit: bool = True,
+        require_auxiliary_frame: bool = True,
     ) -> str:
         explicit = str(kwargs.get("parent_session_id") or "")
         if include_explicit and explicit:
@@ -604,7 +605,7 @@ class AuxiliarySessionMixin:
                 if frame is None:
                     return ""
                 caller_self = frame.f_locals.get("self")
-                if not self._caller_is_auxiliary_agent_frame(caller_self):
+                if require_auxiliary_frame and not self._caller_is_auxiliary_agent_frame(caller_self):
                     frame = frame.f_back
                     continue
                 parent = str(getattr(caller_self, "_parent_session_id", "") or "")

--- a/compaction.py
+++ b/compaction.py
@@ -28,6 +28,15 @@ logger = logging.getLogger(__name__)
 
 
 class CompactionMixin:
+    def _maybe_reclassify_late_auxiliary_before_compaction_write(self) -> None:
+        maybe_reclassify = getattr(
+            self,
+            "_maybe_reclassify_current_session_as_auxiliary_before_message_ingest",
+            None,
+        )
+        if callable(maybe_reclassify):
+            maybe_reclassify()
+
     def should_compress(self, prompt_tokens: int = None) -> bool:
         if self._bypasses_lcm_context_management():
             if self._compression_boundary_cooldown_active():
@@ -56,6 +65,7 @@ class CompactionMixin:
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
+        self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
             rough = count_messages_tokens(messages)
@@ -317,6 +327,7 @@ class CompactionMixin:
         self._last_compression_noop_reason = ""
         _compress_started = time.perf_counter()
 
+        self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             bypass_current_tokens = current_tokens
             if bypass_current_tokens is None or bypass_current_tokens <= 0:

--- a/engine.py
+++ b/engine.py
@@ -966,6 +966,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._foreground_rebind_previous_platform = ""
         self._foreground_rebind_previous_conversation_id = ""
 
+    def _clear_foreground_rebind_candidate_if_bound_session_confirmed(self) -> None:
+        if self._foreground_rebind_session_id == self._session_id:
+            self._clear_foreground_rebind_candidate()
+
     def _remember_foreground_rebind_candidate(self, session_id: str) -> None:
         """Remember the foreground view displaced by a provisional normal bind.
 
@@ -1078,8 +1082,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 )
                 self._ingest_messages(messages)
                 self._record_ingest_success()
-                if self._foreground_rebind_session_id == self._session_id:
-                    self._clear_foreground_rebind_candidate()
+                self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 logger.debug(
                     "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
                     self._session_id, len(messages), self._ingest_cursor,
@@ -2970,6 +2973,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             try:
                 self._ingest_messages(messages)
                 self._record_ingest_success()
+                self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
             except Exception as e:
                 self._record_ingest_failure("tool-call ingest", e)
 

--- a/engine.py
+++ b/engine.py
@@ -1051,16 +1051,26 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 include_explicit=False,
                 require_auxiliary_frame=False,
             )
+            rebind_candidate_is_foreground_branch = bool(
+                self._foreground_rebind_parent_session_id
+                and self._session_has_foreground_branch_marker(
+                    self._foreground_rebind_session_id,
+                    self._foreground_rebind_parent_session_id,
+                )
+            )
             if (
-                parent_session_id == self._foreground_rebind_session_id
+                (
+                    parent_session_id == self._foreground_rebind_session_id
+                    and (
+                        not self._foreground_rebind_parent_session_id
+                        or rebind_candidate_is_foreground_branch
+                    )
+                )
                 or (parent_session_id and not self._foreground_rebind_parent_session_id)
                 or (
                     parent_session_id
                     and parent_session_id == self._foreground_rebind_parent_session_id
-                    and self._session_has_foreground_branch_marker(
-                        self._foreground_rebind_session_id,
-                        self._foreground_rebind_parent_session_id,
-                    )
+                    and rebind_candidate_is_foreground_branch
                 )
             ):
                 self._foreground_rebind_previous_session_id = self._foreground_session_id

--- a/engine.py
+++ b/engine.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import sqlite3
 import threading
 import time
 from pathlib import Path
@@ -972,6 +973,57 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         if self._foreground_rebind_session_id == self._session_id:
             self._clear_foreground_rebind_candidate()
 
+    def _session_has_foreground_branch_marker(
+        self,
+        session_id: str,
+        parent_session_id: str,
+    ) -> bool:
+        """Return True when Hermes state.db records ``session_id`` as a real branch.
+
+        An un-ingested foreground branch and a provisional late-marked auxiliary
+        child can both expose the same in-process parent id before either has
+        durable LCM rows. The canonical host signal for real foreground branches
+        is the ``sessions.model_config._branched_from`` marker in state.db; use
+        it to decide whether a displaced un-ingested candidate is safe to restore.
+        """
+        session_id = str(session_id or "")
+        parent_session_id = str(parent_session_id or "")
+        if not session_id or not parent_session_id:
+            return False
+        path = self._state_db_path()
+        if not path.exists():
+            return False
+        try:
+            uri = path.resolve().as_uri() + "?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+            try:
+                row = conn.execute(
+                    """
+                    SELECT parent_session_id, model_config
+                    FROM sessions
+                    WHERE id = ?
+                    LIMIT 1
+                    """,
+                    (session_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+        except Exception:
+            logger.debug("LCM foreground branch marker probe failed", exc_info=True)
+            return False
+        if not row:
+            return False
+        row_parent_id = str(row[0] or "")
+        if row_parent_id != parent_session_id:
+            return False
+        try:
+            model_config = json.loads(row[1] or "{}")
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(model_config, dict):
+            return False
+        return str(model_config.get("_branched_from") or "") == parent_session_id
+
     def _remember_foreground_rebind_candidate(self, session_id: str) -> None:
         """Remember the foreground view displaced by a provisional normal bind.
 
@@ -999,8 +1051,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 include_explicit=False,
                 require_auxiliary_frame=False,
             )
-            if parent_session_id == self._foreground_rebind_session_id or (
-                parent_session_id and not self._foreground_rebind_parent_session_id
+            if (
+                parent_session_id == self._foreground_rebind_session_id
+                or (parent_session_id and not self._foreground_rebind_parent_session_id)
+                or (
+                    parent_session_id
+                    and parent_session_id == self._foreground_rebind_parent_session_id
+                    and self._session_has_foreground_branch_marker(
+                        self._foreground_rebind_session_id,
+                        self._foreground_rebind_parent_session_id,
+                    )
+                )
             ):
                 self._foreground_rebind_previous_session_id = self._foreground_session_id
                 self._foreground_rebind_previous_platform = self._foreground_session_platform

--- a/engine.py
+++ b/engine.py
@@ -982,6 +982,13 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return
         if self._foreground_rebind_session_id == session_id:
             return
+        if (
+            self._foreground_rebind_session_id
+            and self._foreground_rebind_previous_session_id
+            and self._foreground_session_id == self._foreground_rebind_session_id
+        ):
+            self._foreground_rebind_session_id = session_id
+            return
         if self._foreground_session_id and self._foreground_session_id != session_id:
             self._foreground_rebind_session_id = session_id
             self._foreground_rebind_previous_session_id = self._foreground_session_id

--- a/engine.py
+++ b/engine.py
@@ -1078,6 +1078,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 )
                 self._ingest_messages(messages)
                 self._record_ingest_success()
+                if self._foreground_rebind_session_id == self._session_id:
+                    self._clear_foreground_rebind_candidate()
                 logger.debug(
                     "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
                     self._session_id, len(messages), self._ingest_cursor,

--- a/engine.py
+++ b/engine.py
@@ -3866,6 +3866,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._compression_boundary_active_placeholder_digest_budget = {}
             self._compression_boundary_active_placeholder_digest_ordinals = {}
             self._compression_boundary_stored_placeholder_digest_counts = {}
+            self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
             if cached_replay is not None:
                 return cached_replay
             return self._remember_active_replay_messages(messages, replay_messages)
@@ -4096,6 +4097,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._compression_boundary_active_placeholder_digest_budget = {}
             self._compression_boundary_active_placeholder_digest_ordinals = {}
             self._compression_boundary_stored_placeholder_digest_counts = {}
+            self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
             return self._remember_active_replay_messages(messages, active_replay_messages)
 
         protected_messages = protect_messages_for_ingest(
@@ -4131,6 +4133,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._compression_boundary_active_placeholder_digest_ordinals = {}
         self._compression_boundary_stored_placeholder_digest_counts = {}
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
+        self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
         # Most ``protected_messages`` changes are storage-only: inline media,
         # tool results, and data/base64 substrings must stay provider-usable in
         # active replay. Whole-message ``raw_payload`` externalization is the

--- a/engine.py
+++ b/engine.py
@@ -177,6 +177,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._foreground_session_id: str = ""
         self._foreground_session_platform: str = ""
         self._foreground_conversation_id: str = ""
+        self._foreground_rebind_session_id: str = ""
+        self._foreground_rebind_previous_session_id: str = ""
+        self._foreground_rebind_previous_platform: str = ""
+        self._foreground_rebind_previous_conversation_id: str = ""
         self._conversation_id: str = ""
         self._session_match_keys: list[str] = []
         self._session_ignored = False
@@ -434,6 +438,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._foreground_session_id = ""
         self._foreground_session_platform = ""
         self._foreground_conversation_id = ""
+        self._clear_foreground_rebind_candidate()
         self._conversation_id = ""
         self._session_match_keys = []
         self._session_ignored = False
@@ -944,6 +949,54 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         else:
             logger.warning(message, *args)
 
+    def _clear_foreground_rebind_candidate(self) -> None:
+        self._foreground_rebind_session_id = ""
+        self._foreground_rebind_previous_session_id = ""
+        self._foreground_rebind_previous_platform = ""
+        self._foreground_rebind_previous_conversation_id = ""
+
+    def _remember_foreground_rebind_candidate(self, session_id: str) -> None:
+        """Remember the foreground view displaced by a provisional normal bind.
+
+        Bind-time auxiliary detection can miss background-review children when
+        the host seeds its marker late. If that happens, ``on_session_start``
+        temporarily classifies the child as a normal foreground and overwrites
+        the operator-facing foreground pointer. The first-ingest recheck may
+        later prove the child is auxiliary; this snapshot lets that recovery
+        restore the parent foreground instead of falling back to the child.
+        """
+        session_id = str(session_id or "")
+        if not session_id:
+            self._clear_foreground_rebind_candidate()
+            return
+        if self._foreground_rebind_session_id == session_id:
+            return
+        if self._foreground_session_id and self._foreground_session_id != session_id:
+            self._foreground_rebind_session_id = session_id
+            self._foreground_rebind_previous_session_id = self._foreground_session_id
+            self._foreground_rebind_previous_platform = self._foreground_session_platform
+            self._foreground_rebind_previous_conversation_id = self._foreground_conversation_id
+            return
+        self._clear_foreground_rebind_candidate()
+
+    def _restore_foreground_after_late_auxiliary_reclassification(self, session_id: str) -> None:
+        if self._foreground_session_id != session_id:
+            if self._foreground_rebind_session_id == session_id:
+                self._clear_foreground_rebind_candidate()
+            return
+        if (
+            self._foreground_rebind_session_id == session_id
+            and self._foreground_rebind_previous_session_id
+        ):
+            self._foreground_session_id = self._foreground_rebind_previous_session_id
+            self._foreground_session_platform = self._foreground_rebind_previous_platform
+            self._foreground_conversation_id = self._foreground_rebind_previous_conversation_id
+        else:
+            self._foreground_session_id = ""
+            self._foreground_session_platform = ""
+            self._foreground_conversation_id = ""
+        self._clear_foreground_rebind_candidate()
+
     def _maybe_reclassify_current_session_as_auxiliary_at_ingest(self) -> bool:
         """Defense-in-depth for host markers that arrive after session binding.
 
@@ -972,10 +1025,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return False
 
         self._mark_thread_context_stateless(session_id)
-        if self._foreground_session_id == session_id:
-            self._foreground_session_id = ""
-            self._foreground_session_platform = ""
-            self._foreground_conversation_id = ""
+        self._restore_foreground_after_late_auxiliary_reclassification(session_id)
         logger.info(
             "LCM reclassified session %s as auxiliary at first ingest after bind-time detection missed",
             session_id,
@@ -1123,6 +1173,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._last_compacted_store_id = state.current_frontier_store_id
         self._register_active_engine_binding()
         if not self._session_ignored and not self._session_stateless:
+            self._remember_foreground_rebind_candidate(session_id)
             self._lcm_session_last_normal_conversation_id[session_id] = state.conversation_id
             self._foreground_session_id = session_id
             self._foreground_session_platform = self._session_platform
@@ -1421,6 +1472,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # directly so cron's compress short-circuits correctly via the
         # _session_ignored / _session_stateless gates.
         if not self._session_ignored and not self._session_stateless:
+            self._remember_foreground_rebind_candidate(session_id)
             self._foreground_session_id = session_id
             self._foreground_session_platform = self._session_platform
         if "hermes_home" in kwargs:

--- a/engine.py
+++ b/engine.py
@@ -995,6 +995,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 {},
                 session_id=session_id,
                 include_explicit=False,
+                require_auxiliary_frame=False,
             )
             if parent_session_id == self._foreground_rebind_session_id:
                 self._foreground_rebind_previous_session_id = self._foreground_session_id
@@ -1027,6 +1028,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if (
                 parent_session_id
                 and parent_session_id != session_id
+                and parent_session_id == self._foreground_rebind_previous_session_id
                 and self._lcm_session_last_normal_conversation_id.get(parent_session_id)
             ):
                 self._foreground_session_id = parent_session_id

--- a/engine.py
+++ b/engine.py
@@ -991,6 +991,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             and self._foreground_rebind_previous_session_id
             and self._foreground_session_id == self._foreground_rebind_session_id
         ):
+            parent_session_id = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+            )
+            if parent_session_id == self._foreground_rebind_session_id:
+                self._foreground_rebind_previous_session_id = self._foreground_session_id
+                self._foreground_rebind_previous_platform = self._foreground_session_platform
+                self._foreground_rebind_previous_conversation_id = self._foreground_conversation_id
             self._foreground_rebind_session_id = session_id
             return
         if self._foreground_session_id and self._foreground_session_id != session_id:
@@ -1010,9 +1019,28 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._foreground_rebind_session_id == session_id
             and self._foreground_rebind_previous_session_id
         ):
-            self._foreground_session_id = self._foreground_rebind_previous_session_id
-            self._foreground_session_platform = self._foreground_rebind_previous_platform
-            self._foreground_conversation_id = self._foreground_rebind_previous_conversation_id
+            parent_session_id = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+            )
+            if (
+                parent_session_id
+                and parent_session_id != session_id
+                and self._lcm_session_last_normal_conversation_id.get(parent_session_id)
+            ):
+                self._foreground_session_id = parent_session_id
+                self._foreground_session_platform = self._lcm_session_last_normal_platform.get(
+                    parent_session_id,
+                    self._foreground_rebind_previous_platform,
+                )
+                self._foreground_conversation_id = self._lcm_session_last_normal_conversation_id[
+                    parent_session_id
+                ]
+            else:
+                self._foreground_session_id = self._foreground_rebind_previous_session_id
+                self._foreground_session_platform = self._foreground_rebind_previous_platform
+                self._foreground_conversation_id = self._foreground_rebind_previous_conversation_id
         else:
             self._foreground_session_id = ""
             self._foreground_session_platform = ""

--- a/engine.py
+++ b/engine.py
@@ -1122,15 +1122,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._foreground_conversation_id = ""
         self._clear_foreground_rebind_candidate()
 
-    def _maybe_reclassify_current_session_as_auxiliary_at_ingest(self) -> bool:
+    def _maybe_reclassify_current_session_as_auxiliary_before_message_ingest(self) -> bool:
         """Defense-in-depth for host markers that arrive after session binding.
 
         Older Hermes Agent background-review forks seed ``_memory_write_origin``
-        too late for ``on_session_start`` frame-walk detection. By first ingest
-        the marker is present on the running agent frame, so re-check only while
-        the bound session is still empty. That keeps normal foreground session
-        starts/resets writable and avoids reclassifying sessions after real data
-        has already been stored.
+        too late for ``on_session_start`` frame-walk detection. By the first
+        message-writing entry point the marker is present on the running agent
+        frame, so re-check only while the bound session is still empty. That
+        keeps normal foreground session starts/resets writable and avoids
+        reclassifying sessions after real data has already been stored.
         """
         session_id = str(self._session_id or "")
         if not session_id:
@@ -1170,7 +1170,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         compression runs later the same turn, already-ingested messages
         are skipped (no duplicates).
         """
-        if self._maybe_reclassify_current_session_as_auxiliary_at_ingest():
+        if self._maybe_reclassify_current_session_as_auxiliary_before_message_ingest():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
             return
         if self._bypasses_lcm_context_management():
@@ -3072,15 +3072,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # Ingest live messages if passed (enables current-turn search)
         messages = kwargs.get("messages")
 
-        if name != "lcm_inspect" and messages and self._session_id and not (
-            self._session_ignored or self._session_stateless or self._thread_context_stateless()
-        ):
-            try:
-                self._ingest_messages(messages)
-                self._record_ingest_success()
-                self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
-            except Exception as e:
-                self._record_ingest_failure("tool-call ingest", e)
+        if name != "lcm_inspect" and messages and self._session_id:
+            if self._maybe_reclassify_current_session_as_auxiliary_before_message_ingest():
+                self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
+            elif not (
+                self._session_ignored or self._session_stateless or self._thread_context_stateless()
+            ):
+                try:
+                    self._ingest_messages(messages)
+                    self._record_ingest_success()
+                    self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
+                except Exception as e:
+                    self._record_ingest_failure("tool-call ingest", e)
 
         handlers = {
             "lcm_grep": lcm_tools.lcm_grep,

--- a/engine.py
+++ b/engine.py
@@ -181,6 +181,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._foreground_rebind_previous_session_id: str = ""
         self._foreground_rebind_previous_platform: str = ""
         self._foreground_rebind_previous_conversation_id: str = ""
+        self._foreground_rebind_parent_session_id: str = ""
         self._conversation_id: str = ""
         self._session_match_keys: list[str] = []
         self._session_ignored = False
@@ -965,6 +966,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._foreground_rebind_previous_session_id = ""
         self._foreground_rebind_previous_platform = ""
         self._foreground_rebind_previous_conversation_id = ""
+        self._foreground_rebind_parent_session_id = ""
 
     def _clear_foreground_rebind_candidate_if_bound_session_confirmed(self) -> None:
         if self._foreground_rebind_session_id == self._session_id:
@@ -997,17 +999,27 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 include_explicit=False,
                 require_auxiliary_frame=False,
             )
-            if parent_session_id == self._foreground_rebind_session_id:
+            if parent_session_id == self._foreground_rebind_session_id or (
+                parent_session_id and not self._foreground_rebind_parent_session_id
+            ):
                 self._foreground_rebind_previous_session_id = self._foreground_session_id
                 self._foreground_rebind_previous_platform = self._foreground_session_platform
                 self._foreground_rebind_previous_conversation_id = self._foreground_conversation_id
             self._foreground_rebind_session_id = session_id
+            self._foreground_rebind_parent_session_id = parent_session_id
             return
         if self._foreground_session_id and self._foreground_session_id != session_id:
+            parent_session_id = self._in_process_parent_session_id(
+                {},
+                session_id=session_id,
+                include_explicit=False,
+                require_auxiliary_frame=False,
+            )
             self._foreground_rebind_session_id = session_id
             self._foreground_rebind_previous_session_id = self._foreground_session_id
             self._foreground_rebind_previous_platform = self._foreground_session_platform
             self._foreground_rebind_previous_conversation_id = self._foreground_conversation_id
+            self._foreground_rebind_parent_session_id = parent_session_id
             return
         self._clear_foreground_rebind_candidate()
 

--- a/engine.py
+++ b/engine.py
@@ -1871,6 +1871,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 session_id,
                 conversation_id=kwargs.get("conversation_id"),
             )
+            self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
             self._schedule_ingest_cursor_reconciliation()
             self._clear_pending_reset_boundary()
             self._log_session_filter_diagnostics()
@@ -1878,6 +1879,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
         self._apply_session_start_metadata(session_id, kwargs)
         self._bind_lifecycle_state(session_id, conversation_id=conversation_id)
+        self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
         if frontier > 0:
             state = self._lifecycle.advance_frontier(
                 self._conversation_id,

--- a/engine.py
+++ b/engine.py
@@ -677,6 +677,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return True
 
     @property
+    def bound_session_id(self) -> str:
+        """Session id this engine is actively servicing for ingest/lifecycle.
+
+        This differs from ``current_session_id`` while a side-channel session is
+        bound but operator-facing tools should keep showing the foreground
+        session. Host lifecycle hooks must compare against this value before
+        deciding whether a post-turn ingest needs to rebind the engine.
+        """
+        return self._session_id
+
+    @property
     def current_session_id(self) -> str:
         """User-facing "current session" id surfaced by LCM tools.
 

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -233,6 +233,40 @@ def test_confirmed_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp
         engine.shutdown()
 
 
+def test_tool_call_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(engine, "foreground-b")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-b")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        second_foreground.start_session()
+        engine.handle_tool_call(
+            "lcm_status",
+            {},
+            messages=[{"role": "user", "content": "second foreground tool turn"}],
+        )
+
+        review.start_session()
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late background review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 1
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -1,5 +1,6 @@
 import json
 import importlib.util
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -41,6 +42,45 @@ class _ForegroundAgent(_FakeAgent):
 def _engine(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "lcm.db"))
     return LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+
+
+def _record_state_db_branch(tmp_path, session_id: str, parent_session_id: str) -> None:
+    path = tmp_path / "home" / "state.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions(
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                model_config TEXT,
+                started_at REAL,
+                ended_at REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO sessions(id, parent_session_id, model_config, started_at, ended_at)
+            VALUES (?, ?, ?, 1, NULL)
+            """,
+            (parent_session_id, "", "{}"),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO sessions(id, parent_session_id, model_config, started_at, ended_at)
+            VALUES (?, ?, ?, 2, NULL)
+            """,
+            (
+                session_id,
+                parent_session_id,
+                json.dumps({"_branched_from": parent_session_id}),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _load_plugin_entrypoint_module(module_name: str):
@@ -373,6 +413,43 @@ def test_uningested_foreground_survives_late_review_child_from_stale_parent(tmp_
         first_foreground.ingest_history_as_foreground(
             [{"role": "user", "content": "first foreground turn"}]
         )
+
+        second_foreground.start_session()
+        assert engine.current_session_id == "foreground-b"
+        assert engine.bound_session_id == "foreground-b"
+        assert engine._store.get_session_count("foreground-b") == 0
+
+        stale_review.start_session()
+        stale_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late stale-parent review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 0
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
+def test_uningested_branched_foreground_survives_late_review_child_from_stale_parent(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(
+        engine,
+        "foreground-b",
+        parent_session_id="foreground-a",
+    )
+    stale_review = _FakeAgent(engine, "review-session", parent_session_id="foreground-a")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+        _record_state_db_branch(tmp_path, "foreground-b", "foreground-a")
 
         second_foreground.start_session()
         assert engine.current_session_id == "foreground-b"

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -170,6 +170,37 @@ def test_foreground_post_turn_rebinds_after_late_auxiliary_reclassification(tmp_
         engine.shutdown()
 
 
+def test_stacked_late_auxiliary_binds_restore_original_foreground(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    first_review = _FakeAgent(engine, "review-session-a", parent_session_id="foreground-session")
+    second_review = _FakeAgent(engine, "review-session-b", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        first_review.start_session()
+        assert engine.current_session_id == "review-session-a"
+
+        second_review.start_session()
+        assert engine.current_session_id == "review-session-b"
+
+        second_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "second background review replay"}]
+        )
+
+        assert engine._store.get_session_count("review-session-a") == 0
+        assert engine._store.get_session_count("review-session-b") == 0
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.bound_session_id == "review-session-b"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -201,6 +201,38 @@ def test_stacked_late_auxiliary_binds_restore_original_foreground(tmp_path):
         engine.shutdown()
 
 
+def test_confirmed_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(engine, "foreground-b")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-b")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        second_foreground.start_session()
+        second_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "second foreground turn"}]
+        )
+
+        review.start_session()
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late background review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 1
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -283,6 +283,37 @@ def test_stacked_late_auxiliary_binds_restore_original_foreground(tmp_path):
         engine.shutdown()
 
 
+def test_nested_late_auxiliary_binds_restore_original_foreground(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    first_review = _FakeAgent(engine, "review-session-a", parent_session_id="foreground-session")
+    nested_review = _FakeAgent(engine, "review-session-b", parent_session_id="review-session-a")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        first_review.start_session()
+        assert engine.current_session_id == "review-session-a"
+
+        nested_review.start_session()
+        assert engine.current_session_id == "review-session-b"
+
+        nested_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "nested background review replay"}]
+        )
+
+        assert engine._store.get_session_count("review-session-a") == 0
+        assert engine._store.get_session_count("review-session-b") == 0
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.bound_session_id == "review-session-b"
+    finally:
+        engine.shutdown()
+
+
 def test_confirmed_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp_path):
     engine = _engine(tmp_path)
     first_foreground = _ForegroundAgent(engine, "foreground-a")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -1,3 +1,6 @@
+import json
+
+from hermes_lcm import tools as lcm_tools
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 
@@ -57,6 +60,46 @@ def test_first_ingest_rechecks_background_review_marker_after_missed_bind_time(t
 
         assert engine._store.get_session_count("review-session") == 0
         assert engine._thread_context_has_auxiliary_session("review-session")
+    finally:
+        engine.shutdown()
+
+
+def test_late_first_ingest_auxiliary_reclassification_restores_foreground_view(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+
+        # Host bug shape: bind-time detection sees the foreground defaults, so
+        # on_session_start briefly rebinds the child as a normal foreground.
+        review.start_session()
+        assert engine.current_session_id == "review-session"
+
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "background review replay must not persist"}]
+        )
+
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine._thread_context_has_auxiliary_session("review-session")
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.side_channel_active is True
+
+        status = json.loads(lcm_tools.lcm_status({}, engine=engine))
+        assert status["session_id"] == "foreground-session"
+        assert status["session_filters"]["side_channel_active"] is True
+        assert status["session_filters"]["side_channel_session_id"] == "review-session"
+
+        grep = json.loads(lcm_tools.lcm_grep({"query": "operator"}, engine=engine))
+        assert grep["session_scope"] == "current"
+        assert [hit["session_id"] for hit in grep["results"]] == ["foreground-session"]
     finally:
         engine.shutdown()
 

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -298,6 +298,38 @@ def test_compression_boundary_bind_clears_late_auxiliary_restore_candidate(tmp_p
         engine.shutdown()
 
 
+def test_uningested_foreground_bind_remains_foreground_after_late_review_child(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(engine, "foreground-b")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-b")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        second_foreground.start_session()
+        assert engine.current_session_id == "foreground-b"
+        assert engine.bound_session_id == "foreground-b"
+        assert engine._store.get_session_count("foreground-b") == 0
+
+        review.start_session()
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late background review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 0
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -39,6 +39,9 @@ class _FakeAgent:
     def ingest_history_as_foreground(self, history):
         self.engine.ingest(history)
 
+    def preflight_history_as_foreground(self, history):
+        return self.engine.should_compress_preflight(history)
+
 
 class _ForegroundAgent(_FakeAgent):
     pass
@@ -368,6 +371,43 @@ def test_tool_call_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp
         review.start_session()
         review.ingest_history_after_background_marker(
             [{"role": "user", "content": "late background review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 1
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
+def test_preflight_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(
+        engine,
+        "foreground-b",
+        parent_session_id="foreground-a",
+    )
+    stale_review = _FakeAgent(engine, "review-session", parent_session_id="foreground-stale")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+        _record_state_db_branch(tmp_path, "foreground-b", "foreground-a")
+
+        second_foreground.start_session()
+        second_foreground.preflight_history_as_foreground(
+            [{"role": "user", "content": "second foreground preflight turn"}]
+        )
+
+        stale_review.start_session()
+        stale_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late stale-parent review replay"}]
         )
 
         assert engine._store.get_session_count("foreground-a") == 1

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -330,6 +330,38 @@ def test_uningested_foreground_bind_remains_foreground_after_late_review_child(t
         engine.shutdown()
 
 
+def test_late_review_child_from_stale_parent_does_not_replace_active_foreground(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(engine, "foreground-b")
+    stale_review = _FakeAgent(engine, "review-session", parent_session_id="foreground-a")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        second_foreground.start_session()
+        second_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "second foreground turn"}]
+        )
+
+        stale_review.start_session()
+        stale_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late stale-parent review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 1
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -36,6 +36,16 @@ class _FakeAgent:
         self._memory_write_context = "background_review"
         return self.engine.handle_tool_call("lcm_status", {}, messages=history)
 
+    def preflight_history_after_background_marker(self, history):
+        self._memory_write_origin = "background_review"
+        self._memory_write_context = "background_review"
+        return self.engine.should_compress_preflight(history)
+
+    def compress_history_after_background_marker(self, history):
+        self._memory_write_origin = "background_review"
+        self._memory_write_context = "background_review"
+        return self.engine.compress(history)
+
     def ingest_history_as_foreground(self, history):
         self.engine.ingest(history)
 
@@ -202,6 +212,63 @@ def test_late_tool_call_first_write_auxiliary_reclassification_restores_foregrou
         assert status["session_filters"]["side_channel_session_id"] == "review-session"
 
         grep = json.loads(lcm_tools.lcm_grep({"query": "tool-call"}, engine=engine))
+        assert grep["results"] == []
+    finally:
+        engine.shutdown()
+
+
+def test_late_preflight_first_write_auxiliary_reclassification_restores_foreground_view(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        review.start_session()
+        review.preflight_history_after_background_marker(
+            [{"role": "user", "content": "preflight replay must not persist"}]
+        )
+
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine._thread_context_has_auxiliary_session("review-session")
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.side_channel_active is True
+
+        grep = json.loads(lcm_tools.lcm_grep({"query": "preflight"}, engine=engine))
+        assert grep["results"] == []
+    finally:
+        engine.shutdown()
+
+
+def test_late_compress_first_write_auxiliary_reclassification_restores_foreground_view(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        review.start_session()
+        compressed = review.compress_history_after_background_marker(
+            [{"role": "user", "content": "compress replay must not persist"}]
+        )
+
+        assert compressed == [{"role": "user", "content": "compress replay must not persist"}]
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine._thread_context_has_auxiliary_session("review-session")
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.side_channel_active is True
+
+        grep = json.loads(lcm_tools.lcm_grep({"query": "compress"}, engine=engine))
         assert grep["results"] == []
     finally:
         engine.shutdown()

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -1,4 +1,7 @@
 import json
+import importlib.util
+import sys
+from pathlib import Path
 
 from hermes_lcm import tools as lcm_tools
 from hermes_lcm.config import LCMConfig
@@ -38,6 +41,21 @@ class _ForegroundAgent(_FakeAgent):
 def _engine(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "lcm.db"))
     return LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+
+
+def _load_plugin_entrypoint_module(module_name: str):
+    repo_root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        str(repo_root / "__init__.py"),
+        submodule_search_locations=[str(repo_root)],
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_first_ingest_rechecks_background_review_marker_after_missed_bind_time(tmp_path):
@@ -100,6 +118,54 @@ def test_late_first_ingest_auxiliary_reclassification_restores_foreground_view(t
         grep = json.loads(lcm_tools.lcm_grep({"query": "operator"}, engine=engine))
         assert grep["session_scope"] == "current"
         assert [hit["session_id"] for hit in grep["results"]] == ["foreground-session"]
+    finally:
+        engine.shutdown()
+
+
+def test_foreground_post_turn_rebinds_after_late_auxiliary_reclassification(tmp_path):
+    lcm_plugin = _load_plugin_entrypoint_module("hermes_lcm_post_hook_rebind_regression")
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        review.start_session()
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "background review replay must not persist"}]
+        )
+        assert engine.current_session_id == "foreground-session"
+        assert engine.bound_session_id == "review-session"
+        assert engine.side_channel_active is True
+
+        # The auxiliary thread has ended; the next post_llm_call is a foreground
+        # turn. The hook must compare against the bound ingest session, not the
+        # operator-facing current_session_id, before deciding whether to rebind.
+        engine._clear_thread_context_stateless()
+        lcm_plugin._ensure_engine_bound_to_session(
+            engine,
+            foreground.session_id,
+            platform="cli",
+            conversation_id="conversation:foreground-session",
+        )
+        engine.ingest(
+            [
+                {"role": "user", "content": "operator durable anchor"},
+                {"role": "assistant", "content": "foreground follow-up"},
+            ]
+        )
+
+        assert engine.bound_session_id == "foreground-session"
+        assert engine.current_session_id == "foreground-session"
+        assert engine._store.get_session_count("review-session") == 0
+        foreground_rows = engine._store.get_range("foreground-session", limit=10)
+        review_rows = engine._store.get_range("review-session", limit=10)
+        assert any(row["content"] == "foreground follow-up" for row in foreground_rows)
+        assert all(row["content"] != "foreground follow-up" for row in review_rows)
     finally:
         engine.shutdown()
 

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -362,6 +362,38 @@ def test_late_review_child_from_stale_parent_does_not_replace_active_foreground(
         engine.shutdown()
 
 
+def test_uningested_foreground_survives_late_review_child_from_stale_parent(tmp_path):
+    engine = _engine(tmp_path)
+    first_foreground = _ForegroundAgent(engine, "foreground-a")
+    second_foreground = _ForegroundAgent(engine, "foreground-b")
+    stale_review = _FakeAgent(engine, "review-session", parent_session_id="foreground-a")
+
+    try:
+        first_foreground.start_session()
+        first_foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        second_foreground.start_session()
+        assert engine.current_session_id == "foreground-b"
+        assert engine.bound_session_id == "foreground-b"
+        assert engine._store.get_session_count("foreground-b") == 0
+
+        stale_review.start_session()
+        stale_review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late stale-parent review replay"}]
+        )
+
+        assert engine._store.get_session_count("foreground-a") == 1
+        assert engine._store.get_session_count("foreground-b") == 0
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.current_conversation_id == "conversation:foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -31,6 +31,11 @@ class _FakeAgent:
         self._memory_write_context = "background_review"
         self.engine.ingest(history)
 
+    def handle_tool_call_after_background_marker(self, history):
+        self._memory_write_origin = "background_review"
+        self._memory_write_context = "background_review"
+        return self.engine.handle_tool_call("lcm_status", {}, messages=history)
+
     def ingest_history_as_foreground(self, history):
         self.engine.ingest(history)
 
@@ -158,6 +163,43 @@ def test_late_first_ingest_auxiliary_reclassification_restores_foreground_view(t
         grep = json.loads(lcm_tools.lcm_grep({"query": "operator"}, engine=engine))
         assert grep["session_scope"] == "current"
         assert [hit["session_id"] for hit in grep["results"]] == ["foreground-session"]
+    finally:
+        engine.shutdown()
+
+
+def test_late_tool_call_first_write_auxiliary_reclassification_restores_foreground_view(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-session")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-session")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "operator durable anchor"}]
+        )
+
+        # Bind-time auxiliary detection can miss the review child before the
+        # host marks it as background_review. If the child's first LCM entry
+        # point is a tool call, that path must reclassify before writing the
+        # passed replay messages, just like post-LLM ingest does.
+        review.start_session()
+        status = json.loads(
+            review.handle_tool_call_after_background_marker(
+                [{"role": "user", "content": "tool-call replay must not persist"}]
+            )
+        )
+
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine._thread_context_has_auxiliary_session("review-session")
+        assert engine.current_session_id == "foreground-session"
+        assert engine.current_conversation_id == "conversation:foreground-session"
+        assert engine.side_channel_active is True
+        assert status["session_id"] == "foreground-session"
+        assert status["session_filters"]["side_channel_active"] is True
+        assert status["session_filters"]["side_channel_session_id"] == "review-session"
+
+        grep = json.loads(lcm_tools.lcm_grep({"query": "tool-call"}, engine=engine))
+        assert grep["results"] == []
     finally:
         engine.shutdown()
 

--- a/tests/test_auxiliary_first_ingest.py
+++ b/tests/test_auxiliary_first_ingest.py
@@ -267,6 +267,37 @@ def test_tool_call_foreground_ingest_clears_late_auxiliary_restore_candidate(tmp
         engine.shutdown()
 
 
+def test_compression_boundary_bind_clears_late_auxiliary_restore_candidate(tmp_path):
+    engine = _engine(tmp_path)
+    foreground = _ForegroundAgent(engine, "foreground-a")
+    review = _FakeAgent(engine, "review-session", parent_session_id="foreground-b")
+
+    try:
+        foreground.start_session()
+        foreground.ingest_history_as_foreground(
+            [{"role": "user", "content": "first foreground turn"}]
+        )
+
+        engine.on_session_start(
+            "foreground-b",
+            boundary_reason="compression",
+            old_session_id="foreground-a",
+            platform="cli",
+            conversation_id="conversation:foreground-a",
+        )
+
+        review.start_session()
+        review.ingest_history_after_background_marker(
+            [{"role": "user", "content": "late background review replay"}]
+        )
+
+        assert engine._store.get_session_count("review-session") == 0
+        assert engine.current_session_id == "foreground-b"
+        assert engine.bound_session_id == "review-session"
+    finally:
+        engine.shutdown()
+
+
 def test_first_ingest_recheck_does_not_flag_foreground_session(tmp_path):
     engine = _engine(tmp_path)
     agent = _ForegroundAgent(engine, "foreground-session")


### PR DESCRIPTION
## Summary
- Restore the previous foreground session when a child session is reclassified as auxiliary at first ingest.
- Keep `lcm_status` and default `lcm_grep` scoped to the real foreground session while the auxiliary side channel remains active.
- Add regression coverage for the late background-review marker path and preserve the no-durable-write invariant for auxiliary first-ingest sessions.

## Background
This follows up the Codex P2 from #357: if bind-time auxiliary detection misses a background-review child, first-ingest recovery was marking the child auxiliary but clearing the foreground pointer, which could make current-session tools fall back to the auxiliary child.

## Validation
- Focused auxiliary/session-filtering pytest suite: passed (`20 passed`).
- Ruff on changed files: passed.
- Diff whitespace check: passed.
- Independent reviewer pass completed before publication.

## Risk
Focused hotfix only. The full repository test suite was not rerun; the targeted suite covers the late auxiliary reclassification path, existing auxiliary no-pollution behavior, active-clone packaging paths, and foreground session-filtering behavior.
