### PR TITLE
fix: never block token counting on tiktoken's network download

### DIFF
--- a/tests/test_tokens_encoder_loading.py
+++ b/tests/test_tokens_encoder_loading.py
@@ -21,6 +21,7 @@ def _reset_encoder_state(monkeypatch):
     monkeypatch.setattr(tokens_mod, "_encoder", None)
     monkeypatch.setattr(tokens_mod, "_encoder_ready", False)
     monkeypatch.setattr(tokens_mod, "_encoder_thread", None)
+    monkeypatch.setattr(tokens_mod, "_encoder_generation", 0)
     tokens_mod._count_tokens_cached.cache_clear()
     yield
     tokens_mod._count_tokens_cached.cache_clear()
@@ -73,6 +74,131 @@ def test_encoder_adopted_after_background_load(monkeypatch):
         time.sleep(0.02)
     assert tokens_mod.count_tokens(text) == 42, "real encoder was never adopted"
     assert first != 42  # the pre-adoption call really used the estimator
+
+
+def test_adoption_race_stale_estimate_not_served(monkeypatch):
+    """An in-flight estimator miss must not poison the post-adoption cache.
+
+    Ordering under test (deterministic, event-driven): a count_tokens() call
+    misses the LRU and enters the estimator; the loader then adopts the real
+    encoder (and clears the cache); the paused estimator call finishes last,
+    inserting its result into the *post-clear* cache. Identical counts made
+    after adoption must return the encoder's value, not the stale estimate.
+    """
+
+    class FakeEncoder:
+        def encode(self, text):
+            return list(range(7))
+
+    release_load = threading.Event()
+    fallback_entered = threading.Event()
+    release_fallback = threading.Event()
+
+    def gated_loader():
+        release_load.wait(timeout=10)
+        return FakeEncoder()
+
+    real_fallback = tokens_mod._fallback_token_estimate
+    probe = "y" * 400
+
+    def gated_fallback(text):
+        if text == probe:
+            fallback_entered.set()
+            release_fallback.wait(timeout=10)
+        return real_fallback(text)
+
+    monkeypatch.setattr(tokens_mod, "_load_encoder", gated_loader)
+    monkeypatch.setattr(tokens_mod, "_fallback_token_estimate", gated_fallback)
+    monkeypatch.setattr(tokens_mod, "_ENCODER_FIRST_WAIT_S", 0.01)
+
+    results = []
+    caller = threading.Thread(
+        target=lambda: results.append(tokens_mod.count_tokens(probe)),
+        daemon=True,
+    )
+    caller.start()
+
+    # 1. The caller is inside the estimator (pre-adoption LRU miss in flight).
+    assert fallback_entered.wait(timeout=5.0)
+
+    # 2. The loader adopts the real encoder while that miss is still pending.
+    release_load.set()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and tokens_mod._encoder_generation == 0:
+        time.sleep(0.01)
+    assert tokens_mod._encoder_generation == 1, "encoder was never adopted"
+
+    # 3. The stale estimate lands in the cache *after* adoption's clear.
+    release_fallback.set()
+    caller.join(timeout=5.0)
+    assert not caller.is_alive()
+    assert results == [400 // 4 + 1]  # the in-flight call used the estimator
+
+    # 4. Post-adoption counts for the identical text must be exact -- both the
+    #    first lookup and a repeat (i.e. the cached value is the encoder's).
+    assert tokens_mod.count_tokens(probe) == 7
+    assert tokens_mod.count_tokens(probe) == 7
+
+
+def test_concurrent_callers_single_loader_prompt_returns(monkeypatch):
+    """One loader thread total; non-first callers never wait on the load.
+
+    Pins the concurrency contract: concurrent count_tokens() callers against
+    a hung loader trigger exactly one _load_encoder() invocation, the first
+    caller's wait is bounded, later callers return promptly with estimates,
+    and counts after adoption are exact.
+    """
+
+    class FakeEncoder:
+        def encode(self, text):
+            return list(range(7))
+
+    release_load = threading.Event()
+    load_calls = []
+
+    def gated_loader():
+        load_calls.append(threading.get_ident())
+        release_load.wait(timeout=10)
+        return FakeEncoder()
+
+    monkeypatch.setattr(tokens_mod, "_load_encoder", gated_loader)
+    monkeypatch.setattr(tokens_mod, "_ENCODER_FIRST_WAIT_S", 0.05)
+
+    probe = "z" * 400
+    start = time.monotonic()
+    first = tokens_mod.count_tokens(probe)  # starts the loader, bounded wait
+    first_elapsed = time.monotonic() - start
+    assert first_elapsed < 2.0, f"first caller waited {first_elapsed:.1f}s"
+    assert first == 400 // 4 + 1
+
+    results = []
+    lock = threading.Lock()
+
+    def worker(i):
+        t0 = time.monotonic()
+        value = tokens_mod.count_tokens(f"{'w' * 396}{i:04d}")
+        with lock:
+            results.append((value, time.monotonic() - t0))
+
+    workers = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join(timeout=5.0)
+        assert not t.is_alive()
+
+    assert len(load_calls) == 1, "loader must be started exactly once"
+    assert [v for v, _ in results] == [400 // 4 + 1] * 4  # estimator values
+    assert all(elapsed < 1.0 for _, elapsed in results), (
+        "non-first callers must not wait on the hung loader"
+    )
+
+    release_load.set()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and tokens_mod.count_tokens(probe) != 7:
+        time.sleep(0.02)
+    assert tokens_mod.count_tokens(probe) == 7, "exact counts after adoption"
+    assert len(load_calls) == 1
 
 
 def test_loader_failure_falls_back_to_estimator(monkeypatch):

--- a/tests/test_tokens_encoder_loading.py
+++ b/tests/test_tokens_encoder_loading.py
@@ -1,0 +1,88 @@
+"""Encoder acquisition must never block callers on unbounded network I/O.
+
+tiktoken.get_encoding() downloads its BPE file on first use when it is not
+cached on disk; on restricted-egress hosts that request can hang for minutes
+(measured ~127s per fresh process in a production deployment) and
+_get_encoder() sits on the host's post_llm_call path.  These tests pin the
+contract: a slow/hung loader must not stall count_tokens(), and the real
+encoder is adopted once the background load completes.
+"""
+
+import threading
+import time
+
+import pytest
+
+from hermes_lcm import tokens as tokens_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_encoder_state(monkeypatch):
+    monkeypatch.setattr(tokens_mod, "_encoder", None)
+    monkeypatch.setattr(tokens_mod, "_encoder_ready", False)
+    monkeypatch.setattr(tokens_mod, "_encoder_thread", None)
+    tokens_mod._count_tokens_cached.cache_clear()
+    yield
+    tokens_mod._count_tokens_cached.cache_clear()
+
+
+def test_count_tokens_does_not_block_on_hung_loader(monkeypatch):
+    release = threading.Event()
+
+    def hung_loader():
+        # Simulates the blocked-egress BPE download: never completes within
+        # the test window.
+        release.wait(timeout=30)
+        raise RuntimeError("loader released without an encoder")
+
+    monkeypatch.setattr(tokens_mod, "_load_encoder", hung_loader)
+    monkeypatch.setattr(tokens_mod, "_ENCODER_FIRST_WAIT_S", 0.05)
+
+    start = time.monotonic()
+    count = tokens_mod.count_tokens("hello world " * 1000)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.0, f"count_tokens blocked for {elapsed:.1f}s on the loader"
+    assert count > 0  # estimator result
+    release.set()
+
+
+def test_encoder_adopted_after_background_load(monkeypatch):
+    class FakeEncoder:
+        def encode(self, text):
+            return list(range(42))
+
+    started = threading.Event()
+
+    def slow_loader():
+        started.set()
+        time.sleep(0.1)
+        return FakeEncoder()
+
+    monkeypatch.setattr(tokens_mod, "_load_encoder", slow_loader)
+    monkeypatch.setattr(tokens_mod, "_ENCODER_FIRST_WAIT_S", 0.01)
+
+    text = "adoption probe " * 50
+    first = tokens_mod.count_tokens(text)  # estimator (loader still sleeping)
+    assert started.wait(timeout=2.0)
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if tokens_mod.count_tokens(text) == 42:
+            break
+        time.sleep(0.02)
+    assert tokens_mod.count_tokens(text) == 42, "real encoder was never adopted"
+    assert first != 42  # the pre-adoption call really used the estimator
+
+
+def test_loader_failure_falls_back_to_estimator(monkeypatch):
+    def broken_loader():
+        raise ImportError("tiktoken not installed")
+
+    monkeypatch.setattr(tokens_mod, "_load_encoder", broken_loader)
+    monkeypatch.setattr(tokens_mod, "_ENCODER_FIRST_WAIT_S", 0.5)
+
+    count = tokens_mod.count_tokens("x" * 400)
+    assert count == 400 // 4 + 1  # ascii estimator path
+    assert tokens_mod._encoder_ready is True
+    assert tokens_mod._encoder is None

--- a/tokens.py
+++ b/tokens.py
@@ -17,6 +17,13 @@ _encoder = None
 _encoder_ready = False
 _encoder_lock = threading.Lock()
 _encoder_thread = None
+# Cache-key generation, bumped (under _encoder_lock) when the real encoder is
+# adopted. The memoized count is keyed on (text, generation), so an estimator
+# result computed before adoption can only ever be inserted under the old
+# generation: a cache_clear() alone cannot stop an in-flight LRU miss from
+# repopulating the cache with a stale estimate *after* the clear, but a stale
+# insert under a dead key is unreachable by post-adoption lookups.
+_encoder_generation = 0
 
 # Bound on how long a count_tokens() caller will wait for the FIRST encoder
 # load. tiktoken.get_encoding() downloads the BPE file over the network when
@@ -36,7 +43,7 @@ def _load_encoder():
 
 
 def _encoder_loader() -> None:
-    global _encoder, _encoder_ready
+    global _encoder, _encoder_ready, _encoder_generation
     enc = None
     try:
         enc = _load_encoder()
@@ -45,9 +52,14 @@ def _encoder_loader() -> None:
     with _encoder_lock:
         _encoder = enc
         _encoder_ready = True
+        if enc is not None:
+            # Counts for identical text change estimator -> encoder on
+            # adoption; bumping the generation retires every pre-adoption
+            # cache key, including ones an in-flight miss has yet to insert.
+            _encoder_generation += 1
     if enc is not None:
-        # Counts for identical text change estimator -> encoder on adoption;
-        # drop memoized estimates so the cache stays consistent.
+        # Memory hygiene only (correctness comes from the generation key):
+        # evict the now-unreachable old-generation entries.
         _count_tokens_cached.cache_clear()
 
 
@@ -112,10 +124,11 @@ def _count_tokens_core(text) -> int:
 
 
 @lru_cache(maxsize=2048)
-def _count_tokens_cached(text: str) -> int:
+def _count_tokens_cached(text: str, generation: int) -> int:
     # tiktoken encoding is the dominant per-turn cost: assembly and preflight
-    # re-count the same content many times per turn. The encoder is decided
-    # once per process (see _get_encoder), so a content-keyed cache is stable.
+    # re-count the same content many times per turn. The counting function is
+    # stable within one encoder generation (see _encoder_generation), so a
+    # (content, generation) key is stable.
     return _count_tokens_core(text)
 
 
@@ -134,7 +147,7 @@ def count_tokens(text) -> int:
     # (e.g. tool_call arguments as a dict); preserve the legacy tolerance by
     # counting those uncached rather than feeding them to the LRU.
     if isinstance(text, str) and len(text) <= _MAX_CACHEABLE_TOKEN_TEXT_CHARS:
-        return _count_tokens_cached(text)
+        return _count_tokens_cached(text, _encoder_generation)
     return _count_tokens_core(text)
 
 

--- a/tokens.py
+++ b/tokens.py
@@ -4,6 +4,7 @@ Uses tiktoken when available, falls back to char-based estimate.
 """
 
 import logging
+import threading
 from functools import lru_cache
 from typing import Any, Dict, List
 
@@ -13,21 +14,67 @@ logger = logging.getLogger(__name__)
 
 _CHARS_PER_TOKEN = 4
 _encoder = None
-_encoder_checked = False
+_encoder_ready = False
+_encoder_lock = threading.Lock()
+_encoder_thread = None
+
+# Bound on how long a count_tokens() caller will wait for the FIRST encoder
+# load. tiktoken.get_encoding() downloads the BPE file over the network when
+# it is not already cached on disk; on restricted-egress hosts that request
+# can hang for minutes before failing (measured: ~127s per fresh process in a
+# production deployment), and _get_encoder() sits on the host's post-turn
+# hook path -- so the hang blocked reply delivery. Callers that hit the bound
+# use the char-based estimate; the real encoder is adopted (and the count
+# cache cleared) whenever the background load completes.
+_ENCODER_FIRST_WAIT_S = 2.0
+
+
+def _load_encoder():
+    """The (possibly network-backed) tiktoken load. Patchable in tests."""
+    import tiktoken
+    return tiktoken.get_encoding("cl100k_base")
+
+
+def _encoder_loader() -> None:
+    global _encoder, _encoder_ready
+    enc = None
+    try:
+        enc = _load_encoder()
+    except Exception:
+        logger.debug("tiktoken not available, using char-based estimates")
+    with _encoder_lock:
+        _encoder = enc
+        _encoder_ready = True
+    if enc is not None:
+        # Counts for identical text change estimator -> encoder on adoption;
+        # drop memoized estimates so the cache stays consistent.
+        _count_tokens_cached.cache_clear()
 
 
 def _get_encoder():
-    """Lazily load tiktoken cl100k_base encoder."""
-    global _encoder, _encoder_checked
-    if _encoder_checked:
+    """Return the tiktoken encoder, never blocking on unbounded network I/O.
+
+    The load runs in a daemon thread. The first caller waits briefly
+    (_ENCODER_FIRST_WAIT_S) so the common already-cached-on-disk case still
+    gets exact counts immediately; after that, callers never wait -- they use
+    the estimator until the loader finishes.
+    """
+    global _encoder_thread
+    if _encoder_ready:
         return _encoder
-    _encoder_checked = True
-    try:
-        import tiktoken
-        _encoder = tiktoken.get_encoding("cl100k_base")
-    except Exception:
-        logger.debug("tiktoken not available, using char-based estimates")
-    return _encoder
+    first = False
+    with _encoder_lock:
+        if _encoder_ready:
+            return _encoder
+        if _encoder_thread is None:
+            _encoder_thread = threading.Thread(
+                target=_encoder_loader, name="lcm-tiktoken-load", daemon=True
+            )
+            _encoder_thread.start()
+            first = True
+    if first:
+        _encoder_thread.join(timeout=_ENCODER_FIRST_WAIT_S)
+    return _encoder if _encoder_ready else None
 
 
 def _fallback_token_estimate(text: str) -> int:


### PR DESCRIPTION
## Reworked per review — thank you @Tosko4, you were right

Your point 4 sent me back to instrument the actual stack, and the finding invalidates my original design entirely. This PR is now a different, much smaller change; the async executor, backlog semaphore, drain handle, and pre-warm are all **gone**, and the four post-hook tests pass **unmodified** (the hook is synchronous again).

## The real root cause (profiled, reproduced)

`tiktoken.get_encoding("cl100k_base")` downloads its BPE file over the network on first use when it isn't cached on disk. On a restricted-egress host that request hangs until the transport gives up. `_get_encoder()` sits under `count_tokens()` on the ingest path — which hosts run inside the synchronous `post_llm_call` hook — so the first turn after every process start blocked reply delivery.

cProfile of the first ingest of a ~45K-token history on a restricted-egress host:

```
1  128.108s  engine.py ingest
1  128.107s  engine.py _ingest_messages
2  127.852s  tokens.py count_message_tokens
1  127.791s  tiktoken load_tiktoken_bpe → requests.get(...)
```

Second turn, same process: 0.1s. You were right that `ingest()` does no summarization — my "two 60s summary timeouts" reading of the 127s was a coincidence of numbers; the duration is the network transport's give-up time, which is why it was so repeatable.

## The fix

`tokens.py` only: load the encoder in a daemon thread. The first caller waits up to 2s (the common cached-on-disk case still gets exact counts immediately); after that, callers never wait — they use the existing char-based estimator until the loader finishes, then the encoder is adopted and `_count_tokens_cached` is cleared (counts for identical text change on adoption). A permanently blocked download degrades to the estimator for the life of the process — the same posture as tiktoken being uninstalled, which this module already supports.

Measured on the same blocked-egress host: first-turn hook **128.5s → 2.2s**, fully synchronous.

## Your review points

1–3 (stale rebind, foreground serialization, executor lifecycle): all real, all mooted — that machinery no longer exists in this PR.
4 (prove the root cause): profile and reproduction above.

Validation: full suite 1608 passed (3 new tests: hung-loader non-blocking contract, post-load adoption + cache clear, loader-failure fallback); ruff clean; `compileall` clean.