### PR TITLE
feat: recover and hydrate read-tool-truncated content

### DIFF
--- a/command.py
+++ b/command.py
@@ -1255,6 +1255,7 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
     if not session_ids:
         return {
             "messages_deleted": 0,
+            "recovered_content_deleted": 0,
             "nodes_deleted": 0,
             "lifecycle_deleted": 0,
             "lifecycle_skipped": 0,
@@ -1289,6 +1290,10 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
     try:
         conn.execute("BEGIN IMMEDIATE")
         msg_cur = conn.execute(f"DELETE FROM messages WHERE session_id IN ({placeholders})", params)
+        recovered_cur = conn.execute(
+            f"DELETE FROM recovered_tool_content WHERE session_id IN ({placeholders})",
+            params,
+        )
         node_cur = conn.execute(f"DELETE FROM summary_nodes WHERE session_id IN ({placeholders})", params)
         lifecycle_deleted = 0
         for conversation_id in lifecycle_delete_conversation_ids:
@@ -1304,6 +1309,9 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
 
     return {
         "messages_deleted": msg_cur.rowcount if msg_cur.rowcount is not None else 0,
+        "recovered_content_deleted": (
+            recovered_cur.rowcount if recovered_cur.rowcount is not None else 0
+        ),
         "nodes_deleted": node_cur.rowcount if node_cur.rowcount is not None else 0,
         "lifecycle_deleted": lifecycle_deleted,
         "lifecycle_skipped": lifecycle_skipped,
@@ -1371,6 +1379,7 @@ def _doctor_clean_apply_text(engine) -> str:
         f"backup_size: {_fmt_size(int(backup['backup_size']))}",
         f"candidate_sessions: {len(candidates)}",
         f"messages_deleted: {deleted['messages_deleted']}",
+        f"recovered_content_deleted: {deleted['recovered_content_deleted']}",
         f"nodes_deleted: {deleted['nodes_deleted']}",
         f"lifecycle_rows_deleted: {deleted['lifecycle_deleted']}",
         f"lifecycle_rows_skipped: {deleted['lifecycle_skipped']}",

--- a/config.py
+++ b/config.py
@@ -273,6 +273,8 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("max_assembly_tokens", "LCM_MAX_ASSEMBLY_TOKENS", int),
     _EnvFieldSpec("reserve_tokens_floor", "LCM_RESERVE_TOKENS_FLOOR", int),
     _EnvFieldSpec("custom_instructions", "LCM_CUSTOM_INSTRUCTIONS", str),
+    _EnvFieldSpec("read_tool_recovery_enabled", "LCM_READ_TOOL_RECOVERY_ENABLED", bool),
+    _EnvFieldSpec("read_tool_recovery_max_bytes", "LCM_READ_TOOL_RECOVERY_MAX_BYTES", int),
     _EnvFieldSpec("extraction_enabled", "LCM_EXTRACTION_ENABLED", bool),
     _EnvFieldSpec("extraction_model", "LCM_EXTRACTION_MODEL", str),
     _EnvFieldSpec("extraction_output_path", "LCM_EXTRACTION_OUTPUT_PATH", str),
@@ -426,6 +428,16 @@ class LCMConfig:
     # When enabled, already-externalized summarized tool-result transcript rows may
     # be rewritten to compact GC placeholders after successful leaf compaction.
     large_output_transcript_gc_enabled: bool = False
+
+    # -- Read-tool truncation recovery ---
+    # When enabled, an unrecoverable read-tool truncation marker whose source
+    # file is still readable on the local host is recovered: the full content is
+    # stored in the recovered_tool_content sidecar (keyed by marker identity) so
+    # it survives losslessly. The parent messages row keeps the marker, so replay
+    # and reconciliation are unaffected. Off by default.
+    read_tool_recovery_enabled: bool = False
+    # Upper bound (bytes) on a source file re-read for recovery.
+    read_tool_recovery_max_bytes: int = 8 * 1024 * 1024
 
     # -- Models ---
     summary_model: str = ""       # empty = use Hermes auxiliary model

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -246,27 +246,41 @@ def ensure_recovered_tool_content_table(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    index_rows = conn.execute("PRAGMA index_list(recovered_tool_content)").fetchall()
-    marker_index = next(
-        (row for row in index_rows if row[1] == "idx_recovered_session_marker"),
-        None,
-    )
-    if marker_index is not None and not bool(marker_index[2]):
-        conn.execute("DROP INDEX idx_recovered_session_marker")
-        marker_index = None
-    if marker_index is None:
-        # Pre-unique builds could race and create duplicate rows. Preserve the
-        # newest recovery, matching the lookup's existing newest-row behavior,
-        # before enforcing the durable idempotency invariant.
+    # Acquire SQLite's writer reservation before inspecting the legacy index.
+    # Without this, two startup processes can both observe the non-unique index;
+    # one drops it and the other's unguarded DROP then aborts startup. A savepoint
+    # works both in autocommit mode and inside a caller-owned transaction.
+    conn.execute("SAVEPOINT ensure_recovered_tool_content_unique")
+    try:
         conn.execute(
-            "DELETE FROM recovered_tool_content WHERE recovered_id NOT IN ("
-            "SELECT MAX(recovered_id) FROM recovered_tool_content "
-            "GROUP BY session_id, marker_identity_sha)"
+            "UPDATE recovered_tool_content SET recovered_id = recovered_id WHERE 0"
         )
-        conn.execute(
-            "CREATE UNIQUE INDEX idx_recovered_session_marker "
-            "ON recovered_tool_content(session_id, marker_identity_sha)"
+        index_rows = conn.execute("PRAGMA index_list(recovered_tool_content)").fetchall()
+        marker_index = next(
+            (row for row in index_rows if row[1] == "idx_recovered_session_marker"),
+            None,
         )
+        if marker_index is not None and not bool(marker_index[2]):
+            conn.execute("DROP INDEX IF EXISTS idx_recovered_session_marker")
+            marker_index = None
+        if marker_index is None:
+            # Pre-unique builds could race and create duplicate rows. Preserve the
+            # newest recovery, matching the lookup's existing newest-row behavior,
+            # before enforcing the durable idempotency invariant.
+            conn.execute(
+                "DELETE FROM recovered_tool_content WHERE recovered_id NOT IN ("
+                "SELECT MAX(recovered_id) FROM recovered_tool_content "
+                "GROUP BY session_id, marker_identity_sha)"
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_recovered_session_marker "
+                "ON recovered_tool_content(session_id, marker_identity_sha)"
+            )
+        conn.execute("RELEASE SAVEPOINT ensure_recovered_tool_content_unique")
+    except Exception:
+        conn.execute("ROLLBACK TO SAVEPOINT ensure_recovered_tool_content_unique")
+        conn.execute("RELEASE SAVEPOINT ensure_recovered_tool_content_unique")
+        raise
 
 
 def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -220,6 +220,55 @@ def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
     )
 
 
+def ensure_recovered_tool_content_table(conn: sqlite3.Connection) -> None:
+    """Create the sidecar for recovered read-tool-truncated content.
+
+    When the host truncates an oversized read-tool result to an unrecoverable
+    marker (sandbox write failed) and LCM can re-read the source file, the full
+    content is stored here keyed by the marker's identity digest. The parent
+    ``messages`` row keeps the byte-identical truncation marker, so replay, FTS,
+    and cursor reconciliation are untouched -- recovery is an expand-on-demand
+    lookup, never a stored-vs-replay divergence. Additive and version-fenceless
+    like the other sidecars, so downgrades stay safe.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS recovered_tool_content (
+            recovered_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            tool_call_id TEXT DEFAULT '',
+            marker_identity_sha TEXT NOT NULL,
+            source_path TEXT DEFAULT '',
+            recovered_chars INTEGER DEFAULT 0,
+            externalized_ref TEXT DEFAULT '',
+            content TEXT,
+            timestamp REAL NOT NULL
+        )
+        """
+    )
+    index_rows = conn.execute("PRAGMA index_list(recovered_tool_content)").fetchall()
+    marker_index = next(
+        (row for row in index_rows if row[1] == "idx_recovered_session_marker"),
+        None,
+    )
+    if marker_index is not None and not bool(marker_index[2]):
+        conn.execute("DROP INDEX idx_recovered_session_marker")
+        marker_index = None
+    if marker_index is None:
+        # Pre-unique builds could race and create duplicate rows. Preserve the
+        # newest recovery, matching the lookup's existing newest-row behavior,
+        # before enforcing the durable idempotency invariant.
+        conn.execute(
+            "DELETE FROM recovered_tool_content WHERE recovered_id NOT IN ("
+            "SELECT MAX(recovered_id) FROM recovered_tool_content "
+            "GROUP BY session_id, marker_identity_sha)"
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_recovered_session_marker "
+            "ON recovered_tool_content(session_id, marker_identity_sha)"
+        )
+
+
 def ensure_lifecycle_state_columns(conn: sqlite3.Connection) -> None:
     ensure_lifecycle_state_table(conn)
     columns = {
@@ -699,5 +748,9 @@ def run_versioned_migrations(conn: sqlite3.Connection) -> None:
     if current_version < 5:
         mark_migration_step_complete(conn, "v5_message_conversation_id")
         current_version = 5
+
+    # Additive read-tool recovery sidecar. Ensured unconditionally (idempotent)
+    # and intentionally version-fenceless so older builds stay downgrade-safe.
+    ensure_recovered_tool_content_table(conn)
 
     set_schema_version(conn, current_version)

--- a/engine.py
+++ b/engine.py
@@ -2913,6 +2913,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     # host gateways call session-end hooks from lifecycle paths
                     # that must not wait through SQLite's normal busy timeout.
                     self._ingest_messages(messages)
+                    self._maybe_recover_truncated_read_tool_content(messages)
                 except KeyboardInterrupt:
                     logger.warning(
                         "LCM session-end raw-message ingest interrupted; "

--- a/engine.py
+++ b/engine.py
@@ -118,6 +118,11 @@ from .sqlite_util import (
     _temporary_sqlite_busy_timeout,
 )
 from .store import MessageStore
+from .read_tool_recovery import (
+    marker_identity_sha as _read_tool_marker_identity_sha,
+    plan_read_tool_recovery,
+    recover_read_tool_file,
+)
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
@@ -204,6 +209,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # visible; full lossless retention (store with ignored=1) is a larger
         # follow-up that touches cursor reconciliation and FTS.
         self._ignore_pattern_dropped_count: int = 0
+        # Marker-identity digests already attempted for read-tool recovery this
+        # process, so an unrecoverable truncation marker replayed every turn is
+        # re-read from disk at most once instead of on each ingest.
+        self._attempted_read_tool_recovery_markers: set[str] = set()
+        self._recovered_read_tool_content_count: int = 0
 
         # Track which store_ids have been ingested into the DAG
         self._last_compacted_store_id: int = 0
@@ -1194,6 +1204,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     conversation_id=self._conversation_id,
                 )
                 self._ingest_messages(messages)
+                self._maybe_recover_truncated_read_tool_content()
                 self._record_ingest_success()
                 self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 logger.debug(
@@ -3254,6 +3265,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             status["ignore_message_patterns_source"] = self._config.ignore_message_patterns_source
             status["ignored_message_count"] = self._ignored_message_count
             status["ignore_pattern_dropped_count"] = self._ignore_pattern_dropped_count
+            if self._config.read_tool_recovery_enabled:
+                status["read_tool_recovery_enabled"] = True
+                status["recovered_read_tool_content_count"] = self._recovered_read_tool_content_count
             status["ingest_reconciliation"] = dict(self._last_ingest_reconciliation)
             status["overflow_recovery_failed"] = self._last_overflow_recovery_failed
             status["condensation_suppressed_reason"] = self._last_condensation_suppressed_reason
@@ -3402,6 +3416,62 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         except Exception as exc:  # pragma: no cover - defensive only
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
+
+    def _maybe_recover_truncated_read_tool_content(self) -> None:
+        """Recover read-tool results the host truncated unrecoverably.
+
+        For each stored tool message carrying an unrecoverable truncation marker
+        that pairs to a stored read-tool call with an absolute path, re-read the
+        source file
+        (hardened, size-capped) and store the full content in the sidecar keyed
+        by the marker's identity. The parent messages row is never touched, so
+        replay/FTS/reconciliation stay identical; recovery is expand-on-demand
+        only. Best-effort: any failure is swallowed so ingest never breaks, and
+        each marker is attempted at most once per process.
+        """
+        if not self._config.read_tool_recovery_enabled or not self._session_id:
+            return
+        try:
+            # Plan from durable rows after ingest filtering and protection. This
+            # prevents ignored markers from creating orphan sidecar rows and
+            # keys recovery by the exact marker bytes later expansion sees.
+            stored_messages = self._store.get_session_tail(self._session_id, limit=10_000)
+            candidates = plan_read_tool_recovery(stored_messages)
+        except Exception:  # pragma: no cover - defensive; recovery is best-effort
+            logger.debug("LCM read-tool recovery planning failed", exc_info=True)
+            return
+        max_bytes = int(getattr(self._config, "read_tool_recovery_max_bytes", 0) or 0)
+        if max_bytes <= 0:
+            return
+        for candidate in candidates:
+            identity = _read_tool_marker_identity_sha(
+                "tool", candidate["content"], candidate["tool_call_id"]
+            )
+            if identity in self._attempted_read_tool_recovery_markers:
+                continue
+            self._attempted_read_tool_recovery_markers.add(identity)
+            try:
+                recovered = recover_read_tool_file(candidate["path"], max_bytes=max_bytes)
+                if recovered is None:
+                    continue
+                recovered_content, _file_stat = recovered
+                stored_id = self._store.append_recovered_tool_content(
+                    self._session_id,
+                    tool_call_id=candidate["tool_call_id"],
+                    marker_identity_sha=identity,
+                    source_path=candidate["path"],
+                    content=recovered_content,
+                )
+                if stored_id is not None:
+                    self._recovered_read_tool_content_count += 1
+                    logger.info(
+                        "LCM recovered truncated read-tool content: session=%s path=%s chars=%d",
+                        self._session_id,
+                        candidate["path"],
+                        len(recovered_content),
+                    )
+            except Exception:  # pragma: no cover - defensive; recovery is best-effort
+                logger.debug("LCM read-tool recovery failed", exc_info=True)
 
     def _stored_row_externalized_text_parts_for_pattern_matching(self, msg: Dict[str, Any]) -> list[str]:
         ref_sources: list[str] = []

--- a/engine.py
+++ b/engine.py
@@ -3101,6 +3101,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             ):
                 try:
                     self._ingest_messages(messages)
+                    self._maybe_recover_truncated_read_tool_content(messages)
                     self._record_ingest_success()
                     self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 except Exception as e:

--- a/engine.py
+++ b/engine.py
@@ -3460,6 +3460,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 continue
             self._attempted_read_tool_recovery_markers.add(attempt_key)
             try:
+                # Persisted idempotency: a marker recovered by an earlier
+                # process already has a sidecar row — skip the file re-read
+                # instead of relying on the insert's unique constraint after
+                # the expensive I/O.
+                if self._store.has_recovered_tool_content(self._session_id, identity):
+                    continue
                 # Keep identity tied to the durable marker, but validate source
                 # bytes against the original pre-protection marker when present.
                 validation_marker = original_candidates.get(

--- a/engine.py
+++ b/engine.py
@@ -1204,7 +1204,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     conversation_id=self._conversation_id,
                 )
                 self._ingest_messages(messages)
-                self._maybe_recover_truncated_read_tool_content()
+                self._maybe_recover_truncated_read_tool_content(messages)
                 self._record_ingest_success()
                 self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 logger.debug(
@@ -3417,7 +3417,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             logger.debug("LCM ingest cursor reconciliation probe failed: %s", exc)
             self._ingest_cursor_needs_reconcile = False
 
-    def _maybe_recover_truncated_read_tool_content(self) -> None:
+    def _maybe_recover_truncated_read_tool_content(
+        self, original_messages: List[Dict[str, Any]] | None = None
+    ) -> None:
         """Recover read-tool results the host truncated unrecoverably.
 
         For each stored tool message carrying an unrecoverable truncation marker
@@ -3437,6 +3439,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             # keys recovery by the exact marker bytes later expansion sees.
             stored_messages = self._store.get_session_tail(self._session_id, limit=10_000)
             candidates = plan_read_tool_recovery(stored_messages)
+            original_candidates = {
+                (candidate["tool_call_id"], candidate["path"]): candidate["content"]
+                for candidate in plan_read_tool_recovery(original_messages or [])
+            }
         except Exception:  # pragma: no cover - defensive; recovery is best-effort
             logger.debug("LCM read-tool recovery planning failed", exc_info=True)
             return
@@ -3451,7 +3457,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 continue
             self._attempted_read_tool_recovery_markers.add(identity)
             try:
-                recovered = recover_read_tool_file(candidate["path"], max_bytes=max_bytes)
+                # Keep identity tied to the durable marker, but validate source
+                # bytes against the original pre-protection marker when present.
+                validation_marker = original_candidates.get(
+                    (candidate["tool_call_id"], candidate["path"]),
+                    candidate["content"],
+                )
+                recovered = recover_read_tool_file(
+                    candidate["path"],
+                    marker_content=validation_marker,
+                    max_bytes=max_bytes,
+                )
                 if recovered is None:
                     continue
                 recovered_content, _file_stat = recovered

--- a/engine.py
+++ b/engine.py
@@ -209,10 +209,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # visible; full lossless retention (store with ignored=1) is a larger
         # follow-up that touches cursor reconciliation and FTS.
         self._ignore_pattern_dropped_count: int = 0
-        # Marker-identity digests already attempted for read-tool recovery this
-        # process, so an unrecoverable truncation marker replayed every turn is
-        # re-read from disk at most once instead of on each ingest.
-        self._attempted_read_tool_recovery_markers: set[str] = set()
+        # Session/marker pairs already attempted for read-tool recovery this
+        # process, so replay is suppressed without one session preventing the
+        # same marker identity from being recovered into another session's row.
+        self._attempted_read_tool_recovery_markers: set[tuple[str, str]] = set()
         self._recovered_read_tool_content_count: int = 0
 
         # Track which store_ids have been ingested into the DAG
@@ -3429,7 +3429,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         by the marker's identity. The parent messages row is never touched, so
         replay/FTS/reconciliation stay identical; recovery is expand-on-demand
         only. Best-effort: any failure is swallowed so ingest never breaks, and
-        each marker is attempted at most once per process.
+        each marker is attempted at most once per session per process.
         """
         if not self._config.read_tool_recovery_enabled or not self._session_id:
             return
@@ -3453,9 +3453,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             identity = _read_tool_marker_identity_sha(
                 "tool", candidate["content"], candidate["tool_call_id"]
             )
-            if identity in self._attempted_read_tool_recovery_markers:
+            attempt_key = (self._session_id, identity)
+            if attempt_key in self._attempted_read_tool_recovery_markers:
                 continue
-            self._attempted_read_tool_recovery_markers.add(identity)
+            self._attempted_read_tool_recovery_markers.add(attempt_key)
             try:
                 # Keep identity tied to the durable marker, but validate source
                 # bytes against the original pre-protection marker when present.

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -515,23 +515,66 @@ def _stat_generation_metadata(stats: os.stat_result) -> dict[str, int]:
     }
 
 
+def _same_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        int(left.st_dev),
+        int(left.st_ino),
+        stat.S_IFMT(left.st_mode),
+    ) == (
+        int(right.st_dev),
+        int(right.st_ino),
+        stat.S_IFMT(right.st_mode),
+    )
+
+
 def _read_regular_file_no_symlink(
     path: Path, *, max_bytes: int = _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES
 ) -> tuple[str, dict[str, int]] | None:
+    if not path.is_absolute() or not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        return None
     flags = os.O_RDONLY
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    flags |= os.O_NOFOLLOW
     if hasattr(os, "O_NONBLOCK"):
         flags |= os.O_NONBLOCK
+    directory_flags = getattr(os, "O_PATH", os.O_RDONLY) | os.O_DIRECTORY | os.O_NOFOLLOW
+    parts = path.parts[1:]
+    if not parts:
+        return None
+    directory_fd: int | None = None
     fd: int | None = None
     try:
-        lstat_result = os.lstat(str(path))
-        if not stat.S_ISREG(lstat_result.st_mode):
+        directory_fd = os.open(os.sep, directory_flags)
+        for component in parts[:-1]:
+            component_lstat = os.stat(
+                component,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISDIR(component_lstat.st_mode):
+                return None
+            next_directory_fd = os.open(
+                component,
+                directory_flags,
+                dir_fd=directory_fd,
+            )
+            opened_directory_stat = os.fstat(next_directory_fd)
+            if not _same_file_identity(component_lstat, opened_directory_stat):
+                os.close(next_directory_fd)
+                return None
+            os.close(directory_fd)
+            directory_fd = next_directory_fd
+
+        final_lstat = os.stat(
+            parts[-1],
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if not stat.S_ISREG(final_lstat.st_mode) or final_lstat.st_size > max_bytes:
             return None
-        if lstat_result.st_size > max_bytes:
-            return None
-        fd = os.open(str(path), flags)
+        fd = os.open(parts[-1], flags, dir_fd=directory_fd)
         stats_before = os.fstat(fd)
+        if not _same_file_identity(final_lstat, stats_before):
+            return None
         if not stat.S_ISREG(stats_before.st_mode):
             return None
         if stats_before.st_size > max_bytes:
@@ -549,6 +592,11 @@ def _read_regular_file_no_symlink(
         if fd is not None:
             try:
                 os.close(fd)
+            except OSError:
+                pass
+        if directory_fd is not None:
+            try:
+                os.close(directory_fd)
             except OSError:
                 pass
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -557,12 +557,16 @@ def _read_regular_file_no_symlink(
                 directory_flags,
                 dir_fd=directory_fd,
             )
-            opened_directory_stat = os.fstat(next_directory_fd)
-            if not _same_file_identity(component_lstat, opened_directory_stat):
-                os.close(next_directory_fd)
-                return None
-            os.close(directory_fd)
-            directory_fd = next_directory_fd
+            try:
+                opened_directory_stat = os.fstat(next_directory_fd)
+                if not _same_file_identity(component_lstat, opened_directory_stat):
+                    return None
+                os.close(directory_fd)
+                directory_fd = next_directory_fd
+                next_directory_fd = None
+            finally:
+                if next_directory_fd is not None:
+                    os.close(next_directory_fd)
 
         final_lstat = os.stat(
             parts[-1],

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -515,7 +515,9 @@ def _stat_generation_metadata(stats: os.stat_result) -> dict[str, int]:
     }
 
 
-def _read_regular_file_no_symlink(path: Path) -> tuple[str, dict[str, int]] | None:
+def _read_regular_file_no_symlink(
+    path: Path, *, max_bytes: int = _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES
+) -> tuple[str, dict[str, int]] | None:
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -526,13 +528,13 @@ def _read_regular_file_no_symlink(path: Path) -> tuple[str, dict[str, int]] | No
         lstat_result = os.lstat(str(path))
         if not stat.S_ISREG(lstat_result.st_mode):
             return None
-        if lstat_result.st_size > _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES:
+        if lstat_result.st_size > max_bytes:
             return None
         fd = os.open(str(path), flags)
         stats_before = os.fstat(fd)
         if not stat.S_ISREG(stats_before.st_mode):
             return None
-        if stats_before.st_size > _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES:
+        if stats_before.st_size > max_bytes:
             return None
         with os.fdopen(fd, "rb") as handle:
             fd = None

--- a/read_tool_recovery.py
+++ b/read_tool_recovery.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -29,6 +30,11 @@ from .message_content import normalize_content_value
 
 READ_TOOL_NAMES = frozenset({"read_file"})
 DEFAULT_READ_TOOL_RECOVERY_MAX_BYTES = 8 * 1024 * 1024
+_UNRECOVERABLE_TRUNCATION_DETAILS_RE = re.compile(
+    r"\[Truncated:\s*tool response was (?P<count>[\d,]+) chars\.\s*"
+    r"Full output could not be saved to sandbox\.\]",
+    re.IGNORECASE,
+)
 
 
 def is_recoverable_read_tool_marker(text: str | None) -> bool:
@@ -108,16 +114,47 @@ def build_read_tool_call_path_map(messages: List[Dict[str, Any]]) -> Dict[str, s
 def recover_read_tool_file(
     path: str,
     *,
+    marker_content: str,
     max_bytes: int = DEFAULT_READ_TOOL_RECOVERY_MAX_BYTES,
 ) -> tuple[str, dict[str, int]] | None:
     """Re-read an absolute source path with the hardened no-symlink primitive.
 
     Returns ``(content, file_stat)`` or ``None`` when the path is unsafe,
-    non-regular, oversized, a symlink, or changed mid-read (TOCTOU).
+    non-regular, oversized, a symlink, changed mid-read (TOCTOU), or no longer
+    matches the original marker's character count and preview prefix.
     """
     if not path or not Path(path).is_absolute():
         return None
-    return _read_regular_file_no_symlink(Path(path), max_bytes=max_bytes)
+    recovered = _read_regular_file_no_symlink(Path(path), max_bytes=max_bytes)
+    if recovered is None:
+        return None
+    content, _file_stat = recovered
+    if not recovered_content_matches_marker(content, marker_content):
+        return None
+    return recovered
+
+
+def recovered_content_matches_marker(content: str, marker_content: str) -> bool:
+    """Validate recovered text against the original host truncation marker."""
+    if not isinstance(content, str) or not isinstance(marker_content, str):
+        return False
+    match = _UNRECOVERABLE_TRUNCATION_DETAILS_RE.search(marker_content)
+    if match is None:
+        return False
+    try:
+        expected_chars = int(match.group("count").replace(",", ""))
+    except ValueError:
+        return False
+    if len(content) != expected_chars:
+        return False
+    preview = marker_content[:match.start()]
+    # Hermes inserts a blank line between the original preview and its marker;
+    # it is framing, not part of the source file prefix.
+    if preview.endswith("\r\n\r\n"):
+        preview = preview[:-4]
+    elif preview.endswith("\n\n"):
+        preview = preview[:-2]
+    return bool(preview) and content.startswith(preview)
 
 
 def plan_read_tool_recovery(

--- a/read_tool_recovery.py
+++ b/read_tool_recovery.py
@@ -1,0 +1,154 @@
+"""Lossless recovery of read-tool results the host truncated unrecoverably.
+
+When an oversized read-tool result overflows the per-turn budget and the host
+cannot persist it to a sandbox file, it is replaced by an unrecoverable
+``[Truncated: ... could not be saved to sandbox.]`` marker and the original
+content is lost from LCM's durable store. For the ``read_file`` tool the source
+path is still known (the originating tool call's ``path`` argument), so on the
+local host LCM can re-read the file and preserve the full content.
+
+This module holds only the pure, side-effect-light helpers (pairing, marker
+identity, safe recovery). Persistence into the ``recovered_tool_content``
+sidecar and the ingest wiring live in the store/engine so this stays testable
+in isolation and free of reconciliation coupling: the parent ``messages`` row
+always keeps the byte-identical marker, so replay/FTS/reconcile never change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .ingest_protection import (
+    _is_unrecoverable_tool_truncation_marker,
+    _read_regular_file_no_symlink,
+)
+from .message_content import normalize_content_value
+
+READ_TOOL_NAMES = frozenset({"read_file"})
+DEFAULT_READ_TOOL_RECOVERY_MAX_BYTES = 8 * 1024 * 1024
+
+
+def is_recoverable_read_tool_marker(text: str | None) -> bool:
+    """True when a tool message carries an unrecoverable truncation marker."""
+    return _is_unrecoverable_tool_truncation_marker(text)
+
+
+def marker_identity_sha(role: str, content: str, tool_call_id: str) -> str:
+    """Stable digest of the stored marker row, used as the sidecar lookup key.
+
+    Keyed on the exact bytes the parent ``messages`` row holds so an expand-time
+    lookup finds the recovered content deterministically, with no dependence on
+    the reconciliation identity machinery.
+    """
+    h = hashlib.sha256()
+    h.update((role or "").encode("utf-8"))
+    h.update(b"\x00")
+    h.update((content or "").encode("utf-8"))
+    h.update(b"\x00")
+    h.update((tool_call_id or "").encode("utf-8"))
+    return h.hexdigest()
+
+
+def _tool_call_function(tool_call: Any) -> tuple[str, Any] | None:
+    if not isinstance(tool_call, dict):
+        return None
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    if not isinstance(name, str):
+        return None
+    return name, function.get("arguments")
+
+
+def _extract_path_argument(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            return ""
+    if not isinstance(arguments, dict):
+        return ""
+    path = arguments.get("path")
+    return path if isinstance(path, str) else ""
+
+
+def build_read_tool_call_path_map(messages: List[Dict[str, Any]]) -> Dict[str, str]:
+    """Map each read-tool ``tool_call_id`` to its absolute ``path`` argument.
+
+    Only calls to a known read tool with an absolute path are included; anything
+    else is skipped so recovery never touches an arbitrary or relative path.
+    """
+    path_map: Dict[str, str] = {}
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            parsed = _tool_call_function(tool_call)
+            if parsed is None:
+                continue
+            name, arguments = parsed
+            if name not in READ_TOOL_NAMES:
+                continue
+            call_id = tool_call.get("id") if isinstance(tool_call, dict) else None
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            path = _extract_path_argument(arguments)
+            if path and Path(path).is_absolute():
+                path_map[call_id] = path
+    return path_map
+
+
+def recover_read_tool_file(
+    path: str,
+    *,
+    max_bytes: int = DEFAULT_READ_TOOL_RECOVERY_MAX_BYTES,
+) -> tuple[str, dict[str, int]] | None:
+    """Re-read an absolute source path with the hardened no-symlink primitive.
+
+    Returns ``(content, file_stat)`` or ``None`` when the path is unsafe,
+    non-regular, oversized, a symlink, or changed mid-read (TOCTOU).
+    """
+    if not path or not Path(path).is_absolute():
+        return None
+    return _read_regular_file_no_symlink(Path(path), max_bytes=max_bytes)
+
+
+def plan_read_tool_recovery(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return recovery candidates: tool messages with a marker and a paired path.
+
+    Each candidate is ``{"index", "tool_call_id", "content", "path"}``. Pairing
+    uses the read-tool call map built from the same message list, so recovery is
+    scoped to the turn that produced the marker.
+    """
+    path_map = build_read_tool_call_path_map(messages)
+    if not path_map:
+        return []
+    candidates: List[Dict[str, Any]] = []
+    for index, msg in enumerate(messages):
+        if not isinstance(msg, dict) or str(msg.get("role") or "") != "tool":
+            continue
+        content = normalize_content_value(msg.get("content")) or ""
+        if not is_recoverable_read_tool_marker(content):
+            continue
+        tool_call_id = str(msg.get("tool_call_id") or "")
+        path = path_map.get(tool_call_id)
+        if not path:
+            continue
+        candidates.append(
+            {
+                "index": index,
+                "tool_call_id": tool_call_id,
+                "content": content,
+                "path": path,
+            }
+        )
+    return candidates

--- a/reset_state.py
+++ b/reset_state.py
@@ -50,6 +50,7 @@ class ResetStateMixin:
         self._reset_compaction_progress()
         self._generated_ignored_active_replay_placeholder_hashes = set()
         self._generated_ignored_active_replay_placeholder_message_ids = set()
+        self._attempted_read_tool_recovery_markers = set()
         self._compression_boundary_ingest_pending = False
         self._compression_boundary_active_placeholder_digest_budget = {}
         self._compression_boundary_active_placeholder_digest_ordinals = {}

--- a/store.py
+++ b/store.py
@@ -407,6 +407,77 @@ class MessageStore:
                 ids.append(cur.lastrowid)
         return ids
 
+    # -- Recovered read-tool content sidecar --------------------------------
+
+    def append_recovered_tool_content(self, session_id: str, *,
+                                      tool_call_id: str,
+                                      marker_identity_sha: str,
+                                      source_path: str,
+                                      content: str) -> int | None:
+        """Store recovered read-tool content keyed by the marker's identity.
+
+        The content is run through ingest protection (redaction/inline payload
+        externalization) before persist, exactly like a normal tool row, so a
+        recovered file's sensitive substrings never land unredacted. Idempotent
+        per (session, marker): a second recovery of the same marker is skipped.
+        """
+        if not session_id or not marker_identity_sha:
+            return None
+        protected = protect_message_for_ingest(
+            {"role": "tool", "content": content, "tool_call_id": tool_call_id},
+            config=self._ingest_protection_config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
+        protected_content = _normalize_content_value(protected.get("content"))
+        with self._write_lock, self._conn:
+            cur = self._conn.execute(
+                """INSERT INTO recovered_tool_content
+                   (session_id, tool_call_id, marker_identity_sha, source_path,
+                    recovered_chars, externalized_ref, content, timestamp)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(session_id, marker_identity_sha) DO NOTHING""",
+                (
+                    session_id,
+                    tool_call_id or "",
+                    marker_identity_sha,
+                    source_path or "",
+                    len(protected_content or ""),
+                    "",
+                    protected_content,
+                    time.time(),
+                ),
+            )
+            if cur.rowcount == 0:
+                return None
+            return cur.lastrowid
+
+    def get_recovered_tool_content(self, session_id: str,
+                                   marker_identity_sha: str) -> Dict[str, Any] | None:
+        """Return the recovered content row for a marker, or None."""
+        row = self._conn.execute(
+            "SELECT recovered_id, session_id, tool_call_id, marker_identity_sha, "
+            "source_path, recovered_chars, externalized_ref, content, timestamp "
+            "FROM recovered_tool_content WHERE session_id = ? AND marker_identity_sha = ? "
+            "ORDER BY recovered_id DESC LIMIT 1",
+            (session_id, marker_identity_sha),
+        ).fetchone()
+        if row is None:
+            return None
+        cols = [
+            "recovered_id", "session_id", "tool_call_id", "marker_identity_sha",
+            "source_path", "recovered_chars", "externalized_ref", "content", "timestamp",
+        ]
+        return dict(zip(cols, row))
+
+    def get_recovered_tool_content_count(self, session_id: str) -> int:
+        """Count recovered read-tool rows for a session."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM recovered_tool_content WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else 0
+
     def reassign_session_messages(self, old_session_id: str, new_session_id: str) -> int:
         """Move all persisted messages from one session_id to another."""
         if not old_session_id or not new_session_id or old_session_id == new_session_id:
@@ -414,6 +485,11 @@ class MessageStore:
         with self._write_lock:
             cur = self._conn.execute(
                 "UPDATE messages SET session_id = ? WHERE session_id = ?",
+                (new_session_id, old_session_id),
+            )
+            # Keep the recovered-content sidecar bound to the same session.
+            self._conn.execute(
+                "UPDATE recovered_tool_content SET session_id = ? WHERE session_id = ?",
                 (new_session_id, old_session_id),
             )
             self._conn.commit()
@@ -424,6 +500,10 @@ class MessageStore:
         with self._write_lock:
             cur = self._conn.execute(
                 "DELETE FROM messages WHERE session_id = ?",
+                (session_id,),
+            )
+            self._conn.execute(
+                "DELETE FROM recovered_tool_content WHERE session_id = ?",
                 (session_id,),
             )
             self._conn.commit()

--- a/store.py
+++ b/store.py
@@ -26,7 +26,12 @@ from .db_bootstrap import (
     run_versioned_migrations,
 )
 from .config import LCMConfig
-from .ingest_protection import protect_message_for_ingest, protect_messages_for_ingest
+from .externalize import extract_externalized_ref
+from .ingest_protection import (
+    extract_ingest_externalized_refs,
+    protect_message_for_ingest,
+    protect_messages_for_ingest,
+)
 from .search_query import (
     build_snippet,
     compute_search_candidate_cap,
@@ -430,6 +435,12 @@ class MessageStore:
             session_id=session_id,
         )
         protected_content = _normalize_content_value(protected.get("content"))
+        externalized_refs = extract_ingest_externalized_refs(protected_content or "")
+        externalized_ref = (
+            externalized_refs[0]
+            if externalized_refs
+            else extract_externalized_ref(protected_content or "") or ""
+        )
         with self._write_lock, self._conn:
             cur = self._conn.execute(
                 """INSERT INTO recovered_tool_content
@@ -442,8 +453,8 @@ class MessageStore:
                     tool_call_id or "",
                     marker_identity_sha,
                     source_path or "",
-                    len(protected_content or ""),
-                    "",
+                    len(content or ""),
+                    externalized_ref,
                     protected_content,
                     time.time(),
                 ),

--- a/store.py
+++ b/store.py
@@ -463,6 +463,22 @@ class MessageStore:
                 return None
             return cur.lastrowid
 
+    def has_recovered_tool_content(self, session_id: str,
+                                   marker_identity_sha: str) -> bool:
+        """Whether a recovered row already exists for a marker.
+
+        Cheap persisted-idempotency probe so recovery planning can skip the
+        file re-read entirely for markers recovered in an earlier process
+        (the in-memory attempted-marker set is empty after a restart)."""
+        if not session_id or not marker_identity_sha:
+            return False
+        row = self._conn.execute(
+            "SELECT 1 FROM recovered_tool_content "
+            "WHERE session_id = ? AND marker_identity_sha = ? LIMIT 1",
+            (session_id, marker_identity_sha),
+        ).fetchone()
+        return row is not None
+
     def get_recovered_tool_content(self, session_id: str,
                                    marker_identity_sha: str) -> Dict[str, Any] | None:
         """Return the recovered content row for a marker, or None."""

--- a/store.py
+++ b/store.py
@@ -493,7 +493,7 @@ class MessageStore:
         """Move all persisted messages from one session_id to another."""
         if not old_session_id or not new_session_id or old_session_id == new_session_id:
             return 0
-        with self._write_lock:
+        with self._write_lock, self._conn:
             cur = self._conn.execute(
                 "UPDATE messages SET session_id = ? WHERE session_id = ?",
                 (new_session_id, old_session_id),
@@ -503,12 +503,11 @@ class MessageStore:
                 "UPDATE recovered_tool_content SET session_id = ? WHERE session_id = ?",
                 (new_session_id, old_session_id),
             )
-            self._conn.commit()
             return cur.rowcount if cur.rowcount is not None else 0
 
     def delete_session_messages(self, session_id: str) -> int:
         """Delete all messages for a session. Returns count deleted."""
-        with self._write_lock:
+        with self._write_lock, self._conn:
             cur = self._conn.execute(
                 "DELETE FROM messages WHERE session_id = ?",
                 (session_id,),
@@ -517,7 +516,6 @@ class MessageStore:
                 "DELETE FROM recovered_tool_content WHERE session_id = ?",
                 (session_id,),
             )
-            self._conn.commit()
             deleted = cur.rowcount if cur.rowcount is not None else 0
             return deleted
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -1436,6 +1436,13 @@ def test_lcm_doctor_clean_apply_is_backup_first_and_deletes_safe_candidates(tmp_
 
     engine._store.append("cron_20260414", {"role": "user", "content": "scheduled report"}, token_estimate=12)
     engine._store.append("normal_session", {"role": "user", "content": "real conversation"}, token_estimate=20)
+    engine._store.append_recovered_tool_content(
+        "cron_20260414",
+        tool_call_id="read-1",
+        marker_identity_sha="cron-marker",
+        source_path="/tmp/scheduled-report.txt",
+        content="recovered scheduled report",
+    )
     engine._dag.add_node(SummaryNode(
         session_id="cron_20260414",
         depth=0,
@@ -1457,6 +1464,7 @@ def test_lcm_doctor_clean_apply_is_backup_first_and_deletes_safe_candidates(tmp_
     backup_path = Path(backup_line.split(": ", 1)[1])
     assert backup_path.exists()
     assert engine._store.get_range("cron_20260414") == []
+    assert engine._store.get_recovered_tool_content_count("cron_20260414") == 0
     assert engine._dag.get_session_nodes("cron_20260414") == []
     assert engine._lifecycle.get_by_conversation("cron_20260414") is None
     assert len(engine._store.get_range("normal_session")) == 1

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -138,6 +138,52 @@ class TestPureHelpers:
             str(link), marker_content=_marker_for_content("secret")
         ) is None
 
+    def test_recover_rejects_symlinked_ancestor(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        content = "content reached through a symlinked ancestor"
+        (real_dir / "source.txt").write_text(content, encoding="utf-8")
+        linked_dir = tmp_path / "linked"
+        try:
+            os.symlink(real_dir, linked_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            return  # platform without symlink support
+
+        assert recover_read_tool_file(
+            str(linked_dir / "source.txt"), marker_content=_marker_for_content(content)
+        ) is None
+
+    def test_recover_rejects_final_path_replacement_between_stat_and_open(
+        self, tmp_path, monkeypatch
+    ):
+        source = tmp_path / "source.txt"
+        original = "shared prefix original-data"
+        replacement = "shared prefix attacker-data"
+        assert len(original) == len(replacement)
+        source.write_text(original, encoding="utf-8")
+        replacement_path = tmp_path / "replacement.txt"
+        replacement_path.write_text(replacement, encoding="utf-8")
+        parked_path = tmp_path / "parked.txt"
+        original_open = ingest_protection_mod.os.open
+        replaced = False
+
+        def replace_before_open(path, flags, *args, **kwargs):
+            nonlocal replaced
+            is_final_open = str(path) in {str(source), source.name}
+            if is_final_open and not replaced:
+                replaced = True
+                os.replace(source, parked_path)
+                os.replace(replacement_path, source)
+            return original_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(ingest_protection_mod.os, "open", replace_before_open)
+
+        assert recover_read_tool_file(
+            str(source),
+            marker_content=_marker_for_content(original, preview_chars=len("shared prefix ")),
+        ) is None
+        assert replaced is True
+
     def test_recover_rejects_oversized(self, tmp_path):
         f = tmp_path / "big.txt"
         f.write_text("x" * 100, encoding="utf-8")
@@ -539,6 +585,68 @@ class TestEngineRecovery:
 
         assert result["content"] == file_content
         assert result["recovered_chars"] == len(file_content)
+
+    def test_cross_session_expansion_does_not_hydrate_protected_recovered_content(
+        self, tmp_path
+    ):
+        protected = "PROTECTED_RECOVERED_PAYLOAD_" + ("QUJD" * 1_500)
+        source = tmp_path / "protected-source.txt"
+        source.write_text(protected, encoding="utf-8")
+        engine = self._engine(
+            tmp_path,
+            enabled=True,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=500,
+            large_output_externalization_path=str(tmp_path / "externalized"),
+        )
+        engine.ingest([
+            {"role": "user", "content": "read protected content"},
+            _read_call("call-protected", str(source)),
+            {
+                "role": "tool",
+                "tool_call_id": "call-protected",
+                "content": _marker_for_content(protected),
+            },
+        ])
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+
+        config = engine._config
+        engine.shutdown()
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "chat-2", platform="cli", conversation_id="c2", context_length=200000
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="chat-2",
+            depth=0,
+            summary="Foreign protected source",
+            token_count=10,
+            source_token_count=10,
+            source_ids=[tool_row["store_id"]],
+            source_type="messages",
+        ))
+
+        by_store_id = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+        by_node_id = json.loads(lcm_tools.lcm_expand(
+            {"node_id": node_id, "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+
+        assert by_store_id["from_current_session"] is False
+        assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_store_id)
+        assert by_store_id["content"].startswith("[Externalized tool output:")
+        assert by_store_id["externalized_ref"]
+        assert "cannot be expanded" in by_store_id["externalized_note"]
+        assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_node_id)
+        assert by_node_id["expanded"][0]["content"].startswith(
+            "[Externalized tool output:"
+        )
 
     def test_store_id_expansion_restores_embedded_externalized_payload_in_place(self, tmp_path):
         encoded_one = "QUJD" * 1_500

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import os
+import re
 import sqlite3
 
+from hermes_lcm import message_patterns as message_patterns_mod
 from hermes_lcm.config import LCMConfig
+from hermes_lcm.db_bootstrap import ensure_recovered_tool_content_table
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.read_tool_recovery import (
     build_read_tool_call_path_map,
     is_recoverable_read_tool_marker,
     marker_identity_sha,
     plan_read_tool_recovery,
+    recovered_content_matches_marker,
     recover_read_tool_file,
 )
 from hermes_lcm.store import MessageStore
@@ -22,6 +27,44 @@ def _marker(chars: int = 5000) -> str:
         f"[Truncated: tool response was {chars:,} chars. "
         "Full output could not be saved to sandbox.]"
     )
+
+
+def _marker_for_content(content: str, preview_chars: int = 16) -> str:
+    return (
+        content[:preview_chars]
+        + "\n\n"
+        + f"[Truncated: tool response was {len(content):,} chars. "
+        + "Full output could not be saved to sandbox.]"
+    )
+
+
+def _run_recovered_content_migration(db_path: str, start, results) -> None:
+    try:
+        conn = sqlite3.connect(db_path, timeout=10.0)
+        conn.execute("PRAGMA busy_timeout=10000")
+        start.wait(timeout=10)
+        ensure_recovered_tool_content_table(conn)
+        conn.commit()
+        conn.close()
+        results.put(None)
+    except Exception as exc:
+        results.put(repr(exc))
+
+
+class _TimeoutPattern:
+    def __init__(self, pattern: str):
+        self._compiled = re.compile(pattern)
+        self.pattern = pattern
+
+    def search(self, text: str, *, timeout=None):
+        assert timeout is not None
+        return self._compiled.search(text)
+
+
+class _TimeoutRegexEngine:
+    @staticmethod
+    def compile(pattern: str):
+        return _TimeoutPattern(pattern)
 
 
 def _read_call(call_id: str, path: str) -> dict:
@@ -69,8 +112,11 @@ class TestPureHelpers:
 
     def test_recover_reads_absolute_regular_file(self, tmp_path):
         f = tmp_path / "src.txt"
-        f.write_text("hello lossless world", encoding="utf-8")
-        recovered = recover_read_tool_file(str(f))
+        content = "hello lossless world"
+        f.write_text(content, encoding="utf-8")
+        recovered = recover_read_tool_file(
+            str(f), marker_content=_marker_for_content(content)
+        )
         assert recovered is not None
         content, _stat = recovered
         assert content == "hello lossless world"
@@ -83,15 +129,31 @@ class TestPureHelpers:
             os.symlink(target, link)
         except (OSError, NotImplementedError):
             return  # platform without symlink support
-        assert recover_read_tool_file(str(link)) is None
+        assert recover_read_tool_file(
+            str(link), marker_content=_marker_for_content("secret")
+        ) is None
 
     def test_recover_rejects_oversized(self, tmp_path):
         f = tmp_path / "big.txt"
         f.write_text("x" * 100, encoding="utf-8")
-        assert recover_read_tool_file(str(f), max_bytes=10) is None
+        assert recover_read_tool_file(
+            str(f), marker_content=_marker_for_content("x" * 100), max_bytes=10
+        ) is None
 
     def test_recover_rejects_relative_path(self):
-        assert recover_read_tool_file("relative.txt") is None
+        assert recover_read_tool_file(
+            "relative.txt", marker_content=_marker_for_content("irrelevant")
+        ) is None
+
+    def test_recovered_content_matches_original_marker(self):
+        content = "the complete original file"
+        assert recovered_content_matches_marker(content, _marker_for_content(content))
+
+    def test_recovered_content_rejects_changed_source(self):
+        original = "the complete original file"
+        changed = "the complete modified file"
+        assert len(changed) == len(original)
+        assert not recovered_content_matches_marker(changed, _marker_for_content(original))
 
     def test_plan_pairs_marker_to_path(self, tmp_path):
         f = tmp_path / "src.txt"
@@ -209,6 +271,60 @@ class TestStoreSidecar:
         assert rows == [("newer",)]
         assert any(row[1] == "idx_recovered_session_marker" and row[2] == 1 for row in index_rows)
 
+    def test_bootstrap_legacy_index_migration_is_process_safe(self, tmp_path):
+        db_path = tmp_path / "lcm.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE recovered_tool_content (
+                recovered_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                tool_call_id TEXT DEFAULT '',
+                marker_identity_sha TEXT NOT NULL,
+                source_path TEXT DEFAULT '',
+                recovered_chars INTEGER DEFAULT 0,
+                externalized_ref TEXT DEFAULT '',
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+            CREATE INDEX idx_recovered_session_marker
+                ON recovered_tool_content(session_id, marker_identity_sha);
+            INSERT INTO recovered_tool_content
+                (session_id, marker_identity_sha, content, timestamp)
+                VALUES ('s1', 'same', 'older', 1), ('s1', 'same', 'newer', 2);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        context = multiprocessing.get_context("fork")
+        start = context.Event()
+        results = context.Queue()
+        processes = [
+            context.Process(
+                target=_run_recovered_content_migration,
+                args=(str(db_path), start, results),
+            )
+            for _ in range(6)
+        ]
+        for process in processes:
+            process.start()
+        start.set()
+        for process in processes:
+            process.join(timeout=15)
+            assert process.exitcode == 0
+        assert [results.get(timeout=2) for _ in processes] == [None] * len(processes)
+
+        conn = sqlite3.connect(db_path)
+        rows = conn.execute(
+            "SELECT content FROM recovered_tool_content "
+            "WHERE session_id = 's1' AND marker_identity_sha = 'same'"
+        ).fetchall()
+        indexes = conn.execute("PRAGMA index_list(recovered_tool_content)").fetchall()
+        conn.close()
+        assert rows == [("newer",)]
+        assert any(row[1] == "idx_recovered_session_marker" and row[2] == 1 for row in indexes)
+
     def test_sensitive_content_redacted(self, tmp_path):
         store = self._store(tmp_path, large_output_externalization_path=str(tmp_path / "ext"))
         setattr(store._ingest_protection_config, "sensitive_patterns_enabled", True)
@@ -249,11 +365,16 @@ class TestEngineRecovery:
 
     def _turn(self, tmp_path):
         f = tmp_path / "source.txt"
-        f.write_text("the full 2MB file content that the host truncated", encoding="utf-8")
+        content = "the full 2MB file content that the host truncated"
+        f.write_text(content, encoding="utf-8")
         return f, [
             {"role": "user", "content": "read the file"},
             _read_call("call_1", str(f)),
-            {"role": "tool", "tool_call_id": "call_1", "content": _marker()},
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": _marker_for_content(content),
+            },
         ]
 
     def test_disabled_recovers_nothing(self, tmp_path):
@@ -274,13 +395,14 @@ class TestEngineRecovery:
         assert is_recoverable_read_tool_marker(tool_rows[0]["content"])
 
         # ...but the full file content is recovered into the sidecar.
-        sha = marker_identity_sha("tool", _marker(), "call_1")
+        sha = marker_identity_sha("tool", turn[-1]["content"], "call_1")
         recovered = engine._store.get_recovered_tool_content("chat-1", sha)
         assert recovered is not None
         assert recovered["content"] == f.read_text(encoding="utf-8")
         assert recovered["source_path"] == str(f)
 
-    def test_ignored_marker_is_not_recovered(self, tmp_path):
+    def test_ignored_marker_is_not_recovered(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", _TimeoutRegexEngine)
         engine = self._engine(
             tmp_path,
             enabled=True,
@@ -302,7 +424,9 @@ class TestEngineRecovery:
             sensitive_patterns=["api_key"],
         )
         f, turn = self._turn(tmp_path)
-        turn[-1]["content"] = 'api_key="supersecretvalue"\n' + _marker()
+        content = 'api_key="supersecretvalue"\n' + f.read_text(encoding="utf-8")
+        f.write_text(content, encoding="utf-8")
+        turn[-1]["content"] = _marker_for_content(content, preview_chars=28)
         engine.ingest(turn)
         tool_row = next(
             row for row in engine._store.get_session_messages("chat-1")
@@ -313,7 +437,11 @@ class TestEngineRecovery:
         assert stored_sha != raw_sha
         recovered = engine._store.get_recovered_tool_content("chat-1", stored_sha)
         assert recovered is not None
-        assert recovered["content"] == f.read_text(encoding="utf-8")
+        assert "[LCM sensitive redaction:" in recovered["content"]
+        assert "supersecretvalue" not in recovered["content"]
+        assert recovered["content"].endswith(
+            "the full 2MB file content that the host truncated"
+        )
         assert engine._store.get_recovered_tool_content("chat-1", raw_sha) is None
 
     def test_recovery_is_attempted_once_per_marker(self, tmp_path):
@@ -324,10 +452,20 @@ class TestEngineRecovery:
         # must prevent a second re-read, so the first recovery is preserved.
         f.write_text("changed content", encoding="utf-8")
         engine.ingest(turn)
-        sha = marker_identity_sha("tool", _marker(), "call_1")
+        sha = marker_identity_sha("tool", turn[-1]["content"], "call_1")
         recovered = engine._store.get_recovered_tool_content("chat-1", sha)
         assert recovered["content"] == "the full 2MB file content that the host truncated"
         assert engine._store.get_recovered_tool_content_count("chat-1") == 1
+
+    def test_changed_source_is_not_stored_as_lossless_recovery(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        original = f.read_text(encoding="utf-8")
+        changed = original.replace("full", "fake")
+        assert len(changed) == len(original)
+        f.write_text(changed, encoding="utf-8")
+        engine.ingest(turn)
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 0
 
     def test_status_surfaces_recovery_count_when_enabled(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -571,6 +571,42 @@ class TestEngineRecovery:
         assert result["content_source"] == "recovered_read_tool_content"
         assert result["transcript_content"] == tool_row["content"]
 
+    def test_cross_session_store_id_does_not_fetch_plaintext_recovered_sidecar(
+        self, tmp_path, monkeypatch
+    ):
+        engine = self._engine(tmp_path, enabled=True)
+        _source, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+
+        config = engine._config
+        engine.shutdown()
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "chat-2", platform="cli", conversation_id="c2", context_length=200000
+        )
+        sidecar_fetches = []
+        original_fetch = engine._store.get_recovered_tool_content
+
+        def record_fetch(*args, **kwargs):
+            sidecar_fetches.append((args, kwargs))
+            return original_fetch(*args, **kwargs)
+
+        monkeypatch.setattr(engine._store, "get_recovered_tool_content", record_fetch)
+        result = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+
+        assert sidecar_fetches == []
+        assert result["from_current_session"] is False
+        assert result["content"] == tool_row["content"]
+        assert "full 2MB file content" not in json.dumps(result)
+        assert "content_source" not in result
+
     def test_store_id_expansion_hydrates_externalized_recovered_content(self, tmp_path):
         file_content = "LINE ONE\nLINE TWO\n" * 200
         source = tmp_path / "large-source.txt"
@@ -671,15 +707,16 @@ class TestEngineRecovery:
             source_type="messages",
         ))
 
-        by_store_id = json.loads(lcm_tools.lcm_expand(
-            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
-            engine=engine,
-        ))
         hydration_calls = []
+        original_sidecar_fetch = engine._store.get_recovered_tool_content
         original_recover = lcm_tools._get_recovered_read_tool_content
         original_load = lcm_tools._get_externalized_payload
         original_restore = lcm_tools._restore_ingest_placeholder_for_lookup
         original_find = lcm_tools.find_externalized_payload_for_message
+
+        def record_sidecar_fetch(*args, **kwargs):
+            hydration_calls.append("get_recovered_tool_content")
+            return original_sidecar_fetch(*args, **kwargs)
 
         def record_recover(*args, **kwargs):
             hydration_calls.append("_get_recovered_read_tool_content")
@@ -697,10 +734,17 @@ class TestEngineRecovery:
             hydration_calls.append("find_externalized_payload_for_message")
             return original_find(*args, **kwargs)
 
+        monkeypatch.setattr(
+            engine._store, "get_recovered_tool_content", record_sidecar_fetch
+        )
         monkeypatch.setattr(lcm_tools, "_get_recovered_read_tool_content", record_recover)
         monkeypatch.setattr(lcm_tools, "_get_externalized_payload", record_load)
         monkeypatch.setattr(lcm_tools, "_restore_ingest_placeholder_for_lookup", record_restore)
         monkeypatch.setattr(lcm_tools, "find_externalized_payload_for_message", record_find)
+        by_store_id = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
         by_node_id = json.loads(lcm_tools.lcm_expand(
             {"node_id": node_id, "max_tokens": 1_000_000},
             engine=engine,
@@ -709,9 +753,8 @@ class TestEngineRecovery:
         assert hydration_calls == []
         assert by_store_id["from_current_session"] is False
         assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_store_id)
-        assert by_store_id["content"].startswith("[Externalized tool output:")
-        assert by_store_id["externalized_ref"]
-        assert "cannot be expanded" in by_store_id["externalized_note"]
+        assert by_store_id["content"] == tool_row["content"]
+        assert "content_source" not in by_store_id
         assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_node_id)
         assert by_node_id["expanded"][0]["content"] == tool_row["content"]
         assert by_node_id["expanded"][0]["content_source"] == "message"

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -606,6 +606,17 @@ class TestEngineRecovery:
         assert result["recovered"] == 1
         assert result["content"] == source.read_text(encoding="utf-8")
 
+    def test_session_end_final_flush_recovers_content(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        source, turn = self._turn(tmp_path)
+
+        engine.on_session_end("chat-1", turn)
+
+        identity = marker_identity_sha("tool", turn[-1]["content"], "call_1")
+        recovered = engine._store.get_recovered_tool_content("chat-1", identity)
+        assert recovered is not None
+        assert recovered["content"] == source.read_text(encoding="utf-8")
+
     def test_node_expansion_hydrates_recovered_content(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)
         f, turn = self._turn(tmp_path)

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -465,6 +465,52 @@ class TestEngineRecovery:
         assert result["content"] == file_content
         assert result["recovered_chars"] == len(file_content)
 
+    def test_store_id_expansion_restores_embedded_externalized_payload_in_place(self, tmp_path):
+        encoded = "QUJD" * 1_500
+        file_content = f"prefix remains\n{encoded}\nsuffix remains"
+        source = tmp_path / "embedded-payload.txt"
+        source.write_text(file_content, encoding="utf-8")
+        engine = self._engine(
+            tmp_path,
+            enabled=True,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=500,
+            large_output_externalization_path=str(tmp_path / "externalized"),
+        )
+        engine.ingest([
+            {"role": "user", "content": "read it"},
+            {
+                "role": "assistant",
+                "content": "reading",
+                "tool_calls": [{
+                    "id": "call-embedded",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": json.dumps({"path": str(source)}),
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-embedded",
+                "content": _marker_for_content(file_content),
+            },
+        ])
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+
+        result = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+
+        assert result["content"] == file_content
+        assert result["content"].startswith("prefix remains\n")
+        assert result["content"].endswith("\nsuffix remains")
+
     def test_node_expansion_hydrates_recovered_content(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)
         f, turn = self._turn(tmp_path)
@@ -548,6 +594,33 @@ class TestEngineRecovery:
         recovered = engine._store.get_recovered_tool_content("chat-1", sha)
         assert recovered["content"] == "the full 2MB file content that the host truncated"
         assert engine._store.get_recovered_tool_content_count("chat-1") == 1
+
+    def test_identical_marker_attempted_in_another_session_is_recovered(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        source, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        first_session_attempts = set(engine._attempted_read_tool_recovery_markers)
+
+        engine.on_session_start(
+            "chat-2", platform="cli", conversation_id="c2", context_length=200000
+        )
+        # Preserve the process-level attempt cache to model another active
+        # session having already encountered this identical marker identity.
+        engine._attempted_read_tool_recovery_markers = first_session_attempts
+        engine.ingest(turn)
+
+        identity = marker_identity_sha("tool", turn[-1]["content"], "call_1")
+        assert engine._store.get_recovered_tool_content("chat-1", identity) is not None
+        assert engine._store.get_recovered_tool_content("chat-2", identity) is not None
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-2")
+            if row["role"] == "tool"
+        )
+        result = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+        assert result["content"] == source.read_text(encoding="utf-8")
 
     def test_changed_source_is_not_stored_as_lossless_recovery(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -926,6 +926,39 @@ class TestEngineRecovery:
         assert recovered["content"] == "the full 2MB file content that the host truncated"
         assert engine._store.get_recovered_tool_content_count("chat-1") == 1
 
+    def test_persisted_recovery_skips_file_reread_after_restart(self, tmp_path, monkeypatch):
+        """A marker recovered by an earlier process must not trigger the
+        expensive file re-read again: the sidecar row is the durable guard,
+        checked before recover_read_tool_file, not after via the insert's
+        unique constraint."""
+        import hermes_lcm.engine as engine_module
+
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        sha = marker_identity_sha("tool", turn[-1]["content"], "call_1")
+        assert engine._store.get_recovered_tool_content("chat-1", sha) is not None
+
+        # Simulate a process restart: the in-memory attempt cache is empty.
+        engine._attempted_read_tool_recovery_markers = set()
+        reread_calls = []
+        original_recover = engine_module.recover_read_tool_file
+
+        def _spy_recover(path, **kwargs):
+            reread_calls.append(path)
+            return original_recover(path, **kwargs)
+
+        monkeypatch.setattr(
+            engine_module, "recover_read_tool_file", _spy_recover
+        )
+        f.write_text("changed content", encoding="utf-8")
+        engine.ingest(turn)
+
+        assert reread_calls == [], "sidecar row must preempt the file re-read"
+        recovered = engine._store.get_recovered_tool_content("chat-1", sha)
+        assert recovered["content"] == "the full 2MB file content that the host truncated"
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 1
+
     def test_identical_marker_attempted_in_another_session_is_recovered(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)
         source, turn = self._turn(tmp_path)

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -6,9 +6,11 @@ import os
 import re
 import sqlite3
 
+import hermes_lcm.tools as lcm_tools
 from hermes_lcm import message_patterns as message_patterns_mod
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.db_bootstrap import ensure_recovered_tool_content_table
+from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.read_tool_recovery import (
     build_read_tool_call_path_map,
@@ -400,6 +402,96 @@ class TestEngineRecovery:
         assert recovered is not None
         assert recovered["content"] == f.read_text(encoding="utf-8")
         assert recovered["source_path"] == str(f)
+
+    def test_store_id_expansion_hydrates_recovered_content(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+
+        result = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+
+        assert result["content"] == f.read_text(encoding="utf-8")
+        assert result["content_source"] == "recovered_read_tool_content"
+        assert result["transcript_content"] == tool_row["content"]
+
+    def test_store_id_expansion_hydrates_externalized_recovered_content(self, tmp_path):
+        file_content = "LINE ONE\nLINE TWO\n" * 200
+        source = tmp_path / "large-source.txt"
+        source.write_text(file_content, encoding="utf-8")
+        engine = self._engine(
+            tmp_path,
+            enabled=True,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=500,
+            large_output_externalization_path=str(tmp_path / "externalized"),
+        )
+        engine.ingest([
+            {"role": "user", "content": "read it"},
+            {
+                "role": "assistant",
+                "content": "reading",
+                "tool_calls": [{
+                    "id": "call-large",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": json.dumps({"path": str(source)}),
+                    },
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-large",
+                "content": _marker_for_content(file_content),
+            },
+        ])
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+
+        result = json.loads(lcm_tools.lcm_expand(
+            {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+
+        assert result["content"] == file_content
+        assert result["recovered_chars"] == len(file_content)
+
+    def test_node_expansion_hydrates_recovered_content(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="chat-1",
+            depth=0,
+            summary="Recovered read output",
+            token_count=10,
+            source_token_count=10,
+            source_ids=[tool_row["store_id"]],
+            source_type="messages",
+        ))
+
+        result = json.loads(lcm_tools.lcm_expand(
+            {"node_id": node_id, "max_tokens": 1_000_000},
+            engine=engine,
+        ))
+        expanded = result["expanded"][0]
+
+        assert expanded["content"] == f.read_text(encoding="utf-8")
+        assert expanded["content_source"] == "recovered_read_tool_content"
+        assert expanded["transcript_content"] == tool_row["content"]
 
     def test_ignored_marker_is_not_recovered(self, tmp_path, monkeypatch):
         monkeypatch.setattr(message_patterns_mod, "_regex_engine", _TimeoutRegexEngine)

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -641,6 +641,19 @@ class TestEngineRecovery:
             row for row in engine._store.get_session_messages("chat-1")
             if row["role"] == "tool"
         )
+        externalized_ref = next((tmp_path / "externalized").glob("*.json")).name
+        ref_store_id = engine._store.append(
+            "chat-1",
+            {
+                "role": "tool",
+                "tool_call_id": "call-protected-ref",
+                "content": (
+                    "[Externalized tool output: tool_call_id=call-protected-ref; "
+                    f"chars={len(protected)}; bytes={len(protected.encode())}; "
+                    f"ref={externalized_ref}]"
+                ),
+            },
+        )
 
         config = engine._config
         engine.shutdown()
@@ -654,7 +667,7 @@ class TestEngineRecovery:
             summary="Foreign protected source",
             token_count=10,
             source_token_count=10,
-            source_ids=[tool_row["store_id"]],
+            source_ids=[tool_row["store_id"], ref_store_id],
             source_type="messages",
         ))
 
@@ -664,8 +677,8 @@ class TestEngineRecovery:
         ))
         hydration_calls = []
         original_recover = lcm_tools._get_recovered_read_tool_content
-        original_load = lcm_tools.load_externalized_payload
-        original_restore = lcm_tools.restore_ingest_payload_placeholders
+        original_load = lcm_tools._get_externalized_payload
+        original_restore = lcm_tools._restore_ingest_placeholder_for_lookup
         original_find = lcm_tools.find_externalized_payload_for_message
 
         def record_recover(*args, **kwargs):
@@ -673,11 +686,11 @@ class TestEngineRecovery:
             return original_recover(*args, **kwargs)
 
         def record_load(*args, **kwargs):
-            hydration_calls.append("load_externalized_payload")
+            hydration_calls.append("_get_externalized_payload")
             return original_load(*args, **kwargs)
 
         def record_restore(*args, **kwargs):
-            hydration_calls.append("restore_ingest_payload_placeholders")
+            hydration_calls.append("_restore_ingest_placeholder_for_lookup")
             return original_restore(*args, **kwargs)
 
         def record_find(*args, **kwargs):
@@ -685,8 +698,8 @@ class TestEngineRecovery:
             return original_find(*args, **kwargs)
 
         monkeypatch.setattr(lcm_tools, "_get_recovered_read_tool_content", record_recover)
-        monkeypatch.setattr(lcm_tools, "load_externalized_payload", record_load)
-        monkeypatch.setattr(lcm_tools, "restore_ingest_payload_placeholders", record_restore)
+        monkeypatch.setattr(lcm_tools, "_get_externalized_payload", record_load)
+        monkeypatch.setattr(lcm_tools, "_restore_ingest_placeholder_for_lookup", record_restore)
         monkeypatch.setattr(lcm_tools, "find_externalized_payload_for_message", record_find)
         by_node_id = json.loads(lcm_tools.lcm_expand(
             {"node_id": node_id, "max_tokens": 1_000_000},
@@ -702,6 +715,12 @@ class TestEngineRecovery:
         assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_node_id)
         assert by_node_id["expanded"][0]["content"] == tool_row["content"]
         assert by_node_id["expanded"][0]["content_source"] == "message"
+        assert by_node_id["expanded"][1]["content"].startswith("[Externalized tool output:")
+        assert by_node_id["expanded"][1]["externalized"] == {
+            "ref": externalized_ref,
+            "session_id": "chat-1",
+            "tool_call_id": "call-protected-ref",
+        }
 
     def test_store_id_expansion_restores_embedded_externalized_payload_in_place(self, tmp_path):
         encoded_one = "QUJD" * 1_500

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -184,6 +184,35 @@ class TestPureHelpers:
         ) is None
         assert replaced is True
 
+    def test_recover_closes_new_directory_fd_when_fstat_fails(self, tmp_path, monkeypatch):
+        nested = tmp_path / "unique-fstat-failure-directory"
+        nested.mkdir()
+        source = nested / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        original_open = ingest_protection_mod.os.open
+        original_fstat = ingest_protection_mod.os.fstat
+        opened_directory_fd = None
+
+        def track_directory_open(path, flags, *args, **kwargs):
+            nonlocal opened_directory_fd
+            fd = original_open(path, flags, *args, **kwargs)
+            if path == nested.name:
+                opened_directory_fd = fd
+            return fd
+
+        def fail_opened_directory_fstat(fd):
+            if fd == opened_directory_fd:
+                raise OSError("injected directory fstat failure")
+            return original_fstat(fd)
+
+        monkeypatch.setattr(ingest_protection_mod.os, "open", track_directory_open)
+        monkeypatch.setattr(ingest_protection_mod.os, "fstat", fail_opened_directory_fstat)
+
+        assert ingest_protection_mod._read_regular_file_no_symlink(source) is None
+        assert opened_directory_fd is not None
+        with pytest.raises(OSError):
+            original_fstat(opened_directory_fd)
+
     def test_recover_rejects_oversized(self, tmp_path):
         f = tmp_path / "big.txt"
         f.write_text("x" * 100, encoding="utf-8")
@@ -587,7 +616,7 @@ class TestEngineRecovery:
         assert result["recovered_chars"] == len(file_content)
 
     def test_cross_session_expansion_does_not_hydrate_protected_recovered_content(
-        self, tmp_path
+        self, tmp_path, monkeypatch
     ):
         protected = "PROTECTED_RECOVERED_PAYLOAD_" + ("QUJD" * 1_500)
         source = tmp_path / "protected-source.txt"
@@ -633,20 +662,46 @@ class TestEngineRecovery:
             {"store_id": tool_row["store_id"], "max_tokens": 1_000_000},
             engine=engine,
         ))
+        hydration_calls = []
+        original_recover = lcm_tools._get_recovered_read_tool_content
+        original_load = lcm_tools.load_externalized_payload
+        original_restore = lcm_tools.restore_ingest_payload_placeholders
+        original_find = lcm_tools.find_externalized_payload_for_message
+
+        def record_recover(*args, **kwargs):
+            hydration_calls.append("_get_recovered_read_tool_content")
+            return original_recover(*args, **kwargs)
+
+        def record_load(*args, **kwargs):
+            hydration_calls.append("load_externalized_payload")
+            return original_load(*args, **kwargs)
+
+        def record_restore(*args, **kwargs):
+            hydration_calls.append("restore_ingest_payload_placeholders")
+            return original_restore(*args, **kwargs)
+
+        def record_find(*args, **kwargs):
+            hydration_calls.append("find_externalized_payload_for_message")
+            return original_find(*args, **kwargs)
+
+        monkeypatch.setattr(lcm_tools, "_get_recovered_read_tool_content", record_recover)
+        monkeypatch.setattr(lcm_tools, "load_externalized_payload", record_load)
+        monkeypatch.setattr(lcm_tools, "restore_ingest_payload_placeholders", record_restore)
+        monkeypatch.setattr(lcm_tools, "find_externalized_payload_for_message", record_find)
         by_node_id = json.loads(lcm_tools.lcm_expand(
             {"node_id": node_id, "max_tokens": 1_000_000},
             engine=engine,
         ))
 
+        assert hydration_calls == []
         assert by_store_id["from_current_session"] is False
         assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_store_id)
         assert by_store_id["content"].startswith("[Externalized tool output:")
         assert by_store_id["externalized_ref"]
         assert "cannot be expanded" in by_store_id["externalized_note"]
         assert "PROTECTED_RECOVERED_PAYLOAD_" not in json.dumps(by_node_id)
-        assert by_node_id["expanded"][0]["content"].startswith(
-            "[Externalized tool output:"
-        )
+        assert by_node_id["expanded"][0]["content"] == tool_row["content"]
+        assert by_node_id["expanded"][0]["content_source"] == "message"
 
     def test_store_id_expansion_restores_embedded_externalized_payload_in_place(self, tmp_path):
         encoded_one = "QUJD" * 1_500

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.read_tool_recovery import (
+    build_read_tool_call_path_map,
+    is_recoverable_read_tool_marker,
+    marker_identity_sha,
+    plan_read_tool_recovery,
+    recover_read_tool_file,
+)
+from hermes_lcm.store import MessageStore
+
+
+def _marker(chars: int = 5000) -> str:
+    return (
+        "preview of the start of the file...\n\n"
+        f"[Truncated: tool response was {chars:,} chars. "
+        "Full output could not be saved to sandbox.]"
+    )
+
+
+def _read_call(call_id: str, path: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": "reading the file",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": "read_file", "arguments": json.dumps({"path": path})},
+            }
+        ],
+    }
+
+
+class TestPureHelpers:
+    def test_marker_detection(self):
+        assert is_recoverable_read_tool_marker(_marker())
+        assert not is_recoverable_read_tool_marker("ordinary tool output")
+        assert not is_recoverable_read_tool_marker(None)
+
+    def test_marker_identity_is_stable_and_content_sensitive(self):
+        a = marker_identity_sha("tool", "x", "c1")
+        assert a == marker_identity_sha("tool", "x", "c1")
+        assert a != marker_identity_sha("tool", "y", "c1")
+        assert a != marker_identity_sha("tool", "x", "c2")
+
+    def test_path_map_only_absolute_read_calls(self, tmp_path):
+        abs_path = str(tmp_path / "f.txt")
+        messages = [
+            _read_call("c1", abs_path),
+            _read_call("c2", "relative/path.txt"),
+            {
+                "role": "assistant",
+                "content": "other tool",
+                "tool_calls": [
+                    {"id": "c3", "type": "function",
+                     "function": {"name": "terminal", "arguments": json.dumps({"path": abs_path})}}
+                ],
+            },
+        ]
+        path_map = build_read_tool_call_path_map(messages)
+        assert path_map == {"c1": abs_path}
+
+    def test_recover_reads_absolute_regular_file(self, tmp_path):
+        f = tmp_path / "src.txt"
+        f.write_text("hello lossless world", encoding="utf-8")
+        recovered = recover_read_tool_file(str(f))
+        assert recovered is not None
+        content, _stat = recovered
+        assert content == "hello lossless world"
+
+    def test_recover_rejects_symlink(self, tmp_path):
+        target = tmp_path / "real.txt"
+        target.write_text("secret", encoding="utf-8")
+        link = tmp_path / "link.txt"
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError):
+            return  # platform without symlink support
+        assert recover_read_tool_file(str(link)) is None
+
+    def test_recover_rejects_oversized(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_text("x" * 100, encoding="utf-8")
+        assert recover_read_tool_file(str(f), max_bytes=10) is None
+
+    def test_recover_rejects_relative_path(self):
+        assert recover_read_tool_file("relative.txt") is None
+
+    def test_plan_pairs_marker_to_path(self, tmp_path):
+        f = tmp_path / "src.txt"
+        f.write_text("data", encoding="utf-8")
+        messages = [
+            _read_call("c1", str(f)),
+            {"role": "tool", "tool_call_id": "c1", "content": _marker()},
+            {"role": "tool", "tool_call_id": "c1", "content": "not a marker"},
+        ]
+        plan = plan_read_tool_recovery(messages)
+        assert len(plan) == 1
+        assert plan[0]["path"] == str(f)
+        assert plan[0]["tool_call_id"] == "c1"
+
+    def test_plan_empty_without_read_call(self):
+        messages = [{"role": "tool", "tool_call_id": "c1", "content": _marker()}]
+        assert plan_read_tool_recovery(messages) == []
+
+
+class TestStoreSidecar:
+    def _store(self, tmp_path, **overrides):
+        config = LCMConfig(database_path=str(tmp_path / "lcm.db"), **overrides)
+        return MessageStore(tmp_path / "lcm.db", ingest_protection_config=config)
+
+    def test_table_created(self, tmp_path):
+        store = self._store(tmp_path)
+        tables = {
+            r[0] for r in store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "recovered_tool_content" in tables
+
+    def test_append_and_lookup(self, tmp_path):
+        store = self._store(tmp_path)
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        rid = store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="full recovered content",
+        )
+        assert rid is not None
+        row = store.get_recovered_tool_content("s1", sha)
+        assert row["content"] == "full recovered content"
+        assert row["source_path"] == "/abs/f.txt"
+        assert row["recovered_chars"] == len("full recovered content")
+        assert store.get_recovered_tool_content_count("s1") == 1
+
+    def test_append_is_idempotent_per_marker(self, tmp_path):
+        store = self._store(tmp_path)
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        first = store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content",
+        )
+        second = store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content again",
+        )
+        assert first is not None
+        assert second is None
+        assert store.get_recovered_tool_content_count("s1") == 1
+
+    def test_idempotency_is_enforced_across_store_instances(self, tmp_path):
+        first_store = self._store(tmp_path)
+        second_store = MessageStore(
+            tmp_path / "lcm.db",
+            ingest_protection_config=LCMConfig(database_path=str(tmp_path / "lcm.db")),
+        )
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        first = first_store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content",
+        )
+        second = second_store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content again",
+        )
+        assert first is not None
+        assert second is None
+        assert first_store.get_recovered_tool_content_count("s1") == 1
+
+    def test_bootstrap_deduplicates_legacy_rows_before_unique_index(self, tmp_path):
+        db_path = tmp_path / "lcm.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE recovered_tool_content (
+                recovered_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                tool_call_id TEXT DEFAULT '',
+                marker_identity_sha TEXT NOT NULL,
+                source_path TEXT DEFAULT '',
+                recovered_chars INTEGER DEFAULT 0,
+                externalized_ref TEXT DEFAULT '',
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+            CREATE INDEX idx_recovered_session_marker
+                ON recovered_tool_content(session_id, marker_identity_sha);
+            INSERT INTO recovered_tool_content
+                (session_id, marker_identity_sha, content, timestamp)
+                VALUES ('s1', 'same', 'older', 1), ('s1', 'same', 'newer', 2);
+            """
+        )
+        conn.commit()
+        conn.close()
+        store = self._store(tmp_path)
+        rows = store._conn.execute(
+            "SELECT content FROM recovered_tool_content "
+            "WHERE session_id = 's1' AND marker_identity_sha = 'same'"
+        ).fetchall()
+        index_rows = store._conn.execute(
+            "PRAGMA index_list(recovered_tool_content)"
+        ).fetchall()
+        assert rows == [("newer",)]
+        assert any(row[1] == "idx_recovered_session_marker" and row[2] == 1 for row in index_rows)
+
+    def test_sensitive_content_redacted(self, tmp_path):
+        store = self._store(tmp_path, large_output_externalization_path=str(tmp_path / "ext"))
+        setattr(store._ingest_protection_config, "sensitive_patterns_enabled", True)
+        setattr(store._ingest_protection_config, "sensitive_patterns", ["api_key"])
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        store.append_recovered_tool_content(
+            "s1", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content='api_key="AKIA0987654321SECRET"',
+        )
+        stored = store.get_recovered_tool_content("s1", sha)["content"]
+        assert "AKIA0987654321SECRET" not in stored
+        assert "[LCM sensitive redaction:" in stored
+
+    def test_reassign_and_delete_follow_parent(self, tmp_path):
+        store = self._store(tmp_path)
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        store.append_recovered_tool_content(
+            "old", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content",
+        )
+        store.reassign_session_messages("old", "new")
+        assert store.get_recovered_tool_content_count("old") == 0
+        assert store.get_recovered_tool_content_count("new") == 1
+        store.delete_session_messages("new")
+        assert store.get_recovered_tool_content_count("new") == 0
+
+
+class TestEngineRecovery:
+    def _engine(self, tmp_path, *, enabled: bool, **overrides):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm.db"),
+            read_tool_recovery_enabled=enabled,
+            **overrides,
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("chat-1", platform="cli", conversation_id="c1", context_length=200000)
+        return engine
+
+    def _turn(self, tmp_path):
+        f = tmp_path / "source.txt"
+        f.write_text("the full 2MB file content that the host truncated", encoding="utf-8")
+        return f, [
+            {"role": "user", "content": "read the file"},
+            _read_call("call_1", str(f)),
+            {"role": "tool", "tool_call_id": "call_1", "content": _marker()},
+        ]
+
+    def test_disabled_recovers_nothing(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=False)
+        _f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 0
+
+    def test_enabled_recovers_full_content_without_touching_messages(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+
+        # The stored active row still holds the byte-identical marker.
+        rows = engine._store.get_session_messages("chat-1")
+        tool_rows = [r for r in rows if r["role"] == "tool"]
+        assert len(tool_rows) == 1
+        assert is_recoverable_read_tool_marker(tool_rows[0]["content"])
+
+        # ...but the full file content is recovered into the sidecar.
+        sha = marker_identity_sha("tool", _marker(), "call_1")
+        recovered = engine._store.get_recovered_tool_content("chat-1", sha)
+        assert recovered is not None
+        assert recovered["content"] == f.read_text(encoding="utf-8")
+        assert recovered["source_path"] == str(f)
+
+    def test_ignored_marker_is_not_recovered(self, tmp_path):
+        engine = self._engine(
+            tmp_path,
+            enabled=True,
+            ignore_message_patterns=[r"Full output could not be saved to sandbox"],
+        )
+        _f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        assert not any(
+            row["role"] == "tool"
+            for row in engine._store.get_session_messages("chat-1")
+        )
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 0
+
+    def test_recovery_key_uses_protected_stored_marker(self, tmp_path):
+        engine = self._engine(
+            tmp_path,
+            enabled=True,
+            sensitive_patterns_enabled=True,
+            sensitive_patterns=["api_key"],
+        )
+        f, turn = self._turn(tmp_path)
+        turn[-1]["content"] = 'api_key="supersecretvalue"\n' + _marker()
+        engine.ingest(turn)
+        tool_row = next(
+            row for row in engine._store.get_session_messages("chat-1")
+            if row["role"] == "tool"
+        )
+        stored_sha = marker_identity_sha("tool", tool_row["content"], "call_1")
+        raw_sha = marker_identity_sha("tool", turn[-1]["content"], "call_1")
+        assert stored_sha != raw_sha
+        recovered = engine._store.get_recovered_tool_content("chat-1", stored_sha)
+        assert recovered is not None
+        assert recovered["content"] == f.read_text(encoding="utf-8")
+        assert engine._store.get_recovered_tool_content("chat-1", raw_sha) is None
+
+    def test_recovery_is_attempted_once_per_marker(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        # Mutate the file, then re-ingest the same marker: the in-memory guard
+        # must prevent a second re-read, so the first recovery is preserved.
+        f.write_text("changed content", encoding="utf-8")
+        engine.ingest(turn)
+        sha = marker_identity_sha("tool", _marker(), "call_1")
+        recovered = engine._store.get_recovered_tool_content("chat-1", sha)
+        assert recovered["content"] == "the full 2MB file content that the host truncated"
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 1
+
+    def test_status_surfaces_recovery_count_when_enabled(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        _f, turn = self._turn(tmp_path)
+        engine.ingest(turn)
+        status = engine.get_status()
+        assert status["read_tool_recovery_enabled"] is True
+        assert status["recovered_read_tool_content_count"] == 1
+
+    def test_no_read_call_means_no_recovery(self, tmp_path):
+        engine = self._engine(tmp_path, enabled=True)
+        turn = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "orphan", "content": _marker()},
+        ]
+        engine.ingest(turn)
+        assert engine._store.get_recovered_tool_content_count("chat-1") == 0

--- a/tests/test_read_tool_recovery.py
+++ b/tests/test_read_tool_recovery.py
@@ -6,7 +6,10 @@ import os
 import re
 import sqlite3
 
+import pytest
+
 import hermes_lcm.tools as lcm_tools
+from hermes_lcm import ingest_protection as ingest_protection_mod
 from hermes_lcm import message_patterns as message_patterns_mod
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.db_bootstrap import ensure_recovered_tool_content_table
@@ -145,6 +148,36 @@ class TestPureHelpers:
     def test_recover_rejects_relative_path(self):
         assert recover_read_tool_file(
             "relative.txt", marker_content=_marker_for_content("irrelevant")
+        ) is None
+
+    def test_recover_rejects_non_regular_file(self, tmp_path):
+        assert recover_read_tool_file(
+            str(tmp_path), marker_content=_marker_for_content("irrelevant")
+        ) is None
+
+    def test_recover_rejects_malformed_marker(self, tmp_path):
+        source = tmp_path / "source.txt"
+        source.write_text("complete content", encoding="utf-8")
+        assert recover_read_tool_file(
+            str(source), marker_content="[Truncated: malformed]"
+        ) is None
+
+    def test_recover_rejects_changed_file_generation(self, tmp_path, monkeypatch):
+        source = tmp_path / "changed-during-read.txt"
+        content = "content whose generation changes during recovery"
+        source.write_text(content, encoding="utf-8")
+        generations = iter([
+            {"dev": 1, "ino": 2, "size": len(content), "mtime_ns": 3},
+            {"dev": 1, "ino": 2, "size": len(content), "mtime_ns": 4},
+        ])
+        monkeypatch.setattr(
+            ingest_protection_mod,
+            "_stat_generation_metadata",
+            lambda _stat: next(generations),
+        )
+
+        assert recover_read_tool_file(
+            str(source), marker_content=_marker_for_content(content)
         ) is None
 
     def test_recovered_content_matches_original_marker(self):
@@ -353,6 +386,48 @@ class TestStoreSidecar:
         store.delete_session_messages("new")
         assert store.get_recovered_tool_content_count("new") == 0
 
+    def test_reassign_rolls_back_parent_when_sidecar_update_fails(self, tmp_path):
+        store = self._store(tmp_path)
+        store.append("old", {"role": "user", "content": "keep me"})
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        store.append_recovered_tool_content(
+            "old", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content",
+        )
+        store._conn.execute(
+            "CREATE TRIGGER fail_recovered_reassign BEFORE UPDATE "
+            "ON recovered_tool_content BEGIN SELECT RAISE(ABORT, 'sidecar update failed'); END"
+        )
+        store._conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="sidecar update failed"):
+            store.reassign_session_messages("old", "new")
+
+        assert store.get_session_count("old") == 1
+        assert store.get_session_count("new") == 0
+        assert store.get_recovered_tool_content_count("old") == 1
+        assert store.get_recovered_tool_content_count("new") == 0
+
+    def test_delete_rolls_back_parent_when_sidecar_delete_fails(self, tmp_path):
+        store = self._store(tmp_path)
+        store.append("session", {"role": "user", "content": "keep me"})
+        sha = marker_identity_sha("tool", _marker(), "c1")
+        store.append_recovered_tool_content(
+            "session", tool_call_id="c1", marker_identity_sha=sha,
+            source_path="/abs/f.txt", content="content",
+        )
+        store._conn.execute(
+            "CREATE TRIGGER fail_recovered_delete BEFORE DELETE "
+            "ON recovered_tool_content BEGIN SELECT RAISE(ABORT, 'sidecar delete failed'); END"
+        )
+        store._conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="sidecar delete failed"):
+            store.delete_session_messages("session")
+
+        assert store.get_session_count("session") == 1
+        assert store.get_recovered_tool_content_count("session") == 1
+
 
 class TestEngineRecovery:
     def _engine(self, tmp_path, *, enabled: bool, **overrides):
@@ -466,8 +541,12 @@ class TestEngineRecovery:
         assert result["recovered_chars"] == len(file_content)
 
     def test_store_id_expansion_restores_embedded_externalized_payload_in_place(self, tmp_path):
-        encoded = "QUJD" * 1_500
-        file_content = f"prefix remains\n{encoded}\nsuffix remains"
+        encoded_one = "QUJD" * 1_500
+        encoded_two = "REVG" * 1_500
+        file_content = (
+            f"prefix remains\n{encoded_one}\nmiddle remains\n"
+            f"{encoded_two}\nsuffix remains"
+        )
         source = tmp_path / "embedded-payload.txt"
         source.write_text(file_content, encoding="utf-8")
         engine = self._engine(
@@ -510,6 +589,22 @@ class TestEngineRecovery:
         assert result["content"] == file_content
         assert result["content"].startswith("prefix remains\n")
         assert result["content"].endswith("\nsuffix remains")
+
+    def test_live_tool_call_recovers_before_same_turn_expand(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, enabled=True)
+        source, turn = self._turn(tmp_path)
+
+        def expand_after_live_ingest(_args, *, engine):
+            return json.dumps({
+                "recovered": engine._store.get_recovered_tool_content_count("chat-1"),
+                "content": source.read_text(encoding="utf-8"),
+            })
+
+        monkeypatch.setattr(lcm_tools, "lcm_expand", expand_after_live_ingest)
+        result = json.loads(engine.handle_tool_call("lcm_expand", {}, messages=turn))
+
+        assert result["recovered"] == 1
+        assert result["content"] == source.read_text(encoding="utf-8")
 
     def test_node_expansion_hydrates_recovered_content(self, tmp_path):
         engine = self._engine(tmp_path, enabled=True)

--- a/tools.py
+++ b/tools.py
@@ -464,9 +464,18 @@ def _expand_message_sources(
             has_more = next_source_offset < total_sources
             continue
         transcript_content = stored.get("content", "")
+        stored_session_id = str(stored.get("session_id") or "")
+        owns_protected_payload = (
+            bool(engine.current_session_id)
+            and stored_session_id == engine.current_session_id
+        )
         content = transcript_content
         content_source = "message"
-        recovered = _get_recovered_read_tool_content(engine, stored)
+        recovered = (
+            _get_recovered_read_tool_content(engine, stored)
+            if owns_protected_payload
+            else None
+        )
         if recovered is not None:
             content = recovered.get("content") or ""
             content_source = "recovered_read_tool_content"
@@ -474,11 +483,10 @@ def _expand_message_sources(
         ref_payload = None
         ingest_refs = extract_ingest_externalized_refs(transcript_content)
         ref = ingest_refs[0] if ingest_refs else extract_externalized_ref(transcript_content)
-        if ref:
+        if ref and owns_protected_payload:
             ref_payload = _get_externalized_payload(
                 engine,
                 ref,
-                allowed_session_ids={engine.current_session_id, stored.get("session_id", "")},
             )
             if ref_payload is not None and ref_payload.get("kind") != "ingest_payload":
                 externalized = ref_payload
@@ -510,7 +518,7 @@ def _expand_message_sources(
         if recovered is not None:
             expanded["recovered_source_path"] = recovered.get("source_path") or ""
             expanded["recovered_chars"] = recovered.get("recovered_chars", len(content))
-        if stored.get("role") == "tool":
+        if stored.get("role") == "tool" and owns_protected_payload:
             if externalized is not None:
                 externalized_summary = dict(externalized)
                 externalized_summary.pop("content", None)

--- a/tools.py
+++ b/tools.py
@@ -131,7 +131,17 @@ def _get_recovered_read_tool_content(
         return None
 
     recovered_content = recovered.get("content") or ""
-    externalized_ref = str(recovered.get("externalized_ref") or "").strip()
+    restored_content = restore_ingest_payload_placeholders(
+        recovered_content,
+        config=engine._config,
+        hermes_home=engine._hermes_home,
+        session_id=stored_session_id,
+    )
+    if restored_content != recovered_content:
+        recovered_content = restored_content
+        externalized_ref = ""
+    else:
+        externalized_ref = str(recovered.get("externalized_ref") or "").strip()
     if externalized_ref:
         refs = [externalized_ref]
     else:

--- a/tools.py
+++ b/tools.py
@@ -36,6 +36,10 @@ from .ingest_protection import (
 )
 from .model_routing import apply_lcm_model_route
 from .presets import preset_status_payload
+from .read_tool_recovery import (
+    is_recoverable_read_tool_marker,
+    marker_identity_sha as _read_tool_marker_identity_sha,
+)
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 from .session_patterns import build_session_match_keys, compile_session_pattern
 from .store import build_message_fts_spec
@@ -104,6 +108,52 @@ def _get_externalized_payload(
     if payload_session_id and payload_session_id not in allowed:
         return None
     return payload
+
+
+def _get_recovered_read_tool_content(
+    engine: "LCMEngine", stored: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Resolve a recovered read-tool sidecar, including protected externalization."""
+    transcript_content = stored.get("content", "") or ""
+    if not is_recoverable_read_tool_marker(transcript_content):
+        return None
+    stored_session_id = str(stored.get("session_id") or "")
+    identity = _read_tool_marker_identity_sha(
+        str(stored.get("role") or "tool"),
+        transcript_content,
+        str(stored.get("tool_call_id") or ""),
+    )
+    try:
+        recovered = engine._store.get_recovered_tool_content(stored_session_id, identity)
+    except Exception:  # pragma: no cover - expansion remains best-effort
+        return None
+    if recovered is None:
+        return None
+
+    recovered_content = recovered.get("content") or ""
+    externalized_ref = str(recovered.get("externalized_ref") or "").strip()
+    if externalized_ref:
+        refs = [externalized_ref]
+    else:
+        refs = extract_ingest_externalized_refs(recovered_content)
+        legacy_ref = extract_externalized_ref(recovered_content)
+        if legacy_ref and legacy_ref not in refs:
+            refs.append(legacy_ref)
+    for ref in refs:
+        if not ref:
+            continue
+        payload = _get_externalized_payload(
+            engine,
+            ref,
+            allowed_session_ids={engine.current_session_id, stored_session_id},
+        )
+        if payload is not None and payload.get("kind") in {"ingest_payload", "tool_result"}:
+            recovered_content = payload.get("content") or ""
+            break
+
+    resolved = dict(recovered)
+    resolved["content"] = recovered_content
+    return resolved
 
 
 def _truncate_text_to_token_budget(text: str, max_tokens: int) -> tuple[str, bool]:
@@ -405,6 +455,10 @@ def _expand_message_sources(
         transcript_content = stored.get("content", "")
         content = transcript_content
         content_source = "message"
+        recovered = _get_recovered_read_tool_content(engine, stored)
+        if recovered is not None:
+            content = recovered.get("content") or ""
+            content_source = "recovered_read_tool_content"
         externalized = None
         ref_payload = None
         ingest_refs = extract_ingest_externalized_refs(transcript_content)
@@ -440,8 +494,11 @@ def _expand_message_sources(
             "next_content_offset": sliced["next_content_offset"],
             "content_source": content_source,
         }
-        if content_source == "externalized_payload":
+        if content_source != "message":
             expanded["transcript_content"] = transcript_content
+        if recovered is not None:
+            expanded["recovered_source_path"] = recovered.get("source_path") or ""
+            expanded["recovered_chars"] = recovered.get("recovered_chars", len(content))
         if stored.get("role") == "tool":
             if externalized is not None:
                 externalized_summary = dict(externalized)
@@ -1401,7 +1458,9 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         if stored is None:
             return json.dumps({"error": f"Message store_id {store_id} not found"})
         transcript_content = stored.get("content", "") or ""
-        sliced = _slice_content_for_response(transcript_content, max_tokens, content_offset)
+        recovered = _get_recovered_read_tool_content(engine, stored)
+        content = recovered.get("content") or "" if recovered is not None else transcript_content
+        sliced = _slice_content_for_response(content, max_tokens, content_offset)
         engine_session_id = engine.current_session_id
         stored_session_id = stored.get("session_id", "")
         result: Dict[str, Any] = {
@@ -1422,6 +1481,11 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             "next_content_offset": sliced["next_content_offset"],
             "has_more": sliced["has_more"],
         }
+        if recovered is not None:
+            result["content_source"] = "recovered_read_tool_content"
+            result["transcript_content"] = transcript_content
+            result["recovered_source_path"] = recovered.get("source_path") or ""
+            result["recovered_chars"] = recovered.get("recovered_chars", len(content))
         # Surface externalized-payload metadata when the row references one. Content
         # is not hydrated by default, mirroring the existing _expand_message_sources
         # default. Externalized lookup remains session-scoped (per the existing

--- a/tools.py
+++ b/tools.py
@@ -113,7 +113,7 @@ def _get_externalized_payload(
 def _get_recovered_read_tool_content(
     engine: "LCMEngine", stored: dict[str, Any]
 ) -> dict[str, Any] | None:
-    """Resolve a recovered read-tool sidecar, including protected externalization."""
+    """Resolve a recovered read-tool sidecar within the current session's protection scope."""
     transcript_content = stored.get("content", "") or ""
     if not is_recoverable_read_tool_marker(transcript_content):
         return None
@@ -131,35 +131,36 @@ def _get_recovered_read_tool_content(
         return None
 
     recovered_content = recovered.get("content") or ""
-    restored_content = restore_ingest_payload_placeholders(
-        recovered_content,
-        config=engine._config,
-        hermes_home=engine._hermes_home,
-        session_id=stored_session_id,
+    may_hydrate_protected_content = (
+        bool(engine.current_session_id)
+        and stored_session_id == engine.current_session_id
     )
-    if restored_content != recovered_content:
-        recovered_content = restored_content
-        externalized_ref = ""
-    else:
-        externalized_ref = str(recovered.get("externalized_ref") or "").strip()
-    if externalized_ref:
-        refs = [externalized_ref]
-    else:
-        refs = extract_ingest_externalized_refs(recovered_content)
-        legacy_ref = extract_externalized_ref(recovered_content)
-        if legacy_ref and legacy_ref not in refs:
-            refs.append(legacy_ref)
-    for ref in refs:
-        if not ref:
-            continue
-        payload = _get_externalized_payload(
-            engine,
-            ref,
-            allowed_session_ids={engine.current_session_id, stored_session_id},
+    if may_hydrate_protected_content:
+        restored_content = restore_ingest_payload_placeholders(
+            recovered_content,
+            config=engine._config,
+            hermes_home=engine._hermes_home,
+            session_id=engine.current_session_id,
         )
-        if payload is not None and payload.get("kind") in {"ingest_payload", "tool_result"}:
-            recovered_content = payload.get("content") or ""
-            break
+        if restored_content != recovered_content:
+            recovered_content = restored_content
+            externalized_ref = ""
+        else:
+            externalized_ref = str(recovered.get("externalized_ref") or "").strip()
+        if externalized_ref:
+            refs = [externalized_ref]
+        else:
+            refs = extract_ingest_externalized_refs(recovered_content)
+            legacy_ref = extract_externalized_ref(recovered_content)
+            if legacy_ref and legacy_ref not in refs:
+                refs.append(legacy_ref)
+        for ref in refs:
+            if not ref:
+                continue
+            payload = _get_externalized_payload(engine, ref)
+            if payload is not None and payload.get("kind") in {"ingest_payload", "tool_result"}:
+                recovered_content = payload.get("content") or ""
+                break
 
     resolved = dict(recovered)
     resolved["content"] = recovered_content
@@ -1502,6 +1503,11 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         # _get_externalized_payload contract); cross-session rows surface only the
         # ref string, with a hint pointing at the same-session expansion path.
         ref_values = [transcript_content]
+        if recovered is not None:
+            ref_values.append(str(recovered.get("content") or ""))
+            recovered_ref = str(recovered.get("externalized_ref") or "").strip()
+            if recovered_ref:
+                ref_values.append(recovered_ref)
         if stored.get("tool_calls"):
             try:
                 ref_values.append(json.dumps(stored.get("tool_calls"), ensure_ascii=False, sort_keys=True))

--- a/tools.py
+++ b/tools.py
@@ -118,6 +118,9 @@ def _get_recovered_read_tool_content(
     if not is_recoverable_read_tool_marker(transcript_content):
         return None
     stored_session_id = str(stored.get("session_id") or "")
+    current_session_id = str(engine.current_session_id or "")
+    if not current_session_id or stored_session_id != current_session_id:
+        return None
     identity = _read_tool_marker_identity_sha(
         str(stored.get("role") or "tool"),
         transcript_content,
@@ -1483,11 +1486,18 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         if stored is None:
             return json.dumps({"error": f"Message store_id {store_id} not found"})
         transcript_content = stored.get("content", "") or ""
-        recovered = _get_recovered_read_tool_content(engine, stored)
-        content = recovered.get("content") or "" if recovered is not None else transcript_content
-        sliced = _slice_content_for_response(content, max_tokens, content_offset)
         engine_session_id = engine.current_session_id
         stored_session_id = stored.get("session_id", "")
+        owns_protected_payload = (
+            bool(engine_session_id) and stored_session_id == engine_session_id
+        )
+        recovered = (
+            _get_recovered_read_tool_content(engine, stored)
+            if owns_protected_payload
+            else None
+        )
+        content = recovered.get("content") or "" if recovered is not None else transcript_content
+        sliced = _slice_content_for_response(content, max_tokens, content_offset)
         result: Dict[str, Any] = {
             "store_id": store_id,
             "source_type": "raw_message",

--- a/tools.py
+++ b/tools.py
@@ -518,6 +518,12 @@ def _expand_message_sources(
         if recovered is not None:
             expanded["recovered_source_path"] = recovered.get("source_path") or ""
             expanded["recovered_chars"] = recovered.get("recovered_chars", len(content))
+        if ref and not owns_protected_payload:
+            expanded["externalized"] = {
+                "ref": ref,
+                "session_id": stored_session_id,
+                "tool_call_id": stored.get("tool_call_id", ""),
+            }
         if stored.get("role") == "tool" and owns_protected_payload:
             if externalized is not None:
                 externalized_summary = dict(externalized)


### PR DESCRIPTION
## Summary

Completes lossless recovery and hydration for truncated `read_file` results on the existing PR branch.

- Persists recoverable results in a protected sidecar keyed from the exact stored marker bytes.
- Runs recovery after post-turn ingest, live tool-call ingest before same-turn `lcm_expand`, and the session-end final flush.
- Restores exact whole externalized payloads wholesale and embedded/multiple placeholders in place without dropping surrounding text.
- Makes cross-instance insertion, legacy dedup migration, retention cleanup, session reassign, and session delete safe and atomic.
- Binds file recovery to descriptor identity with no-symlink traversal, generation and size checks.
- Restricts recovered sidecar hydration to the owning session, including direct `store_id` expansion.

## Why

The live ingest and final-flush paths could durably store only the truncation marker without creating the recovered sidecar before expansion. Earlier recovery also left file-identity and session-ownership gaps: a raced or symlinked path could be read, and a foreign session could hydrate protected recovered content through expansion. This update closes those paths while leaving parent message bytes unchanged and keeping recovery best-effort and opt-in.

## Validation

Exact reviewed head: `3f81f1d932e232495817eb70d32abe4df4631b40`.

- RED: two adversarial foreign-session cases failed before the ownership repair.
- `uv run --python 3.11 --with pytest python -m pytest tests/test_read_tool_recovery.py -q -o addopts=` → 44 passed.
- Targeted symlinked-ancestor, final-path-replacement, and foreign-session direct-`store_id` selectors → 3 passed in 0.04s.
- Adjacent suites → 1122 passed.
- Full suite → 1654 passed, 12 xfailed.
- `ruff check` and `python -m py_compile` on the changed Python surface → passed.
- `git diff --check upstream/main...3f81f1d932e232495817eb70d32abe4df4631b40` → passed.
- Bounded added-production-line security scan → 124 lines inspected, 0 findings.
- Independent same-card review → ACCEPT with no blocking findings.

## Notes

- The branch incorporated PR base `main` at `31675c6ed54abd747578b4da4b1589d81b18384a` with a normal merge commit; publication to this head was a normal fast-forward with no force or history rewrite.
- Recovery rejects relative paths, symlinks and symlinked ancestors, non-regular files, changed generations, oversized files, malformed markers, and missing call/result pairs.
- Follow-on PR #365 remains open and unchanged at `accfa02722809aa79720e041452c98c8197bf82a`.
- This PR remains open and unmerged.

## Refs

- PR #364 (this PR)
- Follow-on: #365
