### PR TITLE
feat: stub externalized tool results in active replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ Most installs only need `plugins.enabled` and `context.engine: lcm`.
 | `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
+| `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` | `false` | Replace token-heavy textual tool results with recoverable externalized refs in active replay; current-turn ingest is immediate and historical assembly respects the protected fresh tail; requires large-output externalization |
+| `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS` | `25000` | Token-aware threshold for active-replay tool-result stubbing |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |
 | `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
@@ -512,6 +514,21 @@ Externalization for ordinary large tool output is opt-in. When enabled,
 oversized tool results are written to plugin-managed JSON files and referenced
 from summaries. They remain inspectable through
 `lcm_describe(externalized_ref=...)` and `lcm_expand(externalized_ref=...)`.
+
+Active-replay stubbing is a second, independently opt-in replay policy. When
+both externalization and active-replay stubbing are enabled, newly ingested
+textual tool results above the token threshold are durably externalized and
+replaced immediately in provider-visible replay, including results in the
+protected fresh tail. This lets a stub-only replay change converge even when no
+leaf is eligible for compaction. A historical assembly pass applies the same
+policy to older tool results before budgeting, while respecting the protected
+fresh tail. Tool-call ids and compatible structured text block types/keys are
+retained; raw SQLite rows and DAG lineage are not rewritten by the historical
+pass. Structured image/media results remain inline, preserving the provider
+replay contract established by Hermes-LCM PR #226. If durable externalization
+cannot be confirmed, replay keeps the original payload inline. Results from
+`lcm_describe` and `lcm_expand` also remain inline so recovery does not
+recursively produce another ref.
 
 The storage-boundary payload guard is separate from that opt-in. LCM always
 scans messages at the store boundary before writing `messages.content` or

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,6 +9,22 @@ The benchmark harness is offline by default:
 - no live Hermes config mutation
 - writes isolated to the requested output directory
 
+## Active tool-result stubbing benchmark
+
+The focused active-replay benchmark builds ten deterministic synthetic tool
+results near 30K tokens each, protects the newest two pairs as the fresh tail,
+and compares provider-visible assembly with stubbing disabled and enabled. It
+verifies that every emitted ref recovers byte-identical normalized content and
+prints aggregate-only JSON:
+
+```bash
+python benchmarks/benchmark_active_tool_stubbing.py \
+  --output /tmp/hermes-lcm-active-tool-stubbing.json
+```
+
+The result measures provider-visible prompt tokens and local assembly latency.
+It is not a provider billing-cost measurement and contains no raw payload text.
+
 ## Run the default replay suite
 
 ```bash

--- a/benchmarks/benchmark_active_tool_stubbing.py
+++ b/benchmarks/benchmark_active_tool_stubbing.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Measure provider-visible token savings from active tool-result stubbing.
+
+The workload is synthetic and deterministic. It never calls a provider, reads a
+Hermes profile, or includes transcript data. Ten assistant/tool pairs carry a
+roughly 30K-token textual result each; the newest two pairs are protected by the
+four-message fresh tail, leaving eight results eligible for active-replay
+stubbing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarking.replay import _ensure_hermes_lcm_package
+
+
+def _payload_for_target_tokens(target_tokens: int) -> str:
+    """Return deterministic text with exactly ``target_tokens`` estimator tokens."""
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.tokens import count_tokens
+
+    payload = " x" * target_tokens
+    actual = count_tokens(payload)
+    if actual != target_tokens:
+        raise RuntimeError(
+            f"deterministic payload token mismatch: expected={target_tokens} actual={actual}"
+        )
+    return payload
+
+
+def _tool_pair(call_id: str, payload: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "content": "tool",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "synthetic_benchmark_tool",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": payload},
+    ]
+
+
+def _run_mode(
+    root: Path,
+    messages: list[dict[str, Any]],
+    *,
+    enabled: bool,
+    stub_threshold_tokens: int,
+) -> dict[str, Any]:
+    _ensure_hermes_lcm_package()
+    from hermes_lcm.config import LCMConfig
+    from hermes_lcm.engine import LCMEngine
+    import hermes_lcm.externalize as externalize
+    from hermes_lcm.externalize import extract_externalized_ref, load_externalized_payload
+    from hermes_lcm.message_content import normalize_content_value
+    from hermes_lcm.tokens import count_messages_tokens
+
+    mode = "enabled" if enabled else "disabled"
+    hermes_home = root / mode / "hermes"
+    config = LCMConfig(
+        database_path=str(root / mode / "lcm.db"),
+        fresh_tail_count=4,
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=12_000,
+        large_output_active_replay_stubbing_enabled=enabled,
+        large_output_active_replay_stub_threshold_tokens=stub_threshold_tokens,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(hermes_home))
+    engine.on_session_start(
+        f"active-stub-benchmark-{mode}",
+        platform="benchmark",
+        conversation_id=f"active-stub-benchmark-{mode}",
+        context_length=400_000,
+    )
+    try:
+        anchor = {"role": "system", "content": ""}
+        fixed_epoch = 1_700_000_000.0
+        fixed_time = time.gmtime(fixed_epoch)
+        nanoseconds = itertools.count(1_700_000_000_000_000_000)
+        with (
+            patch.object(externalize.time, "gmtime", return_value=fixed_time),
+            patch.object(externalize.time, "time", return_value=fixed_epoch),
+            patch.object(externalize.time, "time_ns", side_effect=lambda: next(nanoseconds)),
+        ):
+            started = time.perf_counter()
+            engine._assemble_context(
+                anchor,
+                messages,
+            )
+            cold_ms = (time.perf_counter() - started) * 1_000
+
+            started = time.perf_counter()
+            warm = engine._assemble_context(
+                anchor,
+                messages,
+            )
+            warm_ms = (time.perf_counter() - started) * 1_000
+
+        recovered = 0
+        stubbed = 0
+        original_tools = {
+            str(message.get("tool_call_id") or ""): message
+            for message in messages
+            if message.get("role") == "tool"
+        }
+        for assembled in warm:
+            if assembled.get("role") != "tool":
+                continue
+            original = original_tools.get(str(assembled.get("tool_call_id") or ""))
+            if original is None:
+                continue
+            assembled_text = normalize_content_value(assembled.get("content")) or ""
+            ref = extract_externalized_ref(assembled_text)
+            if not ref:
+                continue
+            stubbed += 1
+            payload = load_externalized_payload(
+                ref,
+                config=config,
+                hermes_home=str(hermes_home),
+            )
+            original_text = normalize_content_value(original.get("content")) or ""
+            if payload is not None and payload.get("content") == original_text:
+                recovered += 1
+
+        return {
+            "mode": mode,
+            "assembled_tokens": count_messages_tokens(warm),
+            "cold_assembly_ms": round(cold_ms, 3),
+            "warm_assembly_ms": round(warm_ms, 3),
+            "stubbed_results": stubbed,
+            "recovered_results": recovered,
+            "recovery_equal": recovered == stubbed,
+            "raw_content_included": False,
+        }
+    finally:
+        engine.shutdown()
+
+
+def run_benchmark(*, payload_tokens: int = 30_000) -> dict[str, Any]:
+    _ensure_hermes_lcm_package()
+    messages: list[dict[str, Any]] = []
+    for index in range(10):
+        # The small deterministic adjustments preserve the originally observed
+        # 300,288 -> 60,709 benchmark shape while every payload remains within
+        # 11 tokens of the documented 30K-token target.
+        adjustment = 4 if index == 0 else 6 if index < 4 else 5 if index < 8 else 11 if index == 8 else -2
+        payload = _payload_for_target_tokens(payload_tokens + adjustment)
+        messages.extend(_tool_pair(f"benchmark-call-{index}", payload))
+
+    with tempfile.TemporaryDirectory(prefix="hermes-lcm-active-stub-") as temp_dir:
+        root = Path(temp_dir)
+        disabled = _run_mode(
+            root,
+            messages,
+            enabled=False,
+            stub_threshold_tokens=25_000,
+        )
+        enabled = _run_mode(
+            root,
+            messages,
+            enabled=True,
+            stub_threshold_tokens=25_000,
+        )
+
+    tokens_saved = disabled["assembled_tokens"] - enabled["assembled_tokens"]
+    reduction_percent = (
+        tokens_saved / disabled["assembled_tokens"] * 100
+        if disabled["assembled_tokens"]
+        else 0.0
+    )
+    return {
+        "schema_version": 1,
+        "workload": {
+            "tool_pairs": 10,
+            "fresh_tail_messages": 4,
+            "eligible_tool_results": 8,
+            "target_payload_tokens": payload_tokens,
+            "payload_token_adjustments": [4, 6, 6, 6, 5, 5, 5, 5, 11, -2],
+            "synthetic_only": True,
+        },
+        "disabled": disabled,
+        "enabled": enabled,
+        "tokens_saved": tokens_saved,
+        "reduction_percent": round(reduction_percent, 2),
+        "recovery_equal": enabled["recovery_equal"],
+        "billing_cost_measurement": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload-tokens", type=int, default=30_000)
+    parser.add_argument("--output", help="Optional path for aggregate JSON output")
+    args = parser.parse_args(argv)
+    if args.payload_tokens <= 25_000:
+        parser.error("--payload-tokens must exceed the 25,000-token stub threshold")
+
+    result = run_benchmark(payload_tokens=args.payload_tokens)
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    if args.output:
+        output = Path(args.output).resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0 if result["recovery_equal"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compaction.py
+++ b/compaction.py
@@ -159,10 +159,10 @@ class CompactionMixin:
             if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
                 return self._mark_preflight_compression_requested()
             return False
-        if self._should_force_overflow_recovery(observed_tokens=rough):
-            return self._mark_preflight_compression_requested()
         if self._compression_boundary_cooldown_active():
             return False
+        if self._should_force_overflow_recovery(observed_tokens=rough):
+            return self._mark_preflight_compression_requested()
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
             if pre_ingest_placeholder_ambiguous_noop:
                 self._last_compression_status = "noop"

--- a/compaction.py
+++ b/compaction.py
@@ -65,6 +65,7 @@ class CompactionMixin:
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
+        self._preflight_cleanup_only_due_to_boundary_cooldown = False
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
@@ -109,13 +110,34 @@ class CompactionMixin:
                     return True
                 return False
         if replay_messages is not None and replay_messages != messages:
+            replay_rough = count_messages_tokens(replay_messages)
+            cleanup_requested = self._replay_diff_requests_ingest_cleanup(
+                messages,
+                replay_messages,
+            )
+            force_overflow_requested = self._should_force_overflow_recovery(
+                observed_tokens=rough,
+                messages=messages,
+            ) or self._should_force_overflow_recovery(
+                observed_tokens=replay_rough,
+                messages=replay_messages,
+            )
+            if cleanup_requested:
+                if (
+                    not force_overflow_requested
+                    and self._compression_boundary_cooldown_active()
+                ):
+                    self._preflight_cleanup_only_due_to_boundary_cooldown = True
+                return self._mark_preflight_compression_requested()
+            if force_overflow_requested:
+                return self._mark_preflight_compression_requested()
+            # A boundary skip cools down summary-producing leaf/condensation
+            # work. It must not prevent the host from adopting a replay cleanup
+            # that ingest has already made durable (for example a live tool
+            # result stub); those returns above are deterministic and add no
+            # summarizer spend.
             if self._compression_boundary_cooldown_active():
                 return False
-            replay_rough = count_messages_tokens(replay_messages)
-            if self._should_force_overflow_recovery(observed_tokens=replay_rough):
-                return self._mark_preflight_compression_requested()
-            if self._replay_diff_requests_ingest_cleanup(messages, replay_messages):
-                return self._mark_preflight_compression_requested()
             if pre_ingest_placeholder_ambiguous_noop:
                 self._last_compression_status = "noop"
                 self._last_compression_noop_reason = pre_ingest_noop_reason
@@ -137,10 +159,10 @@ class CompactionMixin:
             if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
                 return self._mark_preflight_compression_requested()
             return False
-        if self._compression_boundary_cooldown_active():
-            return False
         if self._should_force_overflow_recovery(observed_tokens=rough):
             return self._mark_preflight_compression_requested()
+        if self._compression_boundary_cooldown_active():
+            return False
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
             if pre_ingest_placeholder_ambiguous_noop:
                 self._last_compression_status = "noop"
@@ -177,6 +199,8 @@ class CompactionMixin:
                 if replay_text.startswith("[Externalized LCM ingest payload:"):
                     return True
                 if replay_text.startswith("[Externalized payload: kind=raw_payload;"):
+                    return True
+                if replay_text.startswith("[Externalized tool output:"):
                     return True
                 if replay_text.startswith("[LCM active replay placeholder: assistant output quarantined;"):
                     return True
@@ -370,6 +394,34 @@ class CompactionMixin:
         # or provider context after the durable row has been written.
         working_messages = self._ingest_messages(messages)
         ingest_cleanup_changed_active_context = working_messages != messages
+        cleanup_only_due_to_boundary_cooldown = bool(
+            self._preflight_cleanup_only_due_to_boundary_cooldown
+            and not force_overflow
+        )
+        self._preflight_cleanup_only_due_to_boundary_cooldown = False
+        if cleanup_only_due_to_boundary_cooldown:
+            sanitized_messages = self._sanitize_active_context_messages(
+                working_messages,
+                insert_missing_tool_stubs=False,
+            )
+            self._refresh_raw_backlog_debt(
+                sanitized_messages,
+                observed_tokens=observed_prompt_tokens,
+            )
+            self._ingest_cursor = len(sanitized_messages)
+            self._last_compression_status = "sanitized"
+            self._last_compression_noop_reason = ""
+            self._write_generated_ignored_placeholder_hash_counts(
+                self._generated_placeholder_digest_budget_for_active_replay(
+                    sanitized_messages
+                )
+            )
+            self._write_generated_ignored_placeholder_hash_ordinals(
+                self._generated_placeholder_digest_ordinals_for_active_replay(
+                    sanitized_messages
+                )
+            )
+            return sanitized_messages
         anchor_source_messages = list(working_messages)
         pressure_messages = messages if len(messages) == len(working_messages) else working_messages
         leaf_compacted_this_turn = False
@@ -671,6 +723,7 @@ class CompactionMixin:
                     working_messages,
                     compressed,
                     assembly_cap_override=recovery_assembly_cap,
+                    ingest_cleanup_changed_active_context=ingest_cleanup_changed_active_context,
                 )
             active_context_messages = self._drop_preexisting_generated_ignored_dependent_eof_replies(
                 working_messages,

--- a/config.py
+++ b/config.py
@@ -280,6 +280,8 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("large_output_externalization_enabled", "LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", bool),
     _EnvFieldSpec("large_output_externalization_threshold_chars", "LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", int),
     _EnvFieldSpec("large_output_externalization_path", "LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", str),
+    _EnvFieldSpec("large_output_active_replay_stubbing_enabled", "LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED", bool),
+    _EnvFieldSpec("large_output_active_replay_stub_threshold_tokens", "LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS", int),
     _EnvFieldSpec("large_output_transcript_gc_enabled", "LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED", bool),
     _EnvFieldSpec("summary_model", "LCM_SUMMARY_MODEL", str),
     _EnvFieldSpec("summary_circuit_breaker_failure_threshold", "LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", int),
@@ -423,6 +425,15 @@ class LCMConfig:
     large_output_externalization_threshold_chars: int = 12_000
     # Explicit storage directory for externalized payloads (empty = auto under hermes home).
     large_output_externalization_path: str = ""
+    # Replace eligible textual tool results with durable compact refs in
+    # provider-visible replay. Current-turn ingest is intercepted immediately;
+    # historical assembly separately respects the protected fresh tail. This
+    # remains opt-in and requires large-output externalization.
+    large_output_active_replay_stubbing_enabled: bool = False
+    # Token-aware active-replay threshold. The character threshold above still
+    # controls ordinary ingest externalization; this threshold controls when a
+    # provider-visible textual tool result is replaced by its durable ref.
+    large_output_active_replay_stub_threshold_tokens: int = 25_000
     # When enabled, already-externalized summarized tool-result transcript rows may
     # be rewritten to compact GC placeholders after successful leaf compaction.
     large_output_transcript_gc_enabled: bool = False

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -151,6 +151,8 @@ environment variables:
 | `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
+| `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` | `false` | Replace token-heavy textual tool results with recoverable externalized refs in active replay; current-turn ingest is immediate and historical assembly respects the protected fresh tail; requires large-output externalization |
+| `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS` | `25000` | Token-aware threshold for active-replay tool-result stubbing |
 | `LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED` | `false` | Rewrite already-externalized summarized tool rows to compact placeholders |
 | `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | `0.0` | Disabled at `0.0`; when set, permits critical-pressure bypasses for bounded deferred catch-up and cache-friendly follow-on condensation only |
 | `LCM_SUMMARY_MODEL` | auxiliary | Override summarization model |
@@ -447,6 +449,20 @@ Externalization for ordinary large tool output is opt-in. When enabled,
 oversized tool results are written to plugin-managed JSON files and referenced
 from summaries. They remain inspectable later through
 `lcm_describe(externalized_ref=...)` and `lcm_expand(externalized_ref=...)`.
+
+Active-replay stubbing is separately opt-in and requires ordinary large-output
+externalization. Newly ingested textual tool results above the token threshold
+are durably externalized and immediately replaced in provider-visible replay,
+including results in the protected fresh tail. Preflight adopts that replay
+change even if no leaf compaction is eligible. A second historical assembly
+pass replaces older eligible results before evaluating the assembly budget and
+respects the protected fresh tail. Tool roles, `tool_call_id` values, and
+compatible structured text block types/keys are retained; the historical pass
+does not rewrite raw SQLite/DAG lineage. Structured image/media tool results
+remain inline, preserving the provider-replay contract established by PR #226.
+Failure to durably externalize is fail-open: the provider receives the original
+inline payload. Results from `lcm_describe` and `lcm_expand` also stay inline so
+recovery does not recursively create another drilldown step.
 
 The storage-boundary payload guard is separate from that opt-in. LCM always
 scans messages at the store boundary before writing `messages.content` or

--- a/engine.py
+++ b/engine.py
@@ -55,6 +55,7 @@ from .extraction import (
 from .ingest_protection import (
     _expected_persisted_output_chars,
     _has_lossy_sensitive_redaction,
+    _contains_media_payload,
     _is_hermes_persisted_output_marker,
     _persisted_output_inline_preview_sha256,
     _persisted_output_preview_prefix_digest,
@@ -297,6 +298,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # Cooldown timestamp to prevent compression cascade after boundary skip.
         # Set when skip-carry-over path is taken in _continue_compression_boundary.
         self._last_boundary_skip_time: float = 0
+        # One-shot handoff from preflight: adopt an already-durable replay
+        # cleanup during boundary cooldown without running summary work.
+        self._preflight_cleanup_only_due_to_boundary_cooldown = False
         # Temporary source window used only while compress() assembles context.
         # _assemble_context also serves tests and recovery paths directly, so
         # keep anchoring opt-in rather than changing its public behavior.
@@ -4106,6 +4110,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             config=self._config,
             hermes_home=self._hermes_home,
         )
+        recovery_tool_call_ids = self._active_replay_recovery_tool_call_ids(
+            active_replay_messages
+        )
         for (absolute_idx, _replay_msg), protected_msg in zip(
             messages_to_store_with_index,
             protected_messages,
@@ -4118,6 +4125,19 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 active_message = dict(active_replay_messages[absolute_idx])
                 active_message["content"] = protected_msg["content"]
                 active_replay_messages[absolute_idx] = active_message
+                continue
+
+            active_message = active_replay_messages[absolute_idx]
+            stubbed_message = self._maybe_stub_active_tool_result(
+                active_message,
+                recovery_tool_call_ids=recovery_tool_call_ids,
+            )
+            if stubbed_message is not None:
+                if active_replay_messages is replay_messages:
+                    active_replay_messages = self._copy_active_replay_messages_preserving_generated_ids(
+                        replay_messages
+                    )
+                active_replay_messages[absolute_idx] = stubbed_message
 
         estimates = [count_message_tokens(m) for m in protected_messages]
         self._store._append_protected_batch(
@@ -4134,11 +4154,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._compression_boundary_stored_placeholder_digest_counts = {}
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
         self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
-        # Most ``protected_messages`` changes are storage-only: inline media,
-        # tool results, and data/base64 substrings must stay provider-usable in
-        # active replay. Whole-message ``raw_payload`` externalization is the
-        # exception: it intentionally returns a compact active stub so the host
-        # does not replay huge opaque text while SQLite stores only the stub.
+        # Most ``protected_messages`` changes are storage-only: inline media and
+        # data/base64 substrings stay provider-usable in active replay. The
+        # exceptions are whole-message ``raw_payload`` externalization and the
+        # separately opt-in textual tool-result interceptor above.
         return self._remember_active_replay_messages(messages, active_replay_messages)
 
     @staticmethod
@@ -4350,6 +4369,188 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             cleaned,
             insert_missing_tool_stubs=insert_missing_tool_stubs,
         )
+
+    @staticmethod
+    def _active_tool_stub_content(original_content: Any, placeholder: str) -> Any:
+        """Preserve compatible structured text-block shape when inserting a ref."""
+        if not isinstance(original_content, list):
+            return placeholder
+        for block in original_content:
+            if isinstance(block, str):
+                return [placeholder]
+            if not isinstance(block, dict):
+                continue
+            block_type = str(block.get("type") or "").lower()
+            if block_type not in {"text", "input_text", "output_text"}:
+                continue
+            for value_key in ("text", "content"):
+                text_value = block.get(value_key)
+                if isinstance(text_value, str):
+                    return [{"type": block_type, value_key: placeholder}]
+                if not isinstance(text_value, dict):
+                    continue
+                for nested_key in ("value", "content"):
+                    if isinstance(text_value.get(nested_key), str):
+                        return [{
+                            "type": block_type,
+                            value_key: {nested_key: placeholder},
+                        }]
+        # _is_textual_tool_result_content() only admits supported shapes, so
+        # this fallback is defensive rather than a normal provider path.
+        return [{"type": "text", "text": placeholder}]
+
+    @staticmethod
+    def _structured_text_block_value(block: Dict[str, Any]) -> str | None:
+        for value_key in ("text", "content"):
+            text_value = block.get(value_key)
+            if isinstance(text_value, str):
+                return text_value
+            if not isinstance(text_value, dict):
+                continue
+            for nested_key in ("value", "content"):
+                nested = text_value.get(nested_key)
+                if isinstance(nested, str):
+                    return nested
+        return None
+
+    @staticmethod
+    def _is_textual_tool_result_content(content: Any) -> bool:
+        """Return whether active stubbing can preserve provider semantics."""
+        if _contains_media_payload(content):
+            return False
+        if isinstance(content, str):
+            return True
+        if not isinstance(content, list) or not content:
+            return False
+        for block in content:
+            if isinstance(block, str):
+                continue
+            if not isinstance(block, dict):
+                return False
+            if str(block.get("type") or "").lower() not in {
+                "text",
+                "input_text",
+                "output_text",
+            }:
+                return False
+            if LCMEngine._structured_text_block_value(block) is None:
+                return False
+        return True
+
+    def _active_replay_recovery_tool_call_ids(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> set[str]:
+        recovery_tool_call_ids: set[str] = set()
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                call_id = _tool_call_id(tool_call)
+                function = tool_call.get("function") or {}
+                tool_name = str(function.get("name") or "") if isinstance(function, dict) else ""
+                if call_id and tool_name in {"lcm_describe", "lcm_expand"}:
+                    recovery_tool_call_ids.add(call_id)
+        return recovery_tool_call_ids
+
+    def _maybe_stub_active_tool_result(
+        self,
+        message: Dict[str, Any],
+        *,
+        recovery_tool_call_ids: set[str],
+    ) -> Dict[str, Any] | None:
+        if not getattr(self._config, "large_output_active_replay_stubbing_enabled", False):
+            return None
+        if not getattr(self._config, "large_output_externalization_enabled", False):
+            return None
+        if not isinstance(message, dict) or message.get("role") != "tool":
+            return None
+        tool_call_id = str(message.get("tool_call_id") or "").strip()
+        if not tool_call_id or tool_call_id in recovery_tool_call_ids:
+            return None
+        content = message.get("content")
+        if not self._is_textual_tool_result_content(content):
+            return None
+        normalized_content = normalize_content_value(content) or ""
+        if not normalized_content or is_externalized_placeholder(normalized_content):
+            return None
+        threshold = max(
+            1,
+            int(
+                getattr(
+                    self._config,
+                    "large_output_active_replay_stub_threshold_tokens",
+                    25_000,
+                )
+                or 0
+            ),
+        )
+        if count_tokens(normalized_content) <= threshold:
+            return None
+        externalized = maybe_externalize_tool_output(
+            normalized_content,
+            tool_call_id=tool_call_id,
+            session_id=self._session_id,
+            config=self._config,
+            hermes_home=self._hermes_home,
+            force=True,
+        )
+        if externalized is None:
+            return None
+        replacement = dict(message)
+        replacement["content"] = self._active_tool_stub_content(
+            content,
+            externalized["placeholder"],
+        )
+        return replacement
+
+    def _stub_large_tool_results_for_active_replay(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Replace eligible old tool payloads with durable refs for assembly.
+
+        This is provider-replay-only. It never mutates the input messages, raw
+        SQLite rows, or DAG lineage. The newest ``fresh_tail_count`` messages
+        stay inline, matching Lossless Claw's protected-tail contract.
+        """
+        if not getattr(self._config, "large_output_active_replay_stubbing_enabled", False):
+            return messages
+        if not getattr(self._config, "large_output_externalization_enabled", False):
+            return messages
+        protected_tail_count = max(0, int(getattr(self._config, "fresh_tail_count", 0) or 0))
+        eligible_end = max(0, len(messages) - protected_tail_count)
+        if eligible_end <= 0:
+            return messages
+
+        recovery_tool_call_ids = self._active_replay_recovery_tool_call_ids(messages)
+
+        result = list(messages)
+        stubbed_count = 0
+        tokens_saved = 0
+        for idx, message in enumerate(messages[:eligible_end]):
+            replacement = self._maybe_stub_active_tool_result(
+                message,
+                recovery_tool_call_ids=recovery_tool_call_ids,
+            )
+            if replacement is None:
+                continue
+            result[idx] = replacement
+            stubbed_count += 1
+            tokens_saved += max(
+                0,
+                count_message_tokens(message) - count_message_tokens(replacement),
+            )
+
+        if stubbed_count:
+            logger.info(
+                "LCM active replay stubbing: replaced %d evictable tool result(s), saved about %d tokens",
+                stubbed_count,
+                tokens_saved,
+            )
+        return result
 
     def _sanitize_tool_pairs(
         self,
@@ -4697,7 +4898,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             else self._effective_assembly_token_cap()
         )
 
-        tail_selected = tail_messages
+        # Stub durably externalized evictable tool payloads before the assembly
+        # budget pass so the selector sees their reduced provider-visible cost.
+        # The helper protects the configured fresh tail and is fail-open.
+        assembly_tail_messages = self._stub_large_tool_results_for_active_replay(tail_messages)
+        tail_selected = assembly_tail_messages
         anchor_source = getattr(self, "_pending_context_anchor_messages", None)
         if anchor_source is None:
             anchor_source = tail_messages
@@ -4708,7 +4913,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             kept_tail_reversed: list[Dict[str, Any]] = []
             tail_token_total = 0
             tail_for_selection = self._sanitize_active_context_messages(
-                tail_messages,
+                assembly_tail_messages,
                 insert_missing_tool_stubs=False,
             )
             skipped_tail_gap = False
@@ -4838,8 +5043,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         original_messages: List[Dict[str, Any]],
         compressed: List[Dict[str, Any]],
         assembly_cap_override: Optional[int] = None,
+        ingest_cleanup_changed_active_context: bool = False,
     ) -> List[Dict[str, Any]]:
-        if compressed != original_messages:
+        if compressed != original_messages or ingest_cleanup_changed_active_context:
             self._last_compression_status = "overflow_recovery"
             self._last_compression_noop_reason = ""
             self._ingest_cursor = len(compressed)

--- a/externalize.py
+++ b/externalize.py
@@ -858,6 +858,7 @@ def maybe_externalize_tool_output(
     session_id: str = "",
     config,
     hermes_home: str = "",
+    force: bool = False,
 ) -> Dict[str, Any] | None:
     return maybe_externalize_payload(
         content,
@@ -867,6 +868,7 @@ def maybe_externalize_tool_output(
         role="tool",
         config=config,
         hermes_home=hermes_home,
+        force=force,
     )
 
 

--- a/tests/test_active_tool_stubbing.py
+++ b/tests/test_active_tool_stubbing.py
@@ -1,0 +1,466 @@
+"""Focused tests for opt-in active-replay tool-result stubbing."""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+import hermes_lcm.engine as lcm_engine
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.externalize import extract_externalized_ref, load_externalized_payload
+from hermes_lcm.message_content import normalize_content_value
+
+
+@pytest.fixture
+def make_engine(tmp_path):
+    engines = []
+
+    def build(**overrides):
+        settings = dict(
+            database_path=str(tmp_path / f"active-stub-{len(engines)}.db"),
+            fresh_tail_count=2,
+            large_output_externalization_enabled=True,
+            large_output_externalization_threshold_chars=1_000_000,
+            large_output_active_replay_stubbing_enabled=True,
+            large_output_active_replay_stub_threshold_tokens=5,
+        )
+        settings.update(overrides)
+        config = LCMConfig(**settings)
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        engine_index = len(engines)
+        engine.on_session_start(
+            f"active-stub-test-{engine_index}",
+            conversation_id=f"active-stub-conversation-{engine_index}",
+            context_length=200_000,
+        )
+        engines.append(engine)
+        return engine
+
+    yield build
+
+    for engine in engines:
+        engine.shutdown()
+
+
+def tool_pair(call_id, payload, tool_name="read_file"):
+    return [
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": payload},
+    ]
+
+
+def assembled_tool(result, call_id):
+    return next(
+        message
+        for message in result
+        if message.get("role") == "tool" and message.get("tool_call_id") == call_id
+    )
+
+
+def test_active_stubbing_is_default_off(tmp_path):
+    config = LCMConfig(
+        database_path=str(tmp_path / "default-off.db"),
+        fresh_tail_count=2,
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=1,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+    engine._session_id = "default-off-test"
+    payload = "old tool payload " * 100
+    tail = tool_pair("old-call", payload) + tool_pair("fresh-call", "fresh result")
+    try:
+        result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+    finally:
+        engine.shutdown()
+
+    assert assembled_tool(result, "old-call")["content"] == payload
+
+
+def test_stubs_only_token_heavy_evictable_results_and_preserves_pairing(make_engine):
+    engine = make_engine()
+    old_payload = "alpha beta gamma delta epsilon " * 30
+    fresh_payload = "fresh result " * 30
+    tail = tool_pair("old-call", old_payload) + tool_pair("fresh-call", fresh_payload)
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    old_result = assembled_tool(result, "old-call")
+    fresh_result = assembled_tool(result, "fresh-call")
+    assert old_result["content"].startswith("[Externalized tool output:")
+    assert "ref=" in old_result["content"]
+    assert fresh_result["content"] == fresh_payload
+    assistant_call_ids = {
+        call["id"]
+        for message in result
+        for call in (message.get("tool_calls") or [])
+    }
+    assert {"old-call", "fresh-call"} <= assistant_call_ids
+    assert {old_result["tool_call_id"], fresh_result["tool_call_id"]} <= assistant_call_ids
+    first_ref = extract_externalized_ref(old_result["content"])
+
+    second_result = engine._assemble_context(
+        {"role": "system", "content": "system"},
+        tail,
+    )
+    second_ref = extract_externalized_ref(assembled_tool(second_result, "old-call")["content"])
+    assert second_ref == first_ref
+    assert len(list((Path(engine._hermes_home) / "lcm-large-outputs").glob("*.json"))) == 1
+
+
+def test_token_threshold_can_force_externalization_below_character_threshold(make_engine):
+    engine = make_engine()
+    payload = "one two three four five six seven eight nine ten"
+    tail = tool_pair("token-call", payload) + tool_pair("fresh-call", "fresh result")
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    stub = assembled_tool(result, "token-call")["content"]
+    assert stub.startswith("[Externalized tool output:")
+    ref = extract_externalized_ref(stub)
+    assert ref
+    recovered = load_externalized_payload(
+        ref,
+        config=engine._config,
+        hermes_home=engine._hermes_home,
+    )
+    assert recovered is not None
+    assert recovered["content"] == payload
+    expanded = json.loads(
+        engine.handle_tool_call(
+            "lcm_expand",
+            {"externalized_ref": ref, "max_tokens": 1_000},
+        )
+    )
+    assert expanded["content"] == payload
+
+
+def test_structured_text_tool_content_remains_array_shaped_and_recoverable(make_engine):
+    engine = make_engine()
+    payload = [
+        {"type": "text", "text": "structured payload " * 40},
+        {"type": "input_text", "text": "second textual block " * 20},
+    ]
+    tail = tool_pair("structured-call", payload) + tool_pair("fresh-call", "fresh result")
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    stub_content = assembled_tool(result, "structured-call")["content"]
+    assert isinstance(stub_content, list)
+    assert stub_content == [{"type": "text", "text": stub_content[0]["text"]}]
+    assert stub_content[0]["text"].startswith("[Externalized tool output:")
+    ref = extract_externalized_ref(stub_content[0]["text"])
+    recovered = load_externalized_payload(
+        ref,
+        config=engine._config,
+        hermes_home=engine._hermes_home,
+    )
+    assert recovered is not None
+    assert json.loads(recovered["content"]) == json.loads(normalize_content_value(payload))
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_shape"),
+    [
+        (
+            [{"type": "input_text", "text": "input payload " * 40}],
+            lambda placeholder: [{"type": "input_text", "text": placeholder}],
+        ),
+        (
+            [{"type": "output_text", "text": {"value": "output payload " * 40}}],
+            lambda placeholder: [
+                {"type": "output_text", "text": {"value": placeholder}}
+            ],
+        ),
+        (
+            [{"type": "text", "content": {"content": "content payload " * 40}}],
+            lambda placeholder: [
+                {"type": "text", "content": {"content": placeholder}}
+            ],
+        ),
+    ],
+)
+def test_structured_text_stub_preserves_compatible_block_type_and_key(
+    make_engine,
+    payload,
+    expected_shape,
+):
+    engine = make_engine(fresh_tail_count=0)
+    tail = tool_pair("shape-call", payload)
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    stub_content = assembled_tool(result, "shape-call")["content"]
+    placeholder = stub_content[0].get("text") or stub_content[0].get("content")
+    if isinstance(placeholder, dict):
+        placeholder = placeholder.get("value") or placeholder.get("content")
+    assert isinstance(placeholder, str)
+    assert placeholder.startswith("[Externalized tool output:")
+    assert stub_content == expected_shape(placeholder)
+
+
+def test_structured_media_tool_result_stays_provider_usable_inline(make_engine):
+    engine = make_engine()
+    payload = [
+        {"type": "text", "text": "image follows " * 40},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64," + "A" * 1_000},
+        },
+    ]
+    tail = tool_pair("media-call", payload) + tool_pair("fresh-call", "fresh result")
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    assert assembled_tool(result, "media-call")["content"] == payload
+
+
+def test_externalization_failure_leaves_original_payload_inline(make_engine, monkeypatch):
+    engine = make_engine()
+    payload = "must remain inline " * 40
+    tail = tool_pair("fail-open-call", payload) + tool_pair("fresh-call", "fresh result")
+    monkeypatch.setattr(lcm_engine, "maybe_externalize_tool_output", lambda *args, **kwargs: None)
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    assert assembled_tool(result, "fail-open-call")["content"] == payload
+
+
+@pytest.mark.parametrize("tool_name", ["lcm_describe", "lcm_expand"])
+def test_recovery_tool_output_is_not_recursively_stubbed(make_engine, tool_name):
+    engine = make_engine()
+    payload = "recovered full payload " * 100
+    tail = tool_pair("recovery-call", payload, tool_name=tool_name) + tool_pair(
+        "fresh-call",
+        "fresh result",
+    )
+
+    result = engine._assemble_context({"role": "system", "content": "system"}, tail)
+
+    assert assembled_tool(result, "recovery-call")["content"] == payload
+
+
+def test_overflow_recovery_uses_same_active_stub_policy(make_engine):
+    engine = make_engine()
+    payload = "overflow payload " * 100
+    tail = tool_pair("overflow-call", payload) + tool_pair("fresh-call", "fresh result")
+
+    result = engine._assemble_overflow_recovery_context(
+        {"role": "system", "content": "system"},
+        tail,
+        assembly_cap_override=10_000,
+    )
+
+    assert assembled_tool(result, "overflow-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+
+
+def test_stubbing_happens_before_assembly_budget_selection(make_engine):
+    stubbed_engine = make_engine()
+    baseline_engine = make_engine(large_output_active_replay_stubbing_enabled=False)
+    payload = "budget pressure payload " * 2_000
+    tail = tool_pair("budget-call", payload) + tool_pair("fresh-call", "fresh result")
+
+    stubbed = stubbed_engine._assemble_context(
+        {"role": "system", "content": "system"},
+        tail,
+        assembly_cap_override=250,
+    )
+    baseline = baseline_engine._assemble_context(
+        {"role": "system", "content": "system"},
+        tail,
+        assembly_cap_override=250,
+    )
+
+    assert assembled_tool(stubbed, "budget-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert not any(
+        message.get("tool_call_id") == "budget-call" for message in baseline
+    )
+
+
+def test_orphan_tool_result_is_not_externalized_as_a_phantom_reference(make_engine):
+    engine = make_engine(fresh_tail_count=1)
+    orphan_payload = "orphan payload " * 40
+    messages = [
+        {"role": "tool", "content": orphan_payload},
+        {"role": "user", "content": "fresh request"},
+    ]
+
+    stubbed = engine._stub_large_tool_results_for_active_replay(messages)
+
+    assert stubbed == messages
+
+
+def test_live_interceptor_adopts_current_tool_stub_below_compaction_threshold(make_engine):
+    engine = make_engine(fresh_tail_count=32, leaf_chunk_tokens=20_000)
+    engine.threshold_tokens = 100_000
+    payload = "live current payload " * 100
+    messages = [
+        {"role": "system", "content": "system"},
+        *tool_pair("live-call", payload),
+    ]
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=1_000)
+
+    assert assembled_tool(result, "live-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.last_compression_status == "sanitized"
+
+
+def test_live_stub_adoption_outranks_compression_boundary_cooldown(make_engine):
+    engine = make_engine(fresh_tail_count=32, leaf_chunk_tokens=20_000)
+    engine.threshold_tokens = 100_000
+    engine._last_boundary_skip_time = time.time()
+    payload = "durable live payload during cooldown " * 100
+    messages = [
+        {"role": "system", "content": "system"},
+        *tool_pair("cooldown-live-call", payload),
+    ]
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=1_000)
+
+    stub = assembled_tool(result, "cooldown-live-call")["content"]
+    assert stub.startswith("[Externalized tool output:")
+    ref = extract_externalized_ref(stub)
+    recovered = load_externalized_payload(
+        ref,
+        config=engine._config,
+        hermes_home=engine._hermes_home,
+    )
+    assert recovered is not None
+    assert recovered["content"] == payload
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.last_compression_status == "sanitized"
+
+
+def test_live_stub_cooldown_adoption_skips_eligible_leaf_work(make_engine, monkeypatch):
+    engine = make_engine(fresh_tail_count=2, leaf_chunk_tokens=1)
+    engine.threshold_tokens = 100_000
+    engine._last_boundary_skip_time = time.time()
+    payload = "fresh durable payload with old eligible backlog " * 100
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old request with eligible raw backlog"},
+        {"role": "assistant", "content": "old answer with eligible raw backlog"},
+        *tool_pair("cooldown-eligible-call", payload),
+    ]
+
+    def fail_if_summarized(**_kwargs):
+        raise AssertionError("boundary cooldown cleanup must not summarize")
+
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_if_summarized)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=1_000)
+
+    assert assembled_tool(result, "cooldown-eligible-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert any(message.get("content") == "old request with eligible raw backlog" for message in result)
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.last_compression_status == "sanitized"
+
+
+def test_live_interceptor_converges_when_no_leaf_is_eligible(make_engine):
+    engine = make_engine(fresh_tail_count=32, leaf_chunk_tokens=20_000)
+    engine.threshold_tokens = 1
+    payload = "no eligible leaf payload " * 100
+    messages = [
+        {"role": "system", "content": "system"},
+        *tool_pair("no-leaf-call", payload),
+    ]
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=10_000)
+
+    assert assembled_tool(result, "no-leaf-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+
+
+def test_live_interceptor_survives_fresh_tail_overflow_recovery(make_engine):
+    engine = make_engine(
+        fresh_tail_count=32,
+        max_assembly_tokens=200,
+        leaf_chunk_tokens=20_000,
+    )
+    payload = "fresh overflow payload " * 2_000
+    messages = [
+        {"role": "system", "content": "system"},
+        *tool_pair("fresh-overflow-call", payload),
+    ]
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=None)
+
+    assert assembled_tool(result, "fresh-overflow-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.last_compression_status in {"sanitized", "overflow_recovery"}
+
+
+def test_live_interceptor_is_preserved_after_normal_leaf_compaction(make_engine, monkeypatch):
+    engine = make_engine(fresh_tail_count=2, leaf_chunk_tokens=1)
+    engine.threshold_tokens = 1
+    payload = "current result after compaction " * 100
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old request"},
+        {"role": "assistant", "content": "old answer"},
+        *tool_pair("normal-call", payload),
+    ]
+    monkeypatch.setattr(
+        lcm_engine,
+        "summarize_with_escalation",
+        lambda **_kwargs: ("old work summary\nExpand for details about: old work", 1),
+    )
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=20_000)
+
+    assert assembled_tool(result, "normal-call")["content"].startswith(
+        "[Externalized tool output:"
+    )
+    assert engine._dag.get_session_node_count(engine._session_id) == 1
+    assert engine.last_compression_status == "compacted"
+
+
+def test_live_interceptor_keeps_media_and_recovery_results_inline(make_engine):
+    engine = make_engine(fresh_tail_count=32, leaf_chunk_tokens=20_000)
+    engine.threshold_tokens = 100_000
+    media_payload = [
+        {"type": "text", "text": "image follows " * 40},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64," + "A" * 1_000}},
+    ]
+    messages = [
+        {"role": "system", "content": "system"},
+        *tool_pair("media-live-call", media_payload),
+        *tool_pair("recovery-live-call", "recovered payload " * 100, tool_name="lcm_expand"),
+    ]
+
+    assert engine.should_compress_preflight(messages) is False
+    cached = engine._cached_active_replay_messages(messages)
+
+    assert cached is not None
+    assert assembled_tool(cached, "media-live-call")["content"] == media_payload
+    assert assembled_tool(cached, "recovery-live-call")["content"] == "recovered payload " * 100

--- a/tests/test_active_tool_stubbing.py
+++ b/tests/test_active_tool_stubbing.py
@@ -3,6 +3,7 @@
 import json
 import time
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -67,6 +68,20 @@ def assembled_tool(result, call_id):
         for message in result
         if message.get("role") == "tool" and message.get("tool_call_id") == call_id
     )
+
+
+def externalized_raw_cleanup_messages():
+    original = [{"role": "user", "content": "large raw payload"}]
+    cleanup = [
+        {
+            "role": "user",
+            "content": (
+                "[Externalized payload: kind=raw_payload; role=user; "
+                "chars=17; bytes=17; ref=raw-payload.json]"
+            ),
+        }
+    ]
+    return original, cleanup
 
 
 def test_active_stubbing_is_default_off(tmp_path):
@@ -349,6 +364,72 @@ def test_live_stub_adoption_outranks_compression_boundary_cooldown(make_engine):
     assert recovered["content"] == payload
     assert engine._dag.get_session_node_count(engine._session_id) == 0
     assert engine.last_compression_status == "sanitized"
+
+
+def test_flag_off_plain_preflight_cooldown_blocks_threshold_and_overflow(make_engine):
+    engine = make_engine(
+        large_output_active_replay_stubbing_enabled=False,
+        max_assembly_tokens=10,
+    )
+    engine.threshold_tokens = 1
+    engine._last_boundary_skip_time = time.time()
+    messages = [{"role": "user", "content": "plain branch pressure " * 100}]
+
+    assert engine._should_force_overflow_recovery(messages=messages) is True
+    assert engine.should_compress_preflight(messages) is False
+
+
+def test_flag_off_replay_cleanup_preflight_outranks_boundary_cooldown(
+    make_engine,
+    monkeypatch,
+):
+    engine = make_engine(large_output_active_replay_stubbing_enabled=False)
+    engine.threshold_tokens = 100_000
+    engine._last_boundary_skip_time = time.time()
+    messages, cleanup_messages = externalized_raw_cleanup_messages()
+    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: cleanup_messages)
+
+    assert engine.should_compress_preflight(messages) is True
+    assert engine._preflight_cleanup_only_due_to_boundary_cooldown is True
+
+
+def test_flag_off_replay_cleanup_cooldown_publishes_without_summary_llm(
+    make_engine,
+    monkeypatch,
+):
+    engine = make_engine(large_output_active_replay_stubbing_enabled=False)
+    engine.threshold_tokens = 100_000
+    engine._last_boundary_skip_time = time.time()
+    messages, cleanup_messages = externalized_raw_cleanup_messages()
+    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: cleanup_messages)
+    summary_spy = Mock(
+        side_effect=AssertionError("cooldown-limited replay cleanup must not summarize")
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=1_000)
+
+    assert result == cleanup_messages
+    assert engine.last_compression_status == "sanitized"
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    summary_spy.assert_not_called()
+
+
+def test_flag_off_noncleanup_replay_diff_remains_blocked_during_cooldown(
+    make_engine,
+    monkeypatch,
+):
+    engine = make_engine(large_output_active_replay_stubbing_enabled=False)
+    engine.threshold_tokens = 1
+    engine._last_boundary_skip_time = time.time()
+    messages = [{"role": "user", "content": "original visible payload"}]
+    replay_messages = [{"role": "user", "content": "normalized visible payload"}]
+    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: replay_messages)
+
+    assert engine._replay_diff_requests_ingest_cleanup(messages, replay_messages) is False
+    assert engine._should_force_overflow_recovery(messages=replay_messages) is False
+    assert engine.should_compress_preflight(messages) is False
 
 
 def test_live_stub_cooldown_adoption_skips_eligible_leaf_work(make_engine, monkeypatch):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -550,6 +550,8 @@ class TestConfig:
         assert c.large_output_externalization_enabled is False
         assert c.large_output_externalization_threshold_chars == 12_000
         assert c.large_output_externalization_path == ""
+        assert c.large_output_active_replay_stubbing_enabled is False
+        assert c.large_output_active_replay_stub_threshold_tokens == 25_000
         assert c.large_output_transcript_gc_enabled is False
         assert c.deferred_maintenance_enabled is False
         assert c.deferred_maintenance_max_passes == 4
@@ -599,6 +601,8 @@ class TestConfig:
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", "true")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", "4096")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", "/tmp/lcm-large-outputs")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED", "true")
+        monkeypatch.setenv("LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS", "8192")
         monkeypatch.setenv("LCM_LARGE_OUTPUT_TRANSCRIPT_GC_ENABLED", "true")
         c = LCMConfig.from_env()
         assert c.fresh_tail_count == 32
@@ -634,6 +638,8 @@ class TestConfig:
         assert c.large_output_externalization_enabled is True
         assert c.large_output_externalization_threshold_chars == 4096
         assert c.large_output_externalization_path == "/tmp/lcm-large-outputs"
+        assert c.large_output_active_replay_stubbing_enabled is True
+        assert c.large_output_active_replay_stub_threshold_tokens == 8192
         assert c.large_output_transcript_gc_enabled is True
 
     def test_from_env_invalid_numeric_values_fall_back_to_defaults(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- add **opt-in, token-aware stubbing of oversized textual tool results in provider-visible active
  replay** — externalize first, fail open if durable storage can't be confirmed, replace inline
  content with a Hermes-native recoverable reference
- preserve tool-call pairing, structured text shapes, media payloads, fresh-tail behavior, and
  `lcm_describe`/`lcm_expand` recovery (recovery results are never re-stubbed)
- during a compression-boundary cooldown, a **durable replay cleanup still publishes — with zero
  summarizer spend** (cleanup-only pass; proven by a test that mocks the summary LLM and asserts it
  is never called)
- plain (no-replay-diff) preflight ordering is **unchanged from upstream**: an earlier draft reordered
  the cooldown/overflow checks there; that reorder is reverted out of this PR (happy to propose it
  separately with its own test if the semantics interest you)
- deterministic synthetic benchmark: **79.78% fewer provider-visible prompt tokens** (300,288 →
  60,709), 8/8 eligible payloads recovered equal after normalization

We maintain Martian Engineering's Lossless Claw and are porting the proven pattern into Hermes-LCM.

Tracker: #375
Closes #374

## Why

Hermes-LCM already externalizes large outputs durably, but provider-visible replay can keep carrying
the full text until compaction reaches it — paying the token cost every turn. This policy replaces
qualifying active tool results with recoverable references at ingest and historical-assembly time,
leaving raw SQLite history and DAG lineage unchanged. Disabled by default
(`LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED=false`); media-bearing results stay inline;
storage-confirmation failure keeps the original content.

### Where this hooks into the pipeline

```mermaid
flowchart LR
    I[Ingest] --> C[Compact] --> D[Condense] --> ES[Escalate] --> A[Assemble] --> R[Retrieve]
    S[stub substitution<br/>opt-in] --> X[(externalized<br/>payload sidecars)]
    I -->|oversized textual<br/>tool result| S
    A -->|recoverable ref<br/>in replay| S
    classDef hot fill:#b45309,stroke:#7c2d12,color:#fff
    class I,A,S hot
```

`lcm_describe` / `lcm_expand` recover the original content on demand; raw history is never rewritten.

## Validation

- [x] focused suite `tests/test_active_tool_stubbing.py` — **25 passed**, including four **flag-off
      regression tests**: cooldown still blocks plain threshold/overflow preflight; a durable replay
      cleanup publishes during cooldown; that publish makes **zero** summary-LLM calls
      (`assert_not_called` on the mocked summarizer); non-cleanup replay diffs stay blocked
- [x] full `pytest -q` — **1631 passed, 1 skipped, 12 xfailed**; 3 failures are the known macOS
      baseline (1 tokenizer-dependent + 2 `/var` vs `/private/var`), reproduced identically on the
      untouched upstream clone at `31675c6` — Linux CI is the canonical gate
- [x] `ruff check .` — pass
- [x] `scripts/validate_release.sh --full --keep-going` — diff/compile/shell gates, focused pytest
      (409), benchmark smoke, both stress tiers all pass; the two full-suite variants carry only the
      same three macOS baseline assertions
- [x] deterministic benchmark repeated twice — 300,288 → 60,709 both runs; 8/8 recovery equality
- [x] rebased onto current `main` (`31675c6`), no conflicts

(Fork workflow runs need maintainer approval — validation output above is locally reproducible until
then.)

## Notes

- Opt-in and backward compatible: no database rewrite, no transcript GC required, no live profile
  touched by tests or benchmarks.
- Replay-branch preflight ordering is deliberate and now documented in-code: a boundary skip cools
  down summary-*producing* work, but must not stop the host from adopting a cleanup that ingest has
  already made durable — that pass is deterministic and spends nothing.
- Overlaps: #370 touches the same `compress()`/assembly region — happy to rebase after it lands (the
  rebase cost is ours). #367 rewrites the config field table our two new entries sit near — same
  offer. Sibling #381 shares engine/compaction surface; #382/#383 don't overlap this PR.
