### PR TITLE
fix: ignore template payload refs in doctor scan

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -117,6 +117,13 @@ _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*r
 _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE = re.compile(
     r"\[(?:Externalized|GC'd externalized) (?:tool output|payload):.*?;\s*ref=([^;\]\s]+)\]"
 )
+_TEMPLATE_PAYLOAD_REF_RE = re.compile(
+    r"\{[A-Za-z_][A-Za-z0-9_]*(?:![rsa])?(?::[^{}\r\n]*)?\}"
+)
+_SOURCE_LITERAL_ASSIGNMENT_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:[rubf]{0,2})?(?:\\+)?[\"']\s*$",
+    re.IGNORECASE,
+)
 _PERSISTED_OUTPUT_TAG = "<persisted-output>"
 _PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 _PERSISTED_OUTPUT_SAVED_TO_RE = re.compile(r"^Full output saved to:\s*(?P<path>.+?)\s*$", re.MULTILINE)
@@ -651,6 +658,11 @@ def extract_ingest_externalized_refs(text: str) -> list[str]:
 
 def _is_basename_ref(ref: str) -> bool:
     return bool(ref) and ref.endswith(".json") and "/" not in ref and "\\" not in ref and Path(ref).name == ref
+
+
+def _is_template_payload_ref(ref: str) -> bool:
+    """Return true when a filename still contains a format-field placeholder."""
+    return bool(_TEMPLATE_PAYLOAD_REF_RE.search(ref))
 
 
 def extract_all_externalized_payload_refs(text: str) -> list[str]:
@@ -1675,12 +1687,34 @@ def _looks_like_example_payload_ref(ref: str) -> bool:
     return name.startswith(("example-", "example_", "fake-", "fake_", "dummy-", "dummy_", "placeholder-", "placeholder_"))
 
 
+def _is_template_source_literal_ref(text: str, start: int, ref: str) -> bool:
+    """Return true for an unrendered ref inside a quoted source assignment."""
+    if not _is_template_payload_ref(ref):
+        return False
+    context = text[max(0, start - 160):start]
+    return _SOURCE_LITERAL_ASSIGNMENT_RE.search(context) is not None
+
+
+def _extract_template_source_literal_refs(text: str) -> list[str]:
+    refs: list[str] = []
+    for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
+        for match in pattern.finditer(text):
+            ref = match.group(1).strip()
+            if (
+                _is_basename_ref(ref)
+                and _is_template_source_literal_ref(text, match.start(), ref)
+                and ref not in refs
+            ):
+                refs.append(ref)
+    return refs
+
+
 def _extract_unescaped_externalized_payload_refs(text: str, *, ignore_quoted_spans: bool = False) -> list[str]:
     refs: list[str] = []
     for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
         for match in pattern.finditer(text):
             ref = match.group(1).strip()
-            if not _is_basename_ref(ref):
+            if not _is_basename_ref(ref) or _is_template_source_literal_ref(text, match.start(), ref):
                 continue
             if _looks_like_example_payload_ref(ref) and _is_escaped_placeholder_example(text, match.start()):
                 continue
@@ -1755,7 +1789,7 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                 else:
                     _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True))
         return refs
-    return extract_all_externalized_payload_refs(value)
+    return _extract_unescaped_externalized_payload_refs(value)
 
 
 def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", limit: int = 5) -> dict[str, Any]:
@@ -1772,6 +1806,7 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
         existing_files = {path.name for path in storage_dir.glob("*.json") if path.is_file()}
 
     referenced_refs: set[str] = set()
+    incidental_template_refs: set[str] = set()
     first_location_by_ref: dict[str, dict[str, Any]] = {}
     for store_id, session_id, source, role, content, tool_calls in conn.execute(
         """
@@ -1785,6 +1820,7 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
         for field, value in (("content", content), ("tool_calls", tool_calls)):
             if not isinstance(value, str):
                 continue
+            incidental_template_refs.update(_extract_template_source_literal_refs(value))
             for ref in _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field):
                 referenced_refs.add(ref)
                 first_location_by_ref.setdefault(
@@ -1801,7 +1837,9 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
 
     missing_refs = sorted(ref for ref in referenced_refs if ref not in existing_files)
     existing_ref_count = sum(1 for ref in referenced_refs if ref in existing_files)
-    unreferenced_files = sorted(ref for ref in existing_files if ref not in referenced_refs)
+    unreferenced_files = sorted(
+        ref for ref in existing_files if ref not in referenced_refs and ref not in incidental_template_refs
+    )
 
     return {
         "externalized_payload_refs_total": len(referenced_refs),

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -1925,6 +1925,123 @@ def test_externalized_payload_integrity_scan_reports_missing_and_unreferenced_re
     assert "not-counted.json" not in encoded
 
 
+def test_externalized_payload_integrity_scan_ignores_template_refs_and_fixture_files(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    for ref in (
+        "20260716_120000_tool-call_present_payload_0123456789ab_abcdef.json",
+        "20260716_120000_tool-call_orphan_payload_0123456789ab_abcdef.json",
+        "20260708T120000Z-tool-call-{index}.json",
+    ):
+        (storage_dir / ref).write_text(json.dumps({"content": "fixture payload"}))
+
+    present_ref = "20260716_120000_tool-call_present_payload_0123456789ab_abcdef.json"
+    missing_ref = "20260716_120000_tool-call_missing_payload_0123456789ab_abcdef.json"
+    template_ref = "20260708T120000Z-tool-call-{index}.json"
+    content = "\n".join(
+        [
+            f"[Externalized payload: kind=raw_payload; role=assistant; chars=1; ref={present_ref}]",
+            f"[Externalized payload: kind=raw_payload; role=assistant; chars=1; ref={missing_ref}]",
+            (
+                'fixture_source = "[Externalized tool output: tool_call_id=call-{index}; '
+                f'chars=1; ref={template_ref}]"'
+            ),
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "test",
+            "assistant",
+            content,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 2
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "test",
+            "role": "assistant",
+            "field": "content",
+            "externalized_ref": missing_ref,
+        }
+    ]
+    assert detail["externalized_payload_files_unreferenced"] == 1
+    assert detail["unreferenced_externalized_payload_files"] == [
+        {"externalized_ref": "20260716_120000_tool-call_orphan_payload_0123456789ab_abcdef.json"}
+    ]
+
+
+def test_externalized_payload_integrity_scan_preserves_real_braced_refs(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    present_ref = "20260716_120000_call-{index}_0123456789ab_abcdef.json"
+    missing_ref = "20260716_120000_call-{missing}_0123456789ab_abcdef.json"
+    orphan_ref = "20260716_120000_call-{orphan}_0123456789ab_abcdef.json"
+    for ref in (present_ref, orphan_ref):
+        (storage_dir / ref).write_text(json.dumps({"content": "real payload"}))
+
+    content = "\n".join(
+        [
+            f"[Externalized tool output: tool_call_id=call--index-; chars=1; ref={present_ref}]",
+            f"[Externalized tool output: tool_call_id=call--missing-; chars=1; ref={missing_ref}]",
+        ]
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "test",
+            "tool",
+            content,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 2
+    assert detail["externalized_payload_refs_existing"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"][0]["externalized_ref"] == missing_ref
+    assert detail["externalized_payload_files_unreferenced"] == 1
+    assert detail["unreferenced_externalized_payload_files"] == [{"externalized_ref": orphan_ref}]
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_content_placeholder_with_trailing_text(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()


### PR DESCRIPTION
## Summary
- Ignore unrendered payload filename templates only when they occur in an immediate quoted source assignment, instead of treating them as live recovery references.
- Exclude matching incidental fixture files from unreferenced-payload diagnostics.
- Preserve existing, missing, and orphan diagnostics for genuine references, including real brace-bearing filenames.

## Why
- `/lcm doctor` could classify stored source/test fixture literals such as `20260708T120000Z-tool-call-{index}.json` as missing externalized payloads, then report the matching fixture file as unreferenced.
- This is a narrow follow-up to #278: quoted examples remain filtered, while real structured recovery references still drive integrity findings.

## Validation
- [x] Focused validation: `pytest -q tests/test_ingest_protection.py -k 'externalized_payload_integrity'` -> `20 passed`
- [x] Relevant suite: `pytest -q tests/test_ingest_protection.py tests/test_lcm_command.py` -> `209 passed`
- [x] Default validation:
  - [x] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-t_e423380c-full-2343710` -> PASS
  - [x] Release focused pytest -> `409 passed`
  - [x] `pytest -q` -> `1612 passed, 12 xfailed`
  - [x] low-fd `pytest -q` -> `1612 passed, 12 xfailed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh`
  - [x] benchmark smoke, stress smoke, and release-tier stress validation
  - [x] `git diff --check HEAD^...HEAD && git diff --check && git diff --cached --check`
  - [x] `ruff check ingest_protection.py tests/test_ingest_protection.py`
- [x] Independent exact-head review at `234371096c373cd11f5c84da6ca510ad0b4ce9ee` -> PASS, no blocking findings

## Notes
- No workflow files changed, so `actionlint` was not rerun separately; release validation includes the existing workflow-lint gate in CI.
- The repair and tests use isolated temporary databases/directories only. No live LCM database or payload directory was read or modified.