### PR TITLE
feat: expose durable total compactions in status

### DIFF
--- a/command.py
+++ b/command.py
@@ -521,6 +521,8 @@ def _status_text(engine) -> str:
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"compression_count: {engine.compression_count}",
+        f"total_compactions: {status.get('total_compactions', 0)}",
+        f"total_compactions_scope: {status.get('total_compactions_scope', 'current_conversation')}",
         f"last_compression_status: {status.get('last_compression_status', 'idle')}",
         f"last_compression_noop_reason: {status.get('last_compression_noop_reason', '') or '(none)'}",
         f"context_length: {engine.context_length if session_bound else '(uninitialized)'}",

--- a/compaction.py
+++ b/compaction.py
@@ -1029,5 +1029,12 @@ class CompactionMixin:
         self._write_generated_ignored_placeholder_hash_ordinals(
             self._generated_placeholder_digest_ordinals_for_active_replay(compressed)
         )
+        record_successful_compaction = getattr(
+            self,
+            "_record_successful_compaction_telemetry",
+            None,
+        )
+        if callable(record_successful_compaction):
+            record_successful_compaction()
 
         return compressed

--- a/engine.py
+++ b/engine.py
@@ -13,6 +13,7 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -270,6 +271,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
         self.compression_count = 0
+        # Distinguishes this reset-scoped process counter from overlapping or
+        # previous runtimes that write the same conversation telemetry row.
+        self._compaction_telemetry_counter_epoch = uuid.uuid4().hex
         self._compaction_telemetry_counter_rebaseline_pending = True
         self._compaction_telemetry_turn_reset_pending = False
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
@@ -892,12 +896,30 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     ) -> tuple[int, bool, int]:
         """Return persisted baseline, reset state, and unrecorded compactions."""
         prev_count = int(existing.get("compression_count_at_record", 0) or 0)
+        epoch_baseline = None
+        watermarks = existing.get("counter_epoch_watermarks", [])
+        if isinstance(watermarks, list):
+            for item in watermarks:
+                if (
+                    isinstance(item, list)
+                    and len(item) == 2
+                    and item[0] == self._compaction_telemetry_counter_epoch
+                    and isinstance(item[1], int)
+                    and not isinstance(item[1], bool)
+                    and item[1] >= 0
+                ):
+                    epoch_baseline = item[1]
+                    break
+        if epoch_baseline is not None:
+            prev_count = epoch_baseline
         rebaseline_pending = bool(
             existing
             and self._compaction_telemetry_counter_rebaseline_pending
         )
         delta = (
-            self.compression_count
+            max(0, self.compression_count - epoch_baseline)
+            if epoch_baseline is not None
+            else self.compression_count
             if rebaseline_pending
             else max(0, self.compression_count - prev_count)
         )
@@ -914,20 +936,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if compaction_delta <= 0:
                 return
 
-            record = dict(existing)
-            record.update({
+            updates = {
                 "conversation_id": conversation_id,
-                "total_compactions": (
-                    _normalize_total_compactions(existing.get("total_compactions", 0))
-                    + compaction_delta
-                ),
+                "counter_epoch": self._compaction_telemetry_counter_epoch,
                 "compression_count_at_record": self.compression_count,
                 "turns_since_leaf_compaction": 0,
                 "peak_prompt_tokens_since_leaf_compaction": 0,
                 "last_leaf_compaction_at": time.time(),
                 "last_compaction_duration_ms": round(self._last_compaction_duration_ms, 3),
-            })
-            self._store.write_compaction_telemetry(conversation_id, record)
+            }
+            self._store.increment_compaction_telemetry(
+                conversation_id,
+                compaction_delta,
+                updates,
+            )
             self._compaction_telemetry_counter_rebaseline_pending = False
             # The response hook still owns per-turn token/cache fields. Keep its
             # first post-compaction snapshot at turn zero without recounting.
@@ -1022,11 +1044,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 "last_leaf_compaction_at": last_leaf_compaction_at,
                 "last_compaction_duration_ms": last_compaction_duration_ms,
                 "total_compactions": total_compactions,
+                "counter_epoch": self._compaction_telemetry_counter_epoch,
                 "compression_count_at_record": self.compression_count,
             })
             if cache_state == "hot":
                 record["last_cache_hit_at"] = time.time()
-            self._store.write_compaction_telemetry(conversation_id, record)
+            # Even zero-delta snapshots use the transactional updater so an
+            # overlapping snapshot cannot overwrite a newly incremented total.
+            self._store.increment_compaction_telemetry(
+                conversation_id,
+                compaction_delta,
+                record,
+            )
             self._compaction_telemetry_counter_rebaseline_pending = False
             self._compaction_telemetry_turn_reset_pending = False
         except Exception:
@@ -2212,6 +2241,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id
+        previous_conversation_id = self._conversation_id
+        requested_conversation_id = str(kwargs.get("conversation_id") or session_id)
         self._lcm_current_start_allows_bypass_lineage = False
         requested_platform = str(kwargs.get("platform") or self._session_platform or "")
         pre_reset_preserve_ambiguous_no_frame_old_session = False
@@ -2462,6 +2493,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
         else:
+            if (
+                previous_conversation_id
+                and requested_conversation_id != previous_conversation_id
+            ):
+                self._reset_session_counters()
             self._clear_pending_reset_boundary()
             self._ingest_cursor = 0
             self._last_compacted_store_id = 0

--- a/engine.py
+++ b/engine.py
@@ -271,6 +271,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.cache_metrics_available = False
         self.compression_count = 0
         self._compaction_telemetry_counter_rebaseline_pending = True
+        self._compaction_telemetry_turn_reset_pending = False
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
         self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
@@ -902,6 +903,38 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         return prev_count, rebaseline_pending, delta
 
+    def _record_successful_compaction_telemetry(self) -> None:
+        """Durably count a completed leaf compaction before returning it."""
+        conversation_id = self._conversation_id
+        if not conversation_id:
+            return
+        try:
+            existing = self._store.read_compaction_telemetry(conversation_id) or {}
+            _, _, compaction_delta = self._compaction_telemetry_counter_delta(existing)
+            if compaction_delta <= 0:
+                return
+
+            record = dict(existing)
+            record.update({
+                "conversation_id": conversation_id,
+                "total_compactions": (
+                    _normalize_total_compactions(existing.get("total_compactions", 0))
+                    + compaction_delta
+                ),
+                "compression_count_at_record": self.compression_count,
+                "turns_since_leaf_compaction": 0,
+                "peak_prompt_tokens_since_leaf_compaction": 0,
+                "last_leaf_compaction_at": time.time(),
+                "last_compaction_duration_ms": round(self._last_compaction_duration_ms, 3),
+            })
+            self._store.write_compaction_telemetry(conversation_id, record)
+            self._compaction_telemetry_counter_rebaseline_pending = False
+            # The response hook still owns per-turn token/cache fields. Keep its
+            # first post-compaction snapshot at turn zero without recounting.
+            self._compaction_telemetry_turn_reset_pending = True
+        except Exception:
+            logger.debug("LCM successful compaction telemetry update failed", exc_info=True)
+
     def _record_turn_compaction_telemetry(self) -> None:
         """Persist a per-conversation compaction-telemetry snapshot for this turn.
 
@@ -947,7 +980,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             ) = self._compaction_telemetry_counter_delta(existing)
             compacted = compaction_delta > 0
             rebaselined = (
-                counter_rebaseline_pending or self.compression_count != prev_count
+                self._compaction_telemetry_turn_reset_pending
+                or counter_rebaseline_pending
+                or self.compression_count != prev_count
             )
             if rebaselined:
                 turns_since = 0
@@ -993,6 +1028,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 record["last_cache_hit_at"] = time.time()
             self._store.write_compaction_telemetry(conversation_id, record)
             self._compaction_telemetry_counter_rebaseline_pending = False
+            self._compaction_telemetry_turn_reset_pending = False
         except Exception:
             logger.debug("LCM compaction telemetry update failed", exc_info=True)
 

--- a/engine.py
+++ b/engine.py
@@ -270,6 +270,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
         self.compression_count = 0
+        self._compaction_telemetry_counter_rebaseline_pending = True
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
         self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
@@ -924,7 +925,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
             prev_count = int(existing.get("compression_count_at_record", 0) or 0)
             counter_rebaseline_pending = bool(
-                getattr(self, "_compaction_telemetry_counter_rebaseline_pending", False)
+                existing
+                and getattr(
+                    self,
+                    "_compaction_telemetry_counter_rebaseline_pending",
+                    False,
+                )
             )
             compaction_delta = (
                 self.compression_count

--- a/engine.py
+++ b/engine.py
@@ -885,6 +885,23 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return 0.0
         return self.last_cache_read_tokens / self.last_prompt_tokens
 
+    def _compaction_telemetry_counter_delta(
+        self,
+        existing: Dict[str, Any],
+    ) -> tuple[int, bool, int]:
+        """Return persisted baseline, reset state, and unrecorded compactions."""
+        prev_count = int(existing.get("compression_count_at_record", 0) or 0)
+        rebaseline_pending = bool(
+            existing
+            and self._compaction_telemetry_counter_rebaseline_pending
+        )
+        delta = (
+            self.compression_count
+            if rebaseline_pending
+            else max(0, self.compression_count - prev_count)
+        )
+        return prev_count, rebaseline_pending, delta
+
     def _record_turn_compaction_telemetry(self) -> None:
         """Persist a per-conversation compaction-telemetry snapshot for this turn.
 
@@ -923,20 +940,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             elif cache_state == "cold":
                 cold_streak += 1
 
-            prev_count = int(existing.get("compression_count_at_record", 0) or 0)
-            counter_rebaseline_pending = bool(
-                existing
-                and getattr(
-                    self,
-                    "_compaction_telemetry_counter_rebaseline_pending",
-                    False,
-                )
-            )
-            compaction_delta = (
-                self.compression_count
-                if counter_rebaseline_pending
-                else max(0, self.compression_count - prev_count)
-            )
+            (
+                prev_count,
+                counter_rebaseline_pending,
+                compaction_delta,
+            ) = self._compaction_telemetry_counter_delta(existing)
             compacted = compaction_delta > 0
             rebaselined = (
                 counter_rebaseline_pending or self.compression_count != prev_count
@@ -3458,6 +3466,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         total_compactions = _normalize_total_compactions(
             telemetry.get("total_compactions", 0) if telemetry else 0
         )
+        if conversation_id and conversation_id == self._conversation_id:
+            try:
+                _, _, pending_compactions = self._compaction_telemetry_counter_delta(
+                    telemetry or {}
+                )
+            except (TypeError, ValueError):
+                pending_compactions = 0
+            total_compactions += pending_compactions
         status["total_compactions"] = total_compactions
         status["total_compactions_scope"] = _TOTAL_COMPACTIONS_SCOPE
         status["engine"] = "lcm"

--- a/engine.py
+++ b/engine.py
@@ -134,6 +134,7 @@ logger = logging.getLogger(__name__)
 
 _SESSION_END_BUSY_TIMEOUT_MS = 50
 _CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
+_TOTAL_COMPACTIONS_SCOPE = "current_conversation"
 
 # Auto-focus topic derivation: infer a compact focus hint from the most recent
 # real user turns so that summarization can prioritise current user intent.
@@ -144,6 +145,13 @@ _AUTO_FOCUS_MAX_CHARS = 700
 
 _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
+
+
+def _normalize_total_compactions(value: Any) -> int:
+    """Return a persisted compaction total only when it is a valid counter."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value
 
 
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
@@ -925,7 +933,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     int(existing.get("peak_prompt_tokens_since_leaf_compaction", 0) or 0),
                     prompt_tokens,
                 )
-            total_compactions = int(existing.get("total_compactions", 0) or 0)
+            total_compactions = _normalize_total_compactions(
+                existing.get("total_compactions", 0)
+            )
             if compacted:
                 total_compactions += self.compression_count - prev_count
                 last_leaf_compaction_at = time.time()
@@ -3423,6 +3433,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         session_id = self.current_session_id
         conversation_id = self.current_conversation_id
         lifecycle_state = self._lifecycle.get_by_conversation(conversation_id) if conversation_id else None
+        try:
+            telemetry = self._store.read_compaction_telemetry(conversation_id)
+        except Exception:
+            telemetry = None
+        total_compactions = _normalize_total_compactions(
+            telemetry.get("total_compactions", 0) if telemetry else 0
+        )
+        status["total_compactions"] = total_compactions
+        status["total_compactions_scope"] = _TOTAL_COMPACTIONS_SCOPE
         status["engine"] = "lcm"
         status["runtime_identity"] = self.get_runtime_identity()
         status["ingest_protection"] = sensitive_pattern_status(self._config)
@@ -3491,10 +3510,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     "last_reset_at": lifecycle_state.last_reset_at,
                     "updated_at": lifecycle_state.updated_at,
                 }
-            try:
-                telemetry = self._store.read_compaction_telemetry(conversation_id)
-            except Exception:
-                telemetry = None
             if telemetry:
                 status["compaction_telemetry"] = {
                     "cache_state": telemetry.get("cache_state", "unknown"),
@@ -3513,7 +3528,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     "last_observed_cache_read": telemetry.get("last_observed_cache_read", 0),
                     "last_observed_cache_write": telemetry.get("last_observed_cache_write", 0),
                     "activity_band": telemetry.get("activity_band", "low"),
-                    "total_compactions": telemetry.get("total_compactions", 0),
+                    "total_compactions": total_compactions,
                     "last_leaf_compaction_at": telemetry.get("last_leaf_compaction_at"),
                     "last_compaction_duration_ms": telemetry.get("last_compaction_duration_ms"),
                     "provider": telemetry.get("provider"),

--- a/engine.py
+++ b/engine.py
@@ -890,8 +890,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         Best-effort and diagnostic only: any failure is logged at debug and never
         affects the turn. Turns with no token or cache signal are skipped so idle
         turns do not churn the record. The since-compaction accumulators reset off
-        the monotonic ``compression_count`` (which also drops to 0 on a session
-        reset) rather than instrumenting the compaction hot path.
+        the monotonic ``compression_count``. Session resets mark the next
+        telemetry write for an explicit zero-baseline comparison so compactions
+        that happen before that write are not mistaken for an old baseline.
         """
         conversation_id = self._conversation_id
         if not conversation_id:
@@ -922,8 +923,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 cold_streak += 1
 
             prev_count = int(existing.get("compression_count_at_record", 0) or 0)
-            compacted = self.compression_count > prev_count
-            rebaselined = self.compression_count != prev_count  # compaction or session reset
+            counter_rebaseline_pending = bool(
+                getattr(self, "_compaction_telemetry_counter_rebaseline_pending", False)
+            )
+            compaction_delta = (
+                self.compression_count
+                if counter_rebaseline_pending
+                else max(0, self.compression_count - prev_count)
+            )
+            compacted = compaction_delta > 0
+            rebaselined = (
+                counter_rebaseline_pending or self.compression_count != prev_count
+            )
             if rebaselined:
                 turns_since = 0
                 peak_tokens_since = prompt_tokens
@@ -937,7 +948,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 existing.get("total_compactions", 0)
             )
             if compacted:
-                total_compactions += self.compression_count - prev_count
+                total_compactions += compaction_delta
                 last_leaf_compaction_at = time.time()
                 last_compaction_duration_ms = round(self._last_compaction_duration_ms, 3)
             else:
@@ -967,6 +978,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if cache_state == "hot":
                 record["last_cache_hit_at"] = time.time()
             self._store.write_compaction_telemetry(conversation_id, record)
+            self._compaction_telemetry_counter_rebaseline_pending = False
         except Exception:
             logger.debug("LCM compaction telemetry update failed", exc_info=True)
 

--- a/reset_state.py
+++ b/reset_state.py
@@ -31,6 +31,7 @@ class ResetStateMixin:
         self._last_compression_status = "idle"
         self._last_compression_noop_reason = ""
         self._last_boundary_skip_time = 0
+        self._compaction_telemetry_counter_rebaseline_pending = True
 
     def _reset_compaction_progress(self) -> None:
         """Reset process-local compaction markers for a fresh/unproven session."""

--- a/reset_state.py
+++ b/reset_state.py
@@ -7,6 +7,8 @@ reset or rolled over. State stays on the engine (accessed via ``self``);
 mixing this in leaves every call site and ``self._*`` reference unchanged.
 """
 
+import uuid
+
 
 class ResetStateMixin:
     def _reset_session_counters(self) -> None:
@@ -24,6 +26,7 @@ class ResetStateMixin:
         self.last_cache_write_tokens = 0
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
+        self._compaction_telemetry_counter_epoch = uuid.uuid4().hex
         self._context_probed = False
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False

--- a/reset_state.py
+++ b/reset_state.py
@@ -32,6 +32,7 @@ class ResetStateMixin:
         self._last_compression_noop_reason = ""
         self._last_boundary_skip_time = 0
         self._compaction_telemetry_counter_rebaseline_pending = True
+        self._compaction_telemetry_turn_reset_pending = False
 
     def _reset_compaction_progress(self) -> None:
         """Reset process-local compaction markers for a fresh/unproven session."""

--- a/store.py
+++ b/store.py
@@ -915,6 +915,105 @@ class MessageStore:
             return None
         return data if isinstance(data, dict) else None
 
+    def increment_compaction_telemetry(
+        self,
+        conversation_id: str,
+        increment: int,
+        updates: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Atomically increment and update one conversation's telemetry record."""
+        if not conversation_id:
+            return None
+        if isinstance(increment, bool) or not isinstance(increment, int) or increment < 0:
+            raise ValueError("compaction telemetry increment must be a non-negative integer")
+        conn = self._conn
+        if conn is None:
+            return None
+
+        key = self._compaction_telemetry_key(conversation_id)
+        with self._write_lock:
+            try:
+                # Separate MessageStore instances have separate Python locks.
+                # Acquire SQLite's write reservation before reading so this
+                # read-modify-write serializes across every connection.
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT value FROM metadata WHERE key = ?",
+                    (key,),
+                ).fetchone()
+                try:
+                    existing = json.loads(str(row[0])) if row and row[0] else {}
+                except (ValueError, TypeError):
+                    existing = {}
+                if not isinstance(existing, dict):
+                    existing = {}
+
+                # Per-runtime high-water marks make a committed increment
+                # idempotent when its caller observes an ambiguous exception.
+                # Retain enough recent epochs for overlapping runtimes without
+                # allowing this diagnostic metadata row to grow forever.
+                watermarks = []
+                raw_watermarks = existing.get("counter_epoch_watermarks", [])
+                if isinstance(raw_watermarks, list):
+                    watermarks = [
+                        item
+                        for item in raw_watermarks
+                        if (
+                            isinstance(item, list)
+                            and len(item) == 2
+                            and isinstance(item[0], str)
+                            and item[0]
+                            and isinstance(item[1], int)
+                            and not isinstance(item[1], bool)
+                            and item[1] >= 0
+                        )
+                    ]
+                effective_increment = increment
+                counter_epoch = updates.get("counter_epoch")
+                target_count = updates.get("compression_count_at_record")
+                if (
+                    isinstance(counter_epoch, str)
+                    and counter_epoch
+                    and isinstance(target_count, int)
+                    and not isinstance(target_count, bool)
+                    and target_count >= 0
+                ):
+                    prior_count = next(
+                        (item[1] for item in watermarks if item[0] == counter_epoch),
+                        0,
+                    )
+                    effective_increment = max(0, target_count - prior_count)
+                    watermarks = [item for item in watermarks if item[0] != counter_epoch]
+                    watermarks.append([counter_epoch, max(prior_count, target_count)])
+                    watermarks = watermarks[-64:]
+
+                current_total = existing.get("total_compactions", 0)
+                if (
+                    isinstance(current_total, bool)
+                    or not isinstance(current_total, int)
+                    or current_total < 0
+                ):
+                    current_total = 0
+                record = dict(existing)
+                record.update(updates)
+                record["conversation_id"] = conversation_id
+                record["counter_epoch_watermarks"] = watermarks
+                record["total_compactions"] = current_total + effective_increment
+                conn.execute(
+                    """
+                    INSERT INTO metadata(key, value)
+                    VALUES(?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (key, json.dumps(record, sort_keys=True)),
+                )
+                conn.commit()
+                return record
+            except Exception:
+                if conn.in_transaction:
+                    conn.rollback()
+                raise
+
     def write_compaction_telemetry(self, conversation_id: str, record: Dict[str, Any]) -> None:
         """Upsert the per-conversation compaction-telemetry record.
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -139,6 +139,30 @@ def test_total_compactions_status_survives_session_rollover_for_conversation(eng
     _assert_total_compaction_surfaces(engine, 3)
 
 
+@pytest.mark.parametrize("previous_session_count", [1, 3])
+def test_total_compactions_includes_first_compaction_after_session_rollover(
+    engine,
+    previous_session_count,
+):
+    engine.compression_count = previous_session_count
+    engine.update_from_response(_hot_usage())
+
+    engine.on_session_start(
+        "test-session-next",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+    assert engine.compression_count == 0
+
+    # The first response telemetry can arrive after the new session has already
+    # compacted. Count it even when the new session's counter is equal to or
+    # below the persisted baseline from the previous session.
+    engine.compression_count = 1
+    engine.update_from_response(_hot_usage())
+
+    _assert_total_compaction_surfaces(engine, previous_session_count + 1)
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,6 +1,7 @@
 """Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
 
 import json
+import threading
 
 import pytest
 
@@ -204,6 +205,144 @@ def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_pa
         restarted.shutdown()
 
 
+def test_total_compactions_rebaseline_when_session_id_binds_new_conversation(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    engine.on_session_start(
+        "test-session",
+        platform="discord",
+        conversation_id="conv-2",
+    )
+
+    assert engine.compression_count == 0
+    _assert_total_compaction_surfaces(engine, 0)
+    assert engine._store.read_compaction_telemetry("conv-1")["total_compactions"] == 3
+
+    engine.compression_count = 1
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 1)
+
+
+@pytest.mark.parametrize("record_mode", ["successful_compaction", "response_hook"])
+def test_compactions_increment_total_atomically_across_engines(tmp_path, record_mode):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_test.db"))
+    engines = [
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_a")),
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_b")),
+    ]
+    barrier = threading.Barrier(2, timeout=5)
+    errors = []
+
+    try:
+        for index, current in enumerate(engines):
+            current.on_session_start(
+                f"test-session-{index}",
+                platform="cli",
+                conversation_id="conv-1",
+            )
+            current.compression_count = 1
+            original_increment = current._store.increment_compaction_telemetry
+
+            def paused_increment(
+                conversation_id,
+                increment,
+                updates,
+                *,
+                _increment=original_increment,
+            ):
+                barrier.wait()
+                return _increment(conversation_id, increment, updates)
+
+            current._store.increment_compaction_telemetry = paused_increment
+
+        def record(current):
+            try:
+                if record_mode == "successful_compaction":
+                    current._record_successful_compaction_telemetry()
+                else:
+                    current.update_from_response(_hot_usage())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=record, args=(current,)) for current in engines]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not [thread for thread in threads if thread.is_alive()]
+        assert errors == []
+        telemetry = engines[0]._store.read_compaction_telemetry("conv-1")
+        assert telemetry["total_compactions"] == 2
+    finally:
+        for current in engines:
+            current.shutdown()
+
+
+def test_zero_delta_snapshot_cannot_overwrite_concurrent_increment(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_test.db"))
+    engines = [
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_a")),
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_b")),
+    ]
+    barrier = threading.Barrier(2, timeout=5)
+    errors = []
+
+    try:
+        for index, current in enumerate(engines):
+            current.on_session_start(
+                f"test-session-{index}",
+                platform="cli",
+                conversation_id="conv-1",
+            )
+            original_increment = current._store.increment_compaction_telemetry
+
+            def paused_increment(
+                conversation_id,
+                increment,
+                updates,
+                *,
+                _increment=original_increment,
+            ):
+                barrier.wait()
+                return _increment(conversation_id, increment, updates)
+
+            current._store.increment_compaction_telemetry = paused_increment
+
+        engines[1].compression_count = 1
+
+        def record_snapshot():
+            try:
+                engines[0].update_from_response(_hot_usage())
+            except Exception as exc:
+                errors.append(exc)
+
+        def record_increment():
+            try:
+                engines[1]._record_successful_compaction_telemetry()
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=record_snapshot),
+            threading.Thread(target=record_increment),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not [thread for thread in threads if thread.is_alive()]
+        assert errors == []
+        telemetry = engines[0]._store.read_compaction_telemetry("conv-1")
+        assert telemetry["total_compactions"] == 1
+    finally:
+        for current in engines:
+            current.shutdown()
+
+
 def test_successful_compaction_is_durable_before_response_hook(tmp_path, monkeypatch):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_test.db"),
@@ -276,6 +415,35 @@ def test_response_hook_does_not_recount_durably_recorded_compaction(engine):
     assert telemetry["turns_since_leaf_compaction"] == 0
     assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
     assert telemetry["last_compaction_duration_ms"] == 12.5
+
+
+def test_response_hook_does_not_recount_ambiguous_committed_increment(engine, monkeypatch):
+    real_increment = engine._store.increment_compaction_telemetry
+
+    def commit_then_raise(conversation_id, increment, updates):
+        real_increment(conversation_id, increment, updates)
+        raise RuntimeError("simulated ambiguous commit outcome")
+
+    engine.compression_count = 1
+    engine._last_compaction_duration_ms = 12.5
+    monkeypatch.setattr(engine._store, "increment_compaction_telemetry", commit_then_raise)
+    engine._record_successful_compaction_telemetry()
+
+    committed = engine._store.read_compaction_telemetry("conv-1")
+    assert committed["total_compactions"] == 1
+    assert engine._compaction_telemetry_counter_rebaseline_pending is True
+
+    monkeypatch.setattr(engine._store, "increment_compaction_telemetry", real_increment)
+    engine.update_from_response(_hot_usage(prompt=400))
+
+    telemetry = engine._store.read_compaction_telemetry("conv-1")
+    assert telemetry["total_compactions"] == 1
+    assert telemetry["turns_since_leaf_compaction"] == 0
+    assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
+
+    engine.compression_count = 2
+    engine._record_successful_compaction_telemetry()
+    assert engine._store.read_compaction_telemetry("conv-1")["total_compactions"] == 2
 
 
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,7 +1,11 @@
 """Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
 
+import json
+
 import pytest
 
+from hermes_lcm import tools as lcm_tools
+from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.store import MessageStore
@@ -36,6 +40,28 @@ def _cold_usage(prompt=1000):
 
 def _telemetry(engine):
     return engine.get_status().get("compaction_telemetry")
+
+
+def _slash_status_fields(engine):
+    return {
+        key.strip(): value.strip()
+        for line in handle_lcm_command("status", engine).splitlines()
+        if ":" in line
+        for key, value in [line.split(":", 1)]
+    }
+
+
+def _assert_total_compaction_surfaces(engine, expected):
+    status = engine.get_status()
+    tool_status = json.loads(lcm_tools.lcm_status({}, engine=engine))
+    slash_status = _slash_status_fields(engine)
+
+    assert status["total_compactions"] == expected
+    assert status["total_compactions_scope"] == "current_conversation"
+    assert tool_status["total_compactions"] == expected
+    assert tool_status["total_compactions_scope"] == "current_conversation"
+    assert slash_status["total_compactions"] == str(expected)
+    assert slash_status["total_compactions_scope"] == "current_conversation"
 
 
 def test_records_per_turn_snapshot(engine):
@@ -96,6 +122,49 @@ def test_resets_on_compaction(engine):
     assert t["last_leaf_compaction_at"] is not None
     assert t["last_compaction_duration_ms"] == 12.5
     assert t["peak_prompt_tokens_since_leaf_compaction"] == 400  # reset to current
+
+
+def test_total_compactions_status_survives_session_rollover_for_conversation(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    engine.on_session_start(
+        "test-session-next",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+
+    assert engine.compression_count == 0
+    _assert_total_compaction_surfaces(engine, 3)
+
+
+def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
+    _assert_total_compaction_surfaces(engine, 0)
+
+
+def test_total_compactions_status_is_scoped_to_current_conversation(engine):
+    engine._store.write_compaction_telemetry(
+        "conv-1",
+        {"conversation_id": "conv-1", "total_compactions": 2},
+    )
+    engine._store.write_compaction_telemetry(
+        "other-conversation",
+        {"conversation_id": "other-conversation", "total_compactions": 99},
+    )
+
+    _assert_total_compaction_surfaces(engine, 2)
+
+
+@pytest.mark.parametrize("malformed", [-1, "7", 1.5, True, None, [], {}])
+def test_total_compactions_status_fails_closed_for_malformed_telemetry(engine, malformed):
+    engine._store.write_compaction_telemetry(
+        "conv-1",
+        {"conversation_id": "conv-1", "total_compactions": malformed},
+    )
+
+    _assert_total_compaction_surfaces(engine, 0)
+    assert _telemetry(engine)["total_compactions"] == 0
 
 
 def test_no_conversation_records_nothing(engine):

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -204,6 +204,80 @@ def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_pa
         restarted.shutdown()
 
 
+def test_successful_compaction_is_durable_before_response_hook(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_test.db"),
+        fresh_tail_count=2,
+        leaf_chunk_tokens=1,
+    )
+    conversation_id = "conv-1"
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old question one"},
+        {"role": "assistant", "content": "old answer one"},
+        {"role": "user", "content": "old question two"},
+        {"role": "assistant", "content": "old answer two"},
+        {"role": "user", "content": "fresh question"},
+        {"role": "assistant", "content": "fresh answer"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    first.on_session_start(
+        "test-session",
+        platform="cli",
+        conversation_id=conversation_id,
+        context_length=200_000,
+    )
+
+    def summarize(initial_chunk, **_kwargs):
+        return (
+            list(initial_chunk),
+            100,
+            "Durable summary.\nExpand for details about: old turns",
+            1,
+            1,
+        )
+
+    monkeypatch.setattr(first, "_summarize_leaf_chunk_with_rescue", summarize)
+    first.compress(messages)
+    assert first.compression_count == 1
+    persisted = first._store.read_compaction_telemetry(conversation_id)
+    assert persisted is not None
+    assert persisted["total_compactions"] == 1
+    assert persisted["compression_count_at_record"] == 1
+
+    # Simulate process interruption before update_from_response() can persist
+    # the next per-turn telemetry snapshot.
+    first.shutdown()
+
+    restarted = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    try:
+        restarted.on_session_start(
+            "test-session-next",
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200_000,
+        )
+
+        _assert_total_compaction_surfaces(restarted, 1)
+    finally:
+        restarted.shutdown()
+
+
+def test_response_hook_does_not_recount_durably_recorded_compaction(engine):
+    engine.compression_count = 1
+    engine._last_compaction_duration_ms = 12.5
+    engine._record_successful_compaction_telemetry()
+
+    engine.update_from_response(_hot_usage(prompt=400))
+
+    telemetry = _telemetry(engine)
+    assert telemetry["total_compactions"] == 1
+    assert telemetry["turns_since_leaf_compaction"] == 0
+    assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
+    assert telemetry["last_compaction_duration_ms"] == 12.5
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -163,6 +163,35 @@ def test_total_compactions_includes_first_compaction_after_session_rollover(
     _assert_total_compaction_surfaces(engine, previous_session_count + 1)
 
 
+def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_path):
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_test.db")
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    first.on_session_start(
+        "test-session",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+    first.compression_count = 3
+    first.update_from_response(_hot_usage())
+    first.shutdown()
+
+    restarted = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    try:
+        restarted.on_session_start(
+            "test-session-next",
+            platform="discord",
+            conversation_id="conv-1",
+        )
+        restarted.compression_count = 1
+        restarted.update_from_response(_hot_usage())
+
+        _assert_total_compaction_surfaces(restarted, 4)
+    finally:
+        restarted.shutdown()
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -124,6 +124,18 @@ def test_resets_on_compaction(engine):
     assert t["peak_prompt_tokens_since_leaf_compaction"] == 400  # reset to current
 
 
+def test_total_compactions_status_includes_pending_compaction(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    # Status can be requested after compaction increments the live counter but
+    # before the response hook persists the next telemetry snapshot.
+    engine.compression_count += 1
+
+    _assert_total_compaction_surfaces(engine, 4)
+
+
 def test_total_compactions_status_survives_session_rollover_for_conversation(engine):
     engine.compression_count = 3
     engine.update_from_response(_hot_usage())

--- a/tools.py
+++ b/tools.py
@@ -4614,6 +4614,10 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     return json.dumps({
         "session_id": session_id,
         "compression_count": engine.compression_count,
+        "total_compactions": full_status.get("total_compactions", 0),
+        "total_compactions_scope": full_status.get(
+            "total_compactions_scope", "current_conversation"
+        ),
         "last_compression_status": full_status.get("last_compression_status", "idle"),
         "last_compression_noop_reason": full_status.get("last_compression_noop_reason", ""),
         "threshold_full_sweep": full_status.get("threshold_full_sweep"),


### PR DESCRIPTION
## Summary
- expose additive `total_compactions` in engine status, JSON `lcm_status`, and `/lcm status`
- retain `compression_count` as the resettable current-session metric
- document that `total_compactions` is persisted for the current conversation across session rollovers

## Why
- session rollover resets `compression_count`, which can make durable compaction history appear lost
- the existing per-conversation telemetry record already stores an authoritative cumulative count, so status should expose it rather than derive or invent another value

## Validation
- [x] Focused validation: `python -m pytest -q tests/test_compaction_telemetry.py tests/test_lcm_command.py` -> `86 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` (covered by full suite and release validation)
  - [x] `pytest -q` -> `1613 passed, 12 xfailed`
  - [x] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-total-compactions` -> `PASS: release validation full`
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [x] Workflow validation not applicable; no workflow files changed

## Notes
- `total_compactions` defaults to `0` when no persisted telemetry record exists; it is never synthesized from session-local state.
- Independent exact-head review passed on `bb991eaf5c382cb211685034b680bc0ea7e49d12` against `2c9ffe445b9d0bbbf275a1819bc507228d411ec0`.
