### PR TITLE
test: stabilize preflight noop reset fixture

### DIFF
--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1598,9 +1598,14 @@ class TestEngineABC:
             {"role": "assistant", "content": "fresh " + "y" * 500},
             {"role": "user", "content": "fresh " + "z" * 500},
         ]
+        # Use repeated word-like segments rather than a single-character run:
+        # both cl100k_base and the char fallback must keep this backlog eligible.
         eligible_messages = [
             {"role": "system", "content": "system"},
-            {"role": "user", "content": "old backlog " + "x" * 600},
+            {
+                "role": "user",
+                "content": "old backlog " + "compressible backlog segment " * 100,
+            },
             {"role": "assistant", "content": "old answer " + "y" * 600},
             {"role": "user", "content": "fresh " + "a" * 200},
             {"role": "assistant", "content": "fresh " + "b" * 200},


### PR DESCRIPTION
## Summary
- Replace the tokenizer-sensitive single-character backlog in the preflight no-op reset test with repeated word-like segments.
- Keep the fixture above the configured leaf threshold with both `cl100k_base` and the built-in character fallback.
- Preserve the original `noop` to `pending` status-reset assertions without changing runtime code.

## Why
Current `main` fails `TestEngineABC::test_positive_preflight_clears_prior_noop_status` when `cl100k_base` is available. The old `x * 600` fixture counts above the leaf threshold with the fallback estimator but below it with the real tokenizer, so the engine correctly returns a no-op.

Refs #396.

## Validation
- `HOME=<isolated> HERMES_HOME=<isolated> NOISEGATE_DISABLE=1 python3 -m pytest tests/test_lcm_engine.py::TestEngineABC::test_positive_preflight_clears_prior_noop_status -q -o addopts=`: `1 passed`
- `python3 -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=`: `1015 passed`
- Isolated full suite: `1610 passed, 12 xfailed`
- `ruff check tests/test_lcm_engine.py`: passed
- Python compile checks, shell syntax checks, and `git diff --check`: passed
- Direct token-count probe: replacement backlog content counts as 403 tokens with `cl100k_base` and 729 with the fallback estimator.
- Direct fallback-path probe confirmed the transition from `noop` to `pending`.

## Risk / impact
Low risk. This changes test data only; runtime behavior, storage, schemas, configuration, and public APIs are unchanged.

## Scope boundaries
- Does not change preflight or token-counting behavior.
- Does not add a separate optional-`tiktoken` CI lane.

## Rollout / operator notes
No migration, configuration change, restart, or operator action is required.

## Reviewer focus
Please verify that the replacement fixture remains clearly above `leaf_chunk_tokens=100` under both supported token-counting paths while preserving the intended stale no-op status reset contract.
