### PR TITLE
feat: add store-level replay-flood backstop on batch ingest

### DIFF
--- a/config.py
+++ b/config.py
@@ -273,6 +273,8 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("max_assembly_tokens", "LCM_MAX_ASSEMBLY_TOKENS", int),
     _EnvFieldSpec("reserve_tokens_floor", "LCM_RESERVE_TOKENS_FLOOR", int),
     _EnvFieldSpec("custom_instructions", "LCM_CUSTOM_INSTRUCTIONS", str),
+    _EnvFieldSpec("replay_flood_threshold_external", "LCM_REPLAY_FLOOD_THRESHOLD_EXTERNAL", int),
+    _EnvFieldSpec("replay_flood_threshold_internal", "LCM_REPLAY_FLOOD_THRESHOLD_INTERNAL", int),
     _EnvFieldSpec("extraction_enabled", "LCM_EXTRACTION_ENABLED", bool),
     _EnvFieldSpec("extraction_model", "LCM_EXTRACTION_MODEL", str),
     _EnvFieldSpec("extraction_output_path", "LCM_EXTRACTION_OUTPUT_PATH", str),
@@ -452,6 +454,13 @@ class LCMConfig:
 
     # -- Storage ---
     database_path: str = ""       # empty = HERMES_HOME/lcm.db; LCM_DATABASE_PATH may override
+    # Store-level anti-replay backstop: refuse a single ingest batch that
+    # re-appends already-stored rows in bulk. Thresholds count rows in one
+    # batch whose identity already exists in the session. ``external`` guards
+    # the user role (the host rebroadcast surface); ``internal`` guards
+    # assistant/tool/system rows grouped by identical identity. 0 disables.
+    replay_flood_threshold_external: int = 8
+    replay_flood_threshold_internal: int = 32
 
     # -- Session carry-over ---
     # Depth retained after /new (-1 = all, 0 = nothing, 2 = keep d2+)

--- a/engine.py
+++ b/engine.py
@@ -117,7 +117,7 @@ from .sqlite_util import (
     _is_sqlite_locked_error,
     _temporary_sqlite_busy_timeout,
 )
-from .store import MessageStore
+from .store import MessageStore, ReplayFloodError
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
@@ -221,6 +221,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             "action": "none",
             "reason": "not run",
         }
+        self._replay_flood_refusal_count: int = 0
+        self._last_replay_flood_refusal: str = ""
 
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
@@ -2614,13 +2616,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             config=self._config,
             hermes_home=self._hermes_home,
         )
-        return self._store._append_protected_batch(
-            session_id,
-            protected_messages,
-            [count_message_tokens(msg) for msg in protected_messages],
-            source=source,
-            conversation_id=conversation_id,
-        )
+        try:
+            return self._store._append_protected_batch(
+                session_id,
+                protected_messages,
+                [count_message_tokens(msg) for msg in protected_messages],
+                source=source,
+                conversation_id=conversation_id,
+            )
+        except ReplayFloodError as exc:
+            self._record_replay_flood_refusal(exc, incoming=len(protected_messages))
+            return []
 
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         ended_generation = self._in_process_auxiliary_caller_generation(session_id)
@@ -3255,6 +3261,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             status["ignored_message_count"] = self._ignored_message_count
             status["ignore_pattern_dropped_count"] = self._ignore_pattern_dropped_count
             status["ingest_reconciliation"] = dict(self._last_ingest_reconciliation)
+            if self._replay_flood_refusal_count:
+                status["replay_flood_refusals"] = {
+                    "count": self._replay_flood_refusal_count,
+                    "last": self._last_replay_flood_refusal,
+                }
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
             status["conversation_id"] = conversation_id
@@ -3402,6 +3413,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         except Exception as exc:  # pragma: no cover - defensive only
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
+
+    def _record_replay_flood_refusal(self, exc: ReplayFloodError, *, incoming: int) -> None:
+        self._replay_flood_refusal_count += 1
+        self._last_replay_flood_refusal = str(exc)
+        logger.error(
+            "LCM store refused replay-flood batch (refusal #%d, incoming=%d): %s",
+            self._replay_flood_refusal_count,
+            incoming,
+            exc,
+        )
 
     def _stored_row_externalized_text_parts_for_pattern_matching(self, msg: Dict[str, Any]) -> list[str]:
         ref_sources: list[str] = []
@@ -4120,13 +4141,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 active_replay_messages[absolute_idx] = active_message
 
         estimates = [count_message_tokens(m) for m in protected_messages]
-        self._store._append_protected_batch(
-            self._session_id,
-            protected_messages,
-            estimates,
-            source=self._session_platform,
-            conversation_id=self._conversation_id,
-        )
+        try:
+            self._store._append_protected_batch(
+                self._session_id,
+                protected_messages,
+                estimates,
+                source=self._session_platform,
+                conversation_id=self._conversation_id,
+            )
+        except ReplayFloodError as exc:
+            # Fail loud, persist nothing of the flood batch, and keep the
+            # cursor where it is so a later reconcile can still recover a
+            # genuinely new tail. Active replay stays usable for the host.
+            self._record_replay_flood_refusal(exc, incoming=len(protected_messages))
+            return self._remember_active_replay_messages(messages, active_replay_messages)
         self._ingest_cursor = n
         self._compression_boundary_ingest_pending = False
         self._compression_boundary_active_placeholder_digest_budget = {}

--- a/engine.py
+++ b/engine.py
@@ -3424,6 +3424,63 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             exc,
         )
 
+    def _replay_flood_recovery_prefix_length(self, messages: List[Dict[str, Any]]) -> int:
+        """Return a safely proven durable prefix after a flood refusal."""
+        external_threshold = int(
+            getattr(self._config, "replay_flood_threshold_external", 0) or 0
+        )
+        internal_threshold = int(
+            getattr(self._config, "replay_flood_threshold_internal", 0) or 0
+        )
+        if not messages or (external_threshold <= 0 and internal_threshold <= 0):
+            return 0
+
+        stored_rows: list[Dict[str, Any]] = []
+        after_store_id = 0
+        while True:
+            page = self._store.get_session_messages_after(
+                self._session_id,
+                after_store_id=after_store_id,
+            )
+            if not page:
+                break
+            stored_rows.extend(page)
+            after_store_id = int(page[-1]["store_id"])
+
+        incoming_identities = [self._message_replay_identity(msg) for msg in messages]
+        stored_identities = [
+            self._message_replay_identity(row, stored_row=True) for row in stored_rows
+        ]
+        best = 0
+        for start, stored_identity in enumerate(stored_identities):
+            if stored_identity != incoming_identities[0]:
+                continue
+            matched = 0
+            while (
+                matched < len(incoming_identities)
+                and start + matched < len(stored_identities)
+                and stored_identities[start + matched] == incoming_identities[matched]
+            ):
+                matched += 1
+            best = max(best, matched)
+
+        if best <= 0:
+            return 0
+        prefix = messages[:best]
+        external_replay_proven = external_threshold > 0 and sum(
+            str(msg.get("role") or "unknown") == "user" for msg in prefix
+        ) >= external_threshold
+        internal_identity_counts: dict[tuple[str, str, str, str], int] = {}
+        for msg in prefix:
+            if str(msg.get("role") or "unknown") == "user":
+                continue
+            identity = self._message_replay_identity(msg)
+            internal_identity_counts[identity] = internal_identity_counts.get(identity, 0) + 1
+        internal_replay_proven = internal_threshold > 0 and any(
+            count >= internal_threshold for count in internal_identity_counts.values()
+        )
+        return best if external_replay_proven or internal_replay_proven else 0
+
     def _stored_row_externalized_text_parts_for_pattern_matching(self, msg: Dict[str, Any]) -> list[str]:
         ref_sources: list[str] = []
         content = msg.get("content")
@@ -4150,11 +4207,44 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 conversation_id=self._conversation_id,
             )
         except ReplayFloodError as exc:
-            # Fail loud, persist nothing of the flood batch, and keep the
-            # cursor where it is so a later reconcile can still recover a
-            # genuinely new tail. Active replay stays usable for the host.
             self._record_replay_flood_refusal(exc, incoming=len(protected_messages))
-            return self._remember_active_replay_messages(messages, active_replay_messages)
+            try:
+                recovery_prefix = self._replay_flood_recovery_prefix_length(protected_messages)
+            except Exception as recovery_exc:  # pragma: no cover - defensive only
+                logger.error("LCM replay-flood recovery probe failed: %s", recovery_exc)
+                recovery_prefix = 0
+            if recovery_prefix > 0:
+                recovery_messages = protected_messages[recovery_prefix:]
+                try:
+                    if recovery_messages:
+                        self._store._append_protected_batch(
+                            self._session_id,
+                            recovery_messages,
+                            estimates[recovery_prefix:],
+                            source=self._session_platform,
+                            conversation_id=self._conversation_id,
+                        )
+                except ReplayFloodError as recovery_exc:
+                    logger.error(
+                        "LCM store refused replay-flood recovery tail; dropping refused batch: %s",
+                        recovery_exc,
+                    )
+                    recovery_prefix = 0
+                else:
+                    logger.warning(
+                        "LCM recovered replay-flood batch by trimming %d proven durable prefix rows",
+                        recovery_prefix,
+                    )
+            if recovery_prefix <= 0:
+                # A refused batch is terminal when no contiguous durable
+                # prefix proves a safe tail. Advance past it so later turns
+                # can still persist instead of retrying the same flood forever.
+                self._ingest_cursor = n
+                self._compression_boundary_ingest_pending = False
+                self._compression_boundary_active_placeholder_digest_budget = {}
+                self._compression_boundary_active_placeholder_digest_ordinals = {}
+                self._compression_boundary_stored_placeholder_digest_counts = {}
+                return self._remember_active_replay_messages(messages, active_replay_messages)
         self._ingest_cursor = n
         self._compression_boundary_ingest_pending = False
         self._compression_boundary_active_placeholder_digest_budget = {}

--- a/message_identity.py
+++ b/message_identity.py
@@ -1,0 +1,71 @@
+"""Stable identity helpers for assistant tool calls."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _json_has_duplicate_object_keys(value: str) -> bool:
+    duplicate = False
+
+    def detect_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        nonlocal duplicate
+        seen: set[str] = set()
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in seen:
+                duplicate = True
+            seen.add(key)
+            result[key] = item
+        return result
+
+    try:
+        json.loads(value, object_pairs_hook=detect_pairs)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return duplicate
+
+
+def canonicalize_tool_call_identity_value(value: Any) -> Any:
+    """Canonicalize mappings recursively while preserving list order and values."""
+    if isinstance(value, dict):
+        return {
+            key: canonicalize_tool_call_identity_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [canonicalize_tool_call_identity_value(item) for item in value]
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and stripped[0] in "[{" and not _json_has_duplicate_object_keys(value):
+            try:
+                parsed = json.loads(value)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return value
+            if isinstance(parsed, (dict, list)):
+                canonical = canonicalize_tool_call_identity_value(parsed)
+                return json.dumps(
+                    canonical,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                )
+        return value
+    return value
+
+
+def stable_tool_calls_identity(tool_calls: Any) -> str:
+    """Serialize tool calls for durable storage and replay identity comparisons."""
+    if not tool_calls:
+        return ""
+    try:
+        canonical = canonicalize_tool_call_identity_value(tool_calls)
+        return json.dumps(
+            canonical,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    except (TypeError, ValueError):
+        return str(tool_calls)

--- a/message_identity.py
+++ b/message_identity.py
@@ -27,15 +27,18 @@ def _json_has_duplicate_object_keys(value: str) -> bool:
     return duplicate
 
 
-def canonicalize_tool_call_identity_value(value: Any) -> Any:
-    """Canonicalize mappings recursively while preserving list order and values."""
+def _canonicalize_plain_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {
-            key: canonicalize_tool_call_identity_value(item)
+            key: _canonicalize_plain_value(item)
             for key, item in value.items()
         }
     if isinstance(value, list):
-        return [canonicalize_tool_call_identity_value(item) for item in value]
+        return [_canonicalize_plain_value(item) for item in value]
+    return value
+
+
+def _canonicalize_function_arguments(value: Any) -> Any:
     if isinstance(value, str):
         stripped = value.strip()
         if stripped and stripped[0] in "[{" and not _json_has_duplicate_object_keys(value):
@@ -44,7 +47,7 @@ def canonicalize_tool_call_identity_value(value: Any) -> Any:
             except (TypeError, ValueError, json.JSONDecodeError):
                 return value
             if isinstance(parsed, (dict, list)):
-                canonical = canonicalize_tool_call_identity_value(parsed)
+                canonical = _canonicalize_plain_value(parsed)
                 return json.dumps(
                     canonical,
                     sort_keys=True,
@@ -52,11 +55,30 @@ def canonicalize_tool_call_identity_value(value: Any) -> Any:
                     ensure_ascii=False,
                 )
         return value
-    return value
+    return _canonicalize_plain_value(value)
+
+
+def _canonicalize_tool_call(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return _canonicalize_plain_value(value)
+    canonical = _canonicalize_plain_value(value)
+    function = value.get("function")
+    if isinstance(function, dict) and "arguments" in function:
+        canonical["function"]["arguments"] = _canonicalize_function_arguments(
+            function["arguments"]
+        )
+    return canonical
+
+
+def canonicalize_tool_call_identity_value(value: Any) -> Any:
+    """Canonicalize tool-call structure and direct function arguments only."""
+    if isinstance(value, list):
+        return [_canonicalize_tool_call(item) for item in value]
+    return _canonicalize_tool_call(value)
 
 
 def stable_tool_calls_identity(tool_calls: Any) -> str:
-    """Serialize tool calls for durable storage and replay identity comparisons."""
+    """Serialize tool calls for replay identity comparisons."""
     if not tool_calls:
         return ""
     try:
@@ -69,3 +91,14 @@ def stable_tool_calls_identity(tool_calls: Any) -> str:
         )
     except (TypeError, ValueError):
         return str(tool_calls)
+
+
+def stable_serialized_tool_calls_identity(tool_calls: str | None) -> str:
+    """Parse a durable legacy value before deriving its comparison identity."""
+    if not tool_calls:
+        return ""
+    try:
+        parsed = json.loads(tool_calls)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return tool_calls
+    return stable_tool_calls_identity(parsed)

--- a/reconcile.py
+++ b/reconcile.py
@@ -36,13 +36,13 @@ from .ingest_protection import (
     _has_inline_persisted_output_generation_metadata,
     _has_lossy_sensitive_redaction,
     _is_hermes_persisted_output_marker,
-    _json_has_duplicate_object_keys,
     _persisted_output_marker_identity_digest,
     _persisted_output_saved_path,
     recover_hermes_persisted_output_with_file_stat,
     redact_sensitive_value,
 )
 from .message_content import normalize_content_value, text_content_for_pattern_matching
+from .message_identity import canonicalize_tool_call_identity_value, stable_tool_calls_identity
 from .sanitize import _clean_active_assistant_message
 
 import logging
@@ -55,37 +55,11 @@ _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from co
 class ReconcileMixin:
     @staticmethod
     def _canonicalize_tool_call_identity_value(value: Any) -> Any:
-        if isinstance(value, dict):
-            return {
-                key: ReconcileMixin._canonicalize_tool_call_identity_value(val)
-                for key, val in value.items()
-            }
-        if isinstance(value, list):
-            return [ReconcileMixin._canonicalize_tool_call_identity_value(item) for item in value]
-        if isinstance(value, str):
-            stripped = value.strip()
-            if stripped and stripped[0] in "[{":
-                if _json_has_duplicate_object_keys(value):
-                    return value
-                try:
-                    parsed = json.loads(value)
-                except (TypeError, ValueError, json.JSONDecodeError):
-                    return value
-                if isinstance(parsed, (dict, list)):
-                    canonical = ReconcileMixin._canonicalize_tool_call_identity_value(parsed)
-                    return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-            return value
-        return value
+        return canonicalize_tool_call_identity_value(value)
 
     @staticmethod
     def _stable_tool_calls_identity(tool_calls: Any) -> str:
-        if not tool_calls:
-            return ""
-        try:
-            canonical = ReconcileMixin._canonicalize_tool_call_identity_value(tool_calls)
-            return json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-        except (TypeError, ValueError):
-            return str(tool_calls)
+        return stable_tool_calls_identity(tool_calls)
 
     def _has_durable_persisted_output_replay_identity(self, msg: Dict[str, Any]) -> bool:
         role = str(msg.get("role") or "unknown")

--- a/store.py
+++ b/store.py
@@ -77,6 +77,11 @@ class ReplayFloodError(RuntimeError):
     """
 
 
+def _serialized_tool_calls(message: Dict[str, Any]) -> str:
+    tool_calls = message.get("tool_calls")
+    return json.dumps(tool_calls) if tool_calls else ""
+
+
 def _normalize_source_value(source: str | None) -> str:
     normalized = (source or "").strip()
     return normalized or _UNKNOWN_SOURCE
@@ -393,8 +398,7 @@ class MessageStore:
         with self._write_lock, self._conn:
             self._assert_no_replay_identity_flood(session_id, messages)
             for msg, est in zip(messages, token_estimates):
-                tc = msg.get("tool_calls")
-                tc_json = json.dumps(tc) if tc else None
+                tc_json = _serialized_tool_calls(msg) or None
                 ts = time.time()
                 cur = self._conn.execute(
                     """INSERT INTO messages
@@ -424,12 +428,14 @@ class MessageStore:
             """SELECT 1 FROM messages
                WHERE session_id = ? AND role = ? AND content = ?
                  AND COALESCE(tool_call_id, '') = ?
+                 AND COALESCE(tool_calls, '') = ?
                LIMIT 1""",
             (
                 session_id,
                 msg.get("role", "unknown"),
                 content,
                 str(msg.get("tool_call_id") or ""),
+                _serialized_tool_calls(msg),
             ),
         ).fetchone()
         return row is not None
@@ -454,7 +460,7 @@ class MessageStore:
             getattr(self._ingest_protection_config, "replay_flood_threshold_internal", 0) or 0
         )
         user_rows: List[tuple[Dict[str, Any], str]] = []
-        internal_groups: Dict[tuple[str, str, str], List[tuple[Dict[str, Any], str]]] = {}
+        internal_groups: Dict[tuple[str, str, str, str], List[tuple[Dict[str, Any], str]]] = {}
         for msg in messages:
             content = _normalize_content_value(msg.get("content")) or ""
             if not content:
@@ -463,7 +469,12 @@ class MessageStore:
             if role == "user":
                 user_rows.append((msg, content))
             else:
-                key = (role, content, str(msg.get("tool_call_id") or ""))
+                key = (
+                    role,
+                    content,
+                    str(msg.get("tool_call_id") or ""),
+                    _serialized_tool_calls(msg),
+                )
                 internal_groups.setdefault(key, []).append((msg, content))
 
         if external_threshold > 0 and len(user_rows) >= external_threshold:
@@ -478,7 +489,7 @@ class MessageStore:
                             f"threshold={external_threshold} batch={len(messages)}"
                         )
         if internal_threshold > 0:
-            for (role, _content, _tool_call_id), rows in internal_groups.items():
+            for (role, _content, _tool_call_id, _tool_calls), rows in internal_groups.items():
                 if len(rows) < internal_threshold:
                     continue
                 probe_msg, probe_content = rows[0]

--- a/store.py
+++ b/store.py
@@ -46,7 +46,10 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .message_content import normalize_content_value as _normalize_content_value
-from .message_identity import stable_tool_calls_identity
+from .message_identity import (
+    stable_serialized_tool_calls_identity,
+    stable_tool_calls_identity,
+)
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -79,6 +82,11 @@ class ReplayFloodError(RuntimeError):
 
 
 def _serialized_tool_calls(message: Dict[str, Any]) -> str:
+    tool_calls = message.get("tool_calls")
+    return json.dumps(tool_calls) if tool_calls else ""
+
+
+def _tool_calls_identity(message: Dict[str, Any]) -> str:
     return stable_tool_calls_identity(message.get("tool_calls"))
 
 
@@ -424,21 +432,23 @@ class MessageStore:
 
     def _row_identity_already_stored(self, session_id: str, msg: Dict[str, Any],
                                      content: str) -> bool:
-        row = self._conn.execute(
-            """SELECT 1 FROM messages
+        rows = self._conn.execute(
+            """SELECT tool_calls FROM messages
                WHERE session_id = ? AND role = ? AND COALESCE(content, '') = ?
                  AND COALESCE(tool_call_id, '') = ?
-                 AND COALESCE(tool_calls, '') = ?
-               LIMIT 1""",
+            """,
             (
                 session_id,
                 msg.get("role", "unknown"),
                 content,
                 str(msg.get("tool_call_id") or ""),
-                _serialized_tool_calls(msg),
             ),
-        ).fetchone()
-        return row is not None
+        ).fetchall()
+        identity = _tool_calls_identity(msg)
+        return any(
+            stable_serialized_tool_calls_identity(row[0]) == identity
+            for row in rows
+        )
 
     def _assert_no_replay_identity_flood(self, session_id: str,
                                          messages: List[Dict[str, Any]]) -> None:
@@ -464,7 +474,7 @@ class MessageStore:
         for msg in messages:
             content = _normalize_content_value(msg.get("content")) or ""
             tool_call_id = str(msg.get("tool_call_id") or "")
-            tool_calls = _serialized_tool_calls(msg)
+            tool_calls = _tool_calls_identity(msg)
             if not content and not tool_call_id and not tool_calls:
                 continue
             role = str(msg.get("role", "unknown"))

--- a/store.py
+++ b/store.py
@@ -46,6 +46,7 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .message_content import normalize_content_value as _normalize_content_value
+from .message_identity import stable_tool_calls_identity
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -78,8 +79,7 @@ class ReplayFloodError(RuntimeError):
 
 
 def _serialized_tool_calls(message: Dict[str, Any]) -> str:
-    tool_calls = message.get("tool_calls")
-    return json.dumps(tool_calls) if tool_calls else ""
+    return stable_tool_calls_identity(message.get("tool_calls"))
 
 
 def _normalize_source_value(source: str | None) -> str:

--- a/store.py
+++ b/store.py
@@ -426,7 +426,7 @@ class MessageStore:
                                      content: str) -> bool:
         row = self._conn.execute(
             """SELECT 1 FROM messages
-               WHERE session_id = ? AND role = ? AND content = ?
+               WHERE session_id = ? AND role = ? AND COALESCE(content, '') = ?
                  AND COALESCE(tool_call_id, '') = ?
                  AND COALESCE(tool_calls, '') = ?
                LIMIT 1""",
@@ -463,7 +463,9 @@ class MessageStore:
         internal_groups: Dict[tuple[str, str, str, str], List[tuple[Dict[str, Any], str]]] = {}
         for msg in messages:
             content = _normalize_content_value(msg.get("content")) or ""
-            if not content:
+            tool_call_id = str(msg.get("tool_call_id") or "")
+            tool_calls = _serialized_tool_calls(msg)
+            if not content and not tool_call_id and not tool_calls:
                 continue
             role = str(msg.get("role", "unknown"))
             if role == "user":
@@ -472,8 +474,8 @@ class MessageStore:
                 key = (
                     role,
                     content,
-                    str(msg.get("tool_call_id") or ""),
-                    _serialized_tool_calls(msg),
+                    tool_call_id,
+                    tool_calls,
                 )
                 internal_groups.setdefault(key, []).append((msg, content))
 

--- a/store.py
+++ b/store.py
@@ -67,6 +67,16 @@ def _legacy_blank_source_clause(column: str) -> str:
     return f"({column} IS NULL OR TRIM({column}, {whitespace_chars}) = '')"
 
 
+class ReplayFloodError(RuntimeError):
+    """A single ingest batch re-appends already-stored rows in bulk.
+
+    Raised by the store-level anti-replay backstop before any row of the
+    offending batch is written. The cursor/reconcile layer is the primary
+    duplicate gate; this guard turns a misjudgement that would silently
+    flood the durable session with replayed rows into a loud refusal.
+    """
+
+
 def _normalize_source_value(source: str | None) -> str:
     normalized = (source or "").strip()
     return normalized or _UNKNOWN_SOURCE
@@ -381,6 +391,7 @@ class MessageStore:
 
         ids = []
         with self._write_lock, self._conn:
+            self._assert_no_replay_identity_flood(session_id, messages)
             for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
@@ -406,6 +417,77 @@ class MessageStore:
                 )
                 ids.append(cur.lastrowid)
         return ids
+
+    def _row_identity_already_stored(self, session_id: str, msg: Dict[str, Any],
+                                     content: str) -> bool:
+        row = self._conn.execute(
+            """SELECT 1 FROM messages
+               WHERE session_id = ? AND role = ? AND content = ?
+                 AND COALESCE(tool_call_id, '') = ?
+               LIMIT 1""",
+            (
+                session_id,
+                msg.get("role", "unknown"),
+                content,
+                str(msg.get("tool_call_id") or ""),
+            ),
+        ).fetchone()
+        return row is not None
+
+    def _assert_no_replay_identity_flood(self, session_id: str,
+                                         messages: List[Dict[str, Any]]) -> None:
+        """Refuse a batch that re-appends already-stored rows in bulk.
+
+        Counts rows of the incoming batch whose identity already exists in
+        the session. The user role is the host rebroadcast surface, so any
+        mix of already-stored user rows counts against the external
+        threshold; internal roles (assistant/tool/system) only count when
+        one identical identity repeats within the batch, so legitimately
+        recurring internal rows with distinct content never accumulate.
+        Small deliberate re-appends (ambiguous restart deltas, heartbeat
+        repeats) stay far below the thresholds and are unaffected.
+        """
+        external_threshold = int(
+            getattr(self._ingest_protection_config, "replay_flood_threshold_external", 0) or 0
+        )
+        internal_threshold = int(
+            getattr(self._ingest_protection_config, "replay_flood_threshold_internal", 0) or 0
+        )
+        user_rows: List[tuple[Dict[str, Any], str]] = []
+        internal_groups: Dict[tuple[str, str, str], List[tuple[Dict[str, Any], str]]] = {}
+        for msg in messages:
+            content = _normalize_content_value(msg.get("content")) or ""
+            if not content:
+                continue
+            role = str(msg.get("role", "unknown"))
+            if role == "user":
+                user_rows.append((msg, content))
+            else:
+                key = (role, content, str(msg.get("tool_call_id") or ""))
+                internal_groups.setdefault(key, []).append((msg, content))
+
+        if external_threshold > 0 and len(user_rows) >= external_threshold:
+            replicated = 0
+            for msg, content in user_rows:
+                if self._row_identity_already_stored(session_id, msg, content):
+                    replicated += 1
+                    if replicated >= external_threshold:
+                        raise ReplayFloodError(
+                            f"refused replay-like message batch: session={session_id} "
+                            f"role=user replicated_rows>={replicated} "
+                            f"threshold={external_threshold} batch={len(messages)}"
+                        )
+        if internal_threshold > 0:
+            for (role, _content, _tool_call_id), rows in internal_groups.items():
+                if len(rows) < internal_threshold:
+                    continue
+                probe_msg, probe_content = rows[0]
+                if self._row_identity_already_stored(session_id, probe_msg, probe_content):
+                    raise ReplayFloodError(
+                        f"refused replay-like message batch: session={session_id} "
+                        f"role={role} identical_rows={len(rows)} "
+                        f"threshold={internal_threshold} batch={len(messages)}"
+                    )
 
     def reassign_session_messages(self, old_session_id: str, new_session_id: str) -> int:
         """Move all persisted messages from one session_id to another."""

--- a/tests/test_replay_flood_backstop.py
+++ b/tests/test_replay_flood_backstop.py
@@ -64,6 +64,31 @@ class TestStoreReplayFloodBackstop:
 
         assert len(ids) == len(stored)
 
+    def test_allows_same_content_with_distinct_assistant_tool_calls(self, tmp_path):
+        store = _store(tmp_path)
+        store.append_batch(
+            "tool-call-session",
+            [{"role": "assistant", "content": "calling a tool"}],
+        )
+        batch = [
+            {
+                "role": "assistant",
+                "content": "calling a tool",
+                "tool_calls": [
+                    {
+                        "id": f"call-{idx}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {"index": idx}},
+                    }
+                ],
+            }
+            for idx in range(32)
+        ]
+
+        ids = store.append_batch("tool-call-session", batch)
+
+        assert len(ids) == len(batch)
+
     def test_zero_threshold_disables_guard(self, tmp_path):
         store = _store(
             tmp_path,
@@ -79,7 +104,7 @@ class TestStoreReplayFloodBackstop:
 
 
 class TestEngineReplayFloodBackstop:
-    def test_engine_survives_and_reports_replay_flood_refusal(self, tmp_path):
+    def test_engine_recovers_new_tail_and_subsequent_ingests_after_refusal(self, tmp_path):
         db_path = tmp_path / "flood-engine.db"
         config = LCMConfig(database_path=str(db_path))
         before_restart = LCMEngine(config=config)
@@ -114,13 +139,26 @@ class TestEngineReplayFloodBackstop:
 
         after_restart._ingest_messages(flood)
 
-        assert after_restart._store.get_session_count("flood-engine-session") == len(
-            persisted_messages
-        )
+        assert after_restart._store.get_session_count("flood-engine-session") == len(persisted_messages) + 1
         assert after_restart._replay_flood_refusal_count == 1
         status = after_restart.get_status()
         assert status["replay_flood_refusals"]["count"] == 1
         assert "refused replay-like message batch" in status["replay_flood_refusals"]["last"]
+
+        continued = flood + [
+            {"role": "assistant", "content": "response after recovered turn"},
+            {"role": "user", "content": "subsequent turn"},
+        ]
+        after_restart._ingest_messages(continued)
+
+        rows = after_restart._store.get_session_messages("flood-engine-session")
+        assert len(rows) == len(persisted_messages) + 3
+        assert [row["content"] for row in rows[-3:]] == [
+            "new turn riding the flood",
+            "response after recovered turn",
+            "subsequent turn",
+        ]
+        assert after_restart._replay_flood_refusal_count == 1
 
 
 class TestReplayFloodConfig:

--- a/tests/test_replay_flood_backstop.py
+++ b/tests/test_replay_flood_backstop.py
@@ -1,0 +1,134 @@
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.store import MessageStore, ReplayFloodError
+
+
+def _store(tmp_path, **config_overrides):
+    config = LCMConfig(database_path=str(tmp_path / "lcm.db"), **config_overrides)
+    return MessageStore(tmp_path / "lcm.db", ingest_protection_config=config)
+
+
+class TestStoreReplayFloodBackstop:
+    def test_refuses_user_replay_flood_batch(self, tmp_path):
+        store = _store(tmp_path)
+        stored = [{"role": "user", "content": f"durable message {i}"} for i in range(10)]
+        store.append_batch("flood-session", stored)
+        before = store.get_session_count("flood-session")
+
+        flood = [dict(msg) for msg in stored[:8]]
+        flood.append({"role": "user", "content": "new message riding the flood"})
+
+        with pytest.raises(ReplayFloodError):
+            store.append_batch("flood-session", flood)
+        assert store.get_session_count("flood-session") == before
+
+    def test_allows_fresh_bulk_batch_without_priors(self, tmp_path):
+        store = _store(tmp_path)
+        batch = [{"role": "user", "content": f"brand new message {i}"} for i in range(20)]
+
+        ids = store.append_batch("fresh-session", batch)
+
+        assert len(ids) == len(batch)
+
+    def test_allows_small_duplicate_delta_below_threshold(self, tmp_path):
+        store = _store(tmp_path)
+        stored = [{"role": "user", "content": f"durable message {i}"} for i in range(10)]
+        store.append_batch("delta-session", stored)
+
+        delta = [dict(stored[-2]), dict(stored[-1]), {"role": "user", "content": "new turn"}]
+        ids = store.append_batch("delta-session", delta)
+
+        assert len(ids) == len(delta)
+
+    def test_refuses_internal_identical_identity_burst(self, tmp_path):
+        store = _store(tmp_path)
+        store.append_batch(
+            "internal-session",
+            [{"role": "assistant", "content": "repeated assistant row"}],
+        )
+
+        burst = [{"role": "assistant", "content": "repeated assistant row"} for _ in range(32)]
+        with pytest.raises(ReplayFloodError):
+            store.append_batch("internal-session", burst)
+
+    def test_allows_internal_distinct_duplicate_rows(self, tmp_path):
+        store = _store(tmp_path)
+        stored = [{"role": "assistant", "content": f"assistant row {i}"} for i in range(40)]
+        store.append_batch("distinct-session", stored)
+
+        # Distinct internal identities never accumulate against the internal
+        # threshold even when every row duplicates stored content.
+        ids = store.append_batch("distinct-session", [dict(msg) for msg in stored])
+
+        assert len(ids) == len(stored)
+
+    def test_zero_threshold_disables_guard(self, tmp_path):
+        store = _store(
+            tmp_path,
+            replay_flood_threshold_external=0,
+            replay_flood_threshold_internal=0,
+        )
+        stored = [{"role": "user", "content": f"durable message {i}"} for i in range(10)]
+        store.append_batch("disabled-session", stored)
+
+        ids = store.append_batch("disabled-session", [dict(msg) for msg in stored])
+
+        assert len(ids) == len(stored)
+
+
+class TestEngineReplayFloodBackstop:
+    def test_engine_survives_and_reports_replay_flood_refusal(self, tmp_path):
+        db_path = tmp_path / "flood-engine.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "flood-engine-session",
+            platform="cli",
+            conversation_id="flood-engine-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [{"role": "system", "content": "You are concise."}]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable message {i}"}
+            for i in range(20)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "flood-engine-session",
+            platform="cli",
+            conversation_id="flood-engine-conversation",
+            context_length=200000,
+        )
+        # A middle chunk of the durable history is not anchored at the tail,
+        # so reconciliation stays ambiguous and tries to append the whole
+        # batch; the store-level backstop refuses it.
+        flood = [dict(msg) for msg in persisted_messages[3:11]]
+        flood.append({"role": "user", "content": "new turn riding the flood"})
+
+        after_restart._ingest_messages(flood)
+
+        assert after_restart._store.get_session_count("flood-engine-session") == len(
+            persisted_messages
+        )
+        assert after_restart._replay_flood_refusal_count == 1
+        status = after_restart.get_status()
+        assert status["replay_flood_refusals"]["count"] == 1
+        assert "refused replay-like message batch" in status["replay_flood_refusals"]["last"]
+
+
+class TestReplayFloodConfig:
+    def test_env_overrides_parse(self, monkeypatch):
+        monkeypatch.setenv("LCM_REPLAY_FLOOD_THRESHOLD_EXTERNAL", "5")
+        monkeypatch.setenv("LCM_REPLAY_FLOOD_THRESHOLD_INTERNAL", "64")
+
+        config = LCMConfig.from_env()
+
+        assert config.replay_flood_threshold_external == 5
+        assert config.replay_flood_threshold_internal == 64

--- a/tests/test_replay_flood_backstop.py
+++ b/tests/test_replay_flood_backstop.py
@@ -74,6 +74,48 @@ class TestStoreReplayFloodBackstop:
                 [dict(tool_call) for _ in range(32)],
             )
 
+    def test_refuses_reordered_contentless_tool_call_replay_atomically(self, tmp_path):
+        store = _store(tmp_path)
+        stored = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-canonical",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": {"filters": {"site": "docs", "lang": "en"}, "limit": 5},
+                    },
+                }
+            ],
+        }
+        reordered = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "arguments": {"limit": 5, "filters": {"lang": "en", "site": "docs"}},
+                        "name": "lookup",
+                    },
+                    "id": "call-canonical",
+                }
+            ],
+        }
+        session_id = "canonical-tool-call-session"
+        store.append_batch(session_id, [stored])
+        before = store.get_session_count(session_id)
+
+        with pytest.raises(ReplayFloodError):
+            store.append_batch(session_id, [reordered for _ in range(32)])
+
+        assert store.get_session_count(session_id) == before
+        fresh = {**reordered, "tool_calls": [{**reordered["tool_calls"][0], "id": "call-fresh"}]}
+        assert len(store.append_batch(session_id, [fresh])) == 1
+        assert store.get_session_count(session_id) == before + 1
+
     def test_allows_internal_distinct_duplicate_rows(self, tmp_path):
         store = _store(tmp_path)
         stored = [{"role": "assistant", "content": f"assistant row {i}"} for i in range(40)]
@@ -107,6 +149,35 @@ class TestStoreReplayFloodBackstop:
         ]
 
         ids = store.append_batch("tool-call-session", batch)
+
+        assert len(ids) == len(batch)
+
+    @pytest.mark.parametrize("distinct_field", ["id", "function", "arguments"])
+    def test_contentless_tool_call_identity_preserves_distinct_fields(self, tmp_path, distinct_field):
+        store = _store(tmp_path)
+        session_id = f"distinct-tool-call-{distinct_field}"
+        base_call = {
+            "id": "call-stable",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": {"index": 0}},
+        }
+        store.append_batch(
+            session_id,
+            [{"role": "assistant", "content": None, "tool_calls": [base_call]}],
+        )
+        batch = []
+        for idx in range(32):
+            call = {
+                "id": f"call-{idx}" if distinct_field == "id" else "call-stable",
+                "type": "function",
+                "function": {
+                    "name": f"lookup-{idx}" if distinct_field == "function" else "lookup",
+                    "arguments": {"index": idx} if distinct_field == "arguments" else {"index": 0},
+                },
+            }
+            batch.append({"role": "assistant", "content": None, "tool_calls": [call]})
+
+        ids = store.append_batch(session_id, batch)
 
         assert len(ids) == len(batch)
 

--- a/tests/test_replay_flood_backstop.py
+++ b/tests/test_replay_flood_backstop.py
@@ -53,6 +53,27 @@ class TestStoreReplayFloodBackstop:
         with pytest.raises(ReplayFloodError):
             store.append_batch("internal-session", burst)
 
+    def test_refuses_contentless_assistant_tool_call_replay_burst(self, tmp_path):
+        store = _store(tmp_path)
+        tool_call = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-replayed",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": {"index": 1}},
+                }
+            ],
+        }
+        store.append_batch("contentless-tool-call-session", [tool_call])
+
+        with pytest.raises(ReplayFloodError):
+            store.append_batch(
+                "contentless-tool-call-session",
+                [dict(tool_call) for _ in range(32)],
+            )
+
     def test_allows_internal_distinct_duplicate_rows(self, tmp_path):
         store = _store(tmp_path)
         stored = [{"role": "assistant", "content": f"assistant row {i}"} for i in range(40)]

--- a/tests/test_replay_flood_backstop.py
+++ b/tests/test_replay_flood_backstop.py
@@ -1,3 +1,6 @@
+import json
+import time
+
 import pytest
 
 from hermes_lcm.config import LCMConfig
@@ -115,6 +118,119 @@ class TestStoreReplayFloodBackstop:
         fresh = {**reordered, "tool_calls": [{**reordered["tool_calls"][0], "id": "call-fresh"}]}
         assert len(store.append_batch(session_id, [fresh])) == 1
         assert store.get_session_count(session_id) == before + 1
+
+    @pytest.mark.parametrize("distinct_field", ["json-looking id", "json-looking argument leaf"])
+    def test_json_looking_strings_remain_distinct(self, tmp_path, distinct_field):
+        store = _store(tmp_path)
+        session_id = f"distinct-json-string-{distinct_field}"
+        stored_call = {
+            "id": '{"key":1}',
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "arguments": {"payload": '{"key":1}'},
+            },
+        }
+        incoming_call = {
+            **stored_call,
+            "function": {**stored_call["function"]},
+        }
+        if distinct_field == "json-looking id":
+            incoming_call["id"] = '{"key": 1}'
+        else:
+            incoming_call["function"]["arguments"] = {"payload": '{"key": 1}'}
+        store.append_batch(
+            session_id,
+            [{"role": "assistant", "content": None, "tool_calls": [stored_call]}],
+        )
+
+        batch = [
+            {"role": "assistant", "content": None, "tool_calls": [incoming_call]}
+            for _ in range(32)
+        ]
+
+        assert len(store.append_batch(session_id, batch)) == len(batch)
+
+    def test_refuses_reordered_replay_against_legacy_serialized_row_atomically(self, tmp_path):
+        store = _store(tmp_path)
+        session_id = "legacy-canonical-tool-call-session"
+        stored = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-legacy",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": '{"filters":{"site":"docs","lang":"en"},"limit":5}',
+                    },
+                }
+            ],
+        }
+        reordered = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "function": {
+                        "arguments": '{"limit":5,"filters":{"lang":"en","site":"docs"}}',
+                        "name": "lookup",
+                    },
+                    "type": "function",
+                    "id": "call-legacy",
+                }
+            ],
+        }
+        legacy_tool_calls = json.dumps(stored["tool_calls"])
+        store._conn.execute(
+            """INSERT INTO messages
+               (session_id, role, content, tool_call_id, tool_calls, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (session_id, "assistant", None, None, legacy_tool_calls, time.time()),
+        )
+        store._conn.commit()
+        before = store.get_session_count(session_id)
+        before_cursor = store._conn.execute(
+            "SELECT MAX(store_id) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+        assert store.get_session_messages(session_id)[0]["tool_calls"] == stored["tool_calls"]
+
+        with pytest.raises(ReplayFloodError):
+            store.append_batch(session_id, [reordered for _ in range(32)])
+
+        assert store.get_session_count(session_id) == before
+        assert store._conn.execute(
+            "SELECT MAX(store_id) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0] == before_cursor
+        fresh = {**reordered, "tool_calls": [{**reordered["tool_calls"][0], "id": "call-fresh"}]}
+        fresh_id = store.append_batch(session_id, [fresh])[0]
+        assert fresh_id > before_cursor
+        assert store.get_session_count(session_id) == before + 1
+
+    def test_batch_preserves_legacy_tool_call_serialization(self, tmp_path):
+        store = _store(tmp_path)
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-durable",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": {"z": 1, "a": 2}},
+                }
+            ],
+        }
+
+        store.append_batch("durable-serialization-session", [message])
+
+        stored_value = store._conn.execute(
+            "SELECT tool_calls FROM messages WHERE session_id = ?",
+            ("durable-serialization-session",),
+        ).fetchone()[0]
+        assert stored_value == json.dumps(message["tool_calls"])
 
     def test_allows_internal_distinct_duplicate_rows(self, tmp_path):
         store = _store(tmp_path)


### PR DESCRIPTION
## Summary
Adds a store-level replay-flood backstop before protected batch writes, plus engine-level refusal handling and status telemetry.

The latest repair makes contentless assistant tool-call replay identity stable without changing the durable format:

- user replay floods are refused at the external threshold (default `8`);
- repeated internal identities are refused at the internal threshold (default `32`);
- `tool_calls` participates in assistant replay identity, including contentless tool-call messages;
- direct `function.arguments` objects/lists are canonicalized recursively, so mapping key order does not change identity;
- IDs and nested string-valued argument leaves remain byte-distinct, including JSON-looking strings;
- existing plain `json.dumps(tool_calls)` rows remain visible to the replay probe;
- refusal happens before any insert, leaves count/cursor unchanged, and a later genuinely fresh ingest succeeds;
- thresholds remain configurable with `LCM_REPLAY_FLOOD_THRESHOLD_EXTERNAL` and `LCM_REPLAY_FLOOD_THRESHOLD_INTERNAL`; `0` disables the corresponding guard.

## Why
`messages` has no identity hash or uniqueness constraint, and the protected append path otherwise writes a reconciled batch unconditionally. A bad replay/ambiguity decision could therefore persist duplicate rows, replay them into active context, pollute recall, and skew token accounting.

The guard is deliberately batch-shaped and conservative: normal per-turn deltas avoid existence probes, intentionally ambiguous small duplicate deltas remain admissible, and only a replay-shaped threshold breach becomes a loud, atomic refusal.

## Validation
Run against exact head `2aea878381d31a383c56ec2189032542713f00c2`:

```text
PYTHONPATH=/home/manfred/hermes-agent-upstream-prs uv run --python 3.11 --with pytest python -m pytest tests/test_replay_flood_backstop.py -q -o addopts=
# 18 passed

PYTHONPATH=/home/manfred/hermes-agent-upstream-prs uv run --python 3.11 --with pytest python -m pytest tests/test_lcm_core.py -q -o addopts= -k TestMessageStore
# 65 passed, 225 deselected

PYTHONPATH=/home/manfred/hermes-agent-upstream-prs uv run --python 3.11 --with pytest python -m pytest tests/test_lcm_engine.py tests/test_ingest_protection.py -q -o addopts= -k rebind_reconciliation
# 8 passed, 824 deselected

uv run ruff check message_identity.py store.py tests/test_replay_flood_backstop.py
git diff --check HEAD^ HEAD
# both passed
```

The replay suite covers external/internal thresholds, disabled guards, fresh bulk ingest, distinct IDs/functions/arguments, canonical argument-key ordering, JSON-looking-string adversaries, legacy-row compatibility, atomic refusal, unchanged cursor/count, and fresh recovery.

## Notes
- The guard runs under the store write lock, so replay check and insert are atomic against concurrent writers.
- Durable `tool_calls` serialization is unchanged; canonicalization is comparison-only.
- The reviewed head is a normal fast-forward from the previous PR head `2c04b3f58cf5536de8f1f3de55342a48f524b44e` and incorporates upstream `main` at `31675c6ed54abd747578b4da4b1589d81b18384a` through merge commit `7342c4d118ae891a33ecac4614732610776f27b7`.
- No history rewrite, force-push, merge, close, or human-thread resolution was performed.

## Refs
- Replay identity: `message_identity.py`
- Store backstop and legacy-row comparison: `store.py::_assert_no_replay_identity_flood`
- Refusal/recovery behavior: `engine.py`
- Regression coverage: `tests/test_replay_flood_backstop.py`
- Complements #359, which repairs partial-tail-overlap reconciliation before this defense-in-depth boundary.
