### PR TITLE
fix: retry WAL conversion on lock contention at connection setup

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -99,12 +99,41 @@ def configure_connection(conn: sqlite3.Connection) -> None:
     - mmap_size=268435456 (256 MiB)        : memory-map reads so concurrent
                                               readers cache WAL pages in RAM.
     """
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA synchronous=FULL")
     conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+    _execute_wal_conversion_with_lock_retry(conn)
+    conn.execute("PRAGMA synchronous=FULL")
     conn.execute("PRAGMA wal_autocheckpoint=500")
     conn.execute("PRAGMA journal_size_limit=67108864")
     conn.execute("PRAGMA mmap_size=268435456")
+
+
+def _execute_wal_conversion_with_lock_retry(
+    conn: sqlite3.Connection,
+    *,
+    budget_ms: int = SQLITE_BUSY_TIMEOUT_MS,
+) -> None:
+    """Run ``PRAGMA journal_mode=WAL`` with a bounded lock-contention retry.
+
+    Converting a rollback-journal database to WAL needs the exclusive lock,
+    and SQLite can return ``SQLITE_BUSY`` for that upgrade without consulting
+    the busy handler when other connections are mid-setup on the same file.
+    Concurrent process startup (gateway + CLI + sub-agents) on a not-yet-WAL
+    database therefore crashed sporadically with ``database is locked``.
+    Once the database is in WAL mode the pragma is a plain read and never
+    takes this path, so the retry only matters on first boot after an
+    install/upgrade or on a rollback-journal restore.
+    """
+    deadline = time.monotonic() + budget_ms / 1000.0
+    delay_seconds = 0.005
+    while True:
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or time.monotonic() >= deadline:
+                raise
+        time.sleep(delay_seconds)
+        delay_seconds = min(delay_seconds * 2, 0.25)
 
 
 def add_column_if_missing(

--- a/tests/test_crash_safe_wal.py
+++ b/tests/test_crash_safe_wal.py
@@ -233,10 +233,14 @@ class TestConcurrentStartupMigration:
             conn = sqlite3.connect(str(db_path), timeout=30.0)
             try:
                 configure_connection(conn)
-                barrier.wait()  # maximise overlap on the migration DDL
+                # Timeout + abort-on-error: a thread that fails before the
+                # barrier must break it, or the surviving threads wait forever
+                # and the deadlock hides the original error from the assert.
+                barrier.wait(timeout=60.0)  # maximise overlap on the migration DDL
                 ensure_message_origin_columns(conn)
                 conn.commit()
             except BaseException as exc:  # noqa: BLE001 - re-asserted below
+                barrier.abort()
                 with lock:
                     errors.append(exc)
             finally:
@@ -246,9 +250,15 @@ class TestConcurrentStartupMigration:
         for t in threads:
             t.start()
         for t in threads:
-            t.join()
+            t.join(timeout=120.0)
+        stuck = [t for t in threads if t.is_alive()]
+        assert not stuck, f"{len(stuck)} migration threads still running after join timeout"
 
-        assert not errors, f"concurrent column migration raised: {errors!r}"
+        real_errors = [
+            exc for exc in errors if not isinstance(exc, threading.BrokenBarrierError)
+        ]
+        assert not real_errors, f"concurrent column migration raised: {real_errors!r}"
+        assert not errors, "barrier broke without a recorded root-cause error"
         conn = sqlite3.connect(str(db_path))
         columns = [
             row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()


### PR DESCRIPTION
## Summary
Follow-up to #346 (concurrent-startup migration race), one phase earlier in the same failure class. `configure_connection` runs `PRAGMA journal_mode=WAL` as its first statement. Converting a rollback-journal database to WAL needs the exclusive lock, and SQLite can return `SQLITE_BUSY` for that upgrade **without consulting the busy handler** while sibling connections are mid-setup on the same file. Concurrent process startup (gateway + CLI + sub-agents — the documented topology) on a not-yet-WAL database therefore crashed sporadically with `sqlite3.OperationalError: database is locked` during store construction. Steady state is immune: once the database is WAL, the pragma is a plain read.

Two changes:
- **`db_bootstrap.configure_connection`**: set `busy_timeout` first, then run the WAL conversion through `_execute_wal_conversion_with_lock_retry` — a bounded exponential-backoff retry (5ms→250ms steps, total budget `SQLITE_BUSY_TIMEOUT_MS`) that only swallows lock-contention errors and re-raises everything else or on budget exhaustion.
- **`tests/test_crash_safe_wal.py::TestConcurrentStartupMigration`**: the regression test that exposed this had a second bug of its own — `barrier.wait()` without timeout. The thread that crashed pre-barrier left the seven survivors parked forever, so instead of a red test the whole pytest run deadlocked (observed twice as a `validate_release --full` hang at 4%, 8 threads in futex wait, zero CPU). The barrier now uses a timeout and `abort()` on failure, `join` is bounded with a liveness assert, and the final assert reports the root-cause exception instead of hiding it.

## Why
The hang variant is worse than the crash variant: it silently stalls any CI/validation run that executes the suite, with no error to act on. And the underlying crash is the same first-boot scenario #346 fixed for column DDL — a fresh install or an upgrade from a pre-WAL database with several Hermes processes starting together.

## Validation
```
ruff check db_bootstrap.py tests/test_crash_safe_wal.py     # All checks passed!
python -m pytest tests/ -q                                   # 1590 passed, 12 xfailed
```
Reproduction & proof (Linux, 8-thread barrier race on a rollback-journal seed DB):
- Unfixed: standalone repro script hit `database is locked` from `configure_connection` (`PRAGMA journal_mode=WAL`) within 15 attempts; the unhardened test hung 2/10 runs (killed only by an external timeout).
- Fixed: 60/60 repro attempts clean; hardened test file looped 30× with zero failures or hangs.

## Notes
- Retry scope is deliberately the WAL conversion only — the other pragmas are per-connection settings that do not take the exclusive-lock upgrade path.
- The hardened test now degrades into an actionable assertion (with the recorded root-cause exception) if any future setup-phase error appears, instead of deadlocking the suite.

## Refs
- #346 (atomic column migrations, same concurrent-startup family)
- `db_bootstrap.py::configure_connection`, `SQLITE_BUSY_TIMEOUT_MS`