### PR TITLE
feat(config): support scalar LCM YAML settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,15 @@ Most installs only need `plugins.enabled` and `context.engine: lcm`.
 
 Scalar `LCM_*` settings can also be set under the `lcm:` section in
 `~/.hermes/config.yaml` using the lower-case field name, for example
-`LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true` becomes
-`lcm.dynamic_leaf_chunk_enabled: true`. Environment variables still take
-precedence over YAML, and `lcm_status.config_sources` reports which source won.
+`LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true` becomes:
+
+```yaml
+lcm:
+  dynamic_leaf_chunk_enabled: true
+```
+
+Environment variables still take precedence over YAML, and
+`lcm_status.config_sources` reports which source won.
 
 ### Common settings
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ known-good rolling backup.
 
 Most installs only need `plugins.enabled` and `context.engine: lcm`.
 
+Scalar `LCM_*` settings can also be set under the `lcm:` section in
+`~/.hermes/config.yaml` using the lower-case field name, for example
+`LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true` becomes
+`lcm.dynamic_leaf_chunk_enabled: true`. Environment variables still take
+precedence over YAML, and `lcm_status.config_sources` reports which source won.
+
 ### Common settings
 
 | Variable | Default | Use |

--- a/config.py
+++ b/config.py
@@ -14,42 +14,6 @@ def _parse_pattern_list(raw: str) -> list[str]:
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
-def _parse_int_env(key: str, default: int) -> int:
-    raw = os.environ.get(key)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        return default
-
-
-def _parse_float_env(key: str, default: float) -> float:
-    raw = os.environ.get(key)
-    if raw is None:
-        return default
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        return default
-
-
-def _parse_bool_env(key: str, default: bool) -> bool:
-    raw = os.environ.get(key)
-    if raw is None:
-        return default
-    normalized = raw.strip().lower()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-    return default
-
-
-def _parse_str_env(key: str, default):
-    return os.environ.get(key, default)
-
-
 def _parse_int_env_with_source(
     key: str,
     default: int,
@@ -146,7 +110,8 @@ def _load_hermes_config_yaml() -> dict[str, Any]:
     return root
 
 
-_SUPPORTED_LCM_CONFIG_YAML_KEYS = {"context_threshold"}
+def _supported_lcm_config_yaml_keys() -> frozenset[str]:
+    return frozenset({"context_threshold"} | {spec.name for spec in ENV_FIELD_SPECS})
 
 
 def _ignored_lcm_config_yaml_keys(cfg: dict[str, Any] | None = None) -> list[str]:
@@ -157,7 +122,7 @@ def _ignored_lcm_config_yaml_keys(cfg: dict[str, Any] | None = None) -> list[str
     return sorted(
         str(key)
         for key in lcm_section
-        if str(key) not in _SUPPORTED_LCM_CONFIG_YAML_KEYS
+        if str(key) not in _supported_lcm_config_yaml_keys()
     )
 
 
@@ -177,8 +142,11 @@ def _hermes_compression_threshold(default: float) -> float:
     return value
 
 
-def _hermes_compression_threshold_with_source(default: float) -> tuple[float, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_compression_threshold_with_source(
+    default: float,
+    cfg: dict[str, Any] | None = None,
+) -> tuple[float, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         lcm_section = cfg.get("lcm") or {}
         if isinstance(lcm_section, dict):
@@ -210,8 +178,11 @@ def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
     return value
 
 
-def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[int, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_auxiliary_compression_timeout_ms_with_source(
+    default: int,
+    cfg: dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         auxiliary = cfg.get("auxiliary") or {}
         if not isinstance(auxiliary, dict):
@@ -227,8 +198,11 @@ def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[
         return default, "default"
 
 
-def _hermes_codex_gpt55_autoraise_with_source(default: bool) -> tuple[bool, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_codex_gpt55_autoraise_with_source(
+    default: bool,
+    cfg: dict[str, Any] | None = None,
+) -> tuple[bool, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         compression = cfg.get("compression") or {}
         if not isinstance(compression, dict):
@@ -298,22 +272,77 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("empty_lifecycle_gc_threshold", "LCM_EMPTY_LIFECYCLE_GC_THRESHOLD", int),
 )
 
-_PARSER_BY_TYPE = {
-    int: _parse_int_env,
-    float: _parse_float_env,
-    bool: _parse_bool_env,
-    str: _parse_str_env,
-}
+def _coerce_yaml_value(field: str, raw: Any, py_type: type):
+    try:
+        if py_type is bool:
+            if isinstance(raw, bool):
+                return raw, None
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                if raw == 1:
+                    return True, None
+                if raw == 0:
+                    return False, None
+            if isinstance(raw, str):
+                normalized = raw.strip().lower()
+                if normalized in {"1", "true", "yes", "on"}:
+                    return True, None
+                if normalized in {"0", "false", "no", "off"}:
+                    return False, None
+            return None, f"invalid config_yaml:lcm.{field}={raw!r} ignored"
+        if py_type is int:
+            if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+                return None, f"invalid config_yaml:lcm.{field}={raw!r} ignored"
+            return int(raw), None
+        if py_type is float:
+            if isinstance(raw, bool):
+                return None, f"invalid config_yaml:lcm.{field}={raw!r} ignored"
+            return float(raw), None
+        if py_type is str:
+            if not isinstance(raw, str):
+                return None, f"invalid config_yaml:lcm.{field}={raw!r} ignored"
+            return raw, None
+    except (TypeError, ValueError):
+        return None, f"invalid config_yaml:lcm.{field}={raw!r} ignored"
+    return None, f"unsupported config_yaml:lcm.{field} type {py_type!r} ignored"
 
-# Fields whose env reading needs provenance tracking or a computed default;
-# ``from_env`` handles these explicitly, so the uniform loop skips them.
+
+def _lcm_yaml_value_with_source(
+    field: str,
+    py_type: type,
+    default,
+    *,
+    default_source: str = "default",
+    cfg: dict[str, Any] | None = None,
+) -> tuple[Any, str, str | None]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
+    lcm_section = cfg.get("lcm") if isinstance(cfg, dict) else None
+    if not isinstance(lcm_section, dict) or field not in lcm_section:
+        return default, default_source, None
+    value, warning = _coerce_yaml_value(field, lcm_section.get(field), py_type)
+    if warning:
+        return default, default_source, warning
+    return value, f"config_yaml:lcm.{field}", None
+
+
+def _parse_env_spec_with_source(
+    key: str,
+    py_type: type,
+    default,
+    *,
+    default_source: str = "default",
+) -> tuple[Any, str, str | None]:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default, default_source, None
+    value, warning = _coerce_yaml_value(key, raw, py_type)
+    if warning:
+        return default, default_source, f"invalid env {key}={raw!r} ignored"
+    return value, f"env:{key}", None
+
+# Fields whose YAML/env reading needs a computed default; ``from_env`` handles
+# these explicitly, so the uniform scalar loop skips them.
 _SOURCE_TRACKED_ENV_FIELDS = frozenset({
-    "fresh_tail_count",
-    "leaf_chunk_tokens",
     "context_threshold",
-    "summary_spend_max_calls",
-    "summary_spend_window_seconds",
-    "summary_spend_backoff_seconds",
     "summary_timeout_ms",
 })
 
@@ -485,27 +514,21 @@ class LCMConfig:
     def from_env(cls) -> "LCMConfig":
         """Build config from environment variables (LCM_ prefix)."""
         c = cls()
+        hermes_config = _load_hermes_config_yaml()
         config_sources: dict[str, str] = {}
         config_source_warnings: list[str] = []
 
-        def _record(field: str, source: str, warning: str | None = None) -> None:
+        def _record(field: str, source: str, *warnings: str | None) -> None:
             config_sources[field] = source
-            if warning:
-                config_source_warnings.append(warning)
+            config_source_warnings.extend(warning for warning in warnings if warning)
 
-        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys()
+        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys(hermes_config)
 
-        # Source-tracked fields (provenance recording and/or a computed default)
-        # stay explicit; the uniform loop below skips them.
-        c.fresh_tail_count, source, warning = _parse_int_env_with_source(
-            "LCM_FRESH_TAIL_COUNT", c.fresh_tail_count
+        # Fields with host-config fallbacks stay explicit; the uniform scalar
+        # loop below handles all ordinary env > YAML > default fields.
+        context_default, context_source = _hermes_compression_threshold_with_source(
+            c.context_threshold, hermes_config
         )
-        _record("fresh_tail_count", source, warning)
-        c.leaf_chunk_tokens, source, warning = _parse_int_env_with_source(
-            "LCM_LEAF_CHUNK_TOKENS", c.leaf_chunk_tokens
-        )
-        _record("leaf_chunk_tokens", source, warning)
-        context_default, context_source = _hermes_compression_threshold_with_source(c.context_threshold)
         c.context_threshold, source, warning = _parse_float_env_with_source(
             "LCM_CONTEXT_THRESHOLD",
             context_default,
@@ -513,40 +536,45 @@ class LCMConfig:
         )
         _record("context_threshold", source, warning)
         c.codex_gpt55_autoraise_enabled, source = _hermes_codex_gpt55_autoraise_with_source(
-            c.codex_gpt55_autoraise_enabled
+            c.codex_gpt55_autoraise_enabled, hermes_config
         )
         _record("codex_gpt55_autoraise_enabled", source)
-        c.summary_spend_max_calls, source, warning = _parse_int_env_with_source(
-            "LCM_SUMMARY_SPEND_MAX_CALLS",
-            c.summary_spend_max_calls,
-        )
-        _record("summary_spend_max_calls", source, warning)
-        c.summary_spend_window_seconds, source, warning = _parse_float_env_with_source(
-            "LCM_SUMMARY_SPEND_WINDOW_SECONDS",
-            c.summary_spend_window_seconds,
-        )
-        _record("summary_spend_window_seconds", source, warning)
-        c.summary_spend_backoff_seconds, source, warning = _parse_float_env_with_source(
-            "LCM_SUMMARY_SPEND_BACKOFF_SECONDS",
-            c.summary_spend_backoff_seconds,
-        )
-        _record("summary_spend_backoff_seconds", source, warning)
         summary_timeout_default, summary_timeout_source = _hermes_auxiliary_compression_timeout_ms_with_source(
-            c.summary_timeout_ms
+            c.summary_timeout_ms, hermes_config
+        )
+        yaml_default, yaml_source, yaml_warning = _lcm_yaml_value_with_source(
+            "summary_timeout_ms",
+            int,
+            summary_timeout_default,
+            default_source=summary_timeout_source,
+            cfg=hermes_config,
         )
         c.summary_timeout_ms, source, warning = _parse_int_env_with_source(
             "LCM_SUMMARY_TIMEOUT_MS",
-            summary_timeout_default,
-            default_source=summary_timeout_source,
+            yaml_default,
+            default_source=yaml_source,
         )
-        _record("summary_timeout_ms", source, warning)
+        _record("summary_timeout_ms", source, yaml_warning, warning)
 
         # Every other scalar LCM_* override is applied uniformly from the spec.
+        # Precedence is env > lcm.<field> in config.yaml > dataclass default.
         for spec in ENV_FIELD_SPECS:
             if spec.name in _SOURCE_TRACKED_ENV_FIELDS:
                 continue
-            parser = _PARSER_BY_TYPE[spec.py_type]
-            setattr(c, spec.name, parser(spec.env_key, getattr(c, spec.name)))
+            yaml_default, yaml_source, yaml_warning = _lcm_yaml_value_with_source(
+                spec.name,
+                spec.py_type,
+                getattr(c, spec.name),
+                cfg=hermes_config,
+            )
+            value, source, warning = _parse_env_spec_with_source(
+                spec.env_key,
+                spec.py_type,
+                yaml_default,
+                default_source=yaml_source,
+            )
+            setattr(c, spec.name, value)
+            _record(spec.name, source, yaml_warning, warning)
 
         # Pattern-list overrides carry a source sidecar and stay explicit.
         raw_sensitive_patterns = os.environ.get("LCM_SENSITIVE_PATTERNS")

--- a/config.py
+++ b/config.py
@@ -119,10 +119,11 @@ def _ignored_lcm_config_yaml_keys(cfg: dict[str, Any] | None = None) -> list[str
     lcm_section = cfg.get("lcm") if isinstance(cfg, dict) else None
     if not isinstance(lcm_section, dict):
         return []
+    supported_keys = _supported_lcm_config_yaml_keys()
     return sorted(
         str(key)
         for key in lcm_section
-        if str(key) not in _supported_lcm_config_yaml_keys()
+        if str(key) not in supported_keys
     )
 
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -133,7 +133,11 @@ run `lcm_status` or `/lcm status` again for live per-session fields.
 ## Configuration
 
 Most installs only need `plugins.enabled` and `context.engine: lcm`. Useful
-environment variables:
+settings are shown as environment variables below, but scalar `LCM_*` settings
+can also be set under the `lcm:` section in `~/.hermes/config.yaml` using the
+lower-case field name. For example, `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true`
+becomes `lcm.dynamic_leaf_chunk_enabled: true`. Environment variables still win
+over YAML, and `lcm_status.config_sources` reports the effective source.
 
 | Variable | Default | Use |
 |----------|---------|-----|

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -136,8 +136,15 @@ Most installs only need `plugins.enabled` and `context.engine: lcm`. Useful
 settings are shown as environment variables below, but scalar `LCM_*` settings
 can also be set under the `lcm:` section in `~/.hermes/config.yaml` using the
 lower-case field name. For example, `LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true`
-becomes `lcm.dynamic_leaf_chunk_enabled: true`. Environment variables still win
-over YAML, and `lcm_status.config_sources` reports the effective source.
+becomes:
+
+```yaml
+lcm:
+  dynamic_leaf_chunk_enabled: true
+```
+
+Environment variables still win over YAML, and `lcm_status.config_sources`
+reports the effective source.
 
 | Variable | Default | Use |
 |----------|---------|-----|

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -255,7 +255,7 @@ def test_lcm_status_json_reports_effective_config_sources(tmp_path, monkeypatch)
     assert payload["config_sources"]["summary_spend_window_seconds"] == "env:LCM_SUMMARY_SPEND_WINDOW_SECONDS"
     assert payload["config_sources"]["summary_spend_backoff_seconds"] == "env:LCM_SUMMARY_SPEND_BACKOFF_SECONDS"
     assert engine._summary_spend_guard.max_calls == 0
-    assert "fresh_tail_count" in payload["ignored_config_yaml_lcm_keys"]
+    assert payload["ignored_config_yaml_lcm_keys"] == []
 
 
 def test_lcm_status_does_not_report_invalid_env_as_effective_source(tmp_path, monkeypatch):
@@ -301,7 +301,7 @@ def test_lcm_doctor_warns_about_ignored_lcm_config_yaml_keys(tmp_path, monkeypat
     (hermes_home / "config.yaml").write_text(
         "lcm:\n"
         "  context_threshold: 0.52\n"
-        "  leaf_chunk_tokens: 12345\n"
+        "  leaf_chunk_tokenz: 12345\n"
     )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
@@ -316,7 +316,7 @@ def test_lcm_doctor_warns_about_ignored_lcm_config_yaml_keys(tmp_path, monkeypat
 
     assert payload["overall"] == "warnings"
     assert config_check["status"] == "warn"
-    assert any("lcm.leaf_chunk_tokens" in warning for warning in config_check["detail"])
+    assert any("lcm.leaf_chunk_tokenz" in warning for warning in config_check["detail"])
 
 
 def test_lcm_status_reports_last_compression_noop_reason(engine):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -695,6 +695,123 @@ class TestConfig:
 
         assert c.summary_timeout_ms == 120_000
 
+    def test_from_env_reads_lcm_yaml_scalar_settings(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("""lcm:
+  fresh_tail_count: 24
+  leaf_chunk_tokens: 8000
+  dynamic_leaf_chunk_enabled: true
+  dynamic_leaf_chunk_max: 24000
+  cache_friendly_condensation_enabled: true
+  cache_friendly_min_debt_groups: 3
+  deferred_maintenance_enabled: true
+  deferred_maintenance_max_passes: 5
+  critical_budget_pressure_ratio: 0.9
+  summary_timeout_ms: 90000
+  expansion_context_tokens: 64000
+  custom_instructions: Prefer concise summaries.
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 24
+        assert c.leaf_chunk_tokens == 8000
+        assert c.dynamic_leaf_chunk_enabled is True
+        assert c.dynamic_leaf_chunk_max == 24000
+        assert c.cache_friendly_condensation_enabled is True
+        assert c.cache_friendly_min_debt_groups == 3
+        assert c.deferred_maintenance_enabled is True
+        assert c.deferred_maintenance_max_passes == 5
+        assert c.critical_budget_pressure_ratio == 0.9
+        assert c.summary_timeout_ms == 90_000
+        assert c.expansion_context_tokens == 64_000
+        assert c.custom_instructions == "Prefer concise summaries."
+        assert c.config_sources["fresh_tail_count"] == "config_yaml:lcm.fresh_tail_count"
+        assert c.config_sources["dynamic_leaf_chunk_enabled"] == "config_yaml:lcm.dynamic_leaf_chunk_enabled"
+        assert c.config_sources["summary_timeout_ms"] == "config_yaml:lcm.summary_timeout_ms"
+        assert c.ignored_config_yaml_lcm_keys == []
+
+    def test_from_env_env_overrides_lcm_yaml_scalar_settings(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("""lcm:
+  fresh_tail_count: 24
+  dynamic_leaf_chunk_enabled: false
+  expansion_context_tokens: 64000
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "48")
+        monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_ENABLED", "true")
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 48
+        assert c.dynamic_leaf_chunk_enabled is True
+        assert c.expansion_context_tokens == 64_000
+        assert c.config_sources["fresh_tail_count"] == "env:LCM_FRESH_TAIL_COUNT"
+        assert c.config_sources["dynamic_leaf_chunk_enabled"] == "env:LCM_DYNAMIC_LEAF_CHUNK_ENABLED"
+        assert c.config_sources["expansion_context_tokens"] == "config_yaml:lcm.expansion_context_tokens"
+
+    def test_from_env_invalid_env_falls_back_to_lcm_yaml_scalar(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "lcm:\n  fresh_tail_count: 24\n  dynamic_leaf_chunk_enabled: true\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "nope")
+        monkeypatch.setenv("LCM_DYNAMIC_LEAF_CHUNK_ENABLED", "maybe")
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 24
+        assert c.dynamic_leaf_chunk_enabled is True
+        assert c.config_sources["fresh_tail_count"] == "config_yaml:lcm.fresh_tail_count"
+        assert c.config_sources["dynamic_leaf_chunk_enabled"] == "config_yaml:lcm.dynamic_leaf_chunk_enabled"
+        assert "invalid env LCM_FRESH_TAIL_COUNT='nope' ignored" in c.config_source_warnings
+        assert "invalid env LCM_DYNAMIC_LEAF_CHUNK_ENABLED='maybe' ignored" in c.config_source_warnings
+
+    def test_from_env_invalid_lcm_yaml_scalar_falls_back_with_warning(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("""lcm:
+  fresh_tail_count: nope
+  dynamic_leaf_chunk_enabled: maybe
+""")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 32
+        assert c.dynamic_leaf_chunk_enabled is False
+        assert c.config_sources["fresh_tail_count"] == "default"
+        assert c.config_sources["dynamic_leaf_chunk_enabled"] == "default"
+        assert "invalid config_yaml:lcm.fresh_tail_count='nope' ignored" in c.config_source_warnings
+        assert "invalid config_yaml:lcm.dynamic_leaf_chunk_enabled='maybe' ignored" in c.config_source_warnings
+
+    def test_from_env_reads_lcm_yaml_scalar_settings_without_pyyaml(self, monkeypatch, tmp_path):
+        import hermes_lcm.config as config_mod
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "lcm:\n"
+            "  fresh_tail_count: '24'\n"
+            "  dynamic_leaf_chunk_enabled: true\n"
+            "  critical_budget_pressure_ratio: '0.9'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(config_mod, "yaml", None)
+
+        c = LCMConfig.from_env()
+
+        assert c.fresh_tail_count == 24
+        assert c.dynamic_leaf_chunk_enabled is True
+        assert c.critical_budget_pressure_ratio == 0.9
+        assert c.config_sources["fresh_tail_count"] == "config_yaml:lcm.fresh_tail_count"
+
     def test_from_env_summary_timeout_env_overrides_hermes_auxiliary_timeout(self, monkeypatch, tmp_path):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary

- Allow every scalar `LCM_*` setting represented by `ENV_FIELD_SPECS` to be configured under the `lcm:` section of `~/.hermes/config.yaml`.
- Preserve precedence as environment variable > `lcm.<field>` YAML > existing fallback/default.
- Report the effective source for scalar settings through `lcm_status.config_sources`, while retaining warnings for unsupported `lcm:` keys and invalid values.
- Document the environment-to-YAML name mapping and update status/doctor regressions now that scalar keys are supported.

## Why

Today only `lcm.context_threshold` is supported in YAML on `main`; other LCM tuning controls require process environment variables. That is awkward for operators who otherwise manage Hermes through `config.yaml`, and it makes settings such as dynamic leaf chunking look valid in YAML while `lcm_doctor` correctly reports them as ignored.

This change uses the existing `ENV_FIELD_SPECS` table as the single source of truth, so a setting such as:

```env
LCM_DYNAMIC_LEAF_CHUNK_ENABLED=true
```

can also be written as:

```yaml
lcm:
  dynamic_leaf_chunk_enabled: true
```

Environment variables remain authoritative for deployments that already use them. Invalid environment values fall back to a valid YAML value rather than masking it.

This PR intentionally covers scalar settings only. Structured settings such as model threshold maps and pattern lists remain separate concerns.

## Validation

- `python -m pytest tests/test_lcm_core.py::TestConfig -q` → 27 passed
- `python -m pytest tests/test_lcm_command.py tests/test_lcm_preset_command.py -q` → 89 passed
- `ruff check config.py tests/test_lcm_core.py tests/test_lcm_command.py` → passed
- `python -m compileall -q .` and `python -m py_compile scripts/import_lossless_claw.py` → passed
- `bash -n scripts/install.sh scripts/update.sh` → passed
- `git diff --check` → passed
- Static scan of added lines for hardcoded secrets, shell injection, `eval`/`exec`, unsafe pickle use, and formatted SQL → no findings

## Notes

- Existing YAML keys that were previously reported as unsupported scalar `lcm:` settings will become active after this change. Environment variables still win.
- `lcm.model_thresholds` is not included here; it is tracked separately in #352.
- No defaults are changed.
