### PR TITLE
fix: preserve initial user anchor through compaction

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -439,10 +439,14 @@ class CompactionMixin:
                     pressure_messages[candidate_start:fresh_tail_start],
                 )
             )
+            compactable_store_ids_by_message_id = self._get_store_id_map_for_messages(
+                working_messages[leading_anchor_count:]
+            )
             raw_compactable_pairs = [
                 (working_msg, pressure_msg)
                 for working_msg, pressure_msg in compactable_pairs
                 if not self._is_replayed_context_scaffold_message(working_msg)  # type: ignore[attr-defined]
+                or id(working_msg) in compactable_store_ids_by_message_id
             ]
             if len(raw_compactable_pairs) != len(compactable_pairs):
                 dropped_replayed_scaffold_messages = True

--- a/compaction.py
+++ b/compaction.py
@@ -647,7 +647,11 @@ class CompactionMixin:
             )
             self._dag.add_node(node)
             self._maybe_gc_compacted_tool_results(compacted_chunk, source_store_ids)
-            self._last_compacted_store_id = max(consumed_store_ids) if consumed_store_ids else 0
+            if consumed_store_ids:
+                self._last_compacted_store_id = max(
+                    self._last_compacted_store_id,
+                    max(consumed_store_ids),
+                )
             self._persist_frontier_marker()
 
             pressure_remaining_messages = pressure_messages[leading_anchor_count + selected_raw_len:]

--- a/compaction.py
+++ b/compaction.py
@@ -775,6 +775,10 @@ class CompactionMixin:
             self._write_generated_ignored_placeholder_hash_ordinals(
                 self._generated_placeholder_digest_ordinals_for_active_replay(sanitized_messages)
             )
+            if dropped_replayed_scaffold_messages and sanitized_messages != messages:
+                snapshot_writer = getattr(self, "_write_active_replay_snapshot", None)
+                if callable(snapshot_writer):
+                    snapshot_writer(sanitized_messages)
             return sanitized_messages
 
         # Step 6: Check if condensation is needed
@@ -853,5 +857,9 @@ class CompactionMixin:
         self._write_generated_ignored_placeholder_hash_ordinals(
             self._generated_placeholder_digest_ordinals_for_active_replay(compressed)
         )
+        if compressed != messages:
+            snapshot_writer = getattr(self, "_write_active_replay_snapshot", None)
+            if callable(snapshot_writer):
+                snapshot_writer(compressed)
 
         return compressed

--- a/compaction.py
+++ b/compaction.py
@@ -617,7 +617,15 @@ class CompactionMixin:
             source_lineage_chunk = [
                 message for message in source_lookup_chunk if id(message) not in dependent_reply_message_ids
             ]
+            pre_frontier_sources = self._get_formerly_anchored_user_source_map(
+                working_messages[leading_anchor_count:]
+            )
             source_store_ids = self._get_store_ids_for_messages(source_lineage_chunk)
+            source_store_ids.extend(
+                pre_frontier_sources[id(message)]
+                for message in source_lineage_chunk
+                if id(message) in pre_frontier_sources
+            )
             source_store_ids = sorted(dict.fromkeys(source_store_ids))
             consumed_store_ids = self._get_store_ids_for_messages(source_lookup_chunk)
             consumed_store_ids = sorted(dict.fromkeys(consumed_store_ids))

--- a/compaction.py
+++ b/compaction.py
@@ -433,16 +433,29 @@ class CompactionMixin:
                 break
 
             candidate_start = leading_anchor_count
-            while (
-                candidate_start < fresh_tail_start
-                and self._is_replayed_context_scaffold_message(working_messages[candidate_start])
-            ):
-                candidate_start += 1
-            if candidate_start > leading_anchor_count:
+            compactable_pairs = list(
+                zip(
+                    working_messages[candidate_start:fresh_tail_start],
+                    pressure_messages[candidate_start:fresh_tail_start],
+                )
+            )
+            raw_compactable_pairs = [
+                (working_msg, pressure_msg)
+                for working_msg, pressure_msg in compactable_pairs
+                if not self._is_replayed_context_scaffold_message(working_msg)  # type: ignore[attr-defined]
+            ]
+            if len(raw_compactable_pairs) != len(compactable_pairs):
                 dropped_replayed_scaffold_messages = True
-                working_messages = working_messages[:leading_anchor_count] + working_messages[candidate_start:]
-                pressure_messages = pressure_messages[:leading_anchor_count] + pressure_messages[candidate_start:]
-                candidate_start = leading_anchor_count
+                working_messages = (
+                    working_messages[:candidate_start]
+                    + [working_msg for working_msg, _pressure_msg in raw_compactable_pairs]
+                    + working_messages[fresh_tail_start:]
+                )
+                pressure_messages = (
+                    pressure_messages[:candidate_start]
+                    + [pressure_msg for _working_msg, pressure_msg in raw_compactable_pairs]
+                    + pressure_messages[fresh_tail_start:]
+                )
                 n = len(working_messages)
                 fresh_tail_start = max(0, n - self._config.fresh_tail_count)
                 if fresh_tail_start <= leading_anchor_count:

--- a/compaction.py
+++ b/compaction.py
@@ -386,10 +386,23 @@ class CompactionMixin:
         # or provider context after the durable row has been written.
         working_messages = self._ingest_messages(messages)
         ingest_cleanup_changed_active_context = working_messages != messages
+        restored_working_messages = [
+            self._strip_coalesced_generated_summary_scaffold(message)  # type: ignore[attr-defined]
+            for message in working_messages
+        ]
+        restored_coalesced_summary_tail = any(
+            restored is not original
+            for original, restored in zip(working_messages, restored_working_messages)
+        )
+        if restored_coalesced_summary_tail:
+            working_messages = restored_working_messages
+            ingest_cleanup_changed_active_context = True
         anchor_source_messages = list(working_messages)
         pressure_messages = messages if len(messages) == len(working_messages) else working_messages
+        if restored_coalesced_summary_tail:
+            pressure_messages = working_messages
         leaf_compacted_this_turn = False
-        dropped_replayed_scaffold_messages = False
+        dropped_replayed_scaffold_messages = restored_coalesced_summary_tail
         leaf_passes = 0
         critical_budget_pressure = self._critical_budget_pressure_reached(
             observed_tokens=observed_prompt_tokens,

--- a/compaction.py
+++ b/compaction.py
@@ -37,6 +37,22 @@ class CompactionMixin:
         if callable(maybe_reclassify):
             maybe_reclassify()
 
+    @staticmethod
+    def _split_leading_anchor_and_context_tail(
+        messages: List[Dict[str, Any]],
+        leading_anchor_count: int,
+    ) -> tuple[Optional[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        leading_anchor_count = max(0, min(leading_anchor_count, len(messages)))
+        leading_anchors = messages[:leading_anchor_count]
+        system_msg = (
+            leading_anchors[0]
+            if leading_anchors
+            and isinstance(leading_anchors[0], dict)
+            and leading_anchors[0].get("role") == "system"
+            else None
+        )
+        return system_msg, leading_anchors, messages[leading_anchor_count:]
+
     def should_compress(self, prompt_tokens: int = None) -> bool:
         if self._bypasses_lcm_context_management():
             if self._compression_boundary_cooldown_active():
@@ -408,10 +424,9 @@ class CompactionMixin:
             n = len(working_messages)
             fresh_tail_start = max(0, n - self._config.fresh_tail_count)
 
-            # Keep only a real system prompt anchored. Gateway sessions may
-            # pass only conversation messages, so index 0 can be an old user
-            # turn; that must remain eligible for compaction instead of being
-            # replayed forever as fresh-looking intent.
+            # Keep a real system prompt anchored, plus the narrow single-user
+            # leading query case needed by provider templates that reject a
+            # rendered request with no user-role message.
             leading_anchor_count = self._leading_anchor_count(working_messages)
             if fresh_tail_start <= leading_anchor_count:
                 noop_reason = "no eligible raw backlog outside fresh tail"
@@ -662,10 +677,17 @@ class CompactionMixin:
             )
             if force_overflow and len(messages) >= 1:
                 leading_anchor_count = self._leading_anchor_count(working_messages)
+                system_msg, leading_anchors, context_tail = self._split_leading_anchor_and_context_tail(
+                    working_messages,
+                    leading_anchor_count,
+                )
+                assemble_kwargs = {"assembly_cap_override": recovery_assembly_cap}
+                if len(leading_anchors) > 1:
+                    assemble_kwargs["leading_anchor_messages"] = leading_anchors
                 compressed = self._assemble_overflow_recovery_context(
-                    working_messages[0] if leading_anchor_count else None,
-                    working_messages[leading_anchor_count:],
-                    assembly_cap_override=recovery_assembly_cap,
+                    system_msg if leading_anchor_count else None,
+                    context_tail,
+                    **assemble_kwargs,
                 )
                 return self._finalize_forced_overflow_result(
                     working_messages,
@@ -680,11 +702,18 @@ class CompactionMixin:
                 leading_anchor_count = self._leading_anchor_count(active_context_messages)
                 anchor_leading_count = self._leading_anchor_count(anchor_source_messages)
                 self._pending_context_anchor_messages = anchor_source_messages[anchor_leading_count:]
+                system_msg, leading_anchors, context_tail = self._split_leading_anchor_and_context_tail(
+                    active_context_messages,
+                    leading_anchor_count,
+                )
+                assemble_kwargs = {"assembly_cap_override": recovery_assembly_cap}
+                if len(leading_anchors) > 1:
+                    assemble_kwargs["leading_anchor_messages"] = leading_anchors
                 try:
                     sanitized_messages = self._assemble_context(
-                        active_context_messages[0] if leading_anchor_count else None,
-                        active_context_messages[leading_anchor_count:],
-                        assembly_cap_override=recovery_assembly_cap,
+                        system_msg if leading_anchor_count else None,
+                        context_tail,
+                        **assemble_kwargs,
                     )
                 finally:
                     self._pending_context_anchor_messages = None
@@ -735,11 +764,18 @@ class CompactionMixin:
         leading_anchor_count = self._leading_anchor_count(working_messages)
         anchor_leading_count = self._leading_anchor_count(anchor_source_messages)
         self._pending_context_anchor_messages = anchor_source_messages[anchor_leading_count:]
+        system_msg, leading_anchors, context_tail = self._split_leading_anchor_and_context_tail(
+            working_messages,
+            leading_anchor_count,
+        )
+        assemble_kwargs = {"assembly_cap_override": recovery_assembly_cap}
+        if len(leading_anchors) > 1:
+            assemble_kwargs["leading_anchor_messages"] = leading_anchors
         try:
             compressed = self._assemble_context(
-                working_messages[0] if leading_anchor_count else None,
-                working_messages[leading_anchor_count:],
-                assembly_cap_override=recovery_assembly_cap,
+                system_msg if leading_anchor_count else None,
+                context_tail,
+                **assemble_kwargs,
             )
         finally:
             self._pending_context_anchor_messages = None

--- a/engine.py
+++ b/engine.py
@@ -3712,7 +3712,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 )
             except Exception:
                 return exact_annotation
-            if not rows or rows[0].get("role") != "system":
+            if not rows:
+                return False
+            if rows[0].get("role") != "system":
                 return exact_annotation
             stored_content = normalize_content_value(rows[0].get("content")) or ""
             restored_stored_content = self._identity_content_for_active_cleanup(stored_content)
@@ -3976,6 +3978,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         n = len(messages)
         cursor = min(max(self._ingest_cursor, 0), n)
         scan_start = 0 if self._ingest_cursor_needs_reconcile else cursor
+        reconciled_replay_message_indexes: set[int] = set()
+        self._reconciled_replay_message_indexes = set()
         ignored_original_messages = [False] * n
         if self._compiled_ignore_message_patterns:
             previous_store_id_map = self._current_compress_store_ids_by_message_id
@@ -4030,6 +4034,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 for idx, (original_msg, replay_msg) in enumerate(zip(messages, replay_messages))
             ]
             self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
+            reconciled_replay_message_indexes = self._reconciled_replay_message_indexes
+            self._reconciled_replay_message_indexes = set()
             self._ingest_cursor_needs_reconcile = False
         cursor = min(max(self._ingest_cursor, 0), n)
         if cursor > 0:
@@ -4141,7 +4147,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
             for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
                 absolute_idx = cursor + offset
-                if absolute_idx in self._reconciled_replay_message_indexes:
+                if absolute_idx in reconciled_replay_message_indexes:
                     continue
                 replay_text = text_content_for_pattern_matching(replay_msg.get("content")) or ""
                 original_text = text_content_for_pattern_matching(original_msg.get("content")) or ""

--- a/engine.py
+++ b/engine.py
@@ -305,6 +305,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._current_compress_placeholder_identity_counts: dict[tuple[str, str, str, str], int] = {}
         self._last_active_replay_source_identities: list[tuple[Any, ...]] = []
         self._last_active_replay_messages: list[Dict[str, Any]] = []
+        self._historical_active_replay_matched = False
+        self._reconciled_replay_message_indexes: set[int] = set()
         self._generated_ignored_active_replay_placeholder_message_ids: set[int] = set()
         self._logged_filter_config = False
         self._pending_reset_session_id: str = ""
@@ -3670,6 +3672,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._write_generated_ignored_placeholder_hash_ordinals(
             self._generated_placeholder_digest_ordinals_for_active_replay(active_replay_messages)
         )
+        if self._historical_active_replay_matched:
+            self._write_active_replay_snapshot(active_replay_messages)
         return active_replay_messages
 
     def _cached_active_replay_messages(
@@ -3688,9 +3692,37 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         role = str(msg.get("role") or "")
         content = normalize_content_value(msg.get("content")) or ""
         if role == "system":
-            return (
-                "[Note: This conversation uses Lossless Context Management (LCM)." in content
-                and "Earlier turns have been compacted into hierarchical summaries below." in content
+            current_note = self._append_lcm_note_to_content("")
+            legacy_note = (
+                "\n\n[Note: This conversation uses Lossless Context Management (LCM). "
+                "Earlier turns have been compacted into hierarchical summaries below.]"
+            )
+            exact_annotation = any(
+                content == note.strip() or content.endswith(note)
+                for note in (current_note, legacy_note)
+                if isinstance(note, str)
+            )
+            if not exact_annotation:
+                return False
+            try:
+                rows = self._store.get_session_messages(
+                    self._session_id,
+                    limit=1,
+                    conversation_id=self._conversation_id,
+                )
+            except Exception:
+                return exact_annotation
+            if not rows or rows[0].get("role") != "system":
+                return exact_annotation
+            expected_messages = []
+            for note in (current_note, legacy_note):
+                expected = dict(rows[0])
+                expected["content"] = str(rows[0].get("content") or "") + str(note)
+                expected_messages.append(expected)
+            return any(
+                self._message_replay_identity(msg)
+                == self._message_replay_identity(expected, stored_row=True)
+                for expected in expected_messages
             )
         if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return True
@@ -3705,6 +3737,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def _is_known_generated_summary_scaffold_message(self, msg: Dict[str, Any]) -> bool:
         content = normalize_content_value(msg.get("content")) or ""
+        generated_summaries: set[str] = set()
         for match in re.finditer(
             r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary "
             r"\(d\d+, node (\d+)\)\]",
@@ -3723,9 +3756,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 f"{node.summary}\n"
                 f"[Expand for details: {node.expand_hint}]"
             )
-            if generated in content:
-                return True
-        return False
+            generated_summaries.add(generated)
+        if content in generated_summaries:
+            return True
+        parts = content.split("\n\n---\n\n")
+        return bool(parts) and all(part in generated_summaries for part in parts)
 
     def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:
         if isinstance(value, dict):
@@ -4089,6 +4124,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
             for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
                 absolute_idx = cursor + offset
+                if absolute_idx in self._reconciled_replay_message_indexes:
+                    continue
                 replay_text = text_content_for_pattern_matching(replay_msg.get("content")) or ""
                 original_text = text_content_for_pattern_matching(original_msg.get("content")) or ""
                 volatile_placeholder = self._is_volatile_ignored_quarantine_placeholder(
@@ -4798,7 +4835,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 continue
             if self._preserved_objective_context_content(message):
                 return None
-            if not self._is_prompt_bearing_user_message(message):
+            if not self._is_prompt_bearing_user_message(
+                message,
+                allow_literal_summary_scaffold=True,
+            ):
                 continue
             if any(message == selected for selected in selected_tail_messages):
                 return None
@@ -4938,8 +4978,30 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 combined = "\n\n---\n\n".join(selected_parts)
                 result.append({"role": summary_role, "content": combined})
 
-        # Fresh tail
-        result.extend(tail_selected)
+        # Fresh tail.  A generated assistant summary followed by an assistant
+        # tail is not provider-valid.  Coalesce at that boundary while retaining
+        # the tail's tool_calls so following tool results stay contiguous.
+        if (
+            result
+            and tail_selected
+            and result[-1].get("role") == "assistant"
+            and tail_selected[0].get("role") == "assistant"
+        ):
+            summary_text = text_content_for_pattern_matching(result[-1].get("content")) or ""
+            merged_tail = copy.deepcopy(tail_selected[0])
+            tail_content = merged_tail.get("content")
+            if isinstance(tail_content, list):
+                merged_tail["content"] = [
+                    {"type": "text", "text": summary_text},
+                    *copy.deepcopy(tail_content),
+                ]
+            else:
+                tail_text = "" if tail_content is None else str(tail_content)
+                merged_tail["content"] = summary_text + ("\n\n" + tail_text if tail_text else "")
+            result[-1] = merged_tail
+            result.extend(tail_selected[1:])
+        else:
+            result.extend(tail_selected)
 
         # ── Active-context cleanup / tool-pair guardrail ──
         # Drop assistant turns that carry only blank/internal structured content,
@@ -5026,6 +5088,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     effective_cap,
                     count_messages_tokens(compressed),
                 )
+        if compressed != original_messages:
+            self._write_active_replay_snapshot(compressed)
         return compressed
 
     def _should_force_overflow_recovery(

--- a/engine.py
+++ b/engine.py
@@ -5139,7 +5139,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         minimum_candidate_len = leading_anchor_count
         if len(candidate) == minimum_candidate_len and tail_messages:
-            if any(self._is_prompt_bearing_user_message(message) for message in candidate):
+            has_prompt_bearing_user = any(
+                self._is_prompt_bearing_user_message(message)
+                for message in candidate
+            ) or any(
+                self._is_prompt_bearing_user_message(
+                    message,
+                    allow_literal_summary_scaffold=True,
+                )
+                for message in candidate[:leading_anchor_count]
+            )
+            if has_prompt_bearing_user:
                 return candidate
             fallback = list(leading_anchor_messages or ([system_msg] if system_msg is not None else [])) + [tail_messages[-1]]
             return self._sanitize_active_context_messages(fallback)

--- a/engine.py
+++ b/engine.py
@@ -3698,7 +3698,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 "Earlier turns have been compacted into hierarchical summaries below.]"
             )
             exact_annotation = any(
-                content == note.strip() or content.endswith(note)
+                self._content_has_exact_lcm_annotation(msg.get("content"), note)
                 for note in (current_note, legacy_note)
                 if isinstance(note, str)
             )
@@ -3714,15 +3714,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 return exact_annotation
             if not rows or rows[0].get("role") != "system":
                 return exact_annotation
-            expected_messages = []
-            for note in (current_note, legacy_note):
-                expected = dict(rows[0])
-                expected["content"] = str(rows[0].get("content") or "") + str(note)
-                expected_messages.append(expected)
+            stored_content = normalize_content_value(rows[0].get("content")) or ""
+            restored_stored_content = self._identity_content_for_active_cleanup(stored_content)
+            expected_current = dict(rows[0])
+            expected_current["content"] = self._append_lcm_note_to_content(restored_stored_content)
+            expected_legacy = dict(rows[0])
+            expected_legacy["content"] = stored_content + legacy_note
             return any(
                 self._message_replay_identity(msg)
                 == self._message_replay_identity(expected, stored_row=True)
-                for expected in expected_messages
+                for expected in (expected_current, expected_legacy)
             )
         if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return True
@@ -3734,6 +3735,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 content,
             )
         )
+
+    @staticmethod
+    def _content_has_exact_lcm_annotation(content: Any, note: str) -> bool:
+        if isinstance(content, str):
+            if content == note.strip() or content.endswith(note):
+                return True
+            try:
+                decoded = json.loads(content)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return False
+            if normalize_content_value(decoded) != content:
+                return False
+            content = decoded
+        if not isinstance(content, list) or not content:
+            return False
+        return content[-1] == {"type": "text", "text": note.lstrip()}
 
     def _is_known_generated_summary_scaffold_message(self, msg: Dict[str, Any]) -> bool:
         content = normalize_content_value(msg.get("content")) or ""

--- a/engine.py
+++ b/engine.py
@@ -3818,35 +3818,77 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return msg
         content = msg.get("content")
         content_text = normalize_content_value(content) or ""
-        if content_text.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
-            # Objective text has no closing delimiter, so recover the exact tail
-            # from its durable row instead of guessing where user content ends.
+
+        durable_rows: Optional[list[Dict[str, Any]]] = None
+
+        def matching_durable_rows() -> list[Dict[str, Any]]:
+            nonlocal durable_rows
+            if durable_rows is not None:
+                return durable_rows
             try:
-                durable_rows = self._store.get_session_messages(
+                rows = self._store.get_session_messages(
                     self._session_id,
                     conversation_id=self._conversation_id,
                 )
             except Exception:
-                durable_rows = []
+                rows = []
             incoming_tool_calls = self._stable_tool_calls_identity(msg.get("tool_calls"))
             incoming_tool_call_id = str(msg.get("tool_call_id") or "")
-            for row in reversed(durable_rows):
-                if str(row.get("role") or "") != "assistant":
+            durable_rows = [
+                row
+                for row in reversed(rows)
+                if str(row.get("role") or "") == "assistant"
+                and self._stable_tool_calls_identity(row.get("tool_calls"))
+                == incoming_tool_calls
+                and str(row.get("tool_call_id") or "") == incoming_tool_call_id
+            ]
+            return durable_rows
+
+        def durable_content(row: Dict[str, Any]) -> Any:
+            normalized = normalize_content_value(row.get("content"))
+            if normalized is None:
+                return None
+            return self._identity_content_for_active_cleanup(normalized)
+
+        def normalized_content(value: Any) -> Any:
+            return normalize_content_value(value)
+
+        def has_exact_durable_content(value: Any) -> bool:
+            target = normalized_content(value)
+            return any(
+                normalized_content(durable_content(row)) == target
+                for row in matching_durable_rows()
+            )
+
+        def has_durable_tail(value: Any) -> bool:
+            target = normalized_content(value)
+            for row in matching_durable_rows():
+                if normalized_content(durable_content(row)) == target:
+                    return True
+                if value is None:
                     continue
-                if self._stable_tool_calls_identity(row.get("tool_calls")) != incoming_tool_calls:
-                    continue
-                if str(row.get("tool_call_id") or "") != incoming_tool_call_id:
-                    continue
-                durable_content = self._identity_content_for_active_cleanup(
-                    normalize_content_value(row.get("content")) or ""
+                cleaned_identity = self._active_cleanup_replay_identity(
+                    self._message_replay_identity(row, stored_row=True)
                 )
+                if cleaned_identity is not None and cleaned_identity[1] == (target or ""):
+                    return True
+            return False
+
+        if content_text.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
+            # Objective text has no closing delimiter, so recover the exact tail
+            # from its durable row instead of guessing where user content ends.
+            if has_exact_durable_content(content):
+                return msg
+            incoming_tool_calls = self._stable_tool_calls_identity(msg.get("tool_calls"))
+            for row in matching_durable_rows():
+                tail_content = durable_content(row)
                 if isinstance(content, str):
-                    durable_text = "" if durable_content is None else str(durable_content)
+                    durable_text = "" if tail_content is None else str(tail_content)
                     if durable_text and content.endswith("\n\n" + durable_text):
                         restored = copy.deepcopy(msg)
-                        restored["content"] = durable_content
+                        restored["content"] = tail_content
                         return restored
-                    if durable_content is None and incoming_tool_calls:
+                    if tail_content is None and incoming_tool_calls:
                         restored = copy.deepcopy(msg)
                         restored["content"] = None
                         return restored
@@ -3855,18 +3897,35 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     isinstance(content, list)
                     and content
                     and normalize_content_value(content[1:])
-                    == normalize_content_value(durable_content)
+                    == normalize_content_value(tail_content)
                 ):
                     restored = copy.deepcopy(msg)
-                    restored["content"] = durable_content
+                    restored["content"] = tail_content
                     return restored
         if isinstance(content, str):
             prefix = self._known_generated_summary_scaffold_prefix(content)
             separator = "\n\n"
-            if not prefix or not content.startswith(prefix + separator):
+            if not prefix:
+                return msg
+            if has_exact_durable_content(content):
+                return msg
+            if content == prefix:
+                if not self._stable_tool_calls_identity(msg.get("tool_calls")):
+                    return msg
+                for row in matching_durable_rows():
+                    tail_content = durable_content(row)
+                    if tail_content is None or tail_content == "":
+                        restored = copy.deepcopy(msg)
+                        restored["content"] = tail_content
+                        return restored
+                return msg
+            if not content.startswith(prefix + separator):
+                return msg
+            tail_content = content[len(prefix + separator) :]
+            if not has_durable_tail(tail_content):
                 return msg
             restored = copy.deepcopy(msg)
-            restored["content"] = content[len(prefix + separator) :]
+            restored["content"] = tail_content
             return restored
         if not isinstance(content, list) or not content:
             return msg
@@ -3877,17 +3936,26 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         prefix = self._known_generated_summary_scaffold_prefix(text)
         if not prefix:
             return msg
-        restored = copy.deepcopy(msg)
-        restored_content = restored["content"]
+        if has_exact_durable_content(content):
+            return msg
         if text == prefix:
-            if len(restored_content) == 1:
+            if len(content) == 1:
                 return msg
-            restored["content"] = restored_content[1:]
+            tail_content = content[1:]
+            if not has_durable_tail(tail_content):
+                return msg
+            restored = copy.deepcopy(msg)
+            restored["content"] = tail_content
             return restored
         separator = "\n\n"
         if not text.startswith(prefix + separator):
             return msg
-        restored_content[0]["text"] = text[len(prefix + separator) :]
+        tail_content = copy.deepcopy(content)
+        tail_content[0]["text"] = text[len(prefix + separator) :]
+        if not has_durable_tail(tail_content):
+            return msg
+        restored = copy.deepcopy(msg)
+        restored["content"] = tail_content
         return restored
 
     def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:

--- a/engine.py
+++ b/engine.py
@@ -1493,10 +1493,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         usually compactable because replaying one forever can make stale
         requests look current after later compaction. The exception is the
         narrow Qwen-family chat-template invariant: when a system prompt is
-        followed by the session's only prompt-bearing user query outside the
-        fresh tail, compacting it can leave active context with no raw user-role
-        query at all. Preserve exactly that initial system+user window and keep
-        no-system, later-user, and multi-user sessions compactable.
+        followed by the session's only prompt-bearing user query, compaction or
+        overflow recovery can leave active context with no raw user-role query
+        at all. Preserve exactly that initial system+user window, including when
+        it falls inside the fresh tail, and keep no-system, later-user, and
+        multi-user sessions compactable.
         """
         if not messages:
             return 0
@@ -1505,14 +1506,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if isinstance(messages[0], dict) and messages[0].get("role") == "system"
             else 0
         )
-        fresh_tail_start = max(0, len(messages) - self._config.fresh_tail_count)
-        if fresh_tail_start <= system_anchor_count:
-            return system_anchor_count
         if system_anchor_count == 0:
             return 0
 
         first_user_index = system_anchor_count
-        if first_user_index >= fresh_tail_start or not self._is_prompt_bearing_user_message(
+        if first_user_index >= len(messages) or not self._is_prompt_bearing_user_message(
             messages[first_user_index]
         ):
             return system_anchor_count
@@ -1521,10 +1519,25 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             for message in messages[first_user_index + 1:]
         ):
             return system_anchor_count
+        durable_users = self._store.get_session_nonblank_role_messages(
+            self._session_id,
+            "user",
+            limit=2,
+        )
+        if durable_users:
+            if len(durable_users) != 1:
+                return system_anchor_count
+            if (
+                self._message_replay_identity(messages[first_user_index])
+                != self._message_replay_identity(durable_users[0], stored_row=True)
+            ):
+                return system_anchor_count
         return first_user_index + 1
 
     def _is_prompt_bearing_user_message(self, message: Dict[str, Any]) -> bool:
         if not isinstance(message, dict) or message.get("role") != "user":
+            return False
+        if self._is_replayed_context_scaffold_message(message):
             return False
         if self._is_preserved_todo_context_message(message):
             return False
@@ -1532,6 +1545,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         if self._is_context_summary_content(content):
             return False
         content_text = text_content_for_pattern_matching(content) or ""
+        if not content_text.strip():
+            return False
         if content_text.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return False
         return not (
@@ -4692,9 +4707,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 continue
             if self._preserved_objective_context_content(message):
                 return None
-            if message.get("role") != "user":
-                continue
-            if self._is_preserved_todo_context_message(message):
+            if not self._is_prompt_bearing_user_message(message):
                 continue
             if any(message == selected for selected in selected_tail_messages):
                 return None
@@ -4775,7 +4788,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             tail_selected = list(reversed(kept_tail_reversed))
             summary_budget = max(0, assembly_cap - used - tail_token_total)
         if anchor_source is not None:
-            anchor_part = self._latest_user_context_anchor(anchor_source, tail_selected)
+            anchor_part = self._latest_user_context_anchor(
+                anchor_source,
+                leading_msgs + tail_selected,
+            )
 
         # Collect DAG summaries — highest depth first for context hierarchy
         summary_parts: list[str] = []
@@ -5032,6 +5048,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         minimum_candidate_len = leading_anchor_count
         if len(candidate) == minimum_candidate_len and tail_messages:
+            if any(self._is_prompt_bearing_user_message(message) for message in candidate):
+                return candidate
             fallback = list(leading_anchor_messages or ([system_msg] if system_msg is not None else [])) + [tail_messages[-1]]
             return self._sanitize_active_context_messages(fallback)
         return candidate

--- a/engine.py
+++ b/engine.py
@@ -1522,8 +1522,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         durable_users = self._store.get_session_nonblank_role_messages(
             self._session_id,
             "user",
-            limit=2,
+            limit=max(2, self._store.get_session_count(self._session_id)),
         )
+        durable_users = [
+            message for message in durable_users
+            if self._is_prompt_bearing_user_message(message)
+        ]
         if durable_users:
             if len(durable_users) != 1:
                 return system_anchor_count

--- a/engine.py
+++ b/engine.py
@@ -3813,10 +3813,53 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self,
         msg: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Restore a durable assistant tail coalesced behind generated summary text."""
+        """Restore a durable assistant tail coalesced behind replay scaffolding."""
         if str(msg.get("role") or "") != "assistant":
             return msg
         content = msg.get("content")
+        content_text = normalize_content_value(content) or ""
+        if content_text.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
+            # Objective text has no closing delimiter, so recover the exact tail
+            # from its durable row instead of guessing where user content ends.
+            try:
+                durable_rows = self._store.get_session_messages(
+                    self._session_id,
+                    conversation_id=self._conversation_id,
+                )
+            except Exception:
+                durable_rows = []
+            incoming_tool_calls = self._stable_tool_calls_identity(msg.get("tool_calls"))
+            incoming_tool_call_id = str(msg.get("tool_call_id") or "")
+            for row in reversed(durable_rows):
+                if str(row.get("role") or "") != "assistant":
+                    continue
+                if self._stable_tool_calls_identity(row.get("tool_calls")) != incoming_tool_calls:
+                    continue
+                if str(row.get("tool_call_id") or "") != incoming_tool_call_id:
+                    continue
+                durable_content = self._identity_content_for_active_cleanup(
+                    normalize_content_value(row.get("content")) or ""
+                )
+                if isinstance(content, str):
+                    durable_text = "" if durable_content is None else str(durable_content)
+                    if durable_text and content.endswith("\n\n" + durable_text):
+                        restored = copy.deepcopy(msg)
+                        restored["content"] = durable_content
+                        return restored
+                    if durable_content is None and incoming_tool_calls:
+                        restored = copy.deepcopy(msg)
+                        restored["content"] = None
+                        return restored
+                    continue
+                if (
+                    isinstance(content, list)
+                    and content
+                    and normalize_content_value(content[1:])
+                    == normalize_content_value(durable_content)
+                ):
+                    restored = copy.deepcopy(msg)
+                    restored["content"] = durable_content
+                    return restored
         if isinstance(content, str):
             prefix = self._known_generated_summary_scaffold_prefix(content)
             separator = "\n\n"

--- a/engine.py
+++ b/engine.py
@@ -1523,6 +1523,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._session_id,
             "user",
             limit=max(2, self._store.get_session_count(self._session_id)),
+            conversation_id=self._conversation_id,
         )
         durable_users = [
             message for message in durable_users

--- a/engine.py
+++ b/engine.py
@@ -3715,7 +3715,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if not rows:
                 return False
             if rows[0].get("role") != "system":
-                return exact_annotation
+                return False
             stored_content = normalize_content_value(rows[0].get("content")) or ""
             restored_stored_content = self._identity_content_for_active_cleanup(stored_content)
             expected_current = dict(rows[0])

--- a/engine.py
+++ b/engine.py
@@ -3756,6 +3756,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def _is_known_generated_summary_scaffold_message(self, msg: Dict[str, Any]) -> bool:
         content = normalize_content_value(msg.get("content")) or ""
+        prefix = self._known_generated_summary_scaffold_prefix(content)
+        return bool(prefix) and prefix == content
+
+    def _known_generated_summary_scaffold_prefix(self, content: str) -> str:
+        """Return the exact DAG-backed summary prefix at the start of content."""
         generated_summaries: set[str] = set()
         for match in re.finditer(
             r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary "
@@ -3776,10 +3781,71 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 f"[Expand for details: {node.expand_hint}]"
             )
             generated_summaries.add(generated)
-        if content in generated_summaries:
-            return True
-        parts = content.split("\n\n---\n\n")
-        return bool(parts) and all(part in generated_summaries for part in parts)
+        if not generated_summaries:
+            return ""
+
+        cursor = 0
+        matched_parts = 0
+        while True:
+            generated = next(
+                (
+                    candidate
+                    for candidate in sorted(generated_summaries, key=len, reverse=True)
+                    if content.startswith(candidate, cursor)
+                ),
+                None,
+            )
+            if generated is None:
+                break
+            cursor += len(generated)
+            matched_parts += 1
+            if content.startswith("\n\n---\n\n", cursor):
+                cursor += len("\n\n---\n\n")
+                continue
+            break
+        if not matched_parts:
+            return ""
+        if content[:cursor].endswith("\n\n---\n\n"):
+            cursor -= len("\n\n---\n\n")
+        return content[:cursor]
+
+    def _strip_coalesced_generated_summary_scaffold(
+        self,
+        msg: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Restore a durable assistant tail coalesced behind generated summary text."""
+        if str(msg.get("role") or "") != "assistant":
+            return msg
+        content = msg.get("content")
+        if isinstance(content, str):
+            prefix = self._known_generated_summary_scaffold_prefix(content)
+            separator = "\n\n"
+            if not prefix or not content.startswith(prefix + separator):
+                return msg
+            restored = copy.deepcopy(msg)
+            restored["content"] = content[len(prefix + separator) :]
+            return restored
+        if not isinstance(content, list) or not content:
+            return msg
+        first = content[0]
+        if not isinstance(first, dict) or first.get("type") != "text":
+            return msg
+        text = str(first.get("text") or "")
+        prefix = self._known_generated_summary_scaffold_prefix(text)
+        if not prefix:
+            return msg
+        restored = copy.deepcopy(msg)
+        restored_content = restored["content"]
+        if text == prefix:
+            if len(restored_content) == 1:
+                return msg
+            restored["content"] = restored_content[1:]
+            return restored
+        separator = "\n\n"
+        if not text.startswith(prefix + separator):
+            return msg
+        restored_content[0]["text"] = text[len(prefix + separator) :]
+        return restored
 
     def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:
         if isinstance(value, dict):

--- a/engine.py
+++ b/engine.py
@@ -1519,11 +1519,25 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             for message in messages[first_user_index + 1:]
         ):
             return system_anchor_count
+        durable_conversation_id = self._conversation_id
+        legacy_blank_conversation_only = False
+        durable_message_count = self._store.get_session_count(
+            self._session_id,
+            conversation_id=durable_conversation_id,
+        )
+        if durable_conversation_id and durable_message_count <= 0:
+            durable_conversation_id = ""
+            legacy_blank_conversation_only = True
+            durable_message_count = self._store.get_session_count(
+                self._session_id,
+                legacy_blank_conversation_only=True,
+            )
         durable_users = self._store.get_session_nonblank_role_messages(
             self._session_id,
             "user",
-            limit=max(2, self._store.get_session_count(self._session_id)),
-            conversation_id=self._conversation_id,
+            limit=max(2, durable_message_count),
+            conversation_id=durable_conversation_id,
+            legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
         durable_users = [
             message for message in durable_users

--- a/engine.py
+++ b/engine.py
@@ -1510,14 +1510,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return 0
 
         first_user_index = system_anchor_count
-        if first_user_index >= len(messages) or not self._is_prompt_bearing_user_message(
-            messages[first_user_index]
-        ):
-            return system_anchor_count
-        if any(
-            self._is_prompt_bearing_user_message(message)
-            for message in messages[first_user_index + 1:]
-        ):
+        if first_user_index >= len(messages):
             return system_anchor_count
         durable_conversation_id = self._conversation_id
         legacy_blank_conversation_only = False
@@ -1532,7 +1525,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 self._session_id,
                 legacy_blank_conversation_only=True,
             )
-        durable_users = self._store.get_session_nonblank_role_messages(
+        raw_durable_users = self._store.get_session_nonblank_role_messages(
             self._session_id,
             "user",
             limit=max(2, durable_message_count),
@@ -1540,9 +1533,53 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
         durable_users = [
-            message for message in durable_users
+            message for message in raw_durable_users
             if self._is_prompt_bearing_user_message(message)
         ]
+
+        # A summary-shaped user message is prompt-bearing only when its exact
+        # identity is durable and it is not backed by an actual local DAG node.
+        scaffold_candidate_identities = {
+            self._message_replay_identity(message)
+            for message in messages[first_user_index:]
+            if (
+                not self._is_prompt_bearing_user_message(message)
+                and self._is_prompt_bearing_user_message(
+                    message,
+                    allow_literal_summary_scaffold=True,
+                )
+            )
+        }
+        durable_users.extend(
+            message for message in raw_durable_users
+            if (
+                not self._is_prompt_bearing_user_message(message)
+                and self._message_replay_identity(message, stored_row=True)
+                in scaffold_candidate_identities
+            )
+        )
+
+        def is_durable_prompt_bearing(message: Dict[str, Any]) -> bool:
+            if self._is_prompt_bearing_user_message(message):
+                return True
+            if not self._is_prompt_bearing_user_message(
+                message,
+                allow_literal_summary_scaffold=True,
+            ):
+                return False
+            identity = self._message_replay_identity(message)
+            return any(
+                identity == self._message_replay_identity(user, stored_row=True)
+                for user in durable_users
+            )
+
+        if not is_durable_prompt_bearing(messages[first_user_index]):
+            return system_anchor_count
+        if any(
+            is_durable_prompt_bearing(message)
+            for message in messages[first_user_index + 1:]
+        ):
+            return system_anchor_count
         if durable_users:
             if len(durable_users) != 1:
                 return system_anchor_count
@@ -1553,10 +1590,21 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 return system_anchor_count
         return first_user_index + 1
 
-    def _is_prompt_bearing_user_message(self, message: Dict[str, Any]) -> bool:
+    def _is_prompt_bearing_user_message(
+        self,
+        message: Dict[str, Any],
+        *,
+        allow_literal_summary_scaffold: bool = False,
+    ) -> bool:
         if not isinstance(message, dict) or message.get("role") != "user":
             return False
-        if self._is_replayed_context_scaffold_message(message):
+        if (
+            self._is_replayed_context_scaffold_message(message)
+            and (
+                not allow_literal_summary_scaffold
+                or self._is_known_generated_summary_scaffold_message(message)
+            )
+        ):
             return False
         if self._is_preserved_todo_context_message(message):
             return False
@@ -3654,6 +3702,30 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 content,
             )
         )
+
+    def _is_known_generated_summary_scaffold_message(self, msg: Dict[str, Any]) -> bool:
+        content = normalize_content_value(msg.get("content")) or ""
+        for match in re.finditer(
+            r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary "
+            r"\(d\d+, node (\d+)\)\]",
+            content,
+        ):
+            node = self._dag.get_node(int(match.group(1)))
+            if node is None or node.session_id != self._session_id:
+                continue
+            depth_label = {
+                0: "Recent",
+                1: "Session Arc",
+                2: "Durable",
+            }.get(node.depth, f"Depth-{node.depth}")
+            generated = (
+                f"[{depth_label} Summary (d{node.depth}, node {node.node_id})]\n"
+                f"{node.summary}\n"
+                f"[Expand for details: {node.expand_hint}]"
+            )
+            if generated in content:
+                return True
+        return False
 
     def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:
         if isinstance(value, dict):

--- a/engine.py
+++ b/engine.py
@@ -1486,18 +1486,59 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return []
         return messages[leading_anchor_count:fresh_tail_start]
 
-    @staticmethod
-    def _leading_anchor_count(messages: List[Dict[str, Any]]) -> int:
+    def _leading_anchor_count(self, messages: List[Dict[str, Any]]) -> int:
         """Return the number of non-compactable leading messages.
 
-        Only the system prompt is a safe permanent anchor. Hermes gateway
-        sessions can begin with a user message when core passes conversation
-        history without a system prompt; preserving that first user turn as raw
-        active context lets stale requests look current after later compaction.
+        The system prompt is always a safe permanent anchor. User turns are
+        usually compactable because replaying one forever can make stale
+        requests look current after later compaction. The exception is the
+        narrow Qwen-family chat-template invariant: when a system prompt is
+        followed by the session's only prompt-bearing user query outside the
+        fresh tail, compacting it can leave active context with no raw user-role
+        query at all. Preserve exactly that initial system+user window and keep
+        no-system, later-user, and multi-user sessions compactable.
         """
-        if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
-            return 1
-        return 0
+        if not messages:
+            return 0
+        system_anchor_count = (
+            1
+            if isinstance(messages[0], dict) and messages[0].get("role") == "system"
+            else 0
+        )
+        fresh_tail_start = max(0, len(messages) - self._config.fresh_tail_count)
+        if fresh_tail_start <= system_anchor_count:
+            return system_anchor_count
+        if system_anchor_count == 0:
+            return 0
+
+        first_user_index = system_anchor_count
+        if first_user_index >= fresh_tail_start or not self._is_prompt_bearing_user_message(
+            messages[first_user_index]
+        ):
+            return system_anchor_count
+        if any(
+            self._is_prompt_bearing_user_message(message)
+            for message in messages[first_user_index + 1:]
+        ):
+            return system_anchor_count
+        return first_user_index + 1
+
+    def _is_prompt_bearing_user_message(self, message: Dict[str, Any]) -> bool:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            return False
+        if self._is_preserved_todo_context_message(message):
+            return False
+        content = message.get("content")
+        if self._is_context_summary_content(content):
+            return False
+        content_text = text_content_for_pattern_matching(content) or ""
+        if content_text.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
+            return False
+        return not (
+            self._matches_ignore_message_patterns(message)
+            or self._is_volatile_ignored_quarantine_placeholder(message, content_text)
+            or self._is_ignored_active_replay_placeholder(message, content_text)
+        )
 
     def _raw_backlog_tokens(self, messages: List[Dict[str, Any]]) -> int:
         backlog = self._raw_backlog_messages(messages)
@@ -4664,6 +4705,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self,
         system_msg: Optional[Dict[str, Any]],
         tail_messages: List[Dict[str, Any]],
+        leading_anchor_messages: Optional[List[Dict[str, Any]]] = None,
         assembly_cap_override: Optional[int] = None,
         include_lcm_note: bool = True,
     ) -> List[Dict[str, Any]]:
@@ -4674,22 +4716,29 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
           [highest-depth summary nodes first, then lower]
           [fresh tail messages]
         """
-        result = []
+        result: list[Dict[str, Any]] = []
 
-        # Leading anchor with optional LCM annotation. Only a true system prompt
-        # is a safe permanent anchor; gateway sessions can start directly with
-        # user messages, and those user turns must remain compactable.
-        leading_msg = system_msg.copy() if system_msg is not None else None
-        if leading_msg is not None:
+        # Leading anchors with optional LCM annotation. Usually this is just a
+        # true system prompt. In the narrow single-initial-user case,
+        # _leading_anchor_count preserves system+user so provider templates see
+        # the raw prompt-bearing user before any synthetic summaries.
+        if leading_anchor_messages is not None:
+            leading_msgs = [msg.copy() for msg in leading_anchor_messages]
+        elif system_msg is not None:
+            leading_msgs = [system_msg.copy()]
+        else:
+            leading_msgs = []
+        if leading_msgs:
+            first_leading = leading_msgs[0]
             if (
-                leading_msg.get("role") == "system"
+                first_leading.get("role") == "system"
                 and self.compression_count == 0
                 and include_lcm_note
             ):
-                leading_msg["content"] = self._append_lcm_note_to_content(
-                    leading_msg.get("content", "")
+                first_leading["content"] = self._append_lcm_note_to_content(
+                    first_leading.get("content", "")
                 )
-            result.append(leading_msg)
+            result.extend(leading_msgs)
 
         assembly_cap = (
             assembly_cap_override
@@ -4704,7 +4753,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         anchor_part: Optional[str] = None
         summary_budget = None
         if assembly_cap is not None:
-            used = count_message_tokens(leading_msg) if leading_msg is not None else 0
+            used = count_messages_tokens(leading_msgs) if leading_msgs else 0
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
             tail_for_selection = self._sanitize_active_context_messages(
@@ -4789,7 +4838,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # Drop assistant turns that carry only blank/internal structured content,
         # then ensure provider-valid tool-call/result sequencing.
         result = self._sanitize_active_context_messages(result)
-        if leading_msg is None:
+        if not leading_msgs:
             while result and result[0].get("role") in {"assistant", "tool"}:
                 result = result[1:]
         if (
@@ -4952,8 +5001,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self,
         system_msg: Optional[Dict[str, Any]],
         tail_messages: List[Dict[str, Any]],
+        leading_anchor_messages: Optional[List[Dict[str, Any]]] = None,
         assembly_cap_override: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
+        leading_anchor_count = len(leading_anchor_messages or ([system_msg] if system_msg is not None else []))
         if tail_messages:
             first = tail_messages[0]
             content = first.get("content") or ""
@@ -4962,24 +5013,26 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 candidate = self._assemble_context(
                     system_msg,
                     tail_messages[1:],
+                    leading_anchor_messages=leading_anchor_messages,
                     assembly_cap_override=assembly_cap_override,
                     include_lcm_note=False,
                 )
                 if any(
                     (msg.get("content") or "") == content
-                    for msg in (candidate[1:] if system_msg is not None else candidate)
+                    for msg in candidate[leading_anchor_count:]
                 ):
                     return candidate
 
         candidate = self._assemble_context(
             system_msg,
             tail_messages,
+            leading_anchor_messages=leading_anchor_messages,
             assembly_cap_override=assembly_cap_override,
             include_lcm_note=False,
         )
-        minimum_candidate_len = 1 if system_msg is not None else 0
+        minimum_candidate_len = leading_anchor_count
         if len(candidate) == minimum_candidate_len and tail_messages:
-            fallback = ([system_msg] if system_msg is not None else []) + [tail_messages[-1]]
+            fallback = list(leading_anchor_messages or ([system_msg] if system_msg is not None else [])) + [tail_messages[-1]]
             return self._sanitize_active_context_messages(fallback)
         return candidate
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -44,6 +44,7 @@ from .ingest_protection import (
 )
 from .message_content import normalize_content_value, text_content_for_pattern_matching
 from .sanitize import _clean_active_assistant_message
+from .tokens import count_messages_tokens
 
 import logging
 
@@ -477,9 +478,19 @@ class ReconcileMixin:
         has_durable_compaction_frontier = (
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
         )
+        assembly_cap = self._effective_assembly_token_cap()  # type: ignore[attr-defined]
+        # A tail row that assembly could not fit cannot be replay evidence here;
+        # an identical post-restart row is an ambiguous new delta and must survive.
+        has_feasible_full_tail_replay = (
+            visible_after_anchor == stored_uncompacted_tail
+            and (
+                assembly_cap is None
+                or count_messages_tokens(candidate_messages) <= assembly_cap
+            )
+        )
         return (
             not visible_after_anchor and has_durable_compaction_frontier
-        ) or visible_after_anchor == stored_uncompacted_tail
+        ) or has_feasible_full_tail_replay
 
     def _find_reconciled_cursor_for_store_tail(
         self,
@@ -913,7 +924,7 @@ class ReconcileMixin:
         ]
         stored_head_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
             self._session_id,  # type: ignore[attr-defined]
-            limit=3,
+            limit=tail_limit,
         )
         stored_head = [
             self._message_replay_identity(row, stored_row=True)

--- a/reconcile.py
+++ b/reconcile.py
@@ -463,12 +463,6 @@ class ReconcileMixin:
                 self._is_replayed_context_scaffold_message(message)  # type: ignore[attr-defined]
                 for message in candidate_messages[2:]
             )
-        if candidate_messages[2:] and not any(
-            self._is_replayed_context_scaffold_message(message)
-            for message in candidate_messages[2:]
-        ):
-            return False
-
         visible_after_anchor = [
             self._message_replay_identity(message)
             for message in candidate_messages[2:]

--- a/reconcile.py
+++ b/reconcile.py
@@ -243,6 +243,86 @@ class ReconcileMixin:
             tool_calls_identity,
         )
 
+    def _active_replay_snapshot_key(self) -> str:
+        return f"active_replay_snapshot:{self._session_id}"
+
+    def _write_active_replay_snapshot(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._session_id:
+            return
+        payload = {
+            "conversation_id": str(getattr(self, "_conversation_id", "") or ""),
+            "identities": [list(self._message_replay_identity(message)) for message in messages],
+        }
+        try:
+            self._store.write_metadata_json(
+                [self._active_replay_snapshot_key()],
+                json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
+                skip_unchanged=True,
+            )
+        except Exception:
+            logger.debug("LCM active replay snapshot write failed", exc_info=True)
+
+    def _historical_active_replay_cursor(self, messages: List[Dict[str, Any]]) -> int | None:
+        """Return a replay cursor proven by the exact last emitted snapshot.
+
+        Assembly caps are runtime policy and may change between processes.  The
+        durable emitted identity is therefore the only safe proof for a partial
+        tail replay (especially when a new delta repeats durable content).
+        """
+        self._historical_active_replay_matched = False
+        self._reconciled_replay_message_indexes = set()
+        try:
+            payload = self._store.read_metadata_json(self._active_replay_snapshot_key())
+        except Exception:
+            logger.debug("LCM active replay snapshot read failed", exc_info=True)
+            return None
+        if not isinstance(payload, dict):
+            return None
+        if str(payload.get("conversation_id") or "") != str(
+            getattr(self, "_conversation_id", "") or ""
+        ):
+            return None
+        raw_identities = payload.get("identities")
+        if not isinstance(raw_identities, list) or not raw_identities:
+            return None
+        snapshot = [tuple(identity) for identity in raw_identities if isinstance(identity, list)]
+        if len(snapshot) != len(raw_identities):
+            return None
+        incoming = [self._message_replay_identity(message) for message in messages]
+        if len(incoming) >= len(snapshot) and incoming[: len(snapshot)] == snapshot:
+            self._historical_active_replay_matched = True
+            return len(snapshot)
+        logger.debug(
+            "LCM historical active replay mismatch: incoming=%d snapshot=%d first_diff=%s",
+            len(incoming),
+            len(snapshot),
+            next(
+                (
+                    index
+                    for index, (incoming_identity, snapshot_identity) in enumerate(
+                        zip(incoming, snapshot)
+                    )
+                    if incoming_identity != snapshot_identity
+                ),
+                None,
+            ),
+        )
+
+        # A real new system delta may precede the replayed durable user anchor.
+        # Keep that delta while suppressing only the exact historical suffix.
+        if (
+            len(incoming) == len(snapshot)
+            and len(incoming) > 1
+            and incoming[0][0] == "system"
+            and snapshot[0][0] == "system"
+            and incoming[0] != snapshot[0]
+            and incoming[1:] == snapshot[1:]
+        ):
+            self._historical_active_replay_matched = True
+            self._reconciled_replay_message_indexes = set(range(1, len(incoming)))
+            return 0
+        return None
+
     @staticmethod
     def _matches_store_tail_suffix(
         stored_tail: list[tuple[str, str, str, str]],
@@ -970,6 +1050,19 @@ class ReconcileMixin:
                     )
                     return cursor
             return 0
+
+        historical_cursor = self._historical_active_replay_cursor(messages)
+        if historical_cursor is not None:
+            self._record_ingest_reconciliation(
+                action="advanced cursor",
+                reason="exact historical active replay snapshot",
+                cursor=historical_cursor,
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=0,
+                effective_incoming=historical_cursor,
+            )
+            return historical_cursor
 
         tail_limit = min(max(len(messages) * 4, 64), session_count)
         stored_rows = self._store.get_session_tail(  # type: ignore[attr-defined]

--- a/reconcile.py
+++ b/reconcile.py
@@ -1088,14 +1088,17 @@ class ReconcileMixin:
         ):
             return {}
 
-        durable_users = self._store.get_session_nonblank_role_messages(
-            self._session_id,
-            "user",
-            limit=max(1, self._store.get_session_count(self._session_id)),
-            conversation_id=getattr(self, "_conversation_id", ""),
+        conversation_id = getattr(self, "_conversation_id", "")
+        durable_limit = max(
+            1,
+            self._store.get_session_count(self._session_id),  # type: ignore[attr-defined]
         )
-        if not durable_users:
-            return {}
+        durable_users = self._store.get_session_nonblank_role_messages(  # type: ignore[attr-defined]
+            self._session_id,  # type: ignore[attr-defined]
+            "user",
+            limit=durable_limit,
+            conversation_id=conversation_id,
+        )
         durable_prompt_users = [
             message for message in durable_users
             if self._is_prompt_bearing_user_message(message)
@@ -1104,13 +1107,37 @@ class ReconcileMixin:
             message for message in messages
             if self._is_prompt_bearing_user_message(message)
         ]
-        if [
-            self._message_replay_identity(message, stored_row=True)
-            for message in durable_prompt_users
-        ] != [
+        active_prompt_identities = [
             self._message_replay_identity(message)
             for message in active_prompt_users
-        ]:
+        ]
+        durable_prompt_identities = [
+            self._message_replay_identity(message, stored_row=True)
+            for message in durable_prompt_users
+        ]
+        if conversation_id and durable_prompt_identities != active_prompt_identities:
+            # A rebound legacy session can have the preserved initial user on
+            # blank-provenance rows and later turns on the current conversation.
+            # Full ordered replay equality below remains the lineage proof.
+            legacy_users = self._store.get_session_nonblank_role_messages(  # type: ignore[attr-defined]
+                self._session_id,  # type: ignore[attr-defined]
+                "user",
+                limit=durable_limit,
+                legacy_blank_conversation_only=True,
+            )
+            durable_prompt_users = sorted(
+                [
+                    message
+                    for message in [*legacy_users, *durable_users]
+                    if self._is_prompt_bearing_user_message(message)  # type: ignore[attr-defined]
+                ],
+                key=lambda message: int(message["store_id"]),
+            )
+            durable_prompt_identities = [
+                self._message_replay_identity(message, stored_row=True)
+                for message in durable_prompt_users
+            ]
+        if durable_prompt_identities != active_prompt_identities:
             return {}
 
         initial_user = durable_prompt_users[0]

--- a/reconcile.py
+++ b/reconcile.py
@@ -458,9 +458,10 @@ class ReconcileMixin:
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
             return False
         if has_raw_durable_system_anchor:
-            if len(candidate_messages) != 2:
-                return False
-            return True
+            return all(
+                self._is_replayed_context_scaffold_message(message)  # type: ignore[attr-defined]
+                for message in candidate_messages[2:]
+            )
         if candidate_messages[2:] and not any(
             self._is_replayed_context_scaffold_message(message)
             for message in candidate_messages[2:]

--- a/reconcile.py
+++ b/reconcile.py
@@ -422,16 +422,16 @@ class ReconcileMixin:
         self,
         candidate_messages: list[Dict[str, Any]],
         stored_head: list[tuple[str, str, str, str]],
-        stored_tail: list[tuple[str, str, str, str]],
+        stored_uncompacted_tail: list[tuple[str, str, str, str]],
     ) -> bool:
         """Recognize compacted replay with a raw initial-user provider anchor.
 
         Normal compaction annotates the durable system prompt, preserves the
         sole initial user as a raw provider anchor, inserts generated summary
-        scaffolding, then appends a durable tail suffix. That replay is not a
-        contiguous store suffix, so generic restart reconciliation cannot prove
-        it. Require the exact generated shape plus both durable-head and
-        durable-tail evidence before advancing the cursor.
+        scaffolding, then appends the durable post-frontier tail. That replay is
+        not a contiguous store suffix, so generic restart reconciliation cannot
+        prove it. Require the exact generated shape plus both durable-head and
+        full post-frontier tail coverage before advancing the cursor.
         """
         if len(candidate_messages) < 3 or len(stored_head) < 2:
             return False
@@ -457,14 +457,15 @@ class ReconcileMixin:
             if not self._is_replayed_context_scaffold_message(message)
             and not self._matches_ignore_message_patterns(message)
         ]
-        return self._matches_store_tail_suffix(stored_tail, visible_after_anchor)
+        return visible_after_anchor == stored_uncompacted_tail
 
     def _find_reconciled_cursor_for_store_tail(
         self,
         messages: List[Dict[str, Any]],
         stored_tail: list[tuple[str, str, str, str]],
         *,
-        stored_head: list[tuple[str, str, str, str]] | None = None,
+        stored_head: list[tuple[str, str, str, str]],
+        stored_uncompacted_tail: list[tuple[str, str, str, str]],
         stored_tail_rows: list[Dict[str, Any]] | None = None,
         allow_empty_prefix: bool,
         session_count: int,
@@ -524,8 +525,8 @@ class ReconcileMixin:
             ]
             if self._matches_leading_user_anchor_snapshot(
                 candidate_messages,
-                stored_head or [],
-                stored_tail,
+                stored_head,
+                stored_uncompacted_tail,
             ):
                 return cursor
             if not candidate_prefix:
@@ -893,10 +894,21 @@ class ReconcileMixin:
             self._message_replay_identity(row, stored_row=True)
             for row in stored_head_rows
         ]
+        uncompacted_rows = self._store.get_session_messages_after(
+            self._session_id,
+            after_store_id=max(0, int(self._last_compacted_store_id or 0)),
+            limit=session_count,
+        )
+        stored_uncompacted_tail = [
+            self._message_replay_identity(row, stored_row=True)
+            for row in uncompacted_rows
+            if not self._matches_ignore_message_patterns(row, stored_row=True)
+        ]
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,
             stored_head=stored_head,
+            stored_uncompacted_tail=stored_uncompacted_tail,
             stored_tail_rows=stored_tail_rows,
             allow_empty_prefix=True,
             session_count=len(stored_tail),

--- a/reconcile.py
+++ b/reconcile.py
@@ -244,6 +244,11 @@ class ReconcileMixin:
         )
 
     def _active_replay_snapshot_key(self) -> str:
+        session_id = str(getattr(self, "_session_id", "") or "")
+        conversation_id = str(getattr(self, "_conversation_id", "") or "")
+        return f"active_replay_snapshot_v2:{len(session_id)}:{session_id}:{conversation_id}"
+
+    def _legacy_active_replay_snapshot_key(self) -> str:
         return f"active_replay_snapshot:{self._session_id}"
 
     def _write_active_replay_snapshot(self, messages: List[Dict[str, Any]]) -> None:
@@ -324,16 +329,24 @@ class ReconcileMixin:
         """
         self._historical_active_replay_matched = False
         self._reconciled_replay_message_indexes = set()
-        try:
-            payload = self._store.read_metadata_json(self._active_replay_snapshot_key())
-        except Exception:
-            logger.debug("LCM active replay snapshot read failed", exc_info=True)
-            return None
-        if not isinstance(payload, dict):
-            return None
-        if str(payload.get("conversation_id") or "") != str(
-            getattr(self, "_conversation_id", "") or ""
+        conversation_id = str(getattr(self, "_conversation_id", "") or "")
+        payload = None
+        for key in (
+            self._active_replay_snapshot_key(),
+            self._legacy_active_replay_snapshot_key(),
         ):
+            try:
+                candidate = self._store.read_metadata_json(key)  # type: ignore[attr-defined]
+            except Exception:
+                logger.debug("LCM active replay snapshot read failed", exc_info=True)
+                continue
+            if not isinstance(candidate, dict):
+                continue
+            if str(candidate.get("conversation_id") or "") != conversation_id:
+                continue
+            payload = candidate
+            break
+        if payload is None:
             return None
         raw_identities = payload.get("identities")
         if not isinstance(raw_identities, list) or not raw_identities:
@@ -1414,8 +1427,12 @@ class ReconcileMixin:
         active context has more occurrences of an identical replay identity than
         the store has, the surplus earliest active occurrences are treated as
         synthetic/carry-over and left unmapped so they cannot steal later stored
-        literal copies with the same content.
+        literal copies with the same content. A proven pre-frontier former anchor
+        is mapped before this scan so it cannot consume a repeated post-frontier
+        user row and strand the durable suffix between them.
         """
+        ids_by_message_id = self._get_formerly_anchored_user_source_map(messages)
+        pre_mapped_message_ids = set(ids_by_message_id)
         candidates: list[Dict[str, Any]] = []
         next_candidate_after = self._last_compacted_store_id
         while True:
@@ -1429,6 +1446,8 @@ class ReconcileMixin:
             next_candidate_after = page[-1]["store_id"]
         active_identity_counts: dict[tuple[Any, ...], int] = {}
         for msg in messages:
+            if id(msg) in pre_mapped_message_ids:
+                continue
             identity = self._message_replay_identity(msg)
             active_identity_counts[identity] = active_identity_counts.get(identity, 0) + 1
         stored_identity_counts: dict[tuple[Any, ...], int] = {}
@@ -1545,6 +1564,8 @@ class ReconcileMixin:
             local_surplus_skips = dict(surplus_skips)
             probe_idx = start_store_idx
             for remaining_msg in messages[message_start_idx:]:
+                if id(remaining_msg) in pre_mapped_message_ids:
+                    continue
                 msg_content = normalize_content_value(remaining_msg.get("content")) or ""
                 if (
                     remaining_msg.get("store_id") is None
@@ -1570,9 +1591,10 @@ class ReconcileMixin:
                 probe_idx = match_idx + 1
             return matched_message_ids
 
-        ids_by_message_id: dict[int, int] = {}
         store_idx = 0
         for msg_idx, msg in enumerate(messages):
+            if id(msg) in pre_mapped_message_ids:
+                continue
             msg_content = normalize_content_value(msg.get("content")) or ""
             if msg.get("store_id") is None and self._content_has_externalized_placeholder_ref(msg_content):
                 raw_identity = self._raw_externalized_placeholder_replay_identity(msg)
@@ -1623,7 +1645,4 @@ class ReconcileMixin:
                 ids_by_message_id[id(msg)] = candidates[match_idx]["store_id"]
                 store_idx = match_idx + 1
 
-        ids_by_message_id.update(
-            self._get_formerly_anchored_user_source_map(messages)
-        )
         return ids_by_message_id

--- a/reconcile.py
+++ b/reconcile.py
@@ -308,18 +308,19 @@ class ReconcileMixin:
             ),
         )
 
-        # A real new system delta may precede the replayed durable user anchor.
-        # Keep that delta while suppressing only the exact historical suffix.
+        # A real new system delta may precede the replayed durable user anchor,
+        # and a real new turn may follow the exact emitted snapshot. Keep both
+        # deltas while suppressing only the identity-proven historical segment.
         if (
-            len(incoming) == len(snapshot)
-            and len(incoming) > 1
+            len(incoming) >= len(snapshot)
+            and len(snapshot) > 1
             and incoming[0][0] == "system"
             and snapshot[0][0] == "system"
             and incoming[0] != snapshot[0]
-            and incoming[1:] == snapshot[1:]
+            and incoming[1 : len(snapshot)] == snapshot[1:]
         ):
             self._historical_active_replay_matched = True
-            self._reconciled_replay_message_indexes = set(range(1, len(incoming)))
+            self._reconciled_replay_message_indexes = set(range(1, len(snapshot)))
             return 0
         return None
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -430,10 +430,12 @@ class ReconcileMixin:
         sole initial user as a raw provider anchor, inserts generated summary
         scaffolding, then appends the durable post-frontier tail. Overflow
         recovery may reduce that shape to only the annotated system and user
-        anchor. These replays are not contiguous store suffixes, so generic
-        restart reconciliation cannot prove them. Require the exact generated
-        shape plus both durable-head and full post-frontier tail coverage before
-        advancing the cursor.
+        anchor, omitting even a durable fresh tail that does not fit the assembly
+        cap. These replays are not contiguous store suffixes, so generic restart
+        reconciliation cannot prove them. Accept that exact two-message anchor
+        only when a durable compaction frontier proves it came from compaction;
+        otherwise require both durable-head and full visible post-frontier tail
+        coverage before advancing the cursor.
         """
         if len(candidate_messages) < 2 or len(stored_head) < 2:
             return False
@@ -459,7 +461,13 @@ class ReconcileMixin:
             if not self._is_replayed_context_scaffold_message(message)
             and not self._matches_ignore_message_patterns(message)
         ]
-        return visible_after_anchor == stored_uncompacted_tail
+        has_durable_compaction_frontier = (
+            int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
+        )
+        return (
+            len(candidate_messages) == 2
+            and has_durable_compaction_frontier
+        ) or visible_after_anchor == stored_uncompacted_tail
 
     def _find_reconciled_cursor_for_store_tail(
         self,

--- a/reconcile.py
+++ b/reconcile.py
@@ -879,8 +879,20 @@ class ReconcileMixin:
         if not self._session_id or not messages:
             return 0
 
+        conversation_id = getattr(self, "_conversation_id", "")
         try:
-            session_count = self._store.get_session_count(self._session_id)
+            session_count = self._store.get_session_count(  # type: ignore[attr-defined]
+                self._session_id,  # type: ignore[attr-defined]
+                conversation_id=conversation_id,
+            )
+            # Legacy rows may predate conversation provenance. Preserve the
+            # existing session-wide reconciliation path when the active
+            # conversation has no attributed durable rows to prove its scope.
+            if conversation_id and session_count <= 0:
+                conversation_id = ""
+                session_count = self._store.get_session_count(  # type: ignore[attr-defined]
+                    self._session_id  # type: ignore[attr-defined]
+                )
         except Exception as exc:  # pragma: no cover - defensive only
             logger.debug("LCM ingest cursor reconciliation count failed: %s", exc)
             return 0
@@ -915,7 +927,11 @@ class ReconcileMixin:
             return 0
 
         tail_limit = min(max(len(messages) * 4, 64), session_count)
-        stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)
+        stored_rows = self._store.get_session_tail(  # type: ignore[attr-defined]
+            self._session_id,  # type: ignore[attr-defined]
+            limit=tail_limit,
+            conversation_id=conversation_id,
+        )
         if not stored_rows:
             return 0
         stored_tail_rows = [
@@ -930,6 +946,7 @@ class ReconcileMixin:
         stored_head_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
             self._session_id,  # type: ignore[attr-defined]
             limit=tail_limit,
+            conversation_id=conversation_id,
         )
         stored_head = [
             self._message_replay_identity(row, stored_row=True)
@@ -939,6 +956,7 @@ class ReconcileMixin:
             self._session_id,
             after_store_id=max(0, int(self._last_compacted_store_id or 0)),
             limit=session_count,
+            conversation_id=conversation_id,
         )
         stored_uncompacted_tail = [
             self._message_replay_identity(row, stored_row=True)

--- a/reconcile.py
+++ b/reconcile.py
@@ -418,11 +418,53 @@ class ReconcileMixin:
                 sanitized_tail.append(cleaned_identity)
         return sanitized_tail
 
+    def _matches_leading_user_anchor_snapshot(
+        self,
+        candidate_messages: list[Dict[str, Any]],
+        stored_head: list[tuple[str, str, str, str]],
+        stored_tail: list[tuple[str, str, str, str]],
+    ) -> bool:
+        """Recognize compacted replay with a raw initial-user provider anchor.
+
+        Normal compaction annotates the durable system prompt, preserves the
+        sole initial user as a raw provider anchor, inserts generated summary
+        scaffolding, then appends a durable tail suffix. That replay is not a
+        contiguous store suffix, so generic restart reconciliation cannot prove
+        it. Require the exact generated shape plus both durable-head and
+        durable-tail evidence before advancing the cursor.
+        """
+        if len(candidate_messages) < 3 or len(stored_head) < 2:
+            return False
+        if (
+            str(candidate_messages[0].get("role") or "") != "system"
+            or not self._is_replayed_context_scaffold_message(candidate_messages[0])
+            or not self._is_prompt_bearing_user_message(candidate_messages[1])
+        ):
+            return False
+        if stored_head[0][0] != "system" or stored_head[1][0] != "user":
+            return False
+        if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
+            return False
+        if not any(
+            self._is_replayed_context_scaffold_message(message)
+            for message in candidate_messages[2:]
+        ):
+            return False
+
+        visible_after_anchor = [
+            self._message_replay_identity(message)
+            for message in candidate_messages[2:]
+            if not self._is_replayed_context_scaffold_message(message)
+            and not self._matches_ignore_message_patterns(message)
+        ]
+        return self._matches_store_tail_suffix(stored_tail, visible_after_anchor)
+
     def _find_reconciled_cursor_for_store_tail(
         self,
         messages: List[Dict[str, Any]],
         stored_tail: list[tuple[str, str, str, str]],
         *,
+        stored_head: list[tuple[str, str, str, str]] | None = None,
         stored_tail_rows: list[Dict[str, Any]] | None = None,
         allow_empty_prefix: bool,
         session_count: int,
@@ -480,6 +522,12 @@ class ReconcileMixin:
                 self._message_replay_identity(msg)
                 for msg in candidate_identity_messages
             ]
+            if self._matches_leading_user_anchor_snapshot(
+                candidate_messages,
+                stored_head or [],
+                stored_tail,
+            ):
+                return cursor
             if not candidate_prefix:
                 empty_prefix_cursor = cursor
                 if allow_empty_prefix and (
@@ -840,9 +888,15 @@ class ReconcileMixin:
             self._message_replay_identity(row, stored_row=True)
             for row in stored_tail_rows
         ]
+        stored_head_rows = self._store.get_session_messages(self._session_id, limit=2)
+        stored_head = [
+            self._message_replay_identity(row, stored_row=True)
+            for row in stored_head_rows
+        ]
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,
+            stored_head=stored_head,
             stored_tail_rows=stored_tail_rows,
             allow_empty_prefix=True,
             session_count=len(stored_tail),

--- a/reconcile.py
+++ b/reconcile.py
@@ -428,12 +428,14 @@ class ReconcileMixin:
 
         Normal compaction annotates the durable system prompt, preserves the
         sole initial user as a raw provider anchor, inserts generated summary
-        scaffolding, then appends the durable post-frontier tail. That replay is
-        not a contiguous store suffix, so generic restart reconciliation cannot
-        prove it. Require the exact generated shape plus both durable-head and
-        full post-frontier tail coverage before advancing the cursor.
+        scaffolding, then appends the durable post-frontier tail. Overflow
+        recovery may reduce that shape to only the annotated system and user
+        anchor. These replays are not contiguous store suffixes, so generic
+        restart reconciliation cannot prove them. Require the exact generated
+        shape plus both durable-head and full post-frontier tail coverage before
+        advancing the cursor.
         """
-        if len(candidate_messages) < 3 or len(stored_head) < 2:
+        if len(candidate_messages) < 2 or len(stored_head) < 2:
             return False
         if (
             str(candidate_messages[0].get("role") or "") != "system"
@@ -445,7 +447,7 @@ class ReconcileMixin:
             return False
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
             return False
-        if not any(
+        if candidate_messages[2:] and not any(
             self._is_replayed_context_scaffold_message(message)
             for message in candidate_messages[2:]
         ):

--- a/reconcile.py
+++ b/reconcile.py
@@ -313,9 +313,9 @@ class ReconcileMixin:
                 ]
                 snapshot_endpoint = next(
                     (
-                        index
-                        for index in range(len(durable) - 1, -1, -1)
-                        if durable[index] == snapshot[-1]
+                        start + len(snapshot) - 1
+                        for start in range(len(durable) - len(snapshot), -1, -1)
+                        if durable[start : start + len(snapshot)] == snapshot
                     ),
                     None,
                 )

--- a/reconcile.py
+++ b/reconcile.py
@@ -465,17 +465,20 @@ class ReconcileMixin:
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
         )
         # _assemble_context emits at most one combined summary message directly
-        # after this exact system/user anchor.  Its generated system annotation
-        # plus a durable frontier prove the whole prefix came from LCM. A raw
-        # system anchor followed by summary-shaped content is ambiguous: the
-        # assistant message may be a new delta and must remain ingestible.
+        # after this exact system/user anchor.  Its generated system annotation,
+        # durable frontier, and exact DAG-backed content prove the whole prefix
+        # came from LCM. Shape alone is ambiguous after a capped anchor-only
+        # replay: the assistant message may be a new delta and must remain
+        # ingestible.
         generated_summary_count = (
             1
             if replay_tail
             and has_durable_compaction_frontier
             and has_generated_system_anchor
             and str(replay_tail[0].get("role") or "") == "assistant"
-            and self._is_replayed_context_scaffold_message(replay_tail[0])  # type: ignore[attr-defined]
+            and self._is_known_generated_summary_scaffold_message(  # type: ignore[attr-defined]
+                replay_tail[0]
+            )
             else 0
         )
         visible_after_anchor = [

--- a/reconcile.py
+++ b/reconcile.py
@@ -282,12 +282,32 @@ class ReconcileMixin:
         durable = [
             self._message_replay_identity(row, stored_row=True)
             for row in durable_rows
+            if not self._matches_ignore_message_patterns(row, stored_row=True)  # type: ignore[attr-defined]
         ]
+        normalized_snapshot: list[tuple[str, str, str, str]] = []
+        for identity in snapshot:
+            role, content, tool_call_id, tool_calls_identity = identity
+            message: dict[str, Any] = {"role": role, "content": content}
+            if tool_call_id:
+                message["tool_call_id"] = tool_call_id
+            if tool_calls_identity:
+                try:
+                    message["tool_calls"] = json.loads(tool_calls_identity)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    message["tool_calls"] = tool_calls_identity
+            restored = self._strip_coalesced_generated_summary_scaffold(message)  # type: ignore[attr-defined]
+            if self._is_replayed_context_scaffold_message(restored):  # type: ignore[attr-defined]
+                continue
+            if self._matches_ignore_message_patterns(restored):  # type: ignore[attr-defined]
+                continue
+            normalized_snapshot.append(self._message_replay_identity(restored))
+        if not normalized_snapshot:
+            return None
         snapshot_endpoint = next(
             (
-                start + len(snapshot) - 1
-                for start in range(len(durable) - len(snapshot), -1, -1)
-                if durable[start : start + len(snapshot)] == snapshot
+                start + len(normalized_snapshot) - 1
+                for start in range(len(durable) - len(normalized_snapshot), -1, -1)
+                if durable[start : start + len(normalized_snapshot)] == normalized_snapshot
             ),
             None,
         )

--- a/reconcile.py
+++ b/reconcile.py
@@ -262,6 +262,39 @@ class ReconcileMixin:
         except Exception:
             logger.debug("LCM active replay snapshot write failed", exc_info=True)
 
+    def _durable_suffix_after_snapshot(
+        self,
+        snapshot: list[tuple[str, str, str, str]],
+    ) -> list[tuple[str, str, str, str]] | None:
+        conversation_id = str(getattr(self, "_conversation_id", "") or "")
+        try:
+            session_count = self._store.get_session_count(  # type: ignore[attr-defined]
+                self._session_id,  # type: ignore[attr-defined]
+                conversation_id=conversation_id,
+            )
+            durable_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
+                self._session_id,  # type: ignore[attr-defined]
+                limit=max(1, session_count),
+                conversation_id=conversation_id,
+            )
+        except Exception:
+            return None
+        durable = [
+            self._message_replay_identity(row, stored_row=True)
+            for row in durable_rows
+        ]
+        snapshot_endpoint = next(
+            (
+                start + len(snapshot) - 1
+                for start in range(len(durable) - len(snapshot), -1, -1)
+                if durable[start : start + len(snapshot)] == snapshot
+            ),
+            None,
+        )
+        if snapshot_endpoint is None:
+            return None
+        return durable[snapshot_endpoint + 1 :]
+
     def _historical_active_replay_cursor(self, messages: List[Dict[str, Any]]) -> int | None:
         """Return a replay cursor proven by the exact last emitted snapshot.
 
@@ -294,35 +327,9 @@ class ReconcileMixin:
             cursor = len(snapshot)
             suffix = incoming[cursor:]
             if suffix:
-                conversation_id = str(getattr(self, "_conversation_id", "") or "")
-                try:
-                    session_count = self._store.get_session_count(  # type: ignore[attr-defined]
-                        self._session_id,  # type: ignore[attr-defined]
-                        conversation_id=conversation_id,
-                    )
-                    durable_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
-                        self._session_id,  # type: ignore[attr-defined]
-                        limit=max(1, session_count),
-                        conversation_id=conversation_id,
-                    )
-                except Exception:
-                    durable_rows = []
-                durable = [
-                    self._message_replay_identity(row, stored_row=True)
-                    for row in durable_rows
-                ]
-                snapshot_endpoint = next(
-                    (
-                        start + len(snapshot) - 1
-                        for start in range(len(durable) - len(snapshot), -1, -1)
-                        if durable[start : start + len(snapshot)] == snapshot
-                    ),
-                    None,
-                )
-                if snapshot_endpoint is not None:
-                    durable_suffix = durable[snapshot_endpoint + 1 :]
-                    if durable_suffix and suffix[: len(durable_suffix)] == durable_suffix:
-                        cursor += len(durable_suffix)
+                durable_suffix = self._durable_suffix_after_snapshot(snapshot)
+                if durable_suffix and suffix[: len(durable_suffix)] == durable_suffix:
+                    cursor += len(durable_suffix)
             return cursor
         logger.debug(
             "LCM historical active replay mismatch: incoming=%d snapshot=%d first_diff=%s",
@@ -353,6 +360,13 @@ class ReconcileMixin:
         ):
             self._historical_active_replay_matched = True
             self._reconciled_replay_message_indexes = set(range(1, len(snapshot)))
+            suffix = incoming[len(snapshot) :]
+            if suffix:
+                durable_suffix = self._durable_suffix_after_snapshot(snapshot)
+                if durable_suffix and suffix[: len(durable_suffix)] == durable_suffix:
+                    self._reconciled_replay_message_indexes.update(
+                        range(len(snapshot), len(snapshot) + len(durable_suffix))
+                    )
             return 0
         return None
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -459,13 +459,18 @@ class ReconcileMixin:
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
             return False
         replay_tail = candidate_messages[2:]
+        has_durable_compaction_frontier = (
+            int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
+        )
         # _assemble_context emits at most one combined summary message directly
         # after this exact system/user anchor.  That position and assistant role
-        # are the provenance proof; summary-shaped content later in the batch may
-        # be a genuine user delta and must not be discarded merely by its text.
+        # identify generated scaffolding only when a durable frontier proves LCM
+        # previously compacted this session. Summary-shaped content without that
+        # provenance may be a genuine assistant delta and must remain ingestible.
         generated_summary_count = (
             1
             if replay_tail
+            and has_durable_compaction_frontier
             and str(replay_tail[0].get("role") or "") == "assistant"
             and self._is_replayed_context_scaffold_message(replay_tail[0])  # type: ignore[attr-defined]
             else 0
@@ -477,9 +482,6 @@ class ReconcileMixin:
             for message in replay_tail[generated_summary_count:]
             if not self._matches_ignore_message_patterns(message)  # type: ignore[attr-defined]
         ]
-        has_durable_compaction_frontier = (
-            int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
-        )
         assembly_cap = self._effective_assembly_token_cap()  # type: ignore[attr-defined]
         # A tail row that assembly could not fit cannot be replay evidence here;
         # an identical post-restart row is an ambiguous new delta and must survive.
@@ -1065,6 +1067,7 @@ class ReconcileMixin:
             self._session_id,
             "user",
             limit=max(1, self._store.get_session_count(self._session_id)),
+            conversation_id=getattr(self, "_conversation_id", ""),
         )
         if not durable_users:
             return {}

--- a/reconcile.py
+++ b/reconcile.py
@@ -429,13 +429,14 @@ class ReconcileMixin:
         Normal compaction annotates the durable system prompt, preserves the
         sole initial user as a raw provider anchor, inserts generated summary
         scaffolding, then appends the durable post-frontier tail. Overflow
-        recovery may reduce that shape to only the annotated system and user
-        anchor, omitting even a durable fresh tail that does not fit the assembly
-        cap. These replays are not contiguous store suffixes, so generic restart
-        reconciliation cannot prove them. Accept that exact two-message anchor
-        only when a durable compaction frontier proves it came from compaction;
-        otherwise require both durable-head and full visible post-frontier tail
-        coverage before advancing the cursor.
+        recovery may reduce that shape to the annotated system and user anchor,
+        optionally followed by generated summary scaffolding, while omitting a
+        durable fresh tail that does not fit the assembly cap. These replays are
+        not contiguous store suffixes, so generic restart reconciliation cannot
+        prove them. Accept that scaffold-only anchor prefix when a durable
+        compaction frontier proves it came from compaction; otherwise require
+        both durable-head and full visible post-frontier tail coverage before
+        advancing the cursor.
         """
         if len(candidate_messages) < 2 or len(stored_head) < 2:
             return False
@@ -465,7 +466,7 @@ class ReconcileMixin:
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
         )
         return (
-            len(candidate_messages) == 2
+            not visible_after_anchor
             and has_durable_compaction_frontier
         ) or visible_after_anchor == stored_uncompacted_tail
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -423,6 +423,7 @@ class ReconcileMixin:
         candidate_messages: list[Dict[str, Any]],
         stored_head: list[tuple[str, str, str, str]],
         stored_uncompacted_tail: list[tuple[str, str, str, str]],
+        following_messages: list[Dict[str, Any]],
     ) -> bool:
         """Recognize compacted replay with a raw initial-user provider anchor.
 
@@ -433,23 +434,39 @@ class ReconcileMixin:
         optionally followed by generated summary scaffolding, while omitting a
         durable fresh tail that does not fit the assembly cap. These replays are
         not contiguous store suffixes, so generic restart reconciliation cannot
-        prove them. Accept that scaffold-only anchor prefix when a durable
-        compaction frontier proves it came from compaction; otherwise require
-        both durable-head and full visible post-frontier tail coverage before
-        advancing the cursor.
+        prove them. Accept an exact raw system/user head replay, or a scaffold-only
+        anchor prefix when a durable compaction frontier proves it came from LCM;
+        otherwise require both durable-head and full visible post-frontier tail
+        coverage before advancing the cursor.
         """
         if len(candidate_messages) < 2 or len(stored_head) < 2:
             return False
-        if (
-            str(candidate_messages[0].get("role") or "") != "system"
-            or not self._is_replayed_context_scaffold_message(candidate_messages[0])
-            or not self._is_prompt_bearing_user_message(candidate_messages[1])
-        ):
+        if str(candidate_messages[0].get("role") or "") != "system":
             return False
         if stored_head[0][0] != "system" or stored_head[1][0] != "user":
             return False
+        candidate_system_identity = self._message_replay_identity(candidate_messages[0])
+        has_raw_durable_system_anchor = candidate_system_identity == stored_head[0]
+        has_generated_system_anchor = self._is_replayed_context_scaffold_message(  # type: ignore[attr-defined]
+            candidate_messages[0]
+        )
+        if not (
+            has_raw_durable_system_anchor or has_generated_system_anchor
+        ) or not self._is_prompt_bearing_user_message(  # type: ignore[attr-defined]
+            candidate_messages[1]
+        ):
+            return False
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
             return False
+        if has_raw_durable_system_anchor:
+            if len(candidate_messages) != 2:
+                return False
+            return (
+                not following_messages
+                or len(stored_head) < 3
+                or self._message_replay_identity(following_messages[0])
+                != stored_head[2]
+            )
         if candidate_messages[2:] and not any(
             self._is_replayed_context_scaffold_message(message)
             for message in candidate_messages[2:]
@@ -466,8 +483,7 @@ class ReconcileMixin:
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
         )
         return (
-            not visible_after_anchor
-            and has_durable_compaction_frontier
+            not visible_after_anchor and has_durable_compaction_frontier
         ) or visible_after_anchor == stored_uncompacted_tail
 
     def _find_reconciled_cursor_for_store_tail(
@@ -538,6 +554,7 @@ class ReconcileMixin:
                 candidate_messages,
                 stored_head,
                 stored_uncompacted_tail,
+                messages[cursor:],
             ):
                 return cursor
             if not candidate_prefix:
@@ -900,7 +917,10 @@ class ReconcileMixin:
             self._message_replay_identity(row, stored_row=True)
             for row in stored_tail_rows
         ]
-        stored_head_rows = self._store.get_session_messages(self._session_id, limit=2)
+        stored_head_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
+            self._session_id,  # type: ignore[attr-defined]
+            limit=3,
+        )
         stored_head = [
             self._message_replay_identity(row, stored_row=True)
             for row in stored_head_rows

--- a/reconcile.py
+++ b/reconcile.py
@@ -881,6 +881,7 @@ class ReconcileMixin:
 
         conversation_id = getattr(self, "_conversation_id", "")
         legacy_blank_conversation_only = False
+        include_legacy_blank_conversation = False
         try:
             session_count = self._store.get_session_count(  # type: ignore[attr-defined]
                 self._session_id,  # type: ignore[attr-defined]
@@ -896,6 +897,18 @@ class ReconcileMixin:
                     self._session_id,  # type: ignore[attr-defined]
                     legacy_blank_conversation_only=True,
                 )
+            elif conversation_id:
+                legacy_blank_count = self._store.get_session_count(  # type: ignore[attr-defined]
+                    self._session_id,  # type: ignore[attr-defined]
+                    legacy_blank_conversation_only=True,
+                )
+                if legacy_blank_count > 0:
+                    # Upgraded sessions can have blank-provenance anchors before
+                    # current-conversation rows. Reconcile against that ordered
+                    # union only; attributed rows from other conversations stay
+                    # excluded from replay proof.
+                    include_legacy_blank_conversation = True
+                    session_count += legacy_blank_count
         except Exception as exc:  # pragma: no cover - defensive only
             logger.debug("LCM ingest cursor reconciliation count failed: %s", exc)
             return 0
@@ -936,6 +949,18 @@ class ReconcileMixin:
             conversation_id=conversation_id,
             legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
+        if include_legacy_blank_conversation:
+            stored_rows = sorted(
+                [
+                    *stored_rows,
+                    *self._store.get_session_tail(  # type: ignore[attr-defined]
+                        self._session_id,  # type: ignore[attr-defined]
+                        limit=tail_limit,
+                        legacy_blank_conversation_only=True,
+                    ),
+                ],
+                key=lambda row: int(row["store_id"]),
+            )[-tail_limit:]
         if not stored_rows:
             return 0
         stored_tail_rows = [
@@ -953,17 +978,46 @@ class ReconcileMixin:
             conversation_id=conversation_id,
             legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
+        if include_legacy_blank_conversation:
+            stored_head_rows = sorted(
+                [
+                    *stored_head_rows,
+                    *self._store.get_session_messages(  # type: ignore[attr-defined]
+                        self._session_id,  # type: ignore[attr-defined]
+                        limit=tail_limit,
+                        legacy_blank_conversation_only=True,
+                    ),
+                ],
+                key=lambda row: int(row["store_id"]),
+            )[:tail_limit]
         stored_head = [
             self._message_replay_identity(row, stored_row=True)
             for row in stored_head_rows
         ]
+        uncompacted_after_store_id = max(
+            0,
+            int(self._last_compacted_store_id or 0),  # type: ignore[attr-defined]
+        )
         uncompacted_rows = self._store.get_session_messages_after(
             self._session_id,
-            after_store_id=max(0, int(self._last_compacted_store_id or 0)),
+            after_store_id=uncompacted_after_store_id,
             limit=session_count,
             conversation_id=conversation_id,
             legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
+        if include_legacy_blank_conversation:
+            uncompacted_rows = sorted(
+                [
+                    *uncompacted_rows,
+                    *self._store.get_session_messages_after(  # type: ignore[attr-defined]
+                        self._session_id,  # type: ignore[attr-defined]
+                        after_store_id=uncompacted_after_store_id,
+                        limit=session_count,
+                        legacy_blank_conversation_only=True,
+                    ),
+                ],
+                key=lambda row: int(row["store_id"]),
+            )[:session_count]
         stored_uncompacted_tail = [
             self._message_replay_identity(row, stored_row=True)
             for row in uncompacted_rows

--- a/reconcile.py
+++ b/reconcile.py
@@ -1004,6 +1004,60 @@ class ReconcileMixin:
             str(msg.get("tool_call_id") or ""),
         )
 
+    def _get_formerly_anchored_user_source_map(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> dict[int, int]:
+        """Recover the durable source for an initial user leaving the anchor.
+
+        The normal source mapper is intentionally suffix-only. This exception
+        is safe only when the first active raw is the durable initial user and
+        the active context still covers every durable prompt-bearing user in
+        order. Requiring that full replay coverage prevents a newer
+        repeated-content turn from claiming the older row.
+        """
+        frontier = max(0, int(self._last_compacted_store_id or 0))
+        if (
+            frontier <= 0
+            or not messages
+            or not self._is_prompt_bearing_user_message(messages[0])
+            or not any(
+                self._is_prompt_bearing_user_message(message)
+                for message in messages[1:]
+            )
+        ):
+            return {}
+
+        durable_users = self._store.get_session_nonblank_role_messages(
+            self._session_id,
+            "user",
+            limit=max(1, self._store.get_session_count(self._session_id)),
+        )
+        if not durable_users:
+            return {}
+        durable_prompt_users = [
+            message for message in durable_users
+            if self._is_prompt_bearing_user_message(message)
+        ]
+        active_prompt_users = [
+            message for message in messages
+            if self._is_prompt_bearing_user_message(message)
+        ]
+        if [
+            self._message_replay_identity(message, stored_row=True)
+            for message in durable_prompt_users
+        ] != [
+            self._message_replay_identity(message)
+            for message in active_prompt_users
+        ]:
+            return {}
+
+        initial_user = durable_prompt_users[0]
+        initial_store_id = int(initial_user["store_id"])
+        if initial_store_id > frontier:
+            return {}
+        return {id(messages[0]): initial_store_id}
+
     def _get_store_id_map_for_messages(self, messages: List[Dict[str, Any]]) -> dict[int, int]:
         """Map current raw message objects back to store_ids in stable order.
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -423,7 +423,6 @@ class ReconcileMixin:
         candidate_messages: list[Dict[str, Any]],
         stored_head: list[tuple[str, str, str, str]],
         stored_uncompacted_tail: list[tuple[str, str, str, str]],
-        following_messages: list[Dict[str, Any]],
     ) -> bool:
         """Recognize compacted replay with a raw initial-user provider anchor.
 
@@ -461,12 +460,7 @@ class ReconcileMixin:
         if has_raw_durable_system_anchor:
             if len(candidate_messages) != 2:
                 return False
-            return (
-                not following_messages
-                or len(stored_head) < 3
-                or self._message_replay_identity(following_messages[0])
-                != stored_head[2]
-            )
+            return True
         if candidate_messages[2:] and not any(
             self._is_replayed_context_scaffold_message(message)
             for message in candidate_messages[2:]
@@ -554,7 +548,6 @@ class ReconcileMixin:
                 candidate_messages,
                 stored_head,
                 stored_uncompacted_tail,
-                messages[cursor:],
             ):
                 return cursor
             if not candidate_prefix:
@@ -935,6 +928,46 @@ class ReconcileMixin:
             for row in uncompacted_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
         ]
+        incoming_identities = self._effective_replay_identities(messages)
+        # Stale-snapshot proof uses the raw durable prefix. Ignore-message
+        # filters may suppress noisy rows for tail reconciliation, but filtered
+        # history alone must not create replay evidence for skipping a batch.
+        incoming_has_unproofed_raw_persisted_marker = any(
+            str(msg.get("role") or "") == "tool"
+            and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
+            and recover_hermes_persisted_output_with_file_stat(
+                normalize_content_value(msg.get("content")) or ""
+            )
+            is None
+            for msg in messages
+        )
+        if (
+            not incoming_has_unproofed_raw_persisted_marker
+            and self._is_suspicious_stale_no_overlap_snapshot(
+                incoming_identities,
+                stored_tail,
+                stored_head,
+            )
+        ):
+            self._record_ingest_reconciliation(
+                action="skipped batch",
+                reason="skipped stale no-overlap snapshot",
+                cursor=len(messages),
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=len(stored_tail),
+                effective_incoming=len(incoming_identities),
+            )
+            logger.warning(
+                "LCM skipped stale no-overlap snapshot after existing-session bind: session=%s incoming=%d effective_incoming=%d stored_tail=%d session_count=%d",
+                self._session_id,  # type: ignore[attr-defined]
+                len(messages),
+                len(incoming_identities),
+                len(stored_tail),
+                session_count,
+            )
+            return len(messages)
+
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,
@@ -970,51 +1003,6 @@ class ReconcileMixin:
                 reason,
             )
             return cursor
-
-        incoming_identities = self._effective_replay_identities(messages)
-        stored_head_rows = self._store.get_session_messages(
-            self._session_id,
-            limit=tail_limit,
-        )
-        stored_head = [self._message_replay_identity(row, stored_row=True) for row in stored_head_rows]
-        # Stale-snapshot proof uses the raw durable prefix.  Ignore-message
-        # filters may suppress noisy rows for tail reconciliation, but filtered
-        # history alone must not create replay evidence for skipping a batch.
-        incoming_has_unproofed_raw_persisted_marker = any(
-            str(msg.get("role") or "") == "tool"
-            and _is_hermes_persisted_output_marker(normalize_content_value(msg.get("content")) or "")
-            and recover_hermes_persisted_output_with_file_stat(
-                normalize_content_value(msg.get("content")) or ""
-            )
-            is None
-            for msg in messages
-        )
-        if (
-            not incoming_has_unproofed_raw_persisted_marker
-            and self._is_suspicious_stale_no_overlap_snapshot(
-                incoming_identities,
-                stored_tail,
-                stored_head,
-            )
-        ):
-            self._record_ingest_reconciliation(
-                action="skipped batch",
-                reason="skipped stale no-overlap snapshot",
-                cursor=len(messages),
-                incoming=len(messages),
-                session_count=session_count,
-                stored_tail_count=len(stored_tail),
-                effective_incoming=len(incoming_identities),
-            )
-            logger.warning(
-                "LCM skipped stale no-overlap snapshot after existing-session bind: session=%s incoming=%d effective_incoming=%d stored_tail=%d session_count=%d",
-                self._session_id,
-                len(messages),
-                len(incoming_identities),
-                len(stored_tail),
-                session_count,
-            )
-            return len(messages)
 
         self._record_ingest_reconciliation(
             action="persisted batch",

--- a/reconcile.py
+++ b/reconcile.py
@@ -458,16 +458,24 @@ class ReconcileMixin:
             return False
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
             return False
+        replay_tail = candidate_messages[2:]
+        # _assemble_context emits at most one combined summary message directly
+        # after this exact system/user anchor.  That position and assistant role
+        # are the provenance proof; summary-shaped content later in the batch may
+        # be a genuine user delta and must not be discarded merely by its text.
+        generated_summary_count = (
+            1
+            if replay_tail
+            and str(replay_tail[0].get("role") or "") == "assistant"
+            and self._is_replayed_context_scaffold_message(replay_tail[0])  # type: ignore[attr-defined]
+            else 0
+        )
         if has_raw_durable_system_anchor:
-            return all(
-                self._is_replayed_context_scaffold_message(message)  # type: ignore[attr-defined]
-                for message in candidate_messages[2:]
-            )
+            return len(replay_tail) == generated_summary_count
         visible_after_anchor = [
             self._message_replay_identity(message)
-            for message in candidate_messages[2:]
-            if not self._is_replayed_context_scaffold_message(message)
-            and not self._matches_ignore_message_patterns(message)
+            for message in replay_tail[generated_summary_count:]
+            if not self._matches_ignore_message_patterns(message)  # type: ignore[attr-defined]
         ]
         has_durable_compaction_frontier = (
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0

--- a/reconcile.py
+++ b/reconcile.py
@@ -455,7 +455,8 @@ class ReconcileMixin:
         if not (
             has_raw_durable_system_anchor or has_generated_system_anchor
         ) or not self._is_prompt_bearing_user_message(  # type: ignore[attr-defined]
-            candidate_messages[1]
+            candidate_messages[1],
+            allow_literal_summary_scaffold=True,
         ):
             return False
         if self._message_replay_identity(candidate_messages[1]) != stored_head[1]:
@@ -1166,15 +1167,21 @@ class ReconcileMixin:
         order. Requiring that full replay coverage prevents a newer
         repeated-content turn from claiming the older row.
         """
+        def is_prompt_user(message: Dict[str, Any]) -> bool:
+            # Literal summary-shaped users are eligible only in this
+            # identity-proven lineage path. DAG-backed generated scaffolds
+            # remain excluded by _is_prompt_bearing_user_message.
+            return self._is_prompt_bearing_user_message(  # type: ignore[attr-defined]
+                message,
+                allow_literal_summary_scaffold=True,
+            )
+
         frontier = max(0, int(self._last_compacted_store_id or 0))
         if (
             frontier <= 0
             or not messages
-            or not self._is_prompt_bearing_user_message(messages[0])
-            or not any(
-                self._is_prompt_bearing_user_message(message)
-                for message in messages[1:]
-            )
+            or not is_prompt_user(messages[0])
+            or not any(is_prompt_user(message) for message in messages[1:])
         ):
             return {}
 
@@ -1191,11 +1198,11 @@ class ReconcileMixin:
         )
         durable_prompt_users = [
             message for message in durable_users
-            if self._is_prompt_bearing_user_message(message)
+            if is_prompt_user(message)
         ]
         active_prompt_users = [
             message for message in messages
-            if self._is_prompt_bearing_user_message(message)
+            if is_prompt_user(message)
         ]
         active_prompt_identities = [
             self._message_replay_identity(message)
@@ -1219,7 +1226,7 @@ class ReconcileMixin:
                 [
                     message
                     for message in [*legacy_users, *durable_users]
-                    if self._is_prompt_bearing_user_message(message)  # type: ignore[attr-defined]
+                    if is_prompt_user(message)
                 ],
                 key=lambda message: int(message["store_id"]),
             )
@@ -1454,4 +1461,7 @@ class ReconcileMixin:
                 ids_by_message_id[id(msg)] = candidates[match_idx]["store_id"]
                 store_idx = match_idx + 1
 
+        ids_by_message_id.update(
+            self._get_formerly_anchored_user_source_map(messages)
+        )
         return ids_by_message_id

--- a/reconcile.py
+++ b/reconcile.py
@@ -880,18 +880,21 @@ class ReconcileMixin:
             return 0
 
         conversation_id = getattr(self, "_conversation_id", "")
+        legacy_blank_conversation_only = False
         try:
             session_count = self._store.get_session_count(  # type: ignore[attr-defined]
                 self._session_id,  # type: ignore[attr-defined]
                 conversation_id=conversation_id,
             )
-            # Legacy rows may predate conversation provenance. Preserve the
-            # existing session-wide reconciliation path when the active
-            # conversation has no attributed durable rows to prove its scope.
+            # Legacy rows may predate conversation provenance. Preserve their
+            # reconciliation path without allowing rows attributed to another
+            # conversation on a reused session to become replay evidence.
             if conversation_id and session_count <= 0:
                 conversation_id = ""
+                legacy_blank_conversation_only = True
                 session_count = self._store.get_session_count(  # type: ignore[attr-defined]
-                    self._session_id  # type: ignore[attr-defined]
+                    self._session_id,  # type: ignore[attr-defined]
+                    legacy_blank_conversation_only=True,
                 )
         except Exception as exc:  # pragma: no cover - defensive only
             logger.debug("LCM ingest cursor reconciliation count failed: %s", exc)
@@ -931,6 +934,7 @@ class ReconcileMixin:
             self._session_id,  # type: ignore[attr-defined]
             limit=tail_limit,
             conversation_id=conversation_id,
+            legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
         if not stored_rows:
             return 0
@@ -947,6 +951,7 @@ class ReconcileMixin:
             self._session_id,  # type: ignore[attr-defined]
             limit=tail_limit,
             conversation_id=conversation_id,
+            legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
         stored_head = [
             self._message_replay_identity(row, stored_row=True)
@@ -957,6 +962,7 @@ class ReconcileMixin:
             after_store_id=max(0, int(self._last_compacted_store_id or 0)),
             limit=session_count,
             conversation_id=conversation_id,
+            legacy_blank_conversation_only=legacy_blank_conversation_only,
         )
         stored_uncompacted_tail = [
             self._message_replay_identity(row, stored_row=True)

--- a/reconcile.py
+++ b/reconcile.py
@@ -463,14 +463,15 @@ class ReconcileMixin:
             int(getattr(self, "_last_compacted_store_id", 0) or 0) > 0
         )
         # _assemble_context emits at most one combined summary message directly
-        # after this exact system/user anchor.  That position and assistant role
-        # identify generated scaffolding only when a durable frontier proves LCM
-        # previously compacted this session. Summary-shaped content without that
-        # provenance may be a genuine assistant delta and must remain ingestible.
+        # after this exact system/user anchor.  Its generated system annotation
+        # plus a durable frontier prove the whole prefix came from LCM. A raw
+        # system anchor followed by summary-shaped content is ambiguous: the
+        # assistant message may be a new delta and must remain ingestible.
         generated_summary_count = (
             1
             if replay_tail
             and has_durable_compaction_frontier
+            and has_generated_system_anchor
             and str(replay_tail[0].get("role") or "") == "assistant"
             and self._is_replayed_context_scaffold_message(replay_tail[0])  # type: ignore[attr-defined]
             else 0

--- a/reconcile.py
+++ b/reconcile.py
@@ -291,7 +291,39 @@ class ReconcileMixin:
         incoming = [self._message_replay_identity(message) for message in messages]
         if len(incoming) >= len(snapshot) and incoming[: len(snapshot)] == snapshot:
             self._historical_active_replay_matched = True
-            return len(snapshot)
+            cursor = len(snapshot)
+            suffix = incoming[cursor:]
+            if suffix:
+                conversation_id = str(getattr(self, "_conversation_id", "") or "")
+                try:
+                    session_count = self._store.get_session_count(  # type: ignore[attr-defined]
+                        self._session_id,  # type: ignore[attr-defined]
+                        conversation_id=conversation_id,
+                    )
+                    durable_rows = self._store.get_session_messages(  # type: ignore[attr-defined]
+                        self._session_id,  # type: ignore[attr-defined]
+                        limit=max(1, session_count),
+                        conversation_id=conversation_id,
+                    )
+                except Exception:
+                    durable_rows = []
+                durable = [
+                    self._message_replay_identity(row, stored_row=True)
+                    for row in durable_rows
+                ]
+                snapshot_endpoint = next(
+                    (
+                        index
+                        for index in range(len(durable) - 1, -1, -1)
+                        if durable[index] == snapshot[-1]
+                    ),
+                    None,
+                )
+                if snapshot_endpoint is not None:
+                    durable_suffix = durable[snapshot_endpoint + 1 :]
+                    if durable_suffix and suffix[: len(durable_suffix)] == durable_suffix:
+                        cursor += len(durable_suffix)
+            return cursor
         logger.debug(
             "LCM historical active replay mismatch: incoming=%d snapshot=%d first_diff=%s",
             len(incoming),
@@ -623,10 +655,11 @@ class ReconcileMixin:
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
             candidate_visible_messages = [
-                msg
+                restored
                 for msg in candidate_messages
-                if not self._is_replayed_context_scaffold_message(msg)
-                and not self._matches_ignore_message_patterns(msg)
+                for restored in [self._strip_coalesced_generated_summary_scaffold(msg)]  # type: ignore[attr-defined]
+                if not self._is_replayed_context_scaffold_message(restored)  # type: ignore[attr-defined]
+                and not self._matches_ignore_message_patterns(restored)  # type: ignore[attr-defined]
             ]
             candidate_non_placeholder_messages = [
                 msg
@@ -951,10 +984,11 @@ class ReconcileMixin:
         messages: List[Dict[str, Any]],
     ) -> list[tuple[str, str, str, str]]:
         return [
-            self._message_replay_identity(msg)
+            self._message_replay_identity(restored)
             for msg in messages
-            if not self._is_replayed_context_scaffold_message(msg)
-            and not self._matches_ignore_message_patterns(msg)
+            for restored in [self._strip_coalesced_generated_summary_scaffold(msg)]  # type: ignore[attr-defined]
+            if not self._is_replayed_context_scaffold_message(restored)  # type: ignore[attr-defined]
+            and not self._matches_ignore_message_patterns(restored)  # type: ignore[attr-defined]
         ]
 
     def _is_suspicious_stale_no_overlap_snapshot(

--- a/reconcile.py
+++ b/reconcile.py
@@ -424,6 +424,8 @@ class ReconcileMixin:
         candidate_messages: list[Dict[str, Any]],
         stored_head: list[tuple[str, str, str, str]],
         stored_uncompacted_tail: list[tuple[str, str, str, str]],
+        *,
+        uncompacted_tail_exceeds_assembly_cap: bool,
     ) -> bool:
         """Recognize compacted replay with a raw initial-user provider anchor.
 
@@ -476,14 +478,33 @@ class ReconcileMixin:
             and self._is_replayed_context_scaffold_message(replay_tail[0])  # type: ignore[attr-defined]
             else 0
         )
-        if has_raw_durable_system_anchor:
-            return len(replay_tail) == generated_summary_count
         visible_after_anchor = [
             self._message_replay_identity(message)
             for message in replay_tail[generated_summary_count:]
             if not self._matches_ignore_message_patterns(message)  # type: ignore[attr-defined]
         ]
         assembly_cap = self._effective_assembly_token_cap()  # type: ignore[attr-defined]
+        if has_raw_durable_system_anchor:
+            # Frontier-zero overflow can replay the raw provider anchor plus the
+            # newest durable suffix while omitting an over-cap middle. Accept
+            # that complete incoming prefix only when both the durable history
+            # and the incoming replay prove the exact capped assembly shape.
+            has_capped_partial_tail_replay = (
+                not has_durable_compaction_frontier
+                and uncompacted_tail_exceeds_assembly_cap
+                and bool(visible_after_anchor)
+                and len(visible_after_anchor) < len(stored_uncompacted_tail)
+                and self._matches_store_tail_suffix(
+                    stored_uncompacted_tail,
+                    visible_after_anchor,
+                )
+                and assembly_cap is not None
+                and count_messages_tokens(candidate_messages) <= assembly_cap
+            )
+            return (
+                len(replay_tail) == generated_summary_count
+                or has_capped_partial_tail_replay
+            )
         # A tail row that assembly could not fit cannot be replay evidence here;
         # an identical post-restart row is an ambiguous new delta and must survive.
         has_feasible_full_tail_replay = (
@@ -508,6 +529,7 @@ class ReconcileMixin:
         allow_empty_prefix: bool,
         session_count: int,
         raw_session_count: int,
+        uncompacted_tail_exceeds_assembly_cap: bool,
     ) -> int | None:
         sanitized_replay_tail = self._stored_tail_for_sanitized_active_replay(stored_tail)
         effective_session_count = len(sanitized_replay_tail)
@@ -565,6 +587,9 @@ class ReconcileMixin:
                 candidate_messages,
                 stored_head,
                 stored_uncompacted_tail,
+                uncompacted_tail_exceeds_assembly_cap=(
+                    uncompacted_tail_exceeds_assembly_cap
+                ),
             ):
                 return cursor
             if not candidate_prefix:
@@ -1023,6 +1048,11 @@ class ReconcileMixin:
             for row in uncompacted_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
         ]
+        assembly_cap = self._effective_assembly_token_cap()  # type: ignore[attr-defined]
+        uncompacted_tail_exceeds_assembly_cap = (
+            assembly_cap is not None
+            and count_messages_tokens(uncompacted_rows) > assembly_cap
+        )
         incoming_identities = self._effective_replay_identities(messages)
         # Stale-snapshot proof uses the raw durable prefix. Ignore-message
         # filters may suppress noisy rows for tail reconciliation, but filtered
@@ -1072,6 +1102,9 @@ class ReconcileMixin:
             allow_empty_prefix=True,
             session_count=len(stored_tail),
             raw_session_count=session_count,
+            uncompacted_tail_exceeds_assembly_cap=(
+                uncompacted_tail_exceeds_assembly_cap
+            ),
         )
         if cursor is not None and cursor > 0:
             reason = (

--- a/store.py
+++ b/store.py
@@ -604,6 +604,21 @@ class MessageStore:
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    def get_session_nonblank_role_messages(
+        self,
+        session_id: str,
+        role: str,
+        limit: int = 2,
+    ) -> List[Dict[str, Any]]:
+        """Get the earliest nonblank messages for one role in a session."""
+        rows = self._conn.execute(
+            f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+               WHERE session_id = ? AND role = ? AND TRIM(COALESCE(content, '')) <> ''
+               ORDER BY store_id LIMIT ?""",
+            (session_id, role, limit),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def get_session_messages_after(self, session_id: str,
                                    after_store_id: int = 0,
                                    limit: int = 10000) -> List[Dict[str, Any]]:

--- a/store.py
+++ b/store.py
@@ -594,13 +594,23 @@ class MessageStore:
         return [self._row_to_dict(r) for r in rows]
 
     def get_session_messages(self, session_id: str,
-                             limit: int = 10000) -> List[Dict[str, Any]]:
+                             limit: int = 10000,
+                             conversation_id: str | None = None) -> List[Dict[str, Any]]:
         """Get all messages for a session, ordered by store_id."""
+        conversation_clause, conversation_args = _conversation_filter_clause(
+            "conversation_id", conversation_id
+        )
+        where = "session_id = ?"
+        args: list[Any] = [session_id]
+        if conversation_clause:
+            where += f" AND {conversation_clause}"
+            args.extend(conversation_args)
+        args.append(limit)
         rows = self._conn.execute(
             f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
-               WHERE session_id = ?
+               WHERE {where}
                ORDER BY store_id LIMIT ?""",
-            (session_id, limit),
+            args,
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
@@ -631,39 +641,68 @@ class MessageStore:
 
     def get_session_messages_after(self, session_id: str,
                                    after_store_id: int = 0,
-                                   limit: int = 10000) -> List[Dict[str, Any]]:
+                                   limit: int = 10000,
+                                   conversation_id: str | None = None) -> List[Dict[str, Any]]:
         """Get session messages after a store_id, ordered by store_id."""
+        conversation_clause, conversation_args = _conversation_filter_clause(
+            "conversation_id", conversation_id
+        )
+        where = "session_id = ? AND store_id > ?"
+        args: list[Any] = [session_id, after_store_id]
+        if conversation_clause:
+            where += f" AND {conversation_clause}"
+            args.extend(conversation_args)
+        args.append(limit)
         rows = self._conn.execute(
             f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
-               WHERE session_id = ? AND store_id > ?
+               WHERE {where}
                ORDER BY store_id LIMIT ?""",
-            (session_id, after_store_id, limit),
+            args,
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
-    def get_session_tail(self, session_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
+    def get_session_tail(self, session_id: str, limit: int = 1000,
+                         conversation_id: str | None = None) -> List[Dict[str, Any]]:
         """Get the latest messages for a session, returned in store order."""
         if limit <= 0:
             return []
+        conversation_clause, conversation_args = _conversation_filter_clause(
+            "conversation_id", conversation_id
+        )
+        where = "session_id = ?"
+        args: list[Any] = [session_id]
+        if conversation_clause:
+            where += f" AND {conversation_clause}"
+            args.extend(conversation_args)
+        args.append(limit)
         rows = self._conn.execute(
             f"""SELECT {_MESSAGE_SELECT_COLUMNS}
                FROM (
                    SELECT {_MESSAGE_SELECT_COLUMNS}
                    FROM messages
-                   WHERE session_id = ?
+                   WHERE {where}
                    ORDER BY store_id DESC
                    LIMIT ?
                )
                ORDER BY store_id""",
-            (session_id, limit),
+            args,
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
-    def get_session_count(self, session_id: str) -> int:
+    def get_session_count(self, session_id: str,
+                          conversation_id: str | None = None) -> int:
         """Count messages in a session."""
+        conversation_clause, conversation_args = _conversation_filter_clause(
+            "conversation_id", conversation_id
+        )
+        where = "session_id = ?"
+        args: list[Any] = [session_id]
+        if conversation_clause:
+            where += f" AND {conversation_clause}"
+            args.extend(conversation_args)
         row = self._conn.execute(
-            "SELECT COUNT(*) FROM messages WHERE session_id = ?",
-            (session_id,),
+            f"SELECT COUNT(*) FROM messages WHERE {where}",
+            args,
         ).fetchone()
         return row[0] if row else 0
 

--- a/store.py
+++ b/store.py
@@ -92,6 +92,10 @@ def _conversation_filter_clause(column: str, conversation_id: str | None) -> tup
     return f"{column} = ?", [normalized]
 
 
+def _legacy_blank_conversation_filter_clause(column: str) -> tuple[str, list[str]]:
+    return f"TRIM(COALESCE({column}, '')) = ''", []
+
+
 def _message_role_bias(role: str | None) -> float:
     if role == "user":
         return 0.0
@@ -595,11 +599,17 @@ class MessageStore:
 
     def get_session_messages(self, session_id: str,
                              limit: int = 10000,
-                             conversation_id: str | None = None) -> List[Dict[str, Any]]:
+                             conversation_id: str | None = None,
+                             legacy_blank_conversation_only: bool = False) -> List[Dict[str, Any]]:
         """Get all messages for a session, ordered by store_id."""
-        conversation_clause, conversation_args = _conversation_filter_clause(
-            "conversation_id", conversation_id
-        )
+        if legacy_blank_conversation_only:
+            conversation_clause, conversation_args = _legacy_blank_conversation_filter_clause(
+                "conversation_id"
+            )
+        else:
+            conversation_clause, conversation_args = _conversation_filter_clause(
+                "conversation_id", conversation_id
+            )
         where = "session_id = ?"
         args: list[Any] = [session_id]
         if conversation_clause:
@@ -642,11 +652,17 @@ class MessageStore:
     def get_session_messages_after(self, session_id: str,
                                    after_store_id: int = 0,
                                    limit: int = 10000,
-                                   conversation_id: str | None = None) -> List[Dict[str, Any]]:
+                                   conversation_id: str | None = None,
+                                   legacy_blank_conversation_only: bool = False) -> List[Dict[str, Any]]:
         """Get session messages after a store_id, ordered by store_id."""
-        conversation_clause, conversation_args = _conversation_filter_clause(
-            "conversation_id", conversation_id
-        )
+        if legacy_blank_conversation_only:
+            conversation_clause, conversation_args = _legacy_blank_conversation_filter_clause(
+                "conversation_id"
+            )
+        else:
+            conversation_clause, conversation_args = _conversation_filter_clause(
+                "conversation_id", conversation_id
+            )
         where = "session_id = ? AND store_id > ?"
         args: list[Any] = [session_id, after_store_id]
         if conversation_clause:
@@ -662,13 +678,19 @@ class MessageStore:
         return [self._row_to_dict(r) for r in rows]
 
     def get_session_tail(self, session_id: str, limit: int = 1000,
-                         conversation_id: str | None = None) -> List[Dict[str, Any]]:
+                         conversation_id: str | None = None,
+                         legacy_blank_conversation_only: bool = False) -> List[Dict[str, Any]]:
         """Get the latest messages for a session, returned in store order."""
         if limit <= 0:
             return []
-        conversation_clause, conversation_args = _conversation_filter_clause(
-            "conversation_id", conversation_id
-        )
+        if legacy_blank_conversation_only:
+            conversation_clause, conversation_args = _legacy_blank_conversation_filter_clause(
+                "conversation_id"
+            )
+        else:
+            conversation_clause, conversation_args = _conversation_filter_clause(
+                "conversation_id", conversation_id
+            )
         where = "session_id = ?"
         args: list[Any] = [session_id]
         if conversation_clause:
@@ -690,11 +712,17 @@ class MessageStore:
         return [self._row_to_dict(r) for r in rows]
 
     def get_session_count(self, session_id: str,
-                          conversation_id: str | None = None) -> int:
+                          conversation_id: str | None = None,
+                          legacy_blank_conversation_only: bool = False) -> int:
         """Count messages in a session."""
-        conversation_clause, conversation_args = _conversation_filter_clause(
-            "conversation_id", conversation_id
-        )
+        if legacy_blank_conversation_only:
+            conversation_clause, conversation_args = _legacy_blank_conversation_filter_clause(
+                "conversation_id"
+            )
+        else:
+            conversation_clause, conversation_args = _conversation_filter_clause(
+                "conversation_id", conversation_id
+            )
         where = "session_id = ?"
         args: list[Any] = [session_id]
         if conversation_clause:

--- a/store.py
+++ b/store.py
@@ -630,13 +630,19 @@ class MessageStore:
         role: str,
         limit: int = 2,
         conversation_id: str | None = None,
+        legacy_blank_conversation_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Get the earliest nonblank messages for one role in a session."""
         where = ["session_id = ?", "role = ?", "TRIM(COALESCE(content, '')) <> ''"]
         args: list[Any] = [session_id, role]
-        conversation_clause, conversation_args = _conversation_filter_clause(
-            "conversation_id", conversation_id
-        )
+        if legacy_blank_conversation_only:
+            conversation_clause, conversation_args = _legacy_blank_conversation_filter_clause(
+                "conversation_id"
+            )
+        else:
+            conversation_clause, conversation_args = _conversation_filter_clause(
+                "conversation_id", conversation_id
+            )
         if conversation_clause:
             where.append(conversation_clause)
             args.extend(conversation_args)

--- a/store.py
+++ b/store.py
@@ -609,13 +609,23 @@ class MessageStore:
         session_id: str,
         role: str,
         limit: int = 2,
+        conversation_id: str | None = None,
     ) -> List[Dict[str, Any]]:
         """Get the earliest nonblank messages for one role in a session."""
+        where = ["session_id = ?", "role = ?", "TRIM(COALESCE(content, '')) <> ''"]
+        args: list[Any] = [session_id, role]
+        conversation_clause, conversation_args = _conversation_filter_clause(
+            "conversation_id", conversation_id
+        )
+        if conversation_clause:
+            where.append(conversation_clause)
+            args.extend(conversation_args)
+        args.append(limit)
         rows = self._conn.execute(
             f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
-               WHERE session_id = ? AND role = ? AND TRIM(COALESCE(content, '')) <> ''
+               WHERE {' AND '.join(where)}
                ORDER BY store_id LIMIT ?""",
-            (session_id, role, limit),
+            args,
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4328,6 +4328,75 @@ class TestAssemblyBudgetSelection:
         assert "SMALL_RECENT_SUMMARY" in contents
         assert "HUGE_DURABLE_SUMMARY" not in contents
 
+    @pytest.mark.parametrize("with_tool_call", [False, True], ids=["plain-assistant", "tool-call"])
+    def test_anchored_summary_coalesces_with_assistant_tail_for_valid_roles(
+        self, tmp_path, monkeypatch, with_tool_call
+    ):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=2_000)
+        engine._dag.add_node(SummaryNode(
+            session_id="assembly-session", depth=0,
+            summary="DAG summary for the active request.", token_count=10,
+            source_token_count=100, source_ids=[1], source_type="messages",
+            expand_hint="active request",
+        ))
+        assistant = {"role": "assistant", "content": "Current assistant tail."}
+        tail = [assistant]
+        if with_tool_call:
+            assistant = {
+                "role": "assistant", "content": "Calling terminal.",
+                "tool_calls": [{"id": "call_tail", "function": {"name": "terminal", "arguments": "{}"}}],
+            }
+            tail = [assistant, {"role": "tool", "tool_call_id": "call_tail", "content": "terminal output"}]
+
+        assembled = engine._assemble_context(
+            None, tail,
+            leading_anchor_messages=[
+                {"role": "system", "content": "System anchor."},
+                {"role": "user", "content": "Exact preserved user anchor."},
+            ],
+        )
+
+        assert [message["role"] for message in assembled] == (
+            ["system", "user", "assistant", "tool"] if with_tool_call
+            else ["system", "user", "assistant"]
+        )
+        assert "DAG summary for the active request." in assembled[2]["content"]
+        assert assistant["content"] in assembled[2]["content"]
+        if with_tool_call:
+            assert assembled[2]["tool_calls"] == assistant["tool_calls"]
+            assert assembled[3]["tool_call_id"] == "call_tail"
+
+    def test_latest_literal_local_summary_rendering_remains_current_objective(
+        self, tmp_path, monkeypatch
+    ):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=240)
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id="assembly-session", depth=0,
+            summary="Exact local summary body.", token_count=10,
+            source_token_count=100, source_ids=[1], source_type="messages",
+            expand_hint="local details",
+        ))
+        literal_latest = (
+            f"[Recent Summary (d0, node {node_id})]\nExact local summary body.\n"
+            "[Expand for details: local details]\n"
+            "Now implement this NEW literal user request."
+        )
+        engine._pending_context_anchor_messages = [
+            {"role": "user", "content": "STALE_OLDER_OBJECTIVE"},
+            {"role": "assistant", "content": "large derived output " * 200},
+            {"role": "user", "content": literal_latest},
+            {"role": "assistant", "content": "oversized latest assistant " * 200},
+        ]
+
+        assembled = engine._assemble_context(
+            {"role": "system", "content": "System anchor."},
+            [{"role": "assistant", "content": "oversized latest assistant " * 200}],
+        )
+
+        combined = "\n".join(str(message.get("content", "")) for message in assembled)
+        assert literal_latest in combined
+        assert "STALE_OLDER_OBJECTIVE" not in combined
+
 
 class TestIngestExternalization:
     def _engine(self, tmp_path: Path, **config_overrides):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -1333,6 +1333,26 @@ class TestMessageStore:
             "conv a second",
         ]
 
+    def test_nonblank_role_messages_can_filter_by_conversation_id(self, store):
+        store.append(
+            "sess1",
+            {"role": "user", "content": "prior conversation"},
+            conversation_id="conv-a",
+        )
+        store.append(
+            "sess1",
+            {"role": "user", "content": "current conversation"},
+            conversation_id="conv-b",
+        )
+
+        filtered = store.get_session_nonblank_role_messages(
+            "sess1",
+            "user",
+            conversation_id="conv-b",
+        )
+
+        assert [row["content"] for row in filtered] == ["current conversation"]
+
     def test_session_count(self, store):
         store.append("sess1", {"role": "user", "content": "a"})
         store.append("sess1", {"role": "assistant", "content": "b"})

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,6 +3774,100 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    def _single_initial_user_restart_fixture(self, tmp_path, monkeypatch, db_name):
+        db_path = tmp_path / db_name
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(db_path),
+        )
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "single-initial-user-restart-session",
+            platform="cli",
+            conversation_id="single-initial-user-restart-conversation",
+            context_length=200000,
+        )
+
+        def mock_summary(**kwargs):
+            return "Assistant/tool chain summary.\nExpand for details about: restart anchor", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        user_query = "diagnose restart replay without duplicating durable rows"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {
+                "role": "assistant",
+                "content": "checking logs",
+                "tool_calls": [{"id": "call_logs", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_logs", "content": "log output " + "x" * 200},
+            {
+                "role": "assistant",
+                "content": "checking replay",
+                "tool_calls": [{"id": "call_replay", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_replay", "content": "replay output"},
+            {"role": "assistant", "content": "still investigating"},
+            {"role": "assistant", "content": "final diagnostic"},
+        ]
+        active_context = before_restart.compress(messages)
+        assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
+        assert before_restart._store.get_session_count("single-initial-user-restart-session") == len(messages)
+        before_restart.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "single-initial-user-restart-session",
+            platform="cli",
+            conversation_id="single-initial-user-restart-conversation",
+            context_length=200000,
+        )
+        return after_restart, active_context, messages, user_query
+
+    def test_single_initial_user_anchor_restart_no_delta_does_not_duplicate_durable_rows(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        after_restart, active_context, messages, user_query = self._single_initial_user_restart_fixture(
+            tmp_path,
+            monkeypatch,
+            "single-initial-user-restart-no-delta.db",
+        )
+        try:
+            after_restart._ingest_messages(active_context)
+            rows = after_restart._store.get_session_messages("single-initial-user-restart-session")
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert all("[Recent Summary" not in row["content"] for row in rows)
+
+    def test_single_initial_user_anchor_restart_one_followup_only_persists_delta(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        after_restart, active_context, messages, user_query = self._single_initial_user_restart_fixture(
+            tmp_path,
+            monkeypatch,
+            "single-initial-user-restart-followup.db",
+        )
+        followup = {"role": "user", "content": "follow-up after restart"}
+        try:
+            after_restart._ingest_messages(active_context + [followup])
+            rows = after_restart._store.get_session_messages("single-initial-user-restart-session")
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert rows[-1]["content"] == followup["content"]
+        assert all("[Recent Summary" not in row["content"] for row in rows)
+
     def test_overflow_recovery_keeps_single_initial_user_anchor(self, tmp_path):
         db_path = tmp_path / "single-initial-user-overflow-anchor.db"
         config = LCMConfig(
@@ -3808,6 +3902,105 @@ class TestEngineABC:
         assert engine.last_compression_status == "overflow_recovery"
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
+
+    def test_overflow_recovery_keeps_sole_user_inside_fresh_tail(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=32,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=40,
+            database_path=str(tmp_path / "single-user-inside-fresh-tail.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "single-user-inside-fresh-tail-session"
+        engine.compression_count = 1
+        monkeypatch.setattr(lcm_engine, "count_message_tokens", lambda msg: len(msg.get("content", "")))
+        monkeypatch.setattr(
+            lcm_engine,
+            "count_messages_tokens",
+            lambda messages: sum(len(msg.get("content", "")) for msg in messages),
+        )
+        user_query = "u" * 20
+        messages = [
+            {"role": "system", "content": "s" * 10},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "a" * 40},
+        ]
+
+        try:
+            assert engine._leading_anchor_count(messages) == 2
+            active_context = engine.compress(messages, current_tokens=70)
+        finally:
+            engine.shutdown()
+
+        assert [msg.get("role") for msg in active_context] == ["system", "user"]
+        assert active_context[1]["content"] == user_query
+
+    def test_generated_and_blank_user_messages_are_not_prompt_bearing_anchors(self, tmp_path):
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "synthetic-user-anchor.db")))
+        generated_summary = {
+            "role": "user",
+            "content": "[Recent Summary (d0, node 1)]\nold scaffold\n[Expand for details: old scaffold]",
+        }
+        blank_user = {"role": "user", "content": "  \n\t"}
+        try:
+            assert not engine._is_prompt_bearing_user_message(generated_summary)
+            assert not engine._is_prompt_bearing_user_message(blank_user)
+            assert engine._leading_anchor_count([
+                {"role": "system", "content": "sys"},
+                generated_summary,
+                {"role": "assistant", "content": "tail"},
+            ]) == 1
+            assert engine._leading_anchor_count([
+                {"role": "system", "content": "sys"},
+                blank_user,
+                {"role": "assistant", "content": "tail"},
+            ]) == 1
+        finally:
+            engine.shutdown()
+
+    def test_generated_user_summary_is_not_duplicated_by_later_compaction(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "generated-user-summary-second-compaction.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine._session_id = "generated-user-summary-session"
+        node = SummaryNode(
+            session_id=engine._session_id,
+            depth=0,
+            summary="old scaffold",
+            token_count=2,
+            source_token_count=20,
+            source_ids=[],
+            source_type="messages",
+            expand_hint="old scaffold",
+        )
+        node_id = engine._dag.add_node(node)
+        generated_summary = (
+            f"[Recent Summary (d0, node {node_id})]\n"
+            "old scaffold\n"
+            "[Expand for details: old scaffold]"
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("new assistant summary\nExpand for details about: new work", 1),
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": generated_summary},
+            {"role": "assistant", "content": "derived backlog " + "x" * 200},
+            {"role": "assistant", "content": "fresh tail"},
+        ]
+
+        try:
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        active_text = "\n".join(str(msg.get("content", "")) for msg in active_context)
+        assert active_text.count(generated_summary) == 1
 
     def test_later_user_keeps_initial_user_compactable(self, tmp_path, monkeypatch):
         db_path = tmp_path / "later-user-keeps-initial-compactable.db"
@@ -20598,7 +20791,7 @@ class TestAssemblyGuardrails:
 
         result = instance.compress(messages, current_tokens=90)
 
-        assert result == [messages[0], messages[-1]]
+        assert result == [messages[0], messages[1]]
         assert instance.compression_count == 1
         assert instance._ingest_cursor == len(result)
         assert not instance.get_status()["overflow_recovery_failed"]
@@ -20635,7 +20828,7 @@ class TestAssemblyGuardrails:
 
         result = instance.compress(messages, current_tokens=100)
 
-        assert result == [messages[0], messages[-1]]
+        assert result == [messages[0], messages[1]]
         assert lcm_engine_module.count_messages_tokens(result) < 70
 
     def test_forced_overflow_recovery_does_not_duplicate_existing_summary_message(self, tmp_path, monkeypatch):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4131,6 +4131,83 @@ class TestEngineABC:
             row["role"] == "assistant" and row["content"] == repeated_content for row in rows
         ) == 2
 
+    @pytest.mark.parametrize(
+        "followup",
+        [
+            None,
+            {"role": "user", "content": "new delta after scaffolded frontier-zero replay"},
+        ],
+        ids=["no-delta", "new-delta"],
+    )
+    def test_frontier_zero_overflow_anchor_restart_skips_generated_summary_scaffold(
+        self,
+        tmp_path,
+        followup,
+    ):
+        db_path = tmp_path / f"frontier-zero-overflow-anchor-scaffold-{followup is not None}.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "frontier-zero-overflow-anchor-scaffold-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-scaffold-conversation",
+            context_length=200000,
+        )
+
+        user_query = "preserve this raw provider anchor before the frontier advances"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest derived output " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            assert engine.last_compression_status == "overflow_recovery"
+            assert engine._last_compacted_store_id == 0
+        finally:
+            engine.shutdown()
+
+        summary_scaffold = {
+            "role": "assistant",
+            "content": (
+                "[Recent Summary (d0, node 12)]\n"
+                "Earlier details.\n"
+                "[Expand for details: hint-12]"
+            ),
+        }
+        assert [message.get("role") for message in active_context] == ["system", "user"]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "frontier-zero-overflow-anchor-scaffold-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-scaffold-conversation",
+            context_length=200000,
+        )
+        try:
+            assert after_restart._last_compacted_store_id == 0
+            assert after_restart._is_replayed_context_scaffold_message(summary_scaffold)
+            replay = active_context + [summary_scaffold] + ([followup] if followup is not None else [])
+            after_restart._ingest_messages(replay)
+            rows = after_restart._store.get_session_messages(
+                "frontier-zero-overflow-anchor-scaffold-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + (1 if followup is not None else 0)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert all("[Recent Summary" not in row["content"] for row in rows)
+        if followup is not None:
+            assert rows[-1]["content"] == followup["content"]
+
     def test_two_message_overflow_anchor_restart_does_not_duplicate_durable_rows(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4786,6 +4786,126 @@ class TestEngineABC:
             row["role"] == "assistant" and row["content"] == repeated_content for row in rows
         ) == 2
 
+    @pytest.mark.parametrize("frontier_positive", [False, True], ids=["frontier-zero", "positive-frontier"])
+    @pytest.mark.parametrize(
+        "restart_cap", [180, 800, 0, 100], ids=["unchanged", "increased", "disabled", "decreased"]
+    )
+    @pytest.mark.parametrize("delta_kind", ["none", "new", "repeated"])
+    def test_restart_reconciles_exact_emitted_snapshot_independent_of_current_cap(
+        self, tmp_path, frontier_positive, restart_cap, delta_kind
+    ):
+        db_path = tmp_path / f"snapshot-{frontier_positive}-{restart_cap}-{delta_kind}.db"
+        session_id = "cap-independent-snapshot-session"
+        conversation_id = "cap-independent-snapshot-conversation"
+        messages = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Current durable request."},
+            {"role": "assistant", "content": "omitted repeated content"},
+            {"role": "assistant", "content": "visible durable suffix"},
+        ]
+        emitted = [messages[0], messages[1], messages[-1]]
+        before = LCMEngine(config=LCMConfig(database_path=str(db_path), max_assembly_tokens=180))
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            store_ids = before._store.append_batch(
+                session_id, messages, conversation_id=conversation_id
+            )
+            if frontier_positive:
+                before._lifecycle.advance_frontier(conversation_id, session_id, store_ids[2])
+            before._write_active_replay_snapshot(emitted)
+        finally:
+            before.shutdown()
+
+        delta = None
+        if delta_kind == "new":
+            delta = {"role": "user", "content": "new request after restart"}
+        elif delta_kind == "repeated":
+            delta = {"role": "assistant", "content": messages[2]["content"]}
+        incoming = emitted + ([delta] if delta is not None else [])
+
+        after = LCMEngine(
+            config=LCMConfig(database_path=str(db_path), max_assembly_tokens=restart_cap)
+        )
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages(incoming)
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(messages) + (delta is not None)
+        if delta is not None:
+            assert rows[-1]["role"] == delta["role"]
+            assert rows[-1]["content"] == delta["content"]
+        if delta_kind == "repeated":
+            assert sum(row["content"] == messages[2]["content"] for row in rows) == 2
+
+        repeated_restart = LCMEngine(
+            config=LCMConfig(database_path=str(db_path), max_assembly_tokens=restart_cap)
+        )
+        repeated_restart.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            repeated_restart._ingest_messages(incoming)
+            repeated_rows = repeated_restart._store.get_session_messages(
+                session_id, conversation_id=conversation_id
+            )
+        finally:
+            repeated_restart.shutdown()
+        assert len(repeated_rows) == len(rows)
+
+    def test_new_system_message_with_lcm_annotation_phrases_persists_exactly_once(self, tmp_path):
+        db_path = tmp_path / "literal-lcm-system-phrases.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "literal-lcm-system-phrases-session"
+        conversation_id = "literal-lcm-system-phrases-conversation"
+        durable = [
+            {"role": "system", "content": "Original system."},
+            {"role": "user", "content": "Durable user anchor."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            emitted_system = dict(durable[0])
+            emitted_system["content"] = before._append_lcm_note_to_content(durable[0]["content"])
+            before._write_active_replay_snapshot([emitted_system, durable[1]])
+        finally:
+            before.shutdown()
+
+        literal_system = {
+            "role": "system",
+            "content": (
+                "New literal system delta.\n"
+                "[Note: This conversation uses Lossless Context Management (LCM).\n"
+                "Earlier turns have been compacted into hierarchical summaries below."
+            ),
+        }
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            assert not after._is_replayed_context_scaffold_message(literal_system)
+            after._ingest_messages([literal_system, durable[1]])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(durable) + 1
+        assert sum(
+            row["role"] == "system" and row["content"] == literal_system["content"]
+            for row in rows
+        ) == 1
+        assert sum(row["content"] == durable[1]["content"] for row in rows) == 1
+
     @pytest.mark.parametrize(
         "followup",
         [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4015,6 +4015,83 @@ class TestEngineABC:
         assert [row["content"] for row in rows].count(user_query) == 1
         assert all("[Recent Summary" not in row["content"] for row in rows)
 
+    def test_reused_session_raw_anchor_restart_does_not_duplicate_current_conversation(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "reused-session-raw-anchor-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=10_000,
+            database_path=str(db_path),
+        )
+        session_id = "reused-session-raw-anchor"
+        old_messages = [
+            {"role": "system", "content": "Old conversation system."},
+            {"role": "user", "content": "old conversation request"},
+            {"role": "assistant", "content": "old conversation response"},
+        ]
+        old_engine = LCMEngine(config=config)
+        old_engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="old-conversation",
+            context_length=200000,
+        )
+        try:
+            old_engine.compress(old_messages)
+        finally:
+            old_engine.shutdown()
+
+        current_messages = [
+            {"role": "system", "content": "Current conversation system."},
+            {"role": "user", "content": "current conversation request"},
+        ]
+        current_engine = LCMEngine(config=config)
+        current_engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="current-conversation",
+            context_length=200000,
+        )
+        try:
+            active_context = current_engine.compress(current_messages)
+            assert current_engine.last_compression_status == "noop"
+            assert current_engine.last_compression_noop_reason == (
+                "no eligible raw backlog outside fresh tail"
+            )
+            assert active_context == current_messages
+        finally:
+            current_engine.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="current-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(active_context)
+            rows = after_restart._store.get_session_messages(session_id)
+            reconciliation = after_restart._last_ingest_reconciliation
+        finally:
+            after_restart.shutdown()
+
+        assert reconciliation["action"] == "advanced cursor"
+        assert reconciliation["cursor"] == len(current_messages)
+        assert reconciliation["session_count"] == len(current_messages)
+        assert len(rows) == len(old_messages) + len(current_messages)
+        assert [row["content"] for row in rows].count(current_messages[0]["content"]) == 1
+        assert [row["content"] for row in rows].count(current_messages[1]["content"]) == 1
+        assert [row["conversation_id"] for row in rows] == [
+            "old-conversation",
+            "old-conversation",
+            "old-conversation",
+            "current-conversation",
+            "current-conversation",
+        ]
+
     def test_single_initial_user_anchor_restart_one_followup_only_persists_delta(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5098,6 +5098,86 @@ class TestEngineABC:
         assert [row["content"] for row in rows].count(user_query) == 1
         assert [row["content"] for row in rows].count(fresh_tail) == 1
 
+    def test_capped_anchor_only_replay_preserves_summary_shaped_assistant_delta(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "capped-anchor-only-summary-shaped-assistant.db"
+        config = LCMConfig(
+            fresh_tail_count=0,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        session_id = "capped-anchor-only-summary-shaped-assistant-session"
+        conversation_id = "capped-anchor-only-summary-shaped-assistant-conversation"
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (
+                "Oversized generated summary "
+                + "x" * 1000
+                + "\nExpand for details about: capped anchor",
+                1,
+            ),
+        )
+
+        user_query = "preserve a literal summary-shaped assistant after capped replay"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "y" * 4000},
+            {"role": "assistant", "content": "more derived output " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            assert engine._last_compacted_store_id > 0
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == ["system", "user"]
+        assert engine._is_replayed_context_scaffold_message(active_context[0])
+
+        summary_shaped_assistant = {
+            "role": "assistant",
+            "content": (
+                "[Recent Summary (d0, node 999)]\n"
+                "This is a new real assistant delta after capped replay.\n"
+                "[Expand for details: literal assistant response]"
+            ),
+        }
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        try:
+            assert after_restart._is_replayed_context_scaffold_message(
+                summary_shaped_assistant
+            )
+            assert not after_restart._is_known_generated_summary_scaffold_message(
+                summary_shaped_assistant
+            )
+            after_restart._ingest_messages(active_context + [summary_shaped_assistant])
+            rows = after_restart._store.get_session_messages(session_id)
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert rows[-1]["role"] == "assistant"
+        assert rows[-1]["content"] == summary_shaped_assistant["content"]
+
     def test_anchor_summary_with_omitted_tail_preserves_repeated_new_delta(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4936,19 +4936,26 @@ class TestEngineABC:
         after.on_session_start(
             session_id, platform="cli", conversation_id=conversation_id, context_length=200000
         )
+        later_delta = {"role": "assistant", "content": "Later delta after compaction."}
         try:
             after._ingest_messages(incoming)
-            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+            reconciled_rows = after._store.get_session_messages(
+                session_id, conversation_id=conversation_id
+            )
             reconciliation = after._last_ingest_reconciliation
+            compacted = after._finalize_forced_overflow_result(incoming, [changed_system])
+            after._ingest_messages([*compacted, later_delta])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
         finally:
             after.shutdown()
 
-        assert len(rows) == len(durable) + 2
+        assert len(reconciled_rows) == len(durable) + 2
         assert reconciliation["action"] == "advanced cursor"
-        assert sum(row["content"] == durable[1]["content"] for row in rows) == 1
-        assert sum(row["content"] == durable[2]["content"] for row in rows) == 1
-        assert sum(row["content"] == changed_system["content"] for row in rows) == 1
-        assert sum(row["content"] == appended_turn["content"] for row in rows) == 1
+        assert sum(row["content"] == durable[1]["content"] for row in reconciled_rows) == 1
+        assert sum(row["content"] == durable[2]["content"] for row in reconciled_rows) == 1
+        assert sum(row["content"] == changed_system["content"] for row in reconciled_rows) == 1
+        assert sum(row["content"] == appended_turn["content"] for row in reconciled_rows) == 1
+        assert sum(row["content"] == later_delta["content"] for row in rows) == 1
 
     def test_restart_changed_system_partial_snapshot_resemblance_remains_new_content(
         self,
@@ -5094,6 +5101,46 @@ class TestEngineABC:
             and "Genuinely new structured system message." in row["content"]
             for row in rows
         ) == 1
+
+    def test_new_annotated_system_persists_when_only_legacy_blank_conversation_rows_exist(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "fresh-annotated-system-legacy-blank-conversation.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "fresh-annotated-system-legacy-blank-conversation-session"
+        conversation_id = "fresh-annotated-system-new-conversation"
+        legacy = LCMEngine(config=config)
+        try:
+            legacy._store.append_batch(
+                session_id,
+                [{"role": "user", "content": "Legacy blank-conversation user."}],
+                conversation_id="",
+            )
+            fresh_system = {
+                "role": "system",
+                "content": legacy._append_lcm_note_to_content("Genuinely new system message."),
+            }
+        finally:
+            legacy.shutdown()
+
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            assert not after._is_replayed_context_scaffold_message(fresh_system)
+            after._ingest_messages(
+                [fresh_system, {"role": "user", "content": "New conversation user."}]
+            )
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert [(row["role"], row["content"]) for row in rows] == [
+            ("system", fresh_system["content"]),
+            ("user", "New conversation user."),
+        ]
 
     @pytest.mark.parametrize(
         "followup",

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4423,6 +4423,84 @@ class TestEngineABC:
             for row in rows
         )
 
+    def test_anchor_with_full_fresh_tail_and_no_scaffold_reconciles_restart(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "anchor-full-tail-no-scaffold-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "anchor-full-tail-no-scaffold-session",
+            platform="cli",
+            conversation_id="anchor-full-tail-no-scaffold-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (
+                "Oversized restart summary "
+                + "x" * 1000
+                + "\nExpand for details about: restart",
+                1,
+            ),
+        )
+
+        user_query = "preserve this provider anchor with the complete fresh tail"
+        fresh_tail = "durable fresh tail"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": fresh_tail},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            uncompacted_rows = engine._store.get_session_messages_after(
+                "anchor-full-tail-no-scaffold-session",
+                after_store_id=engine._last_compacted_store_id,
+                limit=len(messages),
+            )
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == [
+            "system",
+            "user",
+            "assistant",
+        ]
+        assert engine._is_replayed_context_scaffold_message(active_context[0])
+        assert not engine._is_replayed_context_scaffold_message(active_context[-1])
+        assert active_context[-1]["content"] == fresh_tail
+        assert [row["content"] for row in uncompacted_rows] == [fresh_tail]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "anchor-full-tail-no-scaffold-session",
+            platform="cli",
+            conversation_id="anchor-full-tail-no-scaffold-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(active_context)
+            rows = after_restart._store.get_session_messages(
+                "anchor-full-tail-no-scaffold-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert [row["content"] for row in rows].count(fresh_tail) == 1
+
     def test_anchor_summary_with_omitted_tail_preserves_repeated_new_delta(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4423,6 +4423,80 @@ class TestEngineABC:
             for row in rows
         )
 
+    def test_anchor_summary_with_omitted_tail_preserves_repeated_new_delta(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "anchor-summary-omitted-tail-repeated-delta.db"
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "anchor-summary-omitted-tail-repeated-delta-session",
+            platform="cli",
+            conversation_id="anchor-summary-omitted-tail-repeated-delta-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Compact restart summary.\nExpand for details about: restart", 1),
+        )
+
+        repeated_content = "durable omitted fresh tail " + "z" * 4000
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "preserve the repeated delta after omitted-tail replay"},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": repeated_content},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            uncompacted_rows = engine._store.get_session_messages_after(
+                "anchor-summary-omitted-tail-repeated-delta-session",
+                after_store_id=engine._last_compacted_store_id,
+                limit=len(messages),
+            )
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == [
+            "system",
+            "user",
+            "assistant",
+        ]
+        assert engine._is_replayed_context_scaffold_message(active_context[-1])
+        assert [row["content"] for row in uncompacted_rows] == [repeated_content]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "anchor-summary-omitted-tail-repeated-delta-session",
+            platform="cli",
+            conversation_id="anchor-summary-omitted-tail-repeated-delta-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(
+                active_context + [{"role": "assistant", "content": repeated_content}]
+            )
+            rows = after_restart._store.get_session_messages(
+                "anchor-summary-omitted-tail-repeated-delta-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert sum(
+            row["role"] == "assistant" and row["content"] == repeated_content
+            for row in rows
+        ) == 2
+
     def test_overflow_recovery_keeps_sole_user_inside_fresh_tail(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=32,
@@ -5264,6 +5338,56 @@ class TestEngineABC:
             "skipped stale no-overlap snapshot"
         )
         assert "skipped stale no-overlap snapshot" in caplog.text
+
+    def test_existing_session_restart_skips_stale_no_overlap_prefix_longer_than_three(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "restart-stale-no-overlap-prefix-longer-than-three.db"
+        config = LCMConfig(database_path=str(db_path))
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "stale-long-prefix-session",
+            platform="cli",
+            conversation_id="stale-long-prefix-conversation",
+            context_length=200000,
+        )
+        persisted_messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "old startup question"},
+            {"role": "assistant", "content": "old startup answer"},
+            {"role": "user", "content": "old startup follow-up"},
+            {"role": "assistant", "content": "old startup follow-up answer"},
+        ]
+        persisted_messages.extend(
+            {"role": "user", "content": f"durable tail message {i}"}
+            for i in range(80)
+        )
+        before_restart._ingest_messages(persisted_messages)
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "stale-long-prefix-session",
+            platform="cli",
+            conversation_id="stale-long-prefix-conversation",
+            context_length=200000,
+        )
+        stale_runtime_snapshot = persisted_messages[:5]
+
+        after_restart._ingest_messages(stale_runtime_snapshot)
+
+        rows = after_restart._store.get_session_messages(
+            "stale-long-prefix-session",
+            limit=len(persisted_messages) + len(stale_runtime_snapshot),
+        )
+        assert len(rows) == len(persisted_messages)
+        assert after_restart._ingest_cursor == len(stale_runtime_snapshot)
+        assert after_restart.get_status()["ingest_reconciliation"]["reason"] == (
+            "skipped stale no-overlap snapshot"
+        )
 
     def test_existing_session_restart_skips_stale_short_snapshot_with_externalized_head_payload(self, tmp_path):
         db_path = tmp_path / "restart-stale-externalized-head.db"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4531,6 +4531,47 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    def test_overflow_recovery_keeps_literal_summary_shaped_user_within_cap(self, tmp_path):
+        max_assembly_tokens = 180
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=max_assembly_tokens,
+            database_path=str(tmp_path / "literal-summary-shaped-overflow-anchor.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "literal-summary-shaped-overflow-anchor-session",
+            platform="cli",
+            conversation_id="literal-summary-shaped-overflow-anchor-conversation",
+            context_length=200000,
+        )
+
+        user_query = (
+            "[Recent Summary (d0, node 999)]\n"
+            "This is literal user-authored content.\n"
+            "[Expand for details: literal request]"
+        )
+        dropped_tail = "latest derived output " + "z" * 4000
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": dropped_tail},
+        ]
+        try:
+            assert engine.should_compress_preflight(messages)
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert engine.last_compression_status == "overflow_recovery"
+        assert [msg.get("role") for msg in active_context] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+        assert count_messages_tokens(active_context) <= max_assembly_tokens
+        assert all(msg.get("content") != dropped_tail for msg in active_context)
+
     @pytest.mark.parametrize(
         "followup",
         [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4064,6 +4064,86 @@ class TestEngineABC:
         assert len(rows) == len(messages)
         assert [row["content"] for row in rows].count(user_query) == 1
 
+    @pytest.mark.parametrize(
+        "followup",
+        [
+            None,
+            {"role": "user", "content": "new delta after omitted-tail replay"},
+        ],
+        ids=["no-delta", "new-delta"],
+    )
+    def test_two_message_overflow_anchor_with_omitted_fresh_tail_reconciles_restart(
+        self,
+        tmp_path,
+        monkeypatch,
+        followup,
+    ):
+        db_path = tmp_path / f"two-message-overflow-omitted-tail-{followup is not None}.db"
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "two-message-overflow-omitted-tail-session",
+            platform="cli",
+            conversation_id="two-message-overflow-omitted-tail-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (
+                "Overflow summary " + "x" * 1000 + "\nExpand for details about: overflow anchor",
+                1,
+            ),
+        )
+
+        user_query = "preserve this provider anchor across omitted-tail replay"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "durable omitted fresh tail " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            uncompacted_rows = engine._store.get_session_messages_after(
+                "two-message-overflow-omitted-tail-session",
+                after_store_id=engine._last_compacted_store_id,
+                limit=len(messages),
+            )
+        finally:
+            engine.shutdown()
+
+        assert [msg.get("role") for msg in active_context] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+        assert [row["content"] for row in uncompacted_rows] == [messages[-1]["content"]]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "two-message-overflow-omitted-tail-session",
+            platform="cli",
+            conversation_id="two-message-overflow-omitted-tail-conversation",
+            context_length=200000,
+        )
+        replay = active_context + ([followup] if followup is not None else [])
+        try:
+            after_restart._ingest_messages(replay)
+            rows = after_restart._store.get_session_messages(
+                "two-message-overflow-omitted-tail-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + (1 if followup is not None else 0)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        if followup is not None:
+            assert rows[-1]["content"] == followup["content"]
+
     def test_overflow_recovery_keeps_sole_user_inside_fresh_tail(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=32,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4630,6 +4630,36 @@ class TestEngineABC:
         finally:
             engine.shutdown()
 
+    def test_non_prompt_bearing_durable_user_does_not_disable_sole_real_user_anchor(
+        self,
+        tmp_path,
+    ):
+        engine = LCMEngine(config=LCMConfig(database_path=str(tmp_path / "durable-synthetic-user.db")))
+        engine._session_id = "durable-synthetic-user-session"
+        user_query = "preserve the only real user query"
+        generated_summary = {
+            "role": "user",
+            "content": "[Recent Summary (d0, node 1)]\nold scaffold\n[Expand for details: old scaffold]",
+        }
+        engine._store.append_batch(
+            engine._session_id,
+            [
+                {"role": "user", "content": user_query},
+                generated_summary,
+            ],
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "tail"},
+        ]
+
+        try:
+            assert not engine._is_prompt_bearing_user_message(generated_summary)
+            assert engine._leading_anchor_count(messages) == 2
+        finally:
+            engine.shutdown()
+
     def test_generated_user_summary_is_not_duplicated_by_later_compaction(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=1,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4901,6 +4901,52 @@ class TestEngineABC:
             message["content"] for message in [*snapshot, *durable_suffix, fresh_delta]
         ]
 
+    def test_restart_snapshot_prefix_uses_full_alignment_before_suppressing_suffix(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "snapshot-prefix-repeated-terminal-identity.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "snapshot-prefix-repeated-terminal-identity-session"
+        conversation_id = "snapshot-prefix-repeated-terminal-identity-conversation"
+        snapshot = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Repeated durable user."},
+        ]
+        durable_suffix = [
+            {"role": "assistant", "content": "Durable response."},
+            dict(snapshot[-1]),
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(
+                session_id,
+                [*snapshot, *durable_suffix],
+                conversation_id=conversation_id,
+            )
+            before._write_active_replay_snapshot(snapshot)
+        finally:
+            before.shutdown()
+
+        fresh_delta = {"role": "assistant", "content": "Fresh response after replay."}
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages([*snapshot, *durable_suffix, fresh_delta])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        expected = [*snapshot, *durable_suffix, fresh_delta]
+        assert [row["content"] for row in rows] == [message["content"] for message in expected]
+        assert sum(row["content"] == durable_suffix[0]["content"] for row in rows) == 1
+        assert sum(row["content"] == snapshot[-1]["content"] for row in rows) == 2
+        assert rows[-1]["content"] == fresh_delta["content"]
+
     def test_new_system_message_with_lcm_annotation_phrases_persists_exactly_once(self, tmp_path):
         db_path = tmp_path / "literal-lcm-system-phrases.db"
         config = LCMConfig(database_path=str(db_path))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4906,6 +4906,103 @@ class TestEngineABC:
         ) == 1
         assert sum(row["content"] == durable[1]["content"] for row in rows) == 1
 
+    def test_restart_skips_generated_structured_system_annotation(self, tmp_path):
+        db_path = tmp_path / "structured-lcm-system-replay.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "structured-lcm-system-replay-session"
+        conversation_id = "structured-lcm-system-replay-conversation"
+        durable = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Original structured system."},
+                    {"type": "image_url", "image_url": {"url": "https://example.test/system.png"}},
+                ],
+            },
+            {"role": "user", "content": "Durable user anchor."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            emitted = before._assemble_context(durable[0], [durable[1]])
+        finally:
+            before.shutdown()
+
+        assert isinstance(emitted[0]["content"], list)
+        assert emitted[0]["content"][-1]["text"].startswith(
+            "[Note: This conversation uses Lossless Context Management (LCM)."
+        )
+        replayed_system = dict(emitted[0])
+        replayed_system["content"] = json.dumps(
+            emitted[0]["content"], ensure_ascii=False, sort_keys=True
+        )
+
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            assert after._is_replayed_context_scaffold_message(replayed_system)
+            after._ingest_messages([replayed_system, *emitted[1:]])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(durable) + 1
+        assert sum(row["role"] == "system" for row in rows) == 1
+        assert all(
+            "Earlier turns have been compacted into hierarchical summaries below."
+            not in row["content"]
+            for row in rows
+            if row["role"] == "system"
+        )
+
+    def test_new_structured_system_with_exact_lcm_annotation_persists(self, tmp_path):
+        db_path = tmp_path / "fresh-structured-lcm-system.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "fresh-structured-lcm-system-session"
+        conversation_id = "fresh-structured-lcm-system-conversation"
+        durable = [
+            {"role": "system", "content": [{"type": "text", "text": "Original system."}]},
+            {"role": "user", "content": "Durable user anchor."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            fresh_system = {
+                "role": "system",
+                "content": before._append_lcm_note_to_content(
+                    [{"type": "text", "text": "Genuinely new structured system message."}]
+                ),
+            }
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            assert not after._is_replayed_context_scaffold_message(fresh_system)
+            after._ingest_messages([fresh_system, durable[1]])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(durable) + 2
+        assert sum(row["role"] == "system" for row in rows) == 2
+        assert sum(
+            row["role"] == "system"
+            and "Genuinely new structured system message." in row["content"]
+            for row in rows
+        ) == 1
+
     @pytest.mark.parametrize(
         "followup",
         [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,10 +3774,12 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
-    def test_second_compaction_keeps_former_initial_user_source_lineage(self, tmp_path, monkeypatch):
+    def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
             leaf_chunk_tokens=1,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=1,
             database_path=str(tmp_path / "former-initial-user-lineage.db"),
         )
         engine = LCMEngine(config=config)
@@ -3816,6 +3818,7 @@ class TestEngineABC:
             )[0]
             original_store_id = original_row["store_id"]
             assert engine._last_compacted_store_id > original_store_id
+            first_frontier = engine._last_compacted_store_id
             assert first_active_context[1]["content"] == original_user
 
             second_messages = first_active_context + [
@@ -3827,6 +3830,7 @@ class TestEngineABC:
             engine.compress(second_messages)
 
             second_node = engine._dag.get_session_nodes(engine._session_id)[-1]
+            assert engine._last_compacted_store_id >= first_frontier
             expanded = json.loads(
                 engine.handle_tool_call("lcm_expand", {"node_id": second_node.node_id})
             )
@@ -3997,6 +4001,68 @@ class TestEngineABC:
         assert engine.last_compression_status == "overflow_recovery"
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
+
+    def test_two_message_overflow_anchor_restart_does_not_duplicate_durable_rows(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "two-message-overflow-anchor-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=0,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "two-message-overflow-anchor-session",
+            platform="cli",
+            conversation_id="two-message-overflow-anchor-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (
+                "Overflow summary " + "x" * 1000 + "\nExpand for details about: overflow anchor",
+                1,
+            ),
+        )
+
+        user_query = "render this request with at least one user message"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest derived output " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert [msg.get("role") for msg in active_context] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "two-message-overflow-anchor-session",
+            platform="cli",
+            conversation_id="two-message-overflow-anchor-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(active_context)
+            rows = after_restart._store.get_session_messages(
+                "two-message-overflow-anchor-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages)
+        assert [row["content"] for row in rows].count(user_query) == 1
 
     def test_overflow_recovery_keeps_sole_user_inside_fresh_tail(self, tmp_path, monkeypatch):
         config = LCMConfig(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3918,6 +3918,85 @@ class TestEngineABC:
             == 1
         )
 
+    def test_second_compaction_keeps_legacy_blank_former_anchor_lineage_after_rebind(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=40,
+            database_path=str(tmp_path / "legacy-former-anchor-lineage.db"),
+        )
+        session_id = "legacy-former-anchor-lineage-session"
+        conversation_id = "legacy-former-anchor-lineage-conversation"
+        summaries = iter([
+            "First-stage assistant summary.\nExpand for details about: initial work",
+            "Second-stage user summary.\nExpand for details about: original request",
+        ])
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (next(summaries), 1),
+        )
+        original_user = "diagnose the legacy Qwen template failure"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": original_user},
+            {"role": "assistant", "content": "checking logs " + "detail " * 30},
+            {"role": "assistant", "content": "checking template " + "detail " * 30},
+            {"role": "assistant", "content": "still investigating " + "detail " * 30},
+            {"role": "assistant", "content": "first-stage tail " + "detail " * 30},
+        ]
+
+        before_rebind = LCMEngine(config=config)
+        before_rebind.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        try:
+            first_active_context = before_rebind.compress(messages)
+            original_row = before_rebind._store.get_session_nonblank_role_messages(
+                session_id,
+                "user",
+                limit=1,
+            )[0]
+            original_store_id = original_row["store_id"]
+            before_rebind._store._conn.execute(
+                "UPDATE messages SET conversation_id = '' WHERE session_id = ?",
+                (session_id,),
+            )
+            before_rebind._store._conn.commit()
+        finally:
+            before_rebind.shutdown()
+
+        after_rebind = LCMEngine(config=config)
+        after_rebind.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        second_messages = first_active_context + [
+            {"role": "user", "content": "now inspect the durable legacy lineage"},
+            {"role": "assistant", "content": "checking source ids"},
+            {"role": "assistant", "content": "checking expansion"},
+        ]
+        try:
+            assert after_rebind._leading_anchor_count(second_messages) == 1
+            after_rebind.compress(second_messages)
+            second_node = after_rebind._dag.get_session_nodes(session_id)[-1]
+            expanded = json.loads(
+                after_rebind.handle_tool_call("lcm_expand", {"node_id": second_node.node_id})
+            )
+        finally:
+            after_rebind.shutdown()
+
+        assert original_store_id in second_node.source_ids
+        assert any(item["content"] == original_user for item in expanded["expanded"])
+
     def test_compaction_preserves_literal_summary_shaped_user_source_lineage(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3886,6 +3886,56 @@ class TestEngineABC:
             == 1
         )
 
+    def test_compaction_preserves_literal_summary_shaped_user_source_lineage(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        engine = LCMEngine(
+            config=LCMConfig(
+                fresh_tail_count=1,
+                leaf_chunk_tokens=1,
+                database_path=str(tmp_path / "literal-summary-shaped-user-lineage.db"),
+            )
+        )
+        engine.on_session_start(
+            "literal-summary-shaped-user-lineage-session",
+            platform="cli",
+            conversation_id="literal-summary-shaped-user-lineage-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Compacted literal summary paste.\nExpand for details about: paste", 1),
+        )
+        literal_summary = (
+            "[Recent Summary (d0, node 999)]\n"
+            "This is literal user-authored content, not generated replay scaffolding.\n"
+            "[Expand for details: literal paste]"
+        )
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": literal_summary},
+            {"role": "assistant", "content": "acknowledging the literal paste"},
+            {"role": "user", "content": "fresh tail"},
+        ]
+
+        try:
+            engine.compress(messages)
+            literal_row = next(
+                row
+                for row in engine._store.get_session_messages(engine._session_id)
+                if row["content"] == literal_summary
+            )
+            node = engine._dag.get_session_nodes(engine._session_id)[-1]
+            expanded = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node.node_id}))
+        finally:
+            engine.shutdown()
+
+        assert literal_row["store_id"] in node.source_ids
+        assert any(item["content"] == literal_summary for item in expanded["expanded"])
+
     def _single_initial_user_restart_fixture(
         self,
         tmp_path,
@@ -6747,6 +6797,10 @@ class TestMessageFiltering:
             {"role": "user", "content": "SECRET ignored objective must not be preserved"},
             {"role": "user", "content": "fresh visible request"},
         ]
+        # Model a scaffold carried from the prior active replay rather than a
+        # new raw message that merely has scaffold-shaped literal content.
+        engine._remember_active_replay_messages(messages[:1], messages[:1])
+        engine._ingest_cursor = 1
 
         result = engine.compress(messages, current_tokens=count_messages_tokens(messages))
         result_text = "\n".join(str(msg.get("content", "")) for msg in result)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4906,6 +4906,98 @@ class TestEngineABC:
         ) == 1
         assert sum(row["content"] == durable[1]["content"] for row in rows) == 1
 
+    def test_restart_changed_system_snapshot_with_appended_turn_suppresses_only_replay(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "changed-system-snapshot-appended-turn.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "changed-system-snapshot-appended-turn-session"
+        conversation_id = "changed-system-snapshot-appended-turn-conversation"
+        durable = [
+            {"role": "system", "content": "Original system."},
+            {"role": "user", "content": "Durable user turn."},
+            {"role": "assistant", "content": "Durable assistant turn."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            before._write_active_replay_snapshot(durable)
+        finally:
+            before.shutdown()
+
+        changed_system = {"role": "system", "content": "Changed system."}
+        appended_turn = {"role": "user", "content": "New turn after restart."}
+        incoming = [changed_system, *durable[1:], appended_turn]
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages(incoming)
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+            reconciliation = after._last_ingest_reconciliation
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(durable) + 2
+        assert reconciliation["action"] == "advanced cursor"
+        assert sum(row["content"] == durable[1]["content"] for row in rows) == 1
+        assert sum(row["content"] == durable[2]["content"] for row in rows) == 1
+        assert sum(row["content"] == changed_system["content"] for row in rows) == 1
+        assert sum(row["content"] == appended_turn["content"] for row in rows) == 1
+
+    def test_restart_changed_system_partial_snapshot_resemblance_remains_new_content(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "changed-system-partial-snapshot-resemblance.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "changed-system-partial-snapshot-resemblance-session"
+        conversation_id = "changed-system-partial-snapshot-resemblance-conversation"
+        durable = [
+            {"role": "system", "content": "Original system."},
+            {"role": "user", "content": "Repeated-looking user turn."},
+            {"role": "assistant", "content": "Original assistant turn."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            before._write_active_replay_snapshot(durable)
+        finally:
+            before.shutdown()
+
+        incoming = [
+            {"role": "system", "content": "Changed system."},
+            dict(durable[1]),
+            {"role": "assistant", "content": "Genuinely new assistant turn."},
+            {"role": "user", "content": "Genuinely new user turn."},
+        ]
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages(incoming)
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+            reconciliation = after._last_ingest_reconciliation
+        finally:
+            after.shutdown()
+
+        assert len(rows) == len(durable) + len(incoming)
+        assert reconciliation["reason"] == "persisted ambiguous delta"
+        assert sum(row["content"] == durable[1]["content"] for row in rows) == 2
+        assert [row["content"] for row in rows[-2:]] == [
+            "Genuinely new assistant turn.",
+            "Genuinely new user turn.",
+        ]
+
     def test_restart_skips_generated_structured_system_annotation(self, tmp_path):
         db_path = tmp_path / "structured-lcm-system-replay.db"
         config = LCMConfig(database_path=str(db_path))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,10 +3774,17 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
-    def _single_initial_user_restart_fixture(self, tmp_path, monkeypatch, db_name):
+    def _single_initial_user_restart_fixture(
+        self,
+        tmp_path,
+        monkeypatch,
+        db_name,
+        *,
+        fresh_tail_count=4,
+    ):
         db_path = tmp_path / db_name
         config = LCMConfig(
-            fresh_tail_count=4,
+            fresh_tail_count=fresh_tail_count,
             leaf_chunk_tokens=1,
             database_path=str(db_path),
         )
@@ -3866,6 +3873,32 @@ class TestEngineABC:
         assert len(rows) == len(messages) + 1
         assert [row["content"] for row in rows].count(user_query) == 1
         assert rows[-1]["content"] == followup["content"]
+        assert all("[Recent Summary" not in row["content"] for row in rows)
+
+    def test_single_initial_user_anchor_restart_repeated_assistant_persists_delta_once(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        after_restart, active_context, messages, user_query = self._single_initial_user_restart_fixture(
+            tmp_path,
+            monkeypatch,
+            "single-initial-user-restart-repeated-assistant.db",
+            fresh_tail_count=0,
+        )
+        repeated_assistant = {"role": "assistant", "content": messages[-1]["content"]}
+        try:
+            assert [message["role"] for message in active_context] == ["system", "user", "assistant"]
+            assert after_restart._is_replayed_context_scaffold_message(active_context[-1])
+            after_restart._ingest_messages(active_context + [repeated_assistant])
+            rows = after_restart._store.get_session_messages("single-initial-user-restart-session")
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert [row["content"] for row in rows].count(repeated_assistant["content"]) == 2
+        assert rows[-1]["content"] == repeated_assistant["content"]
         assert all("[Recent Summary" not in row["content"] for row in rows)
 
     def test_overflow_recovery_keeps_single_initial_user_anchor(self, tmp_path):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4901,6 +4901,48 @@ class TestEngineABC:
             message["content"] for message in [*snapshot, *durable_suffix, fresh_delta]
         ]
 
+    def test_active_replay_snapshots_are_scoped_by_conversation(self, tmp_path):
+        db_path = tmp_path / "conversation-scoped-active-replay-snapshot.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "shared-replay-snapshot-session"
+        conversation_a = "shared-replay-snapshot-conversation-a"
+        conversation_b = "shared-replay-snapshot-conversation-b"
+        snapshot_a = [
+            {"role": "system", "content": "Conversation A system."},
+            {"role": "user", "content": "Conversation A request."},
+        ]
+        snapshot_b = [
+            {"role": "system", "content": "Conversation B system."},
+            {"role": "user", "content": "Conversation B request."},
+        ]
+
+        writer_a = LCMEngine(config=config)
+        writer_a.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_a, context_length=200000
+        )
+        try:
+            writer_a._write_active_replay_snapshot(snapshot_a)
+        finally:
+            writer_a.shutdown()
+
+        writer_b = LCMEngine(config=config)
+        writer_b.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_b, context_length=200000
+        )
+        try:
+            writer_b._write_active_replay_snapshot(snapshot_b)
+        finally:
+            writer_b.shutdown()
+
+        reader_a = LCMEngine(config=config)
+        reader_a.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_a, context_length=200000
+        )
+        try:
+            assert reader_a._historical_active_replay_cursor(snapshot_a) == len(snapshot_a)
+        finally:
+            reader_a.shutdown()
+
     def test_restart_compacted_snapshot_reconciles_durable_suffix_and_new_delta(self, tmp_path):
         db_path = tmp_path / "compacted-snapshot-durable-suffix.db"
         config = LCMConfig(database_path=str(db_path))
@@ -12370,6 +12412,70 @@ class TestEngineCompress:
         assert durable[-1]["content"] in json.dumps(expanded)
         assert "Generated replay material." not in nodes[-1].summary
 
+    def test_generated_summary_scaffold_restores_none_content_tool_call_tail(self, engine):
+        tool_call = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_none_content",
+                "type": "function",
+                "function": {"name": "terminal", "arguments": "{\"command\":\"true\"}"},
+            }],
+        }
+        tool_call_store_id = engine._store.append(engine._session_id, tool_call)
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id=engine._session_id,
+            depth=0,
+            summary="Generated tool-call replay material.",
+            token_count=4,
+            source_token_count=4,
+            source_ids=[tool_call_store_id],
+            source_type="messages",
+            expand_hint="earlier tool work",
+        ))
+        coalesced = {
+            **tool_call,
+            "content": (
+                f"[Recent Summary (d0, node {node_id})]\n"
+                "Generated tool-call replay material.\n"
+                "[Expand for details: earlier tool work]"
+            ),
+        }
+        restored = engine._strip_coalesced_generated_summary_scaffold(
+            coalesced
+        )
+
+        assert coalesced["content"].startswith("[Recent Summary")
+        assert coalesced["tool_calls"] == tool_call["tool_calls"]
+        assert restored["content"] is None
+        assert restored["tool_calls"] == tool_call["tool_calls"]
+
+    def test_generated_summary_scaffold_preserves_genuine_assistant_quotation(self, engine):
+        node_id = engine._dag.add_node(SummaryNode(
+            session_id=engine._session_id,
+            depth=0,
+            summary="Exact generated summary text.",
+            token_count=4,
+            source_token_count=4,
+            source_ids=[],
+            source_type="messages",
+            expand_hint="quoted summary details",
+        ))
+        summary = (
+            f"[Recent Summary (d0, node {node_id})]\n"
+            "Exact generated summary text.\n"
+            "[Expand for details: quoted summary details]"
+        )
+        quotation = {
+            "role": "assistant",
+            "content": summary + "\n\nThis is genuine assistant commentary about the summary.",
+        }
+        engine._store.append(engine._session_id, quotation)
+
+        restored = engine._strip_coalesced_generated_summary_scaffold(quotation)
+
+        assert restored == quotation
+
     def test_compaction_restores_assistant_tool_tail_coalesced_with_preserved_objective(
         self,
         tmp_path,
@@ -14294,6 +14400,46 @@ class TestStoreIdMapping:
         assert pre_frontier_sources == {}
         assert ids_by_message_id[id(active_duplicate)] == later_duplicate_id
         assert ids_by_message_id[id(active_later_user)] == later_user_id
+
+    def test_former_anchor_mapping_precedes_repeated_user_suffix_scan(self, engine):
+        engine._conversation_id = "former-anchor-conversation"
+        initial_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "repeat"},
+            conversation_id=engine._conversation_id,
+        )
+        engine._last_compacted_store_id = initial_store_id
+        intervening_assistant_id = engine._store.append(
+            "test-session",
+            {"role": "assistant", "content": "intervening durable answer"},
+            conversation_id=engine._conversation_id,
+        )
+        later_duplicate_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "repeat"},
+            conversation_id=engine._conversation_id,
+        )
+        engine._store.append(
+            "test-session",
+            {"role": "user", "content": "repeat"},
+            conversation_id="other-conversation-sharing-session",
+        )
+        former_anchor = {"role": "user", "content": "repeat"}
+        intervening_assistant = {
+            "role": "assistant",
+            "content": "intervening durable answer",
+        }
+        later_duplicate = {"role": "user", "content": "repeat"}
+
+        ids_by_message_id = engine._get_store_id_map_for_messages([
+            former_anchor,
+            intervening_assistant,
+            later_duplicate,
+        ])
+
+        assert ids_by_message_id[id(former_anchor)] == initial_store_id
+        assert ids_by_message_id[id(intervening_assistant)] == intervening_assistant_id
+        assert ids_by_message_id[id(later_duplicate)] == later_duplicate_id
 
     def test_singleton_externalized_placeholder_does_not_skip_later_visible_row(self, engine):
         placeholder = (

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3808,6 +3808,38 @@ class TestEngineABC:
         finally:
             engine.shutdown()
 
+    def test_single_user_anchor_falls_back_to_legacy_blank_conversation_rows(self, tmp_path):
+        engine = LCMEngine(
+            config=LCMConfig(database_path=str(tmp_path / "legacy-blank-anchor.db"))
+        )
+        session_id = "legacy-blank-anchor"
+        initial_user = {"role": "user", "content": "legacy initial request"}
+        engine._store.append_batch(
+            session_id,
+            [
+                {"role": "system", "content": "You are concise."},
+                initial_user,
+                {"role": "assistant", "content": "initial response"},
+                {"role": "user", "content": "legacy follow-up request"},
+            ],
+            conversation_id="",
+        )
+        engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="current-anchor-conversation",
+            context_length=200000,
+        )
+
+        try:
+            assert engine._leading_anchor_count([
+                {"role": "system", "content": "You are concise."},
+                initial_user,
+                {"role": "assistant", "content": "working"},
+            ]) == 1
+        finally:
+            engine.shutdown()
+
     def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4901,6 +4901,103 @@ class TestEngineABC:
             message["content"] for message in [*snapshot, *durable_suffix, fresh_delta]
         ]
 
+    def test_restart_compacted_snapshot_reconciles_durable_suffix_and_new_delta(self, tmp_path):
+        db_path = tmp_path / "compacted-snapshot-durable-suffix.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "compacted-snapshot-durable-suffix-session"
+        conversation_id = "compacted-snapshot-durable-suffix-conversation"
+        durable = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Durable request."},
+            {"role": "assistant", "content": "Durable assistant tail."},
+        ]
+        durable_suffix = {"role": "user", "content": "Already durable follow-up."}
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            store_ids = before._store.append_batch(
+                session_id, [*durable, durable_suffix], conversation_id=conversation_id
+            )
+            before._dag.add_node(SummaryNode(
+                session_id=session_id,
+                depth=0,
+                summary="Generated compacted history.",
+                token_count=4,
+                source_token_count=4,
+                source_ids=[store_ids[0]],
+                source_type="messages",
+                expand_hint="older context",
+            ))
+            snapshot = before._assemble_context(
+                durable[0], [durable[-1]], leading_anchor_messages=durable[:2]
+            )
+            before._write_active_replay_snapshot(snapshot)
+        finally:
+            before.shutdown()
+
+        assert "Generated compacted history." in snapshot[-1]["content"]
+        assert durable[-1]["content"] in snapshot[-1]["content"]
+
+        fresh_delta = {"role": "assistant", "content": "Fresh response after restart."}
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages([*snapshot, durable_suffix, fresh_delta])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert [row["content"] for row in rows] == [
+            message["content"] for message in [*durable, durable_suffix, fresh_delta]
+        ]
+
+    def test_restart_snapshot_suffix_proof_ignores_filtered_durable_rows(self, tmp_path):
+        db_path = tmp_path / "snapshot-filtered-durable-suffix.db"
+        config = LCMConfig(
+            database_path=str(db_path), ignore_message_patterns=["^Cronjob Response:"]
+        )
+        session_id = "snapshot-filtered-durable-suffix-session"
+        conversation_id = "snapshot-filtered-durable-suffix-conversation"
+        snapshot = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Durable request."},
+        ]
+        ignored = {"role": "user", "content": "Cronjob Response: old heartbeat"}
+        visible_suffix = {"role": "assistant", "content": "Already durable response."}
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(
+                session_id,
+                [*snapshot, ignored, visible_suffix],
+                conversation_id=conversation_id,
+            )
+            before._write_active_replay_snapshot(snapshot)
+        finally:
+            before.shutdown()
+
+        fresh_delta = {"role": "user", "content": "Fresh request after restart."}
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages([*snapshot, visible_suffix, fresh_delta])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert [row["content"] for row in rows] == [
+            message["content"]
+            for message in [*snapshot, ignored, visible_suffix, fresh_delta]
+        ]
+
     def test_restart_snapshot_prefix_uses_full_alignment_before_suppressing_suffix(
         self, tmp_path
     ):
@@ -12263,6 +12360,88 @@ class TestEngineCompress:
         assert store_ids[-1] in nodes[-1].source_ids
         assert durable[-1]["content"] in json.dumps(expanded)
         assert "Generated replay material." not in nodes[-1].summary
+
+    def test_compaction_restores_assistant_tool_tail_coalesced_with_preserved_objective(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            database_path=str(tmp_path / "coalesced-objective-tool-tail.db"),
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+        )
+        session_id = "coalesced-objective-tool-tail-session"
+        conversation_id = "coalesced-objective-tool-tail-conversation"
+        objective = {"role": "user", "content": "Preserve the current objective."}
+        tool_call = {
+            "role": "assistant",
+            "content": "Running the required tool.",
+            "tool_calls": [{
+                "id": "call_preserved",
+                "type": "function",
+                "function": {"name": "terminal", "arguments": "{\"command\":\"true\"}"},
+            }],
+        }
+        tool_result = {
+            "role": "tool",
+            "tool_call_id": "call_preserved",
+            "content": "Tool result must remain durable.",
+        }
+        durable = [
+            {"role": "system", "content": "System anchor."},
+            objective,
+            {"role": "user", "content": "Provider-visible user anchor."},
+            tool_call,
+            tool_result,
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(session_id, durable, conversation_id=conversation_id)
+            before._pending_context_anchor_messages = [objective]
+            active_context = before._assemble_context(
+                durable[0],
+                [tool_call, tool_result],
+                leading_anchor_messages=[durable[0], durable[2]],
+            )
+            before._write_active_replay_snapshot(active_context)
+        finally:
+            before.shutdown()
+
+        assert "[Current user objective preserved" in active_context[-2]["content"]
+        assert active_context[-2]["tool_calls"] == tool_call["tool_calls"]
+        assert active_context[-1] == tool_result
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Compacted tool work.\nExpand for details about: tool result", 1),
+        )
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after.compress(
+                [*active_context, {"role": "user", "content": "Fresh user delta."}],
+                force=True,
+            )
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+            nodes = after._dag.get_session_nodes(session_id)
+        finally:
+            after.shutdown()
+
+        assert sum(row["content"] == tool_call["content"] for row in rows) == 1
+        assert sum(row["content"] == tool_result["content"] for row in rows) == 1
+        assert rows[3]["tool_calls"] == tool_call["tool_calls"]
+        assert rows[4]["tool_call_id"] == tool_result["tool_call_id"]
+        assert any(
+            store_id in nodes[-1].source_ids
+            for store_id in (rows[3]["store_id"], rows[4]["store_id"])
+        )
 
     def test_compression_serialization_skips_empty_assistant_and_heartbeat_noise(self, engine):
         messages = [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3827,7 +3827,7 @@ class TestEngineABC:
                 {"role": "assistant", "content": "checking expansion"},
             ]
             assert engine._leading_anchor_count(second_messages) == 1
-            engine.compress(second_messages)
+            second_active_context = engine.compress(second_messages)
 
             second_node = engine._dag.get_session_nodes(engine._session_id)[-1]
             assert engine._last_compacted_store_id >= first_frontier
@@ -3839,6 +3839,12 @@ class TestEngineABC:
 
         assert original_store_id in second_node.source_ids
         assert any(item["content"] == original_user for item in expanded["expanded"])
+        assert (
+            "\n".join(str(message.get("content", "")) for message in second_active_context).count(
+                "First-stage assistant summary."
+            )
+            == 1
+        )
 
     def _single_initial_user_restart_fixture(
         self,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4295,6 +4295,59 @@ class TestEngineABC:
         assert len(rows) == len(shared_prefix)
         assert all(not row["conversation_id"] for row in rows)
 
+    def test_restart_reconciles_legacy_anchor_prefix_with_current_conversation_tail(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "mixed-legacy-current-restart.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "mixed-legacy-current-restart"
+        conversation_id = "current-conversation"
+        legacy_anchor = [
+            {"role": "system", "content": "Legacy system prompt."},
+            {"role": "user", "content": "legacy first request"},
+        ]
+
+        seed_engine = LCMEngine(config=config)
+        try:
+            seed_engine._store.append_batch(
+                session_id,
+                legacy_anchor,
+                conversation_id="",
+            )
+            seed_engine._store.append(
+                session_id,
+                {"role": "assistant", "content": "current durable tail"},
+                conversation_id=conversation_id,
+            )
+            seed_engine._store.append_batch(
+                session_id,
+                legacy_anchor,
+                conversation_id="unrelated-conversation",
+            )
+        finally:
+            seed_engine.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(legacy_anchor)
+            rows = after_restart._store.get_session_messages(session_id)
+            reconciliation = after_restart._last_ingest_reconciliation
+        finally:
+            after_restart.shutdown()
+
+        assert reconciliation["action"] == "advanced cursor"
+        assert reconciliation["cursor"] == len(legacy_anchor)
+        assert reconciliation["session_count"] == 3
+        assert len(rows) == 5
+        assert [row["conversation_id"] for row in rows].count(conversation_id) == 1
+
     def test_single_initial_user_anchor_restart_one_followup_only_persists_delta(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4092,6 +4092,98 @@ class TestEngineABC:
             "current-conversation",
         ]
 
+    def test_reused_session_new_conversation_does_not_reconcile_against_prior_conversation(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "reused-session-new-conversation.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "reused-session-new-conversation"
+        shared_prefix = [
+            {"role": "system", "content": "Shared system prompt."},
+            {"role": "user", "content": "shared first request"},
+        ]
+
+        old_engine = LCMEngine(config=config)
+        old_engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="old-conversation",
+            context_length=200000,
+        )
+        try:
+            old_engine._ingest_messages(shared_prefix)
+        finally:
+            old_engine.shutdown()
+
+        current_engine = LCMEngine(config=config)
+        current_engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="current-conversation",
+            context_length=200000,
+        )
+        try:
+            current_engine._ingest_messages(shared_prefix)
+            current_rows = current_engine._store.get_session_messages(
+                session_id,
+                conversation_id="current-conversation",
+            )
+            all_rows = current_engine._store.get_session_messages(session_id)
+            ingest_cursor = current_engine._ingest_cursor
+        finally:
+            current_engine.shutdown()
+
+        assert ingest_cursor == len(shared_prefix)
+        assert [row["role"] for row in current_rows] == ["system", "user"]
+        assert [row["content"] for row in current_rows] == [
+            "Shared system prompt.",
+            "shared first request",
+        ]
+        assert all(row["conversation_id"] == "current-conversation" for row in current_rows)
+        assert len(all_rows) == 4
+
+    def test_reused_session_new_conversation_reconciles_legacy_blank_conversation_rows(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "reused-session-legacy-blank-conversation.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "reused-session-legacy-blank-conversation"
+        shared_prefix = [
+            {"role": "system", "content": "Legacy system prompt."},
+            {"role": "user", "content": "legacy first request"},
+        ]
+
+        seed_engine = LCMEngine(config=config)
+        try:
+            seed_engine._store.append_batch(
+                session_id,
+                shared_prefix,
+                conversation_id="",
+            )
+        finally:
+            seed_engine.shutdown()
+
+        current_engine = LCMEngine(config=config)
+        current_engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id="current-conversation",
+            context_length=200000,
+        )
+        try:
+            current_engine._ingest_messages(shared_prefix)
+            rows = current_engine._store.get_session_messages(session_id)
+            reconciliation = current_engine._last_ingest_reconciliation
+        finally:
+            current_engine.shutdown()
+
+        assert reconciliation["action"] == "advanced cursor"
+        assert reconciliation["cursor"] == len(shared_prefix)
+        assert len(rows) == len(shared_prefix)
+        assert all(not row["conversation_id"] for row in rows)
+
     def test_single_initial_user_anchor_restart_one_followup_only_persists_delta(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3726,6 +3726,133 @@ class TestEngineABC:
         assert "Current user objective preserved" in combined_context
         assert latest_request in combined_context
 
+    def test_compaction_preserves_single_initial_user_query_anchor(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "single-initial-user-anchor.db"
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "single-initial-user-anchor-session",
+            platform="cli",
+            conversation_id="single-initial-user-anchor-conversation",
+            context_length=200000,
+        )
+
+        def mock_summary(**kwargs):
+            return "Assistant/tool chain summary.\nExpand for details about: qwen anchor", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        user_query = "diagnose why the Qwen template rejects this request"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {
+                "role": "assistant",
+                "content": "checking logs",
+                "tool_calls": [{"id": "call_logs", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_logs", "content": "log output " + "x" * 200},
+            {
+                "role": "assistant",
+                "content": "checking template",
+                "tool_calls": [{"id": "call_template", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_template", "content": "template output"},
+            {"role": "assistant", "content": "still investigating"},
+            {"role": "assistant", "content": "final diagnostic"},
+        ]
+        try:
+            assert engine._leading_anchor_count(messages) == 2
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+
+    def test_overflow_recovery_keeps_single_initial_user_anchor(self, tmp_path):
+        db_path = tmp_path / "single-initial-user-overflow-anchor.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "single-initial-user-overflow-anchor-session",
+            platform="cli",
+            conversation_id="single-initial-user-overflow-anchor-conversation",
+            context_length=200000,
+        )
+
+        user_query = "render this request with at least one user message"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest derived output " + "z" * 4000},
+        ]
+        try:
+            assert engine._leading_anchor_count(messages) == 2
+            assert engine.should_compress_preflight(messages)
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert engine.last_compression_status == "overflow_recovery"
+        assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+
+    def test_later_user_keeps_initial_user_compactable(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "later-user-keeps-initial-compactable.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=1,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "later-user-keeps-initial-compactable-session",
+            platform="cli",
+            conversation_id="later-user-keeps-initial-compactable-conversation",
+            context_length=200000,
+        )
+
+        def mock_summary(**kwargs):
+            return "Earlier user request summary.\nExpand for details about: stale setup", 1
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+
+        stale_first_request = "set up the old webhook automation"
+        latest_request = "instead audit the active LCM context"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": stale_first_request},
+            {"role": "assistant", "content": "I will set up the webhook."},
+            {"role": "user", "content": latest_request},
+            {"role": "assistant", "content": "checking active context"},
+            {"role": "assistant", "content": "done"},
+        ]
+        try:
+            assert engine._leading_anchor_count(messages) == 1
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert active_context[1].get("content") != stale_first_request
+        assert not any(
+            msg.get("role") == "user" and msg.get("content") == stale_first_request
+            for msg in active_context
+        )
+        combined_context = "\n".join(str(msg.get("content", "")) for msg in active_context)
+        assert latest_request in combined_context
+
     def test_preserved_objective_anchor_externalizes_inline_payloads(self, tmp_path):
         db_path = tmp_path / "preserved-objective-payload.db"
         data_uri = "data:image/png;base64," + ("QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=" * 20)
@@ -19929,7 +20056,10 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, leading_anchor_messages=None, assembly_cap_override=None, include_lcm_note=True: [
+                *(leading_anchor_messages or ([system_msg] if system_msg is not None else [])),
+                *tail_messages,
+            ],
         )
 
         compressed = engine.compress(self._make_backlog_messages())
@@ -19956,7 +20086,10 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, leading_anchor_messages=None, assembly_cap_override=None, include_lcm_note=True: [
+                *(leading_anchor_messages or ([system_msg] if system_msg is not None else [])),
+                *tail_messages,
+            ],
         )
 
         first = engine.compress(self._make_backlog_messages())
@@ -19991,7 +20124,10 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, leading_anchor_messages=None, assembly_cap_override=None, include_lcm_note=True: [
+                *(leading_anchor_messages or ([system_msg] if system_msg is not None else [])),
+                *tail_messages,
+            ],
         )
 
         engine.compress(self._make_backlog_messages())
@@ -20023,7 +20159,10 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, leading_anchor_messages=None, assembly_cap_override=None, include_lcm_note=True: [
+                *(leading_anchor_messages or ([system_msg] if system_msg is not None else [])),
+                *tail_messages,
+            ],
         )
 
         compressed = engine.compress(messages, current_tokens=90)
@@ -20058,7 +20197,10 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, leading_anchor_messages=None, assembly_cap_override=None, include_lcm_note=True: [
+                *(leading_anchor_messages or ([system_msg] if system_msg is not None else [])),
+                *tail_messages,
+            ],
         )
 
         engine.compress(messages, current_tokens=90)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,6 +3774,40 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    def test_single_user_anchor_ignores_prior_conversation_on_reused_session(self, tmp_path):
+        engine = LCMEngine(
+            config=LCMConfig(database_path=str(tmp_path / "reused-session-anchor.db"))
+        )
+        session_id = "reused-session-anchor"
+        current_conversation_id = "current-anchor-conversation"
+        engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=current_conversation_id,
+            context_length=200000,
+        )
+        engine._store.append(
+            session_id,
+            {"role": "user", "content": "user from an earlier conversation"},
+            conversation_id="prior-anchor-conversation",
+        )
+        current_user = {"role": "user", "content": "only user in the active conversation"}
+        engine._store.append(
+            session_id,
+            current_user,
+            conversation_id=current_conversation_id,
+        )
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            current_user,
+            {"role": "assistant", "content": "working"},
+        ]
+
+        try:
+            assert engine._leading_anchor_count(messages) == 2
+        finally:
+            engine.shutdown()
+
     def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
@@ -4151,7 +4185,7 @@ class TestEngineABC:
         ],
         ids=["no-delta", "new-delta"],
     )
-    def test_frontier_zero_overflow_anchor_restart_skips_generated_summary_scaffold(
+    def test_frontier_zero_overflow_anchor_restart_preserves_ambiguous_summary_shaped_assistant(
         self,
         tmp_path,
         followup,
@@ -4214,9 +4248,12 @@ class TestEngineABC:
         finally:
             after_restart.shutdown()
 
-        assert len(rows) == len(messages) + (1 if followup is not None else 0)
+        assert len(rows) == len(messages) + 1 + (1 if followup is not None else 0)
         assert [row["content"] for row in rows].count(user_query) == 1
-        assert all("[Recent Summary" not in row["content"] for row in rows)
+        assert sum(
+            row["role"] == "assistant" and row["content"] == summary_scaffold["content"]
+            for row in rows
+        ) == 1
         if followup is not None:
             assert rows[-1]["content"] == followup["content"]
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4013,6 +4013,43 @@ class TestEngineABC:
         assert rows[-1]["content"] == repeated_assistant["content"]
         assert all("[Recent Summary" not in row["content"] for row in rows)
 
+    def test_compacted_restart_raw_anchor_preserves_summary_shaped_assistant_delta(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        after_restart, _active_context, messages, user_query = (
+            self._single_initial_user_restart_fixture(
+                tmp_path,
+                monkeypatch,
+                "single-initial-user-restart-summary-shaped-assistant.db",
+            )
+        )
+        raw_anchor = messages[:2]
+        summary_shaped_assistant = {
+            "role": "assistant",
+            "content": (
+                "[Recent Summary (d0, node 999)]\n"
+                "This is a new real assistant delta after restart.\n"
+                "[Expand for details: literal assistant response]"
+            ),
+        }
+        try:
+            assert after_restart._last_compacted_store_id > 0
+            assert not after_restart._is_replayed_context_scaffold_message(raw_anchor[0])
+            assert after_restart._is_replayed_context_scaffold_message(summary_shaped_assistant)
+            after_restart._ingest_messages(raw_anchor + [summary_shaped_assistant])
+            rows = after_restart._store.get_session_messages(
+                "single-initial-user-restart-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert rows[-1]["role"] == "assistant"
+        assert rows[-1]["content"] == summary_shaped_assistant["content"]
+
     def test_overflow_recovery_keeps_single_initial_user_anchor(self, tmp_path):
         db_path = tmp_path / "single-initial-user-overflow-anchor.db"
         config = LCMConfig(

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5045,6 +5045,55 @@ class TestEngineABC:
         assert sum(row["content"] == appended_turn["content"] for row in reconciled_rows) == 1
         assert sum(row["content"] == later_delta["content"] for row in rows) == 1
 
+    def test_restart_changed_system_snapshot_suppresses_durable_suffix_and_keeps_delta(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "changed-system-snapshot-durable-suffix.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "changed-system-snapshot-durable-suffix-session"
+        conversation_id = "changed-system-snapshot-durable-suffix-conversation"
+        snapshot = [
+            {"role": "system", "content": "Original system."},
+            {"role": "user", "content": "Durable user turn."},
+        ]
+        durable_suffix = {"role": "assistant", "content": "Durable assistant suffix."}
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(
+                session_id,
+                [*snapshot, durable_suffix],
+                conversation_id=conversation_id,
+            )
+            before._write_active_replay_snapshot(snapshot)
+        finally:
+            before.shutdown()
+
+        changed_system = {"role": "system", "content": "Changed system."}
+        new_delta = {"role": "user", "content": "Genuinely new trailing delta."}
+        incoming = [changed_system, snapshot[1], durable_suffix, new_delta]
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after._ingest_messages(incoming)
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert [row["content"] for row in rows] == [
+            snapshot[0]["content"],
+            snapshot[1]["content"],
+            durable_suffix["content"],
+            changed_system["content"],
+            new_delta["content"],
+        ]
+        assert sum(row["content"] == durable_suffix["content"] for row in rows) == 1
+
     def test_restart_changed_system_partial_snapshot_resemblance_remains_new_content(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3887,7 +3887,24 @@ class TestEngineABC:
         finally:
             engine.shutdown()
 
-    def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        "original_user",
+        [
+            "diagnose the original Qwen template failure",
+            (
+                "[Recent Summary (d0, node 999)]\n"
+                "Treat this literal text as the original Qwen request.\n"
+                "[Expand for details: literal original request]"
+            ),
+        ],
+        ids=["plain-user", "literal-summary-shaped-user"],
+    )
+    def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(
+        self,
+        tmp_path,
+        monkeypatch,
+        original_user,
+    ):
         config = LCMConfig(
             fresh_tail_count=2,
             leaf_chunk_tokens=40,
@@ -3916,7 +3933,6 @@ class TestEngineABC:
             "summarize_with_escalation",
             mock_summary,
         )
-        original_user = "diagnose the original Qwen template failure"
         messages = [
             {"role": "system", "content": "You are concise."},
             {"role": "user", "content": original_user},
@@ -3957,7 +3973,7 @@ class TestEngineABC:
         assert original_store_id in second_node.source_ids
         assert any(item["content"] == original_user for item in expanded["expanded"])
         assert len(summary_inputs) == 2
-        assert "[Recent Summary" not in summary_inputs[1]
+        assert original_user in summary_inputs[1]
         assert (
             "\n".join(str(message.get("content", "")) for message in second_active_context).count(
                 "First-stage assistant summary."
@@ -4523,10 +4539,23 @@ class TestEngineABC:
         ],
         ids=["no-delta", "new-delta"],
     )
+    @pytest.mark.parametrize(
+        "user_query",
+        [
+            "preserve this provider anchor before the compaction frontier advances",
+            (
+                "[Recent Summary (d0, node 999)]\n"
+                "X\n"
+                "[Expand for details: x]"
+            ),
+        ],
+        ids=["plain-user", "literal-summary-shaped-user"],
+    )
     def test_frontier_zero_overflow_anchor_restart_does_not_duplicate_durable_rows(
         self,
         tmp_path,
         followup,
+        user_query,
     ):
         db_path = tmp_path / "frontier-zero-overflow-anchor-restart.db"
         config = LCMConfig(
@@ -4543,7 +4572,6 @@ class TestEngineABC:
             context_length=200000,
         )
 
-        user_query = "preserve this provider anchor before the compaction frontier advances"
         messages = [
             {"role": "system", "content": "You are concise."},
             {"role": "user", "content": user_query},
@@ -4558,8 +4586,9 @@ class TestEngineABC:
         finally:
             engine.shutdown()
 
-        assert [message.get("role") for message in active_context] == ["system", "user"]
+        assert [message.get("role") for message in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
+        assert len(active_context) < len(messages)
 
         after_restart = LCMEngine(config=config)
         after_restart.on_session_start(
@@ -4570,7 +4599,7 @@ class TestEngineABC:
         )
         try:
             assert after_restart._last_compacted_store_id == 0
-            replay = active_context + ([followup] if followup is not None else [])
+            replay = active_context[:2] + ([followup] if followup is not None else [])
             after_restart._ingest_messages(replay)
             rows = after_restart._store.get_session_messages(
                 "frontier-zero-overflow-anchor-session"

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,6 +3774,53 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    def test_compaction_preserves_literal_summary_shaped_single_user_query_anchor(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        engine = LCMEngine(
+            config=LCMConfig(
+                fresh_tail_count=4,
+                leaf_chunk_tokens=1,
+                database_path=str(tmp_path / "literal-summary-shaped-user-anchor.db"),
+            )
+        )
+        engine.on_session_start(
+            "literal-summary-shaped-user-anchor-session",
+            platform="cli",
+            conversation_id="literal-summary-shaped-user-anchor-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Assistant/tool chain summary.\nExpand for details about: literal anchor", 1),
+        )
+        user_query = (
+            "[Recent Summary (d0, node 999)]\n"
+            "Treat this literal text as my actual request.\n"
+            "[Expand for details: literal prompt]"
+        )
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "checking literal prompt"},
+            {"role": "assistant", "content": "checking prompt provenance"},
+            {"role": "assistant", "content": "checking durable source"},
+            {"role": "assistant", "content": "checking provider template"},
+            {"role": "assistant", "content": "still investigating"},
+            {"role": "assistant", "content": "final diagnostic"},
+        ]
+
+        try:
+            active_context = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+
     def test_single_user_anchor_ignores_prior_conversation_on_reused_session(self, tmp_path):
         engine = LCMEngine(
             config=LCMConfig(database_path=str(tmp_path / "reused-session-anchor.db"))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3777,9 +3777,7 @@ class TestEngineABC:
     def test_second_compaction_keeps_former_initial_user_source_lineage_and_frontier(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
-            leaf_chunk_tokens=1,
-            dynamic_leaf_chunk_enabled=True,
-            dynamic_leaf_chunk_max=1,
+            leaf_chunk_tokens=40,
             database_path=str(tmp_path / "former-initial-user-lineage.db"),
         )
         engine = LCMEngine(config=config)
@@ -3794,19 +3792,25 @@ class TestEngineABC:
             "First-stage assistant summary.\nExpand for details about: initial work",
             "Second-stage user summary.\nExpand for details about: original request",
         ])
+        summary_inputs = []
+
+        def mock_summary(**kwargs):
+            summary_inputs.append(kwargs["text"])
+            return next(summaries), 1
+
         monkeypatch.setattr(
             lcm_engine,
             "summarize_with_escalation",
-            lambda **kwargs: (next(summaries), 1),
+            mock_summary,
         )
         original_user = "diagnose the original Qwen template failure"
         messages = [
             {"role": "system", "content": "You are concise."},
             {"role": "user", "content": original_user},
-            {"role": "assistant", "content": "checking logs"},
-            {"role": "assistant", "content": "checking template"},
-            {"role": "assistant", "content": "still investigating"},
-            {"role": "assistant", "content": "first-stage tail"},
+            {"role": "assistant", "content": "checking logs " + "detail " * 30},
+            {"role": "assistant", "content": "checking template " + "detail " * 30},
+            {"role": "assistant", "content": "still investigating " + "detail " * 30},
+            {"role": "assistant", "content": "first-stage tail " + "detail " * 30},
         ]
 
         try:
@@ -3839,6 +3843,8 @@ class TestEngineABC:
 
         assert original_store_id in second_node.source_ids
         assert any(item["content"] == original_user for item in expanded["expanded"])
+        assert len(summary_inputs) == 2
+        assert "[Recent Summary" not in summary_inputs[1]
         assert (
             "\n".join(str(message.get("content", "")) for message in second_active_context).count(
                 "First-stage assistant summary."

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4859,6 +4859,48 @@ class TestEngineABC:
             repeated_restart.shutdown()
         assert len(repeated_rows) == len(rows)
 
+    def test_restart_snapshot_prefix_reconciles_already_durable_suffix(self, tmp_path):
+        db_path = tmp_path / "snapshot-prefix-durable-suffix.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "snapshot-prefix-durable-suffix-session"
+        conversation_id = "snapshot-prefix-durable-suffix-conversation"
+        snapshot = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Durable request."},
+        ]
+        durable_suffix = [
+            {"role": "assistant", "content": "Already durable response."},
+            {"role": "user", "content": "Already durable follow-up."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            before._store.append_batch(
+                session_id,
+                [*snapshot, *durable_suffix],
+                conversation_id=conversation_id,
+            )
+            before._write_active_replay_snapshot(snapshot)
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        fresh_delta = {"role": "assistant", "content": "Fresh response after replay."}
+        try:
+            after._ingest_messages([*snapshot, *durable_suffix, fresh_delta])
+            rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
+        finally:
+            after.shutdown()
+
+        assert [row["content"] for row in rows] == [
+            message["content"] for message in [*snapshot, *durable_suffix, fresh_delta]
+        ]
+
     def test_new_system_message_with_lcm_annotation_phrases_persists_exactly_once(self, tmp_path):
         db_path = tmp_path / "literal-lcm-system-phrases.db"
         config = LCMConfig(database_path=str(db_path))
@@ -12051,6 +12093,81 @@ class TestEngineCompress:
             messages.append({"role": "user", "content": f"Question {i}: " + "x" * 200})
             messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
         return messages
+
+    def test_compaction_restores_durable_tail_coalesced_with_generated_summary(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "coalesced-summary-durable-tail.db"
+        config = LCMConfig(
+            database_path=str(db_path),
+            fresh_tail_count=1,
+            leaf_chunk_tokens=1,
+        )
+        session_id = "coalesced-summary-durable-tail-session"
+        conversation_id = "coalesced-summary-durable-tail-conversation"
+        durable = [
+            {"role": "system", "content": "System anchor."},
+            {"role": "user", "content": "Initial durable request."},
+            {"role": "assistant", "content": "Genuine durable assistant tail."},
+        ]
+        before = LCMEngine(config=config)
+        before.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            store_ids = before._store.append_batch(
+                session_id, durable, conversation_id=conversation_id
+            )
+            before._dag.add_node(SummaryNode(
+                session_id=session_id,
+                depth=0,
+                summary="Generated replay material.",
+                token_count=4,
+                source_token_count=4,
+                source_ids=[store_ids[0]],
+                source_type="messages",
+                expand_hint="earlier system context",
+            ))
+            active_context = before._assemble_context(
+                durable[0],
+                [durable[-1]],
+                leading_anchor_messages=durable[:2],
+            )
+            before._write_active_replay_snapshot(active_context)
+        finally:
+            before.shutdown()
+
+        assert [message["role"] for message in active_context] == ["system", "user", "assistant"]
+        assert "Generated replay material." in active_context[-1]["content"]
+        assert durable[-1]["content"] in active_context[-1]["content"]
+
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("New compacted summary.\nExpand for details about: durable tail", 1),
+        )
+        after = LCMEngine(config=config)
+        after.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            after.compress(
+                [*active_context, {"role": "user", "content": "Fresh user turn."}],
+                force=True,
+            )
+            nodes = after._dag.get_session_nodes(session_id)
+            expanded = json.loads(
+                after.handle_tool_call("lcm_expand", {"node_id": nodes[-1].node_id})
+            )
+        finally:
+            after.shutdown()
+
+        assert len(nodes) == 2
+        assert store_ids[-1] in nodes[-1].source_ids
+        assert durable[-1]["content"] in json.dumps(expanded)
+        assert "Generated replay material." not in nodes[-1].summary
 
     def test_compression_serialization_skips_empty_assistant_and_heartbeat_noise(self, engine):
         messages = [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4987,12 +4987,21 @@ class TestEngineABC:
         after.on_session_start(
             session_id, platform="cli", conversation_id=conversation_id, context_length=200000
         )
+        matched_texts = []
+
+        class _PrefixMatcher:
+            def search(self, text, timeout=None):
+                matched_texts.append(str(text))
+                return object() if str(text).startswith("Cronjob Response:") else None
+
+        after._compiled_ignore_message_patterns = [_PrefixMatcher()]
         try:
             after._ingest_messages([*snapshot, visible_suffix, fresh_delta])
             rows = after._store.get_session_messages(session_id, conversation_id=conversation_id)
         finally:
             after.shutdown()
 
+        assert ignored["content"] in matched_texts
         assert [row["content"] for row in rows] == [
             message["content"]
             for message in [*snapshot, ignored, visible_suffix, fresh_delta]

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3774,6 +3774,68 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    def test_second_compaction_keeps_former_initial_user_source_lineage(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "former-initial-user-lineage.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "former-initial-user-lineage-session",
+            platform="cli",
+            conversation_id="former-initial-user-lineage-conversation",
+            context_length=200000,
+        )
+
+        summaries = iter([
+            "First-stage assistant summary.\nExpand for details about: initial work",
+            "Second-stage user summary.\nExpand for details about: original request",
+        ])
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: (next(summaries), 1),
+        )
+        original_user = "diagnose the original Qwen template failure"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": original_user},
+            {"role": "assistant", "content": "checking logs"},
+            {"role": "assistant", "content": "checking template"},
+            {"role": "assistant", "content": "still investigating"},
+            {"role": "assistant", "content": "first-stage tail"},
+        ]
+
+        try:
+            first_active_context = engine.compress(messages)
+            original_row = engine._store.get_session_nonblank_role_messages(
+                engine._session_id,
+                "user",
+                limit=1,
+            )[0]
+            original_store_id = original_row["store_id"]
+            assert engine._last_compacted_store_id > original_store_id
+            assert first_active_context[1]["content"] == original_user
+
+            second_messages = first_active_context + [
+                {"role": "user", "content": "now inspect the durable lineage"},
+                {"role": "assistant", "content": "checking source ids"},
+                {"role": "assistant", "content": "checking expansion"},
+            ]
+            assert engine._leading_anchor_count(second_messages) == 1
+            engine.compress(second_messages)
+
+            second_node = engine._dag.get_session_nodes(engine._session_id)[-1]
+            expanded = json.loads(
+                engine.handle_tool_call("lcm_expand", {"node_id": second_node.node_id})
+            )
+        finally:
+            engine.shutdown()
+
+        assert original_store_id in second_node.source_ids
+        assert any(item["content"] == original_user for item in expanded["expanded"])
+
     def _single_initial_user_restart_fixture(
         self,
         tmp_path,
@@ -11996,6 +12058,31 @@ class TestStoreIdMapping:
             assert all(store_id > first_max for store_id in second_node.source_ids)
         finally:
             esc._call_llm_for_summary = original_fn
+
+    def test_former_anchor_source_does_not_hijack_lone_later_duplicate(self, engine):
+        initial_store_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "repeat"},
+        )
+        engine._last_compacted_store_id = initial_store_id
+        later_duplicate_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "repeat"},
+        )
+        later_user_id = engine._store.append(
+            "test-session",
+            {"role": "user", "content": "different follow-up"},
+        )
+        active_duplicate = {"role": "user", "content": "repeat"}
+        active_later_user = {"role": "user", "content": "different follow-up"}
+        active_messages = [active_duplicate, active_later_user]
+
+        pre_frontier_sources = engine._get_formerly_anchored_user_source_map(active_messages)
+        ids_by_message_id = engine._get_store_id_map_for_messages(active_messages)
+
+        assert pre_frontier_sources == {}
+        assert ids_by_message_id[id(active_duplicate)] == later_duplicate_id
+        assert ids_by_message_id[id(active_later_user)] == later_user_id
 
     def test_singleton_externalized_placeholder_does_not_skip_later_visible_row(self, engine):
         placeholder = (

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4413,6 +4413,11 @@ class TestEngineABC:
         assert engine._is_replayed_context_scaffold_message(active_context[-1])
         assert [row["content"] for row in uncompacted_rows] == [messages[-1]["content"]]
 
+        literal_user_delta = {
+            "role": "user",
+            "content": active_context[-1]["content"],
+        }
+
         after_restart = LCMEngine(config=config)
         after_restart.on_session_start(
             "anchor-summary-omitted-tail-session",
@@ -4421,17 +4426,21 @@ class TestEngineABC:
             context_length=200000,
         )
         try:
-            after_restart._ingest_messages(active_context)
+            after_restart._ingest_messages(active_context + [literal_user_delta])
             rows = after_restart._store.get_session_messages(
                 "anchor-summary-omitted-tail-session"
             )
         finally:
             after_restart.shutdown()
 
-        assert len(rows) == len(messages)
+        assert len(rows) == len(messages) + 1
         assert [row["content"] for row in rows].count(user_query) == 1
-        assert all(
-            not after_restart._is_replayed_context_scaffold_message(row)
+        assert sum(
+            row["role"] == "user" and row["content"] == literal_user_delta["content"]
+            for row in rows
+        ) == 1
+        assert not any(
+            row["role"] == "assistant" and row["content"] == active_context[-1]["content"]
             for row in rows
         )
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4002,6 +4002,74 @@ class TestEngineABC:
         assert [msg.get("role") for msg in active_context[:2]] == ["system", "user"]
         assert active_context[1].get("content") == user_query
 
+    @pytest.mark.parametrize(
+        "followup",
+        [
+            None,
+            {"role": "user", "content": "new delta after frontier-zero replay"},
+        ],
+        ids=["no-delta", "new-delta"],
+    )
+    def test_frontier_zero_overflow_anchor_restart_does_not_duplicate_durable_rows(
+        self,
+        tmp_path,
+        followup,
+    ):
+        db_path = tmp_path / "frontier-zero-overflow-anchor-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "frontier-zero-overflow-anchor-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-conversation",
+            context_length=200000,
+        )
+
+        user_query = "preserve this provider anchor before the compaction frontier advances"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest derived output " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            assert engine.last_compression_status == "overflow_recovery"
+            assert engine._last_compacted_store_id == 0
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == ["system", "user"]
+        assert active_context[1].get("content") == user_query
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "frontier-zero-overflow-anchor-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-conversation",
+            context_length=200000,
+        )
+        try:
+            assert after_restart._last_compacted_store_id == 0
+            replay = active_context + ([followup] if followup is not None else [])
+            after_restart._ingest_messages(replay)
+            rows = after_restart._store.get_session_messages(
+                "frontier-zero-overflow-anchor-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + (1 if followup is not None else 0)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        if followup is not None:
+            assert rows[-1]["content"] == followup["content"]
+
     def test_two_message_overflow_anchor_restart_does_not_duplicate_durable_rows(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4144,6 +4144,79 @@ class TestEngineABC:
         if followup is not None:
             assert rows[-1]["content"] == followup["content"]
 
+    def test_anchor_summary_with_omitted_fresh_tail_does_not_persist_scaffold_on_restart(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        db_path = tmp_path / "anchor-summary-omitted-tail-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "anchor-summary-omitted-tail-session",
+            platform="cli",
+            conversation_id="anchor-summary-omitted-tail-conversation",
+            context_length=200000,
+        )
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **kwargs: ("Compact restart summary.\nExpand for details about: restart", 1),
+        )
+
+        user_query = "preserve this provider anchor without ingesting generated summary"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "durable omitted fresh tail " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            uncompacted_rows = engine._store.get_session_messages_after(
+                "anchor-summary-omitted-tail-session",
+                after_store_id=engine._last_compacted_store_id,
+                limit=len(messages),
+            )
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == [
+            "system",
+            "user",
+            "assistant",
+        ]
+        assert engine._is_replayed_context_scaffold_message(active_context[-1])
+        assert [row["content"] for row in uncompacted_rows] == [messages[-1]["content"]]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "anchor-summary-omitted-tail-session",
+            platform="cli",
+            conversation_id="anchor-summary-omitted-tail-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(active_context)
+            rows = after_restart._store.get_session_messages(
+                "anchor-summary-omitted-tail-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages)
+        assert [row["content"] for row in rows].count(user_query) == 1
+        assert all(
+            not after_restart._is_replayed_context_scaffold_message(row)
+            for row in rows
+        )
+
     def test_overflow_recovery_keeps_sole_user_inside_fresh_tail(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=32,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4536,6 +4536,78 @@ class TestEngineABC:
         if followup is not None:
             assert rows[-1]["content"] == followup["content"]
 
+    @pytest.mark.parametrize(
+        "followup",
+        [
+            None,
+            {"role": "user", "content": "new delta after partial tail replay"},
+        ],
+        ids=["no-delta", "new-delta"],
+    )
+    def test_frontier_zero_overflow_partial_tail_replay_does_not_duplicate_tail(
+        self,
+        tmp_path,
+        followup,
+    ):
+        db_path = tmp_path / "frontier-zero-overflow-partial-tail-restart.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        session_id = "frontier-zero-overflow-partial-tail-session"
+        conversation_id = "frontier-zero-overflow-partial-tail-conversation"
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "preserve this provider anchor"},
+            {"role": "assistant", "content": "large derived output " + "x" * 4000},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest compact durable tail"},
+        ]
+
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        try:
+            active_context = engine.compress(messages)
+            assert engine.last_compression_status == "overflow_recovery"
+            assert engine._last_compacted_store_id == 0
+        finally:
+            engine.shutdown()
+
+        assert [message.get("content") for message in active_context] == [
+            messages[0]["content"],
+            messages[1]["content"],
+            messages[-1]["content"],
+        ]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        try:
+            replay = active_context + ([followup] if followup is not None else [])
+            after_restart._ingest_messages(replay)
+            rows = after_restart._store.get_session_messages(session_id)
+            reconciliation = after_restart._last_ingest_reconciliation
+        finally:
+            after_restart.shutdown()
+
+        assert reconciliation["action"] == "advanced cursor"
+        assert reconciliation["cursor"] == len(active_context)
+        assert len(rows) == len(messages) + (1 if followup is not None else 0)
+        assert [row["content"] for row in rows].count(messages[-1]["content"]) == 1
+        if followup is not None:
+            assert rows[-1]["content"] == followup["content"]
+
     def test_frontier_zero_overflow_anchor_restart_repeated_assistant_persists_delta_once(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -4070,6 +4070,67 @@ class TestEngineABC:
         if followup is not None:
             assert rows[-1]["content"] == followup["content"]
 
+    def test_frontier_zero_overflow_anchor_restart_repeated_assistant_persists_delta_once(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "frontier-zero-overflow-anchor-repeated-assistant.db"
+        config = LCMConfig(
+            fresh_tail_count=3,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=180,
+            database_path=str(db_path),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            "frontier-zero-overflow-anchor-repeated-assistant-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-repeated-assistant-conversation",
+            context_length=200000,
+        )
+
+        user_query = "preserve this anchor when the next delta repeats durable content"
+        repeated_content = "large derived output " + "x" * 4000
+        messages = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": user_query},
+            {"role": "assistant", "content": repeated_content},
+            {"role": "assistant", "content": "more derived output " + "y" * 4000},
+            {"role": "assistant", "content": "latest derived output " + "z" * 4000},
+        ]
+        try:
+            active_context = engine.compress(messages)
+            assert engine.last_compression_status == "overflow_recovery"
+            assert engine._last_compacted_store_id == 0
+        finally:
+            engine.shutdown()
+
+        assert [message.get("role") for message in active_context] == ["system", "user"]
+
+        after_restart = LCMEngine(config=config)
+        after_restart.on_session_start(
+            "frontier-zero-overflow-anchor-repeated-assistant-session",
+            platform="cli",
+            conversation_id="frontier-zero-overflow-anchor-repeated-assistant-conversation",
+            context_length=200000,
+        )
+        try:
+            after_restart._ingest_messages(
+                active_context + [{"role": "assistant", "content": repeated_content}]
+            )
+            rows = after_restart._store.get_session_messages(
+                "frontier-zero-overflow-anchor-repeated-assistant-session"
+            )
+        finally:
+            after_restart.shutdown()
+
+        assert len(rows) == len(messages) + 1
+        assert sum(row["role"] == "system" for row in rows) == 1
+        assert sum(row["role"] == "user" and row["content"] == user_query for row in rows) == 1
+        assert sum(
+            row["role"] == "assistant" and row["content"] == repeated_content for row in rows
+        ) == 2
+
     def test_two_message_overflow_anchor_restart_does_not_duplicate_durable_rows(
         self,
         tmp_path,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5102,6 +5102,44 @@ class TestEngineABC:
             for row in rows
         ) == 1
 
+    def test_new_annotated_system_persists_after_current_conversation_user_only_row(
+        self,
+        tmp_path,
+    ):
+        db_path = tmp_path / "fresh-annotated-system-after-user-only-row.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "fresh-annotated-system-after-user-only-row-session"
+        conversation_id = "fresh-annotated-system-after-user-only-row-conversation"
+        durable_user = {"role": "user", "content": "Durable user-only row."}
+
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            session_id, platform="cli", conversation_id=conversation_id, context_length=200000
+        )
+        try:
+            engine._store.append_batch(
+                session_id,
+                [durable_user],
+                conversation_id=conversation_id,
+            )
+            fresh_system = {
+                "role": "system",
+                "content": engine._append_lcm_note_to_content("Genuinely new system message."),
+            }
+
+            assert not engine._is_replayed_context_scaffold_message(fresh_system)
+            engine._ingest_messages([fresh_system])
+            rows = engine._store.get_session_messages(
+                session_id, conversation_id=conversation_id
+            )
+        finally:
+            engine.shutdown()
+
+        assert [(row["role"], row["content"]) for row in rows] == [
+            ("user", durable_user["content"]),
+            ("system", fresh_system["content"]),
+        ]
+
     def test_new_annotated_system_persists_when_only_legacy_blank_conversation_rows_exist(
         self,
         tmp_path,
@@ -6176,6 +6214,7 @@ class TestEngineABC:
             context_length=200000,
         )
         persisted_messages = [
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "initial question"},
             {"role": "assistant", "content": "initial answer"},
             {"role": "user", "content": "retry"},
@@ -6221,6 +6260,7 @@ class TestEngineABC:
             context_length=200000,
         )
         persisted_messages = [
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "initial question"},
             {"role": "assistant", "content": "initial answer"},
             {"role": "user", "content": "retry"},
@@ -6272,6 +6312,7 @@ class TestEngineABC:
             sort_keys=True,
         )
         persisted_messages = [
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "older question"},
             {"role": "assistant", "content": "older answer"},
             {"role": "user", "content": "retry"},
@@ -6329,6 +6370,7 @@ class TestEngineABC:
             sort_keys=True,
         )
         persisted_messages = [
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "older question"},
             {"role": "assistant", "content": "older answer"},
             {"role": "user", "content": "retry"},
@@ -6471,6 +6513,7 @@ class TestEngineABC:
             context_length=200000,
         )
         before_restart._ingest_messages([
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "tail before restart"},
         ])
         before_restart._store.close()
@@ -6494,8 +6537,11 @@ class TestEngineABC:
         after_restart._ingest_messages(active_context)
 
         rows = after_restart._store.get_session_messages("system-scaffold-session")
-        assert len(rows) == 1
-        assert rows[0]["content"] == "tail before restart"
+        assert len(rows) == 2
+        assert [row["content"] for row in rows] == [
+            "You are concise.",
+            "tail before restart",
+        ]
         assert after_restart._ingest_cursor == len(active_context)
 
     def test_existing_session_restart_skips_stale_short_no_overlap_snapshot(self, tmp_path, caplog):
@@ -6764,6 +6810,7 @@ class TestEngineABC:
             context_length=200000,
         )
         persisted_messages = [
+            {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "old first question"},
             {"role": "assistant", "content": "old first answer"},
         ]
@@ -6786,7 +6833,7 @@ class TestEngineABC:
         stale_replay = [
             {
                 "role": "system",
-                "content": "[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
+                "content": "You are concise.\n\n[Note: This conversation uses Lossless Context Management (LCM). Earlier turns have been compacted into hierarchical summaries below.]",
             },
             {
                 "role": "assistant",


### PR DESCRIPTION
## Summary
- preserve the initial real user message across compaction and replay
- keep summary replacement and overflow recovery aligned with multi-message anchors
- add regressions for regular and overflow compaction paths

## Validation
- 5 focused regression tests passed
- 803-test suite passed
- ruff passed
- `git diff --check` passed

Closes #355