### PR TITLE
fix(codex): add gpt-5.6 Codex OAuth effective context cap (372K)

### DIFF
--- a/codex_routing.py
+++ b/codex_routing.py
@@ -26,6 +26,7 @@ _CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
     "gpt-5.5": 272_000,
     "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,
+    "gpt-5.6": 372_000,
     "gpt-5": 272_000,
 }
 


### PR DESCRIPTION
## Summary

- Add a `"gpt-5.6": 372_000` entry to `_CODEX_OAUTH_CONTEXT_CAPS` in `codex_routing.py`.

## Root cause

OpenAI's Codex model catalog reports `context_window: 372000` for GPT-5.6 Sol/Terra/Luna:
https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json

The previous `_CODEX_OAUTH_CONTEXT_CAPS` table had no `gpt-5.6` entry. Bare-slug matching in
`_codex_oauth_context_cap` therefore fell through to the generic `"gpt-5" -> 272_000` fallback,
clamping the real 372K window down to 272K. Because ENG-540's `_effective_context_length` clamps
`raw_context_length` to the cap whenever `raw > cap`, the host-advertised 372K context length got
silently capped at 272K, firing context compression ~100K tokens too early.

This matches the user-visible symptom: `/model` shows "Context: 372,000 tokens" (Hermes core
resolves 372K correctly), but the chat budget drops to 272K (`effective_context_length_reason:
codex_oauth_context_cap`), and compression triggers at 0.8 * 272K = 217.6K.

## Fix

Add `"gpt-5.6": 372_000` ahead of the generic `"gpt-5"` entry. Since matching iterates longest
slug first, all `gpt-5.6*`, `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol` variants resolve to
372K. The clamp then becomes a no-op (raw == cap), preserving the real window.

## Verification

Direct helper check after the change:
```
_codex_oauth_context_cap("gpt-5.6-luna", "openai-codex")  -> 372000
_codex_oauth_context_cap("gpt-5.6-terra", "openai-codex") -> 372000
_codex_oauth_context_cap("gpt-5.6-sol",   "openai-codex") -> 372000
_codex_oauth_context_cap("gpt-5.6",       "openai-codex") -> 372000
_codex_oauth_context_cap("gpt-5.5",       "openai-codex") -> 272000  (unchanged)
_codex_oauth_context_cap("gpt-5.4",       "openai-codex") -> 272000  (unchanged)
```

This mirrors NousResearch/hermes-agent PR #61910 (core-side 372K refresh for GPT-5.6) so the
LCM cap and the host-advertised context length agree.

## Notes

- `gpt-5.5` / `gpt-5.4` remain pinned at 272K, which is correct for the ChatGPT Codex OAuth route
  (see NousResearch/hermes-agent issue #27918 — direct OpenAI API is 1M, but Codex OAuth enforces 272K).
- No test changes: existing `codex_oauth_context_cap` tests use `gpt-5.5`/400K placeholders and are
  unaffected. A `gpt-5.6` regression case can be added if desired; I left it out to keep the diff minimal.