### PR TITLE
fix: preserve ambiguous durable-tail overlap rows

### DIFF
--- a/reconcile.py
+++ b/reconcile.py
@@ -253,28 +253,6 @@ class ReconcileMixin:
             return False
         return stored_tail[-len(candidate_prefix) :] == candidate_prefix
 
-    @staticmethod
-    def _matches_unique_store_tail_suffix(
-        stored_tail: list[tuple[str, str, str, str]],
-        candidate_prefix: list[tuple[str, str, str, str]],
-    ) -> bool:
-        """True when the prefix matches the tail suffix and occurs exactly once.
-
-        Sequence uniqueness narrows an explicitly scaffolded restart replay to
-        one durable suffix.  It is not replay proof by itself: a fresh delta
-        can legitimately repeat even a unique durable suffix.
-        """
-        if not candidate_prefix or len(candidate_prefix) > len(stored_tail):
-            return False
-        if stored_tail[-len(candidate_prefix) :] != candidate_prefix:
-            return False
-        occurrences = 0
-        for start in range(len(stored_tail) - len(candidate_prefix) + 1):
-            if stored_tail[start : start + len(candidate_prefix)] == candidate_prefix:
-                occurrences += 1
-                if occurrences > 1:
-                    return False
-        return True
 
     @staticmethod
     def _strip_inline_persisted_output_generation_identity(
@@ -735,42 +713,6 @@ class ReconcileMixin:
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
                 and raw_suffix_needs_cleanup_equivalence
             )
-            # A synthetic replay scaffold proves that this batch contains
-            # reconstructed active context rather than only fresh delta rows.
-            # Under that anchor, reconcile a unique, cleanup-neutral multi-row
-            # durable suffix followed by a genuine delta.  Without the scaffold
-            # the same shape is ambiguous: users can legitimately repeat even a
-            # unique previous exchange, so preserve the whole batch.
-            has_scaffolded_unique_partial_tail_replay = False
-            if (
-                has_persisted_marker_specific_replay_evidence
-                and has_scaffold_evidence
-                and cursor < len(messages)
-                and len(candidate_prefix) >= 2
-            ):
-                # Raw-tail matches only count when the overlapping stored
-                # suffix is cleanup-neutral: a true replay of cleanup-sensitive
-                # rows arrives sanitized, so exact raw equality there is
-                # evidence of a fresh delta, not of replay (see the
-                # cleanup-sensitive reconciliation guards above).
-                matched_unique_partial_tail = (
-                    matches_sanitized_tail
-                    and len(candidate_prefix) < len(sanitized_replay_tail)
-                    and self._matches_unique_store_tail_suffix(
-                        sanitized_replay_tail, candidate_prefix
-                    )
-                ) or (
-                    matches_raw_tail
-                    and not raw_suffix_needs_cleanup_equivalence
-                    and len(candidate_prefix) < len(stored_tail)
-                    and self._matches_unique_store_tail_suffix(
-                        stored_tail, candidate_prefix
-                    )
-                )
-                if matched_unique_partial_tail:
-                    has_scaffolded_unique_partial_tail_replay = bool(
-                        self._effective_replay_identities(messages[cursor:])
-                    )
             if (
                 has_effective_full_replay
                 or has_externalized_singleton_replay
@@ -782,7 +724,6 @@ class ReconcileMixin:
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay
-                or has_scaffolded_unique_partial_tail_replay
             ):
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None

--- a/reconcile.py
+++ b/reconcile.py
@@ -260,10 +260,9 @@ class ReconcileMixin:
     ) -> bool:
         """True when the prefix matches the tail suffix and occurs exactly once.
 
-        Sequence uniqueness inside the tail window distinguishes a restart
-        replay of the durable tail from repeat-prone traffic (heartbeats,
-        retries) whose fresh rows can coincidentally equal the last stored
-        rows.  Repeated sequences stay ambiguous and are preserved.
+        Sequence uniqueness narrows an explicitly scaffolded restart replay to
+        one durable suffix.  It is not replay proof by itself: a fresh delta
+        can legitimately repeat even a unique durable suffix.
         """
         if not candidate_prefix or len(candidate_prefix) > len(stored_tail):
             return False
@@ -736,17 +735,16 @@ class ReconcileMixin:
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
                 and raw_suffix_needs_cleanup_equivalence
             )
-            # Partial-tail overlap: a restarted host can replay only the last
-            # few durable rows plus new turns.  Full-replay proof fails there,
-            # and appending the whole batch duplicates the overlapping rows.
-            # Accept the overlap as replay only with strong evidence: at least
-            # two rows matching the durable tail anchored at its end, that
-            # sequence occurring exactly once in the tail window (repeat-prone
-            # traffic stays ambiguous and is preserved), and a genuine delta
-            # following the overlap.
-            has_unique_partial_tail_replay = False
+            # A synthetic replay scaffold proves that this batch contains
+            # reconstructed active context rather than only fresh delta rows.
+            # Under that anchor, reconcile a unique, cleanup-neutral multi-row
+            # durable suffix followed by a genuine delta.  Without the scaffold
+            # the same shape is ambiguous: users can legitimately repeat even a
+            # unique previous exchange, so preserve the whole batch.
+            has_scaffolded_unique_partial_tail_replay = False
             if (
                 has_persisted_marker_specific_replay_evidence
+                and has_scaffold_evidence
                 and cursor < len(messages)
                 and len(candidate_prefix) >= 2
             ):
@@ -770,7 +768,7 @@ class ReconcileMixin:
                     )
                 )
                 if matched_unique_partial_tail:
-                    has_unique_partial_tail_replay = bool(
+                    has_scaffolded_unique_partial_tail_replay = bool(
                         self._effective_replay_identities(messages[cursor:])
                     )
             if (
@@ -784,7 +782,7 @@ class ReconcileMixin:
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay
-                or has_unique_partial_tail_replay
+                or has_scaffolded_unique_partial_tail_replay
             ):
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None

--- a/reconcile.py
+++ b/reconcile.py
@@ -254,6 +254,30 @@ class ReconcileMixin:
         return stored_tail[-len(candidate_prefix) :] == candidate_prefix
 
     @staticmethod
+    def _matches_unique_store_tail_suffix(
+        stored_tail: list[tuple[str, str, str, str]],
+        candidate_prefix: list[tuple[str, str, str, str]],
+    ) -> bool:
+        """True when the prefix matches the tail suffix and occurs exactly once.
+
+        Sequence uniqueness inside the tail window distinguishes a restart
+        replay of the durable tail from repeat-prone traffic (heartbeats,
+        retries) whose fresh rows can coincidentally equal the last stored
+        rows.  Repeated sequences stay ambiguous and are preserved.
+        """
+        if not candidate_prefix or len(candidate_prefix) > len(stored_tail):
+            return False
+        if stored_tail[-len(candidate_prefix) :] != candidate_prefix:
+            return False
+        occurrences = 0
+        for start in range(len(stored_tail) - len(candidate_prefix) + 1):
+            if stored_tail[start : start + len(candidate_prefix)] == candidate_prefix:
+                occurrences += 1
+                if occurrences > 1:
+                    return False
+        return True
+
+    @staticmethod
     def _strip_inline_persisted_output_generation_identity(
         identity: tuple[str, str, str, str],
     ) -> tuple[str, str, str, str]:
@@ -712,6 +736,43 @@ class ReconcileMixin:
                 and len(candidate_prefix) >= max(1, self._config.fresh_tail_count)
                 and raw_suffix_needs_cleanup_equivalence
             )
+            # Partial-tail overlap: a restarted host can replay only the last
+            # few durable rows plus new turns.  Full-replay proof fails there,
+            # and appending the whole batch duplicates the overlapping rows.
+            # Accept the overlap as replay only with strong evidence: at least
+            # two rows matching the durable tail anchored at its end, that
+            # sequence occurring exactly once in the tail window (repeat-prone
+            # traffic stays ambiguous and is preserved), and a genuine delta
+            # following the overlap.
+            has_unique_partial_tail_replay = False
+            if (
+                has_persisted_marker_specific_replay_evidence
+                and cursor < len(messages)
+                and len(candidate_prefix) >= 2
+            ):
+                # Raw-tail matches only count when the overlapping stored
+                # suffix is cleanup-neutral: a true replay of cleanup-sensitive
+                # rows arrives sanitized, so exact raw equality there is
+                # evidence of a fresh delta, not of replay (see the
+                # cleanup-sensitive reconciliation guards above).
+                matched_unique_partial_tail = (
+                    matches_sanitized_tail
+                    and len(candidate_prefix) < len(sanitized_replay_tail)
+                    and self._matches_unique_store_tail_suffix(
+                        sanitized_replay_tail, candidate_prefix
+                    )
+                ) or (
+                    matches_raw_tail
+                    and not raw_suffix_needs_cleanup_equivalence
+                    and len(candidate_prefix) < len(stored_tail)
+                    and self._matches_unique_store_tail_suffix(
+                        stored_tail, candidate_prefix
+                    )
+                )
+                if matched_unique_partial_tail:
+                    has_unique_partial_tail_replay = bool(
+                        self._effective_replay_identities(messages[cursor:])
+                    )
             if (
                 has_effective_full_replay
                 or has_externalized_singleton_replay
@@ -723,6 +784,7 @@ class ReconcileMixin:
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay
+                or has_unique_partial_tail_replay
             ):
                 return cursor
         return empty_prefix_cursor if allow_empty_prefix else None

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4522,7 +4522,7 @@ class TestEngineABC:
         assert reconciliation["reason"] == "persisted ambiguous delta"
         assert reconciliation["action"] == "persisted batch"
 
-    def test_existing_session_restart_skips_unique_partial_tail_overlap(self, tmp_path):
+    def test_existing_session_restart_preserves_fresh_delta_repeating_unique_tail_suffix(self, tmp_path):
         db_path = tmp_path / "restart-partial-tail-overlap.db"
         config = LCMConfig(database_path=str(db_path))
         before_restart = LCMEngine(config=config)
@@ -4549,21 +4549,27 @@ class TestEngineABC:
             conversation_id="partial-overlap-conversation",
             context_length=200000,
         )
-        replayed_tail = persisted_messages[-4:]
-        delta = [{"role": "user", "content": "fresh turn after restart"}]
+        repeated_fresh_messages = [dict(message) for message in persisted_messages[-4:]]
+        delta = [
+            *repeated_fresh_messages,
+            {"role": "user", "content": "fresh turn after repeated exchange"},
+        ]
 
-        after_restart._ingest_messages(replayed_tail + delta)
+        after_restart._ingest_messages(delta)
 
         rows = after_restart._store.get_session_messages(
             "partial-overlap-session",
-            limit=len(persisted_messages) + len(delta) + 4,
+            limit=len(persisted_messages) + len(delta),
         )
         assert len(rows) == len(persisted_messages) + len(delta)
-        assert rows[-1]["content"] == "fresh turn after restart"
-        assert after_restart._ingest_cursor == len(replayed_tail) + len(delta)
+        assert [row["content"] for row in rows[-len(delta) :]] == [
+            *[message["content"] for message in repeated_fresh_messages],
+            "fresh turn after repeated exchange",
+        ]
+        assert after_restart._ingest_cursor == len(delta)
         reconciliation = after_restart.get_status()["ingest_reconciliation"]
-        assert reconciliation["action"] == "advanced cursor"
-        assert reconciliation["reason"] == "replayed durable tail"
+        assert reconciliation["action"] == "persisted batch"
+        assert reconciliation["reason"] == "persisted ambiguous delta"
 
     def test_existing_session_restart_repeated_tail_sequence_stays_ambiguous(self, tmp_path):
         db_path = tmp_path / "restart-repeated-tail-sequence.db"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3600,10 +3600,13 @@ class TestEngineABC:
         after_restart._ingest_messages(active_context)
 
         rows = after_restart._store.get_session_messages("compacted-session")
-        # The replayed fresh tail matches the durable tail uniquely, so it is
-        # reconciled as replay instead of being appended a second time.
+        # A scaffold proves that synthetic context was prepended, but does not
+        # prove whether matching durable-tail rows are replay or fresh input.
+        # Preserve the ambiguous fresh rows rather than risk dropping them.
         assert [row["role"] for row in rows] == [
             "system",
+            "user",
+            "assistant",
             "user",
             "assistant",
             "assistant",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3600,10 +3600,10 @@ class TestEngineABC:
         after_restart._ingest_messages(active_context)
 
         rows = after_restart._store.get_session_messages("compacted-session")
+        # The replayed fresh tail matches the durable tail uniquely, so it is
+        # reconciled as replay instead of being appended a second time.
         assert [row["role"] for row in rows] == [
             "system",
-            "user",
-            "assistant",
             "user",
             "assistant",
             "assistant",
@@ -4521,6 +4521,144 @@ class TestEngineABC:
         reconciliation = after_restart.get_status()["ingest_reconciliation"]
         assert reconciliation["reason"] == "persisted ambiguous delta"
         assert reconciliation["action"] == "persisted batch"
+
+    def test_existing_session_restart_skips_unique_partial_tail_overlap(self, tmp_path):
+        db_path = tmp_path / "restart-partial-tail-overlap.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "partial-overlap-session",
+            platform="cli",
+            conversation_id="partial-overlap-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "partial-overlap-session",
+            platform="cli",
+            conversation_id="partial-overlap-conversation",
+            context_length=200000,
+        )
+        replayed_tail = persisted_messages[-4:]
+        delta = [{"role": "user", "content": "fresh turn after restart"}]
+
+        after_restart._ingest_messages(replayed_tail + delta)
+
+        rows = after_restart._store.get_session_messages(
+            "partial-overlap-session",
+            limit=len(persisted_messages) + len(delta) + 4,
+        )
+        assert len(rows) == len(persisted_messages) + len(delta)
+        assert rows[-1]["content"] == "fresh turn after restart"
+        assert after_restart._ingest_cursor == len(replayed_tail) + len(delta)
+        reconciliation = after_restart.get_status()["ingest_reconciliation"]
+        assert reconciliation["action"] == "advanced cursor"
+        assert reconciliation["reason"] == "replayed durable tail"
+
+    def test_existing_session_restart_repeated_tail_sequence_stays_ambiguous(self, tmp_path):
+        db_path = tmp_path / "restart-repeated-tail-sequence.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "repeated-tail-session",
+            platform="cli",
+            conversation_id="repeated-tail-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "heartbeat ping"},
+            {"role": "assistant", "content": "heartbeat pong"},
+            {"role": "user", "content": "heartbeat ping"},
+            {"role": "assistant", "content": "heartbeat pong"},
+        ]
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "repeated-tail-session",
+            platform="cli",
+            conversation_id="repeated-tail-conversation",
+            context_length=200000,
+        )
+        # A fresh heartbeat round repeats the durable tail verbatim; the
+        # repeated sequence must stay ambiguous so the new rows are preserved.
+        delta = [
+            {"role": "user", "content": "heartbeat ping"},
+            {"role": "assistant", "content": "heartbeat pong"},
+            {"role": "user", "content": "new instruction"},
+        ]
+
+        after_restart._ingest_messages(delta)
+
+        rows = after_restart._store.get_session_messages(
+            "repeated-tail-session",
+            limit=len(persisted_messages) + len(delta),
+        )
+        assert len(rows) == len(persisted_messages) + len(delta)
+        assert rows[-1]["content"] == "new instruction"
+        reconciliation = after_restart.get_status()["ingest_reconciliation"]
+        assert reconciliation["action"] == "persisted batch"
+        assert reconciliation["reason"] == "persisted ambiguous delta"
+
+    def test_existing_session_restart_singleton_partial_overlap_stays_ambiguous(self, tmp_path):
+        db_path = tmp_path / "restart-singleton-partial-overlap.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "singleton-overlap-session",
+            platform="cli",
+            conversation_id="singleton-overlap-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(10)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "singleton-overlap-session",
+            platform="cli",
+            conversation_id="singleton-overlap-conversation",
+            context_length=200000,
+        )
+        # One overlapping row is not enough replay evidence; the batch could
+        # be a fresh delta whose first row repeats the durable tail.
+        delta = [
+            dict(persisted_messages[-1]),
+            {"role": "user", "content": "fresh turn after singleton overlap"},
+        ]
+
+        after_restart._ingest_messages(delta)
+
+        rows = after_restart._store.get_session_messages(
+            "singleton-overlap-session",
+            limit=len(persisted_messages) + len(delta),
+        )
+        assert len(rows) == len(persisted_messages) + len(delta)
+        assert rows[-1]["content"] == "fresh turn after singleton overlap"
+        reconciliation = after_restart.get_status()["ingest_reconciliation"]
+        assert reconciliation["action"] == "persisted batch"
+        assert reconciliation["reason"] == "persisted ambiguous delta"
 
     def test_existing_session_restart_scaffold_prefix_does_not_skip_unrelated_new_rows(self, tmp_path):
         db_path = tmp_path / "restart-scaffold-prefix-unrelated.db"


### PR DESCRIPTION
## Summary

Preserve incoming rows whenever a partial durable-tail overlap is ambiguous. A synthetic LCM scaffold proves that context was prepended, but does not independently prove that following rows replay durable history.

This repair removes the unsafe scaffold + unique-partial-tail inference. Explicitly proven replay paths remain unchanged: full exact replay, durable message identity, tool-call/source/generation identity, and cursor-based reconciliation can still advance the ingest cursor. Without such independent proof, reconciliation prefers duplicate-over-loss and persists the incoming rows.

The branch also incorporates current `main` through a normal non-rewriting merge. The previous PR head and current `main` are both ancestors of this head.

## Root cause

The prior heuristic treated a unique multi-row suffix match after synthetic scaffold rows as replay evidence. For stored tail `X, Y` and incoming scaffold + summary + `X, Y, Z`, that advanced past `X, Y` and persisted only `Z`. The scaffold established only that synthetic context existed; it could not distinguish replayed `X, Y` from fresh rows that happened to repeat the durable tail.

Because false-positive deduplication loses messages while false-negative deduplication only duplicates them, ambiguous overlaps must preserve the full incoming delta.

## Behavior

- Ambiguous unique partial-tail overlap: preserve incoming rows.
- Repeated-tail and singleton overlap: remain ambiguous and preserve incoming rows.
- Scaffold-only prefix with fresh matching rows: preserve incoming rows.
- Full exact replay and complete cursor replay: still deduplicate.
- No-overlap ingest: unchanged.
- Durable/tool/source/generation identity: remains available to prove replay.
- Restarted and compacted sessions: do not lose ambiguous rows.

## Validation

Exact head: `83e2334172e3e32676db944e00bc7f0a002dcf5f`

- TDD RED on untouched PR head: compacted restart regression failed because fresh matching `X, Y` rows were dropped (`1 failed, 702 deselected`).
- Focused ambiguity/replay/restart matrix: `10 passed`.
- Full affected file: `703 passed`.
- Independent same-card exact-head review: accepted; focused review run `7 passed, 696 deselected`.
- `ruff check reconcile.py tests/test_lcm_engine.py`: passed.
- `py_compile` for touched product/test files: passed.
- `git diff --check`: passed.
- Added-line security scan: 0 findings.

Hosted CI for this exact head is tracked on the PR.

## Related review

- The earlier Codex P1 correctly identified that unique suffix equality was insufficient replay proof.
- The later Codex P1 correctly identified that a synthetic scaffold still did not make the overlap unambiguous.
- This repair removes that remaining inference rather than adding another heuristic.
