### PR TITLE
fix: preserve the sole real user prompt through compaction

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -408,10 +408,9 @@ class CompactionMixin:
             n = len(working_messages)
             fresh_tail_start = max(0, n - self._config.fresh_tail_count)
 
-            # Keep only a real system prompt anchored. Gateway sessions may
-            # pass only conversation messages, so index 0 can be an old user
-            # turn; that must remain eligible for compaction instead of being
-            # replayed forever as fresh-looking intent.
+            # Keep a real system prompt and, while it is the only real user
+            # turn, its immediately following prompt. Gateway sessions may pass
+            # only conversation messages, so index 0 remains compactable.
             leading_anchor_count = self._leading_anchor_count(working_messages)
             if fresh_tail_start <= leading_anchor_count:
                 noop_reason = "no eligible raw backlog outside fresh tail"
@@ -664,8 +663,9 @@ class CompactionMixin:
                 leading_anchor_count = self._leading_anchor_count(working_messages)
                 compressed = self._assemble_overflow_recovery_context(
                     working_messages[0] if leading_anchor_count else None,
-                    working_messages[leading_anchor_count:],
+                    working_messages[1 if leading_anchor_count else 0:],
                     assembly_cap_override=recovery_assembly_cap,
+                    preserve_leading_user=leading_anchor_count == 2,
                 )
                 return self._finalize_forced_overflow_result(
                     working_messages,
@@ -683,8 +683,9 @@ class CompactionMixin:
                 try:
                     sanitized_messages = self._assemble_context(
                         active_context_messages[0] if leading_anchor_count else None,
-                        active_context_messages[leading_anchor_count:],
+                        active_context_messages[1 if leading_anchor_count else 0:],
                         assembly_cap_override=recovery_assembly_cap,
+                        preserve_leading_user=anchor_leading_count == 2,
                     )
                 finally:
                     self._pending_context_anchor_messages = None
@@ -738,8 +739,9 @@ class CompactionMixin:
         try:
             compressed = self._assemble_context(
                 working_messages[0] if leading_anchor_count else None,
-                working_messages[leading_anchor_count:],
+                working_messages[1 if leading_anchor_count else 0:],
                 assembly_cap_override=recovery_assembly_cap,
+                preserve_leading_user=anchor_leading_count == 2,
             )
         finally:
             self._pending_context_anchor_messages = None

--- a/engine.py
+++ b/engine.py
@@ -1486,18 +1486,64 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return []
         return messages[leading_anchor_count:fresh_tail_start]
 
-    def _is_real_user_prompt_message(self, message: Dict[str, Any]) -> bool:
-        """Return whether a user record is real prompt-bearing conversation."""
+    def _is_scaffold_shaped_user_message(self, message: Dict[str, Any]) -> bool:
+        """Return whether a user message has the shape of generated context."""
+        return (
+            self._is_context_summary_content(message.get("content"))
+            or self._is_replayed_context_scaffold_message(message)
+            or self._is_preserved_todo_context_message(message)
+        )
+
+    def _sole_durable_user_prompt_message(self) -> Optional[Dict[str, Any]]:
+        """Return the session's sole stored user occurrence, if exactly one exists."""
+        if not self._session_id:
+            return None
+        sole_user: Optional[Dict[str, Any]] = None
+        after_store_id = 0
+        try:
+            while True:
+                rows = self._store.load_session_page(
+                    self._session_id,
+                    after_store_id=after_store_id,
+                    limit=1000,
+                    roles=["user"],
+                )
+                if not rows:
+                    break
+                for row in rows:
+                    after_store_id = max(after_store_id, int(row.get("store_id") or 0))
+                    content = normalize_content_value(row.get("content")) or ""
+                    if not content.strip() or self._matches_ignore_message_patterns(row, stored_row=True):
+                        continue
+                    if sole_user is not None:
+                        return None
+                    sole_user = row
+                if len(rows) < 1000:
+                    break
+        except Exception:
+            logger.debug("LCM sole durable user lookup failed", exc_info=True)
+            return None
+        return sole_user
+
+    def _is_real_user_prompt_message(
+        self,
+        message: Dict[str, Any],
+        *,
+        durable_store_id: Optional[int] = None,
+        sole_durable_user: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Return whether a user record is real prompt-bearing conversation.
+
+        Generated scaffold wrappers are content-collision-prone, so their text
+        is never the authority. They count as real only when this exact active
+        occurrence maps to durable storage, or when it matches the session's
+        sole durable user occurrence (which remains valid behind the compaction
+        frontier and across engine restart).
+        """
         if not isinstance(message, dict) or message.get("role") != "user":
             return False
         content = normalize_content_value(message.get("content")) or ""
         if not content.strip():
-            return False
-        if (
-            self._is_context_summary_content(message.get("content"))
-            or self._is_replayed_context_scaffold_message(message)
-            or self._is_preserved_todo_context_message(message)
-        ):
             return False
         pattern_text = text_content_for_pattern_matching(message.get("content")) or ""
         if (
@@ -1507,7 +1553,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             or self._is_ignored_active_replay_placeholder(message, pattern_text)
         ):
             return False
-        return True
+        if not self._is_scaffold_shaped_user_message(message):
+            return True
+        if durable_store_id is not None:
+            return True
+        if sole_durable_user is not None:
+            return self._message_replay_identity(message) == self._message_replay_identity(
+                sole_durable_user,
+                stored_row=True,
+            )
+        return False
 
     def _leading_anchor_count(self, messages: List[Dict[str, Any]]) -> int:
         """Return the number of non-compactable leading messages.
@@ -1519,9 +1574,39 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """
         if not messages or not isinstance(messages[0], dict) or messages[0].get("role") != "system":
             return 0
-        if len(messages) < 2 or not self._is_real_user_prompt_message(messages[1]):
+        if len(messages) < 2:
             return 1
-        if any(self._is_real_user_prompt_message(message) for message in messages[2:]):
+
+        scaffold_candidates = [
+            message
+            for message in messages[1:]
+            if isinstance(message, dict)
+            and message.get("role") == "user"
+            and self._is_scaffold_shaped_user_message(message)
+        ]
+        durable_store_ids_by_message_id = (
+            self._get_store_id_map_for_messages(messages[1:])
+            if scaffold_candidates
+            else {}
+        )
+        sole_durable_user = (
+            self._sole_durable_user_prompt_message()
+            if scaffold_candidates and id(messages[1]) not in durable_store_ids_by_message_id
+            else None
+        )
+        if not self._is_real_user_prompt_message(
+            messages[1],
+            durable_store_id=durable_store_ids_by_message_id.get(id(messages[1])),
+            sole_durable_user=sole_durable_user,
+        ):
+            return 1
+        if any(
+            self._is_real_user_prompt_message(
+                message,
+                durable_store_id=durable_store_ids_by_message_id.get(id(message)),
+            )
+            for message in messages[2:]
+        ):
             return 1
         return 2
 
@@ -4596,6 +4681,28 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return normalized + note
 
     @staticmethod
+    def _prepend_generated_context_to_message(
+        message: Dict[str, Any],
+        generated_context: str,
+    ) -> Dict[str, Any]:
+        """Fold generated context into a same-role tail message without losing metadata."""
+        merged = message.copy()
+        content = message.get("content")
+        if isinstance(content, list):
+            merged["content"] = [
+                {"type": "text", "text": generated_context},
+                *content,
+            ]
+        else:
+            normalized = normalize_content_value(content) or ""
+            merged["content"] = (
+                f"{generated_context}\n\n---\n\n{normalized}"
+                if normalized
+                else generated_context
+            )
+        return merged
+
+    @staticmethod
     def _is_preserved_todo_context_message(message: Dict[str, Any]) -> bool:
         content = text_content_for_pattern_matching(message.get("content")) or ""
         return content.lstrip().startswith(_PRESERVED_TODO_CONTEXT_PREFIX)
@@ -4709,7 +4816,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             and system_msg is not None
             and system_msg.get("role") == "system"
             and tail_messages
-            and self._is_real_user_prompt_message(tail_messages[0])
+            and tail_messages[0].get("role") == "user"
+            and (normalize_content_value(tail_messages[0].get("content")) or "").strip()
         ):
             retained_user_msg = tail_messages[0].copy()
             tail_messages = tail_messages[1:]
@@ -4772,7 +4880,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         summary_parts: list[str] = []
         last_role = result[-1].get("role", "system") if result else "system"
         next_role = tail_selected[0].get("role") if tail_selected else None
-        if not result or result[-1].get("role") == "system":
+        if retained_user_msg is not None:
+            summary_role = "assistant"
+        elif not result or result[-1].get("role") == "system":
             # The summary becomes the first provider-visible message: either no
             # leading anchor exists (gateway-style assembly) or the system
             # prompt is the only anchor, which Anthropic extracts into a
@@ -4781,9 +4891,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             # compaction.
             summary_role = "user"
         else:
-            # Keep an assistant-leading fresh tail attached to its tool results.
-            # An assistant summary immediately before that tail creates adjacent
-            # provider-facing assistant turns, which some templates reject.
             summary_role = "user" if "assistant" in {last_role, next_role} else "assistant"
         if anchor_part is not None:
             anchor_msg = {"role": summary_role, "content": anchor_part}
@@ -4824,7 +4931,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     selected_parts.append(part)
             if selected_parts:
                 combined = "\n\n---\n\n".join(selected_parts)
-                result.append({"role": summary_role, "content": combined})
+                if (
+                    retained_user_msg is not None
+                    and tail_selected
+                    and tail_selected[0].get("role") == summary_role
+                ):
+                    tail_selected = [
+                        self._prepend_generated_context_to_message(tail_selected[0], combined),
+                        *tail_selected[1:],
+                    ]
+                else:
+                    result.append({"role": summary_role, "content": combined})
 
         # Fresh tail
         result.extend(tail_selected)
@@ -4857,6 +4974,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     trimmed_result.append(trimmed)
             result = self._sanitize_active_context_messages(trimmed_result)
 
+        self._remember_assembled_active_context(result)
         return result
 
     def _is_budget_droppable_tail_message(self, message: Dict[str, Any]) -> bool:

--- a/engine.py
+++ b/engine.py
@@ -1494,11 +1494,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             or self._is_preserved_todo_context_message(message)
         )
 
-    def _sole_durable_user_prompt_message(self) -> Optional[Dict[str, Any]]:
-        """Return the session's sole stored user occurrence, if exactly one exists."""
+    def _durable_user_prompt_messages(self, *, stop_after: int = 2) -> List[Dict[str, Any]]:
+        """Return up to ``stop_after`` stored prompt-bearing user occurrences."""
         if not self._session_id:
-            return None
-        sole_user: Optional[Dict[str, Any]] = None
+            return []
+        durable_users: List[Dict[str, Any]] = []
         after_store_id = 0
         try:
             while True:
@@ -1515,15 +1515,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     content = normalize_content_value(row.get("content")) or ""
                     if not content.strip() or self._matches_ignore_message_patterns(row, stored_row=True):
                         continue
-                    if sole_user is not None:
-                        return None
-                    sole_user = row
+                    durable_users.append(row)
+                    if len(durable_users) >= stop_after:
+                        return durable_users
                 if len(rows) < 1000:
                     break
         except Exception:
-            logger.debug("LCM sole durable user lookup failed", exc_info=True)
-            return None
-        return sole_user
+            logger.debug("LCM durable user lookup failed", exc_info=True)
+            return []
+        return durable_users
 
     def _is_real_user_prompt_message(
         self,
@@ -1589,9 +1589,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if scaffold_candidates
             else {}
         )
+        durable_user_prompts = self._durable_user_prompt_messages()
         sole_durable_user = (
-            self._sole_durable_user_prompt_message()
-            if scaffold_candidates and id(messages[1]) not in durable_store_ids_by_message_id
+            durable_user_prompts[0]
+            if (
+                len(durable_user_prompts) == 1
+                and scaffold_candidates
+                and id(messages[1]) not in durable_store_ids_by_message_id
+            )
             else None
         )
         if not self._is_real_user_prompt_message(
@@ -1607,6 +1612,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
             for message in messages[2:]
         ):
+            return 1
+        if len(durable_user_prompts) > 1:
             return 1
         return 2
 
@@ -3682,14 +3689,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
         if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return True
-        if "[Expand for details:" not in content:
-            return False
-        return bool(
-            re.search(
-                r"\[(?:Recent|Session Arc|Durable|Depth-\d+) Summary \(d\d+, node \d+\)\]",
-                content,
-            )
-        )
+        return self._looks_like_active_summary_blob(content)
 
     def _restore_ingest_payload_placeholders_in_value(self, value: Any, *, session_id: str) -> Any:
         if isinstance(value, dict):
@@ -5139,7 +5139,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 )
                 if any(
                     (msg_content := (msg.get("content") or "")) == content
-                    or msg_content.startswith(f"{content}\n\n---\n\n")
+                    or (
+                        isinstance(msg_content, str)
+                        and msg_content.startswith(f"{content}\n\n---\n\n")
+                    )
                     for msg in (candidate[1:] if system_msg is not None else candidate)
                 ):
                     return candidate

--- a/engine.py
+++ b/engine.py
@@ -1486,18 +1486,44 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return []
         return messages[leading_anchor_count:fresh_tail_start]
 
-    @staticmethod
-    def _leading_anchor_count(messages: List[Dict[str, Any]]) -> int:
+    def _is_real_user_prompt_message(self, message: Dict[str, Any]) -> bool:
+        """Return whether a user record is real prompt-bearing conversation."""
+        if not isinstance(message, dict) or message.get("role") != "user":
+            return False
+        content = normalize_content_value(message.get("content")) or ""
+        if not content.strip():
+            return False
+        if (
+            self._is_context_summary_content(message.get("content"))
+            or self._is_replayed_context_scaffold_message(message)
+            or self._is_preserved_todo_context_message(message)
+        ):
+            return False
+        pattern_text = text_content_for_pattern_matching(message.get("content")) or ""
+        if (
+            self._matches_ignore_message_patterns(message)
+            or self._mapped_stored_row_matches_ignore_message_patterns(message)
+            or self._is_volatile_ignored_quarantine_placeholder(message, pattern_text)
+            or self._is_ignored_active_replay_placeholder(message, pattern_text)
+        ):
+            return False
+        return True
+
+    def _leading_anchor_count(self, messages: List[Dict[str, Any]]) -> int:
         """Return the number of non-compactable leading messages.
 
-        Only the system prompt is a safe permanent anchor. Hermes gateway
-        sessions can begin with a user message when core passes conversation
-        history without a system prompt; preserving that first user turn as raw
-        active context lets stale requests look current after later compaction.
+        A system prompt followed by the session's only real user prompt keeps
+        both as a stable raw prefix. Once a later real user turn exists, the
+        initial prompt becomes stale and is compactable again. Gateway sessions
+        without a system prompt retain the historical zero-anchor behavior.
         """
-        if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
+        if not messages or not isinstance(messages[0], dict) or messages[0].get("role") != "system":
+            return 0
+        if len(messages) < 2 or not self._is_real_user_prompt_message(messages[1]):
             return 1
-        return 0
+        if any(self._is_real_user_prompt_message(message) for message in messages[2:]):
+            return 1
+        return 2
 
     def _raw_backlog_tokens(self, messages: List[Dict[str, Any]]) -> int:
         backlog = self._raw_backlog_messages(messages)
@@ -4666,19 +4692,31 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         tail_messages: List[Dict[str, Any]],
         assembly_cap_override: Optional[int] = None,
         include_lcm_note: bool = True,
+        preserve_leading_user: bool = False,
     ) -> List[Dict[str, Any]]:
         """Build the active context from DAG summaries + fresh tail.
 
         Structure:
-          [leading anchor, normally system prompt]
+          [leading anchors: system + sole real user prompt when applicable]
           [highest-depth summary nodes first, then lower]
           [fresh tail messages]
         """
         result = []
 
-        # Leading anchor with optional LCM annotation. Only a true system prompt
-        # is a safe permanent anchor; gateway sessions can start directly with
-        # user messages, and those user turns must remain compactable.
+        retained_user_msg: Optional[Dict[str, Any]] = None
+        if (
+            preserve_leading_user
+            and system_msg is not None
+            and system_msg.get("role") == "system"
+            and tail_messages
+            and self._is_real_user_prompt_message(tail_messages[0])
+        ):
+            retained_user_msg = tail_messages[0].copy()
+            tail_messages = tail_messages[1:]
+
+        # Leading anchors with optional LCM annotation. A true system prompt is
+        # always stable. Its immediately following user prompt is also stable
+        # only while it remains the session's sole real user turn.
         leading_msg = system_msg.copy() if system_msg is not None else None
         if leading_msg is not None:
             if (
@@ -4690,6 +4728,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     leading_msg.get("content", "")
                 )
             result.append(leading_msg)
+        if retained_user_msg is not None:
+            result.append(retained_user_msg)
 
         assembly_cap = (
             assembly_cap_override
@@ -4704,7 +4744,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         anchor_part: Optional[str] = None
         summary_budget = None
         if assembly_cap is not None:
-            used = count_message_tokens(leading_msg) if leading_msg is not None else 0
+            used = count_messages_tokens(result)
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
             tail_for_selection = self._sanitize_active_context_messages(
@@ -4731,6 +4771,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # Collect DAG summaries — highest depth first for context hierarchy
         summary_parts: list[str] = []
         last_role = result[-1].get("role", "system") if result else "system"
+        next_role = tail_selected[0].get("role") if tail_selected else None
         if not result or result[-1].get("role") == "system":
             # The summary becomes the first provider-visible message: either no
             # leading anchor exists (gateway-style assembly) or the system
@@ -4740,7 +4781,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             # compaction.
             summary_role = "user"
         else:
-            summary_role = "assistant" if last_role != "assistant" else "user"
+            # Keep an assistant-leading fresh tail attached to its tool results.
+            # An assistant summary immediately before that tail creates adjacent
+            # provider-facing assistant turns, which some templates reject.
+            summary_role = "user" if "assistant" in {last_role, next_role} else "assistant"
         if anchor_part is not None:
             anchor_msg = {"role": summary_role, "content": anchor_part}
             if summary_budget is None or count_message_tokens(anchor_msg) <= summary_budget:
@@ -4953,6 +4997,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         system_msg: Optional[Dict[str, Any]],
         tail_messages: List[Dict[str, Any]],
         assembly_cap_override: Optional[int] = None,
+        preserve_leading_user: bool = False,
     ) -> List[Dict[str, Any]]:
         if tail_messages:
             first = tail_messages[0]
@@ -4964,6 +5009,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     tail_messages[1:],
                     assembly_cap_override=assembly_cap_override,
                     include_lcm_note=False,
+                    preserve_leading_user=preserve_leading_user,
                 )
                 if any(
                     (msg.get("content") or "") == content
@@ -4976,6 +5022,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             tail_messages,
             assembly_cap_override=assembly_cap_override,
             include_lcm_note=False,
+            preserve_leading_user=preserve_leading_user,
         )
         minimum_candidate_len = 1 if system_msg is not None else 0
         if len(candidate) == minimum_candidate_len and tail_messages:

--- a/engine.py
+++ b/engine.py
@@ -4845,7 +4845,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             else self._effective_assembly_token_cap()
         )
 
-        tail_selected = tail_messages
+        tail_for_selection = self._sanitize_active_context_messages(
+            tail_messages,
+            insert_missing_tool_stubs=False,
+        )
+        tail_selected = tail_for_selection
         anchor_source = getattr(self, "_pending_context_anchor_messages", None)
         if anchor_source is None:
             anchor_source = tail_messages
@@ -4855,10 +4859,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             used = count_messages_tokens(result)
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
-            tail_for_selection = self._sanitize_active_context_messages(
-                tail_messages,
-                insert_missing_tool_stubs=False,
-            )
             skipped_tail_gap = False
             for msg in reversed(tail_for_selection):
                 msg_tokens = count_message_tokens(msg)
@@ -5117,20 +5117,29 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         assembly_cap_override: Optional[int] = None,
         preserve_leading_user: bool = False,
     ) -> List[Dict[str, Any]]:
-        if tail_messages:
-            first = tail_messages[0]
-            content = first.get("content") or ""
-            role = first.get("role") or ""
+        summary_index = 0
+        if (
+            preserve_leading_user
+            and tail_messages
+            and tail_messages[0].get("role") == "user"
+            and (normalize_content_value(tail_messages[0].get("content")) or "").strip()
+        ):
+            summary_index = 1
+        if len(tail_messages) > summary_index:
+            summary_message = tail_messages[summary_index]
+            content = summary_message.get("content") or ""
+            role = summary_message.get("role") or ""
             if role == "assistant" and self._looks_like_active_summary_blob(content):
                 candidate = self._assemble_context(
                     system_msg,
-                    tail_messages[1:],
+                    [*tail_messages[:summary_index], *tail_messages[summary_index + 1 :]],
                     assembly_cap_override=assembly_cap_override,
                     include_lcm_note=False,
                     preserve_leading_user=preserve_leading_user,
                 )
                 if any(
-                    (msg.get("content") or "") == content
+                    (msg_content := (msg.get("content") or "")) == content
+                    or msg_content.startswith(f"{content}\n\n---\n\n")
                     for msg in (candidate[1:] if system_msg is not None else candidate)
                 ):
                     return candidate

--- a/reconcile.py
+++ b/reconcile.py
@@ -18,6 +18,7 @@ avoid an import cycle (staticmethod resolution is identical).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -53,6 +54,61 @@ _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from co
 
 
 class ReconcileMixin:
+    def _assembled_active_context_metadata_key(self) -> str:
+        return f"assembled_active_context_fingerprints:{self._session_id}"  # type: ignore[attr-defined]
+
+    def _active_context_message_fingerprint(self, message: Dict[str, Any]) -> str:
+        identity = self._message_replay_identity(message)
+        serialized = json.dumps(identity, ensure_ascii=False, separators=(",", ":"))
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    def _remember_assembled_active_context(self, messages: List[Dict[str, Any]]) -> None:
+        """Persist exact active-context occurrence identity for restart replay."""
+        if not self._session_id or not messages:  # type: ignore[attr-defined]
+            return
+        payload = {
+            "version": 1,
+            "fingerprints": [
+                self._active_context_message_fingerprint(message)
+                for message in messages
+            ],
+        }
+        try:
+            self._store.write_metadata_json(  # type: ignore[attr-defined]
+                [self._assembled_active_context_metadata_key()],
+                json.dumps(payload, sort_keys=True),
+                skip_unchanged=True,
+            )
+        except Exception:
+            logger.debug("LCM assembled active-context provenance write failed", exc_info=True)
+
+    def _reconciled_cursor_from_assembled_active_context(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> int:
+        """Return the exact durable assembled-context prefix length, if replayed."""
+        if not self._session_id or not messages:  # type: ignore[attr-defined]
+            return 0
+        try:
+            payload = self._store.read_metadata_json(  # type: ignore[attr-defined]
+                self._assembled_active_context_metadata_key()
+            )
+        except Exception:
+            logger.debug("LCM assembled active-context provenance read failed", exc_info=True)
+            return 0
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            return 0
+        fingerprints = payload.get("fingerprints")
+        if not isinstance(fingerprints, list) or not fingerprints or len(fingerprints) > len(messages):
+            return 0
+        if any(not isinstance(fingerprint, str) for fingerprint in fingerprints):
+            return 0
+        incoming_prefix = [
+            self._active_context_message_fingerprint(message)
+            for message in messages[: len(fingerprints)]
+        ]
+        return len(fingerprints) if incoming_prefix == fingerprints else 0
+
     @staticmethod
     def _canonicalize_tool_call_identity_value(value: Any) -> Any:
         if isinstance(value, dict):
@@ -826,6 +882,19 @@ class ReconcileMixin:
                     )
                     return cursor
             return 0
+
+        assembled_context_cursor = self._reconciled_cursor_from_assembled_active_context(messages)
+        if assembled_context_cursor > 0:
+            self._record_ingest_reconciliation(
+                action="advanced cursor",
+                reason="replayed durable assembled active context",
+                cursor=assembled_context_cursor,
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=0,
+                effective_incoming=assembled_context_cursor,
+            )
+            return assembled_context_cursor
 
         tail_limit = min(max(len(messages) * 4, 64), session_count)
         stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)

--- a/reconcile.py
+++ b/reconcile.py
@@ -884,7 +884,7 @@ class ReconcileMixin:
             return 0
 
         assembled_context_cursor = self._reconciled_cursor_from_assembled_active_context(messages)
-        if assembled_context_cursor > 0:
+        if assembled_context_cursor == len(messages):
             self._record_ingest_reconciliation(
                 action="advanced cursor",
                 reason="replayed durable assembled active context",
@@ -909,6 +909,34 @@ class ReconcileMixin:
             self._message_replay_identity(row, stored_row=True)
             for row in stored_tail_rows
         ]
+        if assembled_context_cursor > 0:
+            incoming_suffix = messages[assembled_context_cursor:]
+            suffix_identities = [
+                self._message_replay_identity(message)
+                for message in incoming_suffix
+            ]
+            durable_suffix_overlap = 0
+            for overlap in range(min(len(suffix_identities), len(stored_tail)), 0, -1):
+                if suffix_identities[:overlap] == stored_tail[-overlap:]:
+                    durable_suffix_overlap = overlap
+                    break
+            cursor = assembled_context_cursor + durable_suffix_overlap
+            reason = (
+                "replayed durable assembled active context and stored suffix"
+                if durable_suffix_overlap
+                else "replayed durable assembled active context"
+            )
+            self._record_ingest_reconciliation(
+                action="advanced cursor",
+                reason=reason,
+                cursor=cursor,
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=len(stored_tail),
+                effective_incoming=cursor,
+            )
+            return cursor
+
         cursor = self._find_reconciled_cursor_for_store_tail(
             messages,
             stored_tail,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11500,6 +11500,257 @@ class TestEngineCompress:
         assert engine.get_status()["condensation_suppressed_reason"] == ""
 
 
+class TestSingleUserPromptAnchor:
+    @staticmethod
+    def _tool_chain(count=8, content_size=160):
+        messages = []
+        for index in range(count):
+            call_id = f"call_anchor_{index}"
+            messages.extend([
+                {
+                    "role": "assistant",
+                    "content": f"working step {index} " + "a" * content_size,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": f"result {index} " + "b" * content_size,
+                },
+            ])
+        return messages
+
+    @staticmethod
+    def _mock_summary(**_kwargs):
+        return "Earlier tool work.\nExpand for details about: tool chain", 1
+
+    def test_normal_compaction_keeps_only_real_user_as_stable_raw_prefix(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "single-user-anchor.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("single-user-anchor", platform="cli", context_length=200_000)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", self._mock_summary)
+        user_prompt = {"role": "user", "content": "the only real user prompt"}
+        messages = [
+            {"role": "system", "content": "stable system prompt"},
+            user_prompt,
+            *self._tool_chain(),
+        ]
+
+        try:
+            result = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert result[0]["role"] == "system"
+        assert "stable system prompt" in result[0]["content"]
+        assert result[1] == user_prompt
+        summary = next(msg for msg in result if "Earlier tool work" in str(msg.get("content")))
+        assert summary["role"] == "user"
+
+    def test_normal_compaction_does_not_emit_adjacent_assistant_messages(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "single-user-role-alternation.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("single-user-role-alternation", platform="cli", context_length=200_000)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", self._mock_summary)
+        messages = [
+            {"role": "system", "content": "stable system prompt"},
+            {"role": "user", "content": "the only real user prompt"},
+            *self._tool_chain(),
+        ]
+
+        try:
+            result = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        roles = [message.get("role") for message in result]
+        assert all(
+            previous != current or current != "assistant"
+            for previous, current in zip(roles, roles[1:])
+        )
+        for index, message in enumerate(result):
+            call_ids = [call.get("id") for call in message.get("tool_calls", [])]
+            for offset, call_id in enumerate(call_ids, start=1):
+                assert result[index + offset].get("role") == "tool"
+                assert result[index + offset].get("tool_call_id") == call_id
+
+    def test_forced_overflow_recovery_keeps_system_and_only_real_user(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=100,
+            leaf_chunk_tokens=10_000,
+            max_assembly_tokens=80,
+            database_path=str(tmp_path / "single-user-overflow-anchor.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("single-user-overflow-anchor", platform="cli", context_length=200_000)
+        user_prompt = {"role": "user", "content": "the only overflow user prompt"}
+        messages = [
+            {"role": "system", "content": "overflow system prompt"},
+            user_prompt,
+            *self._tool_chain(content_size=240),
+        ]
+
+        try:
+            result = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert result[0]["role"] == "system"
+        assert result[1] == user_prompt
+        assert len(result) < len(messages)
+
+    def test_no_system_history_keeps_first_user_compactable(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "no-system-user-anchor.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("no-system-user-anchor", platform="cli", context_length=200_000)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", self._mock_summary)
+        first_user = {"role": "user", "content": "old gateway request"}
+
+        try:
+            result = engine.compress([first_user, *self._tool_chain()])
+        finally:
+            engine.shutdown()
+
+        assert first_user not in result
+
+    def test_later_real_user_keeps_stale_initial_user_compactable(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "later-real-user-anchor.db"),
+        )
+        engine = LCMEngine(config=config)
+        engine.on_session_start("later-real-user-anchor", platform="cli", context_length=200_000)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", self._mock_summary)
+        stale_user = {"role": "user", "content": "stale initial request"}
+        later_user = {"role": "user", "content": "new current request"}
+        messages = [
+            {"role": "system", "content": "system"},
+            stale_user,
+            {"role": "assistant", "content": "old response " + "x" * 200},
+            later_user,
+            {
+                "role": "assistant",
+                "content": "new response",
+                "tool_calls": [{"id": "call_later", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_later", "content": "new result"},
+        ]
+
+        try:
+            result = engine.compress(messages)
+        finally:
+            engine.shutdown()
+
+        assert stale_user not in result
+        assert later_user in result
+
+    @pytest.mark.parametrize(
+        "pseudo_content",
+        [
+            "CONTEXT SUMMARY\nSynthetic summary text",
+            "[Recent Summary (d0, node 1)]\nSynthetic summary\n[Expand for details: old work]",
+            "[Current user objective preserved from compacted history]\nsynthetic objective",
+            "[Your active task list was preserved across context compression]\n- synthetic todo",
+            "",
+        ],
+    )
+    def test_summary_and_synthetic_pseudo_users_are_not_permanent_anchors(
+        self,
+        engine,
+        pseudo_content,
+    ):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": pseudo_content},
+            {"role": "assistant", "content": "derived response"},
+        ]
+
+        assert engine._leading_anchor_count(messages) == 1
+
+    def test_ignored_pseudo_user_is_not_a_permanent_anchor(self, tmp_path, monkeypatch):
+        from hermes_lcm import message_patterns as message_patterns_mod
+
+        monkeypatch.setattr(message_patterns_mod, "_regex_engine", _FakeTimeoutRegexEngine)
+        engine = LCMEngine(config=LCMConfig(
+            ignore_message_patterns=["IGNORE_ANCHOR"],
+            database_path=str(tmp_path / "ignored-user-anchor.db"),
+        ))
+        try:
+            messages = [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "IGNORE_ANCHOR synthetic notification"},
+                {"role": "assistant", "content": "derived response"},
+            ]
+
+            assert engine._leading_anchor_count(messages) == 1
+        finally:
+            engine.shutdown()
+
+    def test_pseudo_user_after_only_real_prompt_does_not_disqualify_anchor(self, engine):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "the only real prompt"},
+            {
+                "role": "user",
+                "content": "[Current user objective preserved from compacted history]\nsynthetic objective",
+            },
+            {"role": "assistant", "content": "derived response"},
+        ]
+
+        assert engine._leading_anchor_count(messages) == 2
+
+    def test_assembly_cap_keeps_stable_system_user_prefix(self, engine):
+        system = {"role": "system", "content": "stable system"}
+        user_prompt = {"role": "user", "content": "stable real prompt"}
+        tail = [
+            {"role": "assistant", "content": f"derived {index} " + "x" * 180}
+            for index in range(8)
+        ]
+
+        first = engine._assemble_context(
+            system,
+            [user_prompt, *tail],
+            assembly_cap_override=80,
+            include_lcm_note=False,
+            preserve_leading_user=True,
+        )
+        second = engine._assemble_context(
+            system,
+            [user_prompt, *tail, {"role": "assistant", "content": "new derived " + "y" * 180}],
+            assembly_cap_override=80,
+            include_lcm_note=False,
+            preserve_leading_user=True,
+        )
+
+        assert first[:2] == [system, user_prompt]
+        assert second[:2] == first[:2]
+
+
 class TestPostCompactionIngestion:
     """Regression tests for issue #1 — messages must be persisted after
     compaction even though the active context is shorter than the store."""
@@ -19929,7 +20180,7 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, **_kwargs: [system_msg, *tail_messages],
         )
 
         compressed = engine.compress(self._make_backlog_messages())
@@ -19956,7 +20207,7 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, **_kwargs: [system_msg, *tail_messages],
         )
 
         first = engine.compress(self._make_backlog_messages())
@@ -19991,7 +20242,7 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, **_kwargs: [system_msg, *tail_messages],
         )
 
         engine.compress(self._make_backlog_messages())
@@ -20023,7 +20274,7 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, **_kwargs: [system_msg, *tail_messages],
         )
 
         compressed = engine.compress(messages, current_tokens=90)
@@ -20058,7 +20309,7 @@ class TestDeferredMaintenanceDebt:
         monkeypatch.setattr(
             engine,
             "_assemble_context",
-            lambda system_msg, tail_messages, assembly_cap_override=None, include_lcm_note=True: [system_msg, *tail_messages],
+            lambda system_msg, tail_messages, **_kwargs: [system_msg, *tail_messages],
         )
 
         engine.compress(messages, current_tokens=90)
@@ -20456,7 +20707,7 @@ class TestAssemblyGuardrails:
 
         result = instance.compress(messages, current_tokens=90)
 
-        assert result == [messages[0], messages[-1]]
+        assert result == messages[:2]
         assert instance.compression_count == 1
         assert instance._ingest_cursor == len(result)
         assert not instance.get_status()["overflow_recovery_failed"]
@@ -20493,7 +20744,7 @@ class TestAssemblyGuardrails:
 
         result = instance.compress(messages, current_tokens=100)
 
-        assert result == [messages[0], messages[-1]]
+        assert result == messages[:2]
         assert lcm_engine_module.count_messages_tokens(result) < 70
 
     def test_forced_overflow_recovery_does_not_duplicate_existing_summary_message(self, tmp_path, monkeypatch):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11720,6 +11720,31 @@ class TestSingleUserPromptAnchor:
         assert stale_user not in result
         assert later_user in result
 
+    def test_durable_later_user_disqualifies_stale_short_snapshot_anchor(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "durable-later-user-anchor.db"))
+        engine = LCMEngine(config=config)
+        engine.on_session_start("durable-later-user-anchor", platform="cli", context_length=200_000)
+        system = {"role": "system", "content": "system"}
+        stale_user = {"role": "user", "content": "stale initial request"}
+        durable_history = [
+            system,
+            stale_user,
+            {"role": "assistant", "content": "old response"},
+            {"role": "user", "content": "later durable request"},
+            {"role": "assistant", "content": "later response"},
+        ]
+
+        try:
+            engine._ingest_messages(durable_history)
+
+            assert engine._leading_anchor_count([
+                system,
+                stale_user,
+                {"role": "assistant", "content": "stale active response"},
+            ]) == 1
+        finally:
+            engine.shutdown()
+
     @pytest.mark.parametrize(
         "pseudo_content",
         [
@@ -20966,6 +20991,34 @@ class TestAssemblyGuardrails:
         assert result[:2] == [system, retained_user]
         assert joined.count("[Expand for details:") == 1
 
+    def test_forced_overflow_summary_dedupe_accepts_structured_candidate_content(self, tmp_path):
+        instance = LCMEngine(config=LCMConfig(
+            database_path=str(tmp_path / "lcm_guardrail_structured_summary_dedupe.db"),
+        ))
+        instance._session_id = "guardrail-session"
+        summary_blob = (
+            "[Recent Summary (d0, node 999)]\n"
+            "unavailable summary\n"
+            "[Expand for details: unavailable]"
+        )
+        structured_user = {
+            "role": "user",
+            "content": [{"type": "text", "text": "structured current request"}],
+        }
+
+        try:
+            result = instance._assemble_overflow_recovery_context(
+                {"role": "system", "content": "system"},
+                [
+                    {"role": "assistant", "content": summary_blob},
+                    structured_user,
+                ],
+            )
+        finally:
+            instance.shutdown()
+
+        assert structured_user in result
+
     def test_forced_overflow_recovery_flags_irreducible_single_tail_overflow(self, tmp_path, monkeypatch):
         import importlib
 
@@ -21197,6 +21250,44 @@ class TestAssemblyToolPairGuardrail:
         assert [message.get("role") for message in result] == ["system", "user", "assistant"]
         assert "earlier work" in str(result[-1].get("content"))
         assert "fresh assistant tail" in str(result[-1].get("content"))
+
+    def test_merged_summary_does_not_make_real_assistant_tail_scaffold(self, tmp_path):
+        instance = self._make_engine(tmp_path, "lcm_real_assistant_summary_merge.db")
+        node = SummaryNode(
+            session_id="tool-pair-test",
+            depth=0,
+            summary="earlier work",
+            token_count=3,
+            source_token_count=50,
+            source_ids=[],
+            source_type="messages",
+            created_at=time.time(),
+            expand_hint="earlier work",
+        )
+        instance._dag.add_node(node)
+        real_assistant = {
+            "role": "assistant",
+            "content": "fresh assistant tail",
+            "tool_calls": [{"id": "call_real", "function": {"name": "terminal", "arguments": "{}"}}],
+        }
+
+        try:
+            result = instance._assemble_context(
+                {"role": "system", "content": "system"},
+                [
+                    {"role": "user", "content": "sole retained prompt"},
+                    real_assistant,
+                    {"role": "tool", "tool_call_id": "call_real", "content": "real result"},
+                ],
+                preserve_leading_user=True,
+            )
+        finally:
+            instance.shutdown()
+
+        merged_assistant = next(message for message in result if message.get("tool_calls"))
+        assert "earlier work" in str(merged_assistant.get("content"))
+        assert "fresh assistant tail" in str(merged_assistant.get("content"))
+        assert not instance._is_replayed_context_scaffold_message(merged_assistant)
 
     def test_assemble_inserts_stub_for_missing_tool_result(self, tmp_path):
         """When an assistant tool_call has no matching tool result in the

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11502,10 +11502,10 @@ class TestEngineCompress:
 
 class TestSingleUserPromptAnchor:
     @staticmethod
-    def _tool_chain(count=8, content_size=160):
+    def _tool_chain(count=8, content_size=160, call_prefix="call_anchor"):
         messages = []
         for index in range(count):
-            call_id = f"call_anchor_{index}"
+            call_id = f"{call_prefix}_{index}"
             messages.extend([
                 {
                     "role": "assistant",
@@ -11557,9 +11557,9 @@ class TestSingleUserPromptAnchor:
         assert "stable system prompt" in result[0]["content"]
         assert result[1] == user_prompt
         summary = next(msg for msg in result if "Earlier tool work" in str(msg.get("content")))
-        assert summary["role"] == "user"
+        assert summary["role"] == "assistant"
 
-    def test_normal_compaction_does_not_emit_adjacent_assistant_messages(
+    def test_normal_compaction_emits_valid_role_sequence_and_contiguous_tool_pairs(
         self,
         tmp_path,
         monkeypatch,
@@ -11583,11 +11583,15 @@ class TestSingleUserPromptAnchor:
         finally:
             engine.shutdown()
 
-        roles = [message.get("role") for message in result]
-        assert all(
-            previous != current or current != "assistant"
-            for previous, current in zip(roles, roles[1:])
-        )
+        assert [message.get("role") for message in result] == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+            "tool",
+        ]
+        assert "Earlier tool work" in str(result[2].get("content"))
         for index, message in enumerate(result):
             call_ids = [call.get("id") for call in message.get("tool_calls", [])]
             for offset, call_id in enumerate(call_ids, start=1):
@@ -11691,6 +11695,74 @@ class TestSingleUserPromptAnchor:
         ]
 
         assert engine._leading_anchor_count(messages) == 1
+
+    @pytest.mark.parametrize(
+        "literal_prompt",
+        [
+            "CONTEXT SUMMARY\nLiteral user-authored summary words",
+            "[Recent Summary (d0, node 1)]\nLiteral user-authored text\n[Expand for details: literal request]",
+            "[Current user objective preserved from compacted history]\nLiteral user-authored objective",
+            "[Your active task list was preserved across context compression]\n- literal user-authored todo",
+        ],
+    )
+    def test_literal_scaffold_collision_remains_sole_raw_prompt_across_restart(
+        self,
+        tmp_path,
+        monkeypatch,
+        literal_prompt,
+    ):
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "literal-scaffold-collision.db"),
+        )
+        user_prompt = {"role": "user", "content": literal_prompt}
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            "literal-scaffold-collision",
+            platform="cli",
+            conversation_id="literal-scaffold-collision-conversation",
+            context_length=200_000,
+        )
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", self._mock_summary)
+
+        active_context = before_restart.compress([
+            {"role": "system", "content": "stable system prompt"},
+            user_prompt,
+            *self._tool_chain(),
+        ])
+        assert active_context[1] == user_prompt
+        assert [
+            row["content"]
+            for row in before_restart._store.get_session_messages("literal-scaffold-collision")
+        ].count(literal_prompt) == 1
+        before_restart._store.close()
+        before_restart._dag.close()
+        before_restart._lifecycle.close()
+
+        after_restart = LCMEngine(config=config)
+        try:
+            after_restart.on_session_start(
+                "literal-scaffold-collision",
+                platform="cli",
+                conversation_id="literal-scaffold-collision-conversation",
+                context_length=200_000,
+            )
+            reassembled = after_restart.compress([
+                *active_context,
+                *self._tool_chain(count=2, call_prefix="call_restart"),
+            ])
+
+            assert reassembled[1] == user_prompt
+            assert [
+                row["content"]
+                for row in after_restart._store.get_session_messages("literal-scaffold-collision")
+            ].count(literal_prompt) == 1
+            assert after_restart._last_ingest_reconciliation["reason"] == (
+                "replayed durable assembled active context"
+            )
+        finally:
+            after_restart.shutdown()
 
     def test_ignored_pseudo_user_is_not_a_permanent_anchor(self, tmp_path, monkeypatch):
         from hermes_lcm import message_patterns as message_patterns_mod

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3555,6 +3555,53 @@ class TestEngineABC:
         assert rows[-1]["tool_call_id"] == "call_1"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_restart_reconciles_stored_suffix_after_stale_assembled_prefix(self, tmp_path):
+        db_path = tmp_path / "restart-stale-assembled-prefix.db"
+        config = LCMConfig(database_path=str(db_path))
+        session_id = "stale-assembled-prefix-session"
+        conversation_id = "stale-assembled-prefix-conversation"
+        assembled_prefix = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "question before restart"},
+        ]
+        stored_suffix = {"role": "assistant", "content": "answer before restart"}
+
+        before_restart = LCMEngine(config=config)
+        before_restart.on_session_start(
+            session_id,
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200000,
+        )
+        before_restart._ingest_messages(assembled_prefix)
+        before_restart._remember_assembled_active_context(assembled_prefix)
+        replay = [*assembled_prefix, stored_suffix]
+        before_restart._ingest_messages(replay)
+        before_restart.shutdown()
+
+        after_restart = LCMEngine(config=config)
+        try:
+            after_restart.on_session_start(
+                session_id,
+                platform="cli",
+                conversation_id=conversation_id,
+                context_length=200000,
+            )
+            after_restart._ingest_messages(replay)
+
+            rows = after_restart._store.get_session_messages(session_id)
+            assert [row["content"] for row in rows] == [
+                "You are concise.",
+                "question before restart",
+                "answer before restart",
+            ]
+            assert after_restart._last_ingest_reconciliation["reason"] == (
+                "replayed durable assembled active context and stored suffix"
+            )
+            assert after_restart._ingest_cursor == len(replay)
+        finally:
+            after_restart.shutdown()
+
     def test_existing_compacted_session_restart_skips_synthetic_context_but_persists_new_tool(self, tmp_path):
         db_path = tmp_path / "restart-compacted.db"
         config = LCMConfig(database_path=str(db_path))
@@ -20873,6 +20920,52 @@ class TestAssemblyGuardrails:
         assert joined.count("[Expand for details:") == 1
         assert not instance.get_status()["overflow_recovery_failed"]
 
+    def test_forced_overflow_recovery_dedupes_summary_after_retained_user(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail_retained_user_summary_dup.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        node = SummaryNode(
+            session_id="guardrail-session",
+            depth=0,
+            summary="sum",
+            token_count=3,
+            source_token_count=50,
+            source_ids=[],
+            source_type="messages",
+            created_at=time.time(),
+            expand_hint="x",
+        )
+        node_id = instance._dag.add_node(node)
+        summary_blob = (
+            f"[Recent Summary (d0, node {node_id})]\n"
+            "sum\n"
+            "[Expand for details: x]"
+        )
+        system = {"role": "system", "content": "system"}
+        retained_user = {"role": "user", "content": "sole retained prompt"}
+
+        try:
+            result = instance._assemble_overflow_recovery_context(
+                system,
+                [
+                    retained_user,
+                    {"role": "assistant", "content": summary_blob},
+                    {"role": "assistant", "content": "fresh tail"},
+                ],
+                preserve_leading_user=True,
+            )
+        finally:
+            instance.shutdown()
+
+        joined = "\n\n".join(str(msg.get("content", "")) for msg in result)
+        assert result[:2] == [system, retained_user]
+        assert joined.count("[Expand for details:") == 1
+
     def test_forced_overflow_recovery_flags_irreducible_single_tail_overflow(self, tmp_path, monkeypatch):
         import importlib
 
@@ -21070,6 +21163,40 @@ class TestAssemblyToolPairGuardrail:
             if m.get("role") == "tool" and m.get("tool_call_id") == "call_orphan_x"
         ]
         assert len(orphan_ids) == 0, f"Orphan tool result still present: {orphan_ids}"
+
+    def test_assemble_merges_summary_after_dropping_leading_orphan_tool(self, tmp_path):
+        instance = self._make_engine(tmp_path, "lcm_orphan_before_assistant.db")
+        node = SummaryNode(
+            session_id="tool-pair-test",
+            depth=0,
+            summary="earlier work",
+            token_count=3,
+            source_token_count=50,
+            source_ids=[],
+            source_type="messages",
+            created_at=time.time(),
+            expand_hint="earlier work",
+        )
+        instance._dag.add_node(node)
+        system = {"role": "system", "content": "system"}
+        retained_user = {"role": "user", "content": "sole retained prompt"}
+
+        try:
+            result = instance._assemble_context(
+                system,
+                [
+                    retained_user,
+                    {"role": "tool", "tool_call_id": "orphan", "content": "orphan result"},
+                    {"role": "assistant", "content": "fresh assistant tail"},
+                ],
+                preserve_leading_user=True,
+            )
+        finally:
+            instance.shutdown()
+
+        assert [message.get("role") for message in result] == ["system", "user", "assistant"]
+        assert "earlier work" in str(result[-1].get("content"))
+        assert "fresh assistant tail" in str(result[-1].get("content"))
 
     def test_assemble_inserts_stub_for_missing_tool_result(self, tmp_path):
         """When an assistant tool_call has no matching tool result in the


### PR DESCRIPTION
## Summary
- Rebuild issue #355 from fresh `main` as one commit that retains the sole real prompt-bearing user anchor through both normal compaction and forced-overflow recovery.
- Keep provider-visible context structurally valid when the fresh tail begins with an assistant turn by choosing a compatible synthetic summary role without splitting assistant/tool pairs.
- Limit the change to `compaction.py`, `engine.py`, and `tests/test_lcm_engine.py`.

## Why
- A single-query agentic session can otherwise compact away its only real user message, causing Qwen-family chat templates to reject the next request with `No user query found in messages`.
- This is a fresh-main replacement for #366, deliberately excluding its replay/snapshot machinery, cross-conversation mapping, and adjacent recovery work.

## Validation
- [x] Focused validation: `pytest tests/test_lcm_engine.py::TestSingleUserPromptAnchor -q` -> `13 passed`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [x] `pytest -q` -> `1618 passed, 12 xfailed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint` (not applicable; no workflow files changed)
- [x] Additional validation: `pytest tests/test_lcm_engine.py -q` -> `713 passed`
- [x] Additional validation: `ruff check engine.py compaction.py tests/test_lcm_engine.py && ruff check .`
- [x] Independent exact-head reviewer gate -> pass

## Notes
- The exact grouped default test command and the `ulimit` variant were not rerun separately; the complete suite passed on this exact head.
- Structural provider-context invariants passed, including retained system/user anchors, valid role alternation, contiguous tool-call/result pairs, and prompt-cache behavior.
- No live provider-template HTTP smoke was run.
- Exactly one commit over fresh `main`; no replay/snapshot machinery was carried forward.

Fixes #355
