### PR TITLE
[bench·docs] benchmark methodology: retrieval + judged QA — harnesses, fairness rules, reproduction

### DIFF
--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -1,0 +1,200 @@
+# Benchmark methodology
+
+This is the methodology reference for the two memory-quality layers hermes-lcm
+benchmarks. It documents what each harness measures, the fairness rules both
+must honor, the configurations they run under, and how to reproduce a run.
+Scores land separately as runs complete (see [Results index](#results-index));
+this file describes the method, not a verdict.
+
+## What we measure, two layers
+
+### Layer 1 — retrieval quality
+
+Session-level and turn-level recall@k / NDCG@10 against LongMemEval's labeled
+evidence, computed by the in-tree offline harness
+(`benchmarking/longmemeval.py`, CLI at `scripts/lcm_longmemeval.py`).
+
+- **Dataset**: the pinned `LongMemEval_S` split of `xiaowu0162/longmemeval` on
+  Hugging Face, revision `2ec2a557f339b6c0369619b1ed5793734cc87533` (`fetch`
+  downloads it once; `run` never touches the network for the stub/fastembed
+  path). LongMemEval_S labels each question with its evidence session(s), so
+  recall@k / NDCG@k are computable without an LLM judge.
+- **Isolation**: every question ingests into a **fresh temporary LCM store**
+  (a throwaway SQLite DB under a `tempfile.TemporaryDirectory`) — no store is
+  shared or reused across questions. That per-question isolation is the
+  harness's fairness contract; a template DB may be cloned per question purely
+  to skip repeated schema-migration cost (`--no-db-template` disables the
+  clone and re-bootstraps from scratch).
+- **Summaries**: one deterministic, non-LLM summary per session
+  (`deterministic_session_summary`) — collapsed whitespace, truncated at a
+  fixed character cap, no provider call. This keeps the retrieval layer's
+  inputs reproducible byte-for-byte across runs.
+- **Arms**: `fts` (raw-message full-text search), `summary_vectors`
+  (session-summary KNN), `hybrid_rrf` (FTS + summary RRF fusion),
+  `hybrid_rerank` (RRF fusion reranked — cosine placeholder or the real
+  Voyage cross-encoder with `--rerank`), `chunk_vectors` (raw conversational-
+  chunk KNN), `hybrid_rrf3` (FTS + summary + chunk RRF fusion), and
+  `lcm_recall` — the **production** `tools.lcm_recall` tool (weighted RRF over
+  the FTS/summary/chunk arms, the scope/recency prior, chunk-vs-FTS dedup),
+  invoked directly rather than reimplemented, so this arm scores what a user
+  actually calls.
+- **Session vs. turn scoring**: session-level recall/NDCG treat each evidence
+  session as a hit; turn-level recall/NDCG additionally credit a
+  `(session, turn_index)` key. A summary-based hit cannot localize below its
+  session, so it counts as a session-granularity marker that covers every
+  evidence turn of that session at once — reported markdown flags any arm
+  with this coarseness using a trailing `*`.
+
+### Layer 2 — judged QA accuracy
+
+End-task answer correctness through the full ingest → search → answer →
+judge → report pipeline, run by the org's forked benchmarking harness,
+[electricsheephq/memorybench-benchmark-tool](https://github.com/electricsheephq/memorybench-benchmark-tool)
+(a fork of [supermemoryai/memorybench](https://github.com/supermemoryai/memorybench)),
+branch `adapter/hermes-lcm`.
+
+- The `hermes-lcm` Provider drives a long-lived Python bridge process
+  (`bridge/hermes_lcm_bridge.py`) over newline-delimited JSON on stdin/stdout.
+  `ingest` accumulates each harness session into a **fresh, per-container
+  `lcm.db`** (one SQLite store per question-container — the same
+  fresh-store isolation contract as the retrieval harness, just per QA
+  container instead of per retrieval question); `search` calls the
+  **production `tools.lcm_recall`** tool through the bridge, never a
+  harness-reimplemented stand-in.
+- The judge grades each answer with LongMemEval's own per-question-type judge
+  prompts (`getJudgePromptForType`) — hermes-lcm ships no bespoke prompt (see
+  `benchmarks/qa-harness/src/providers/hermes-lcm/prompts.ts`), so its answers
+  are graded on the same rubric as every other provider.
+- Full reproduction workflow, exact env vars, and the vendored adapter source
+  are in [`qa-harness/REPLICATION.md`](qa-harness/REPLICATION.md).
+
+## Fairness rules
+
+Both layers hold to the same three rules:
+
+1. **The adapter sees only what the harness gives every provider** — the
+   session messages and the query. No dataset-specific logic, no evidence
+   peeking.
+2. **Fresh, dataset-disjoint session id.** The production `lcm_recall` tool
+   applies a scope prior that boosts hits from the *current* conversation, so
+   both harnesses invoke it with a synthetic `current_session_id` that is
+   guaranteed absent from the question's haystack (or from any evidence
+   session) — the scope prior can never silently lift an evidence session by
+   conversation membership. (The recency prior still applies honestly to
+   every hit; that is real production behavior, not a harness artifact.)
+3. **Single-shot retrieval payload, no agentic re-expansion.** The QA layer
+   scores `tools.lcm_recall`'s one-shot snippet payload (≤25 hits, 300 chars
+   each) exactly as a caller would receive it — the adapter never re-queries
+   or re-expands a hit to inflate the answer context.
+
+## Configurations
+
+| Axis | Floor | Recommended |
+|---|---|---|
+| Embeddings | local FastEmbed `BAAI/bge-small-en-v1.5` — free, fully offline | `voyage-context-3` (+ optional `rerank-2.5-lite` rerank arm via `--rerank`) |
+| Answerer / judge (QA layer only) | — | CLI-backed (see below) |
+
+The embeddings floor exists so retrieval-quality numbers are reproducible by
+anyone with no API key and no network at query time. The recommended
+configuration is what we'd point a production deployment at.
+
+For the QA layer's answerer and judge, runs to date use a **CLI-backed
+transport** — a subscription-authenticated CLI (`codex exec` or `claude -p`)
+in place of a metered API SDK call — via `HERMES_MB_LLM_CLI=codex|claude`.
+**Disclose the exact model id per run** in that run's results/notes file: the
+CLI backend reports it through `cliLlmModelId()` (e.g. `gpt-5.6-sol (codex
+default) (via codex exec)`). Any judge other than the LongMemEval leaderboard
+default (`gpt-4o`) makes accuracy numbers **directional only**, until a
+judge-parity rerun with `-j gpt-4o -m gpt-4o` on a metered key.
+
+## Reproduction
+
+### Retrieval layer
+
+```bash
+# One-time: download the pinned dataset file (operator step; run itself is offline).
+python scripts/lcm_longmemeval.py fetch --output /path/to/dataset-dir
+
+# Deterministic offline plumbing check (stub embedder; scores are meaningless).
+python scripts/lcm_longmemeval.py run \
+  --dataset /path/to/dataset-dir/longmemeval_s \
+  --output benchmarks/runs/longmemeval-stub \
+  --provider stub \
+  --json
+
+# Local FastEmbed floor (CI-grade, no network at query time once cached).
+python scripts/lcm_longmemeval.py run \
+  --dataset /path/to/dataset-dir/longmemeval_s \
+  --output benchmarks/runs/longmemeval-fastembed \
+  --provider fastembed \
+  --model BAAI/bge-small-en-v1.5 \
+  --json
+
+# Recommended embeddings, with the real cross-encoder rerank arm.
+python scripts/lcm_longmemeval.py run \
+  --dataset /path/to/dataset-dir/longmemeval_s \
+  --output benchmarks/runs/longmemeval-voyage \
+  --provider voyage \
+  --model voyage-context-3 \
+  --rerank \
+  --json
+```
+
+`--limit N` scores only the first N questions (useful for a smoke run);
+`--no-db-template` disables the reused pre-migrated DB template (bootstraps
+each question's store from scratch instead of cloning a template — mainly
+for measuring the template-clone speedup, not for normal runs). Output is
+`longmemeval_metrics.json` + `longmemeval_metrics.md` in `--output`.
+
+### Judged QA layer
+
+Full clone/install/env/run steps, exact flags, and the vendored adapter
+source are in [`qa-harness/REPLICATION.md`](qa-harness/REPLICATION.md). In
+short, from a checkout of the `adapter/hermes-lcm` branch:
+
+```bash
+export HERMES_LCM_REPO=/path/to/hermes-lcm
+export HERMES_LCM_PYTHON=$HERMES_LCM_REPO/.venv-fastembed/bin/python
+export HERMES_MB_WORKDIR=/fresh/empty/workdir
+export HERMES_MB_PROVIDER=fastembed
+export LCM_LONGMEMEVAL_FASTEMBED_CACHE=/path/to/fastembed-cache
+export HERMES_MB_LLM_CLI=codex   # or: claude
+
+bun run src/index.ts run -p hermes-lcm -b longmemeval \
+  -j gpt-4o -m gpt-4o \
+  -r <run-id> \
+  --concurrency-answer 4 --concurrency-evaluate 4
+```
+
+Re-running the identical command with the same `-r <run-id>` (no `--force`)
+resumes from the last completed phase instead of restarting.
+
+## Caveats
+
+- **MemDelta config-exactness.** Every number in a results file describes
+  *that exact configuration* — dataset revision, provider/model, rerank
+  on/off, harness version. It is never a universal verdict on hermes-lcm's
+  retrieval quality; a different embedding model, chunk policy, or dataset
+  slice is a different measurement, not a contradiction.
+- **Retrieval recall ≠ leaderboard QA accuracy.** The two layers measure
+  different things — recall@k/NDCG against labeled evidence sessions/turns
+  vs. judged end-task answer correctness — and are not comparable to each
+  other or interchangeable as a stand-in for one another.
+- **n is disclosed per run.** Every results file states how many questions
+  were scored (LongMemEval_S's abstention questions are excluded from
+  recall/NDCG scoring and reported separately as an abstention count).
+- **Judge model is disclosed per run.** QA-layer numbers carry the exact
+  answerer/judge model id used; non-`gpt-4o` judges are directional until a
+  judge-parity rerun.
+
+## Results index
+
+| File | Layer | Config | Status |
+|---|---|---|---|
+| [`results/longmemeval-v2-500q-fastembed.md`](results/longmemeval-v2-500q-fastembed.md) | Retrieval | 500q, FastEmbed `bge-small`, per-arm harness | landed |
+| [`results/longmemeval-v3-500q-fastembed.md`](results/longmemeval-v3-500q-fastembed.md) | Retrieval | 500q, FastEmbed `bge-small`, harness turn-scoring fix + `lcm_recall` production-arm subset | landed |
+| `results/longmemeval-voyage-100q.md` | Retrieval | 100q, `voyage-context-3` | pending |
+| `results/qa-accuracy-<run-id>.md` | Judged QA | 500q, FastEmbed `bge-small`, CLI-backed judge | pending |
+
+Scores are appended to this index as runs complete; this file documents the
+method, not a running scoreboard.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # hermes-lcm deterministic benchmarks
 
-This directory contains deterministic replay fixtures and policy files for benchmark-driven LCM preset work.
+This directory contains deterministic replay fixtures and policy files for benchmark-driven LCM preset work. For the retrieval-quality and judged-QA-accuracy benchmarks (LongMemEval harnesses, fairness rules, reproduction, results index), see [`METHODOLOGY.md`](METHODOLOGY.md).
 
 The benchmark harness is offline by default:
 

--- a/benchmarks/qa-harness/REPLICATION.md
+++ b/benchmarks/qa-harness/REPLICATION.md
@@ -1,0 +1,152 @@
+# Judged QA harness — replication
+
+This directory vendors the hermes-lcm-specific pieces of the judged-QA
+benchmark harness so the exact code that ran a reported number lives next to
+this repo, not only on a branch of a separate fork. **The vendored copies
+below are the source of truth for what actually ran; the fork branch is the
+runnable form** (it needs the rest of the harness — orchestrator, benchmark
+loaders, UI — that doesn't belong in this repo).
+
+## Harness identity
+
+- Harness repo: [`electricsheephq/memorybench-benchmark-tool`](https://github.com/electricsheephq/memorybench-benchmark-tool),
+  a fork of upstream [`supermemoryai/memorybench`](https://github.com/supermemoryai/memorybench).
+- Branch: `adapter/hermes-lcm`.
+- Commit this package was vendored from:
+  `b249c9bf9441a351e32595da3bf84f0c734e49e6` (get the current tip yourself with
+  `git -C /path/to/memorybench-benchmark-tool rev-parse HEAD` if replicating
+  against a newer commit).
+
+## Vendored files
+
+```
+qa-harness/
+└── src/
+    ├── providers/hermes-lcm/
+    │   ├── index.ts        the memorybench Provider (spawns the Python bridge)
+    │   ├── prompts.ts       deliberately empty — no bespoke answer/judge prompt
+    │   ├── README.md        provider-level docs (prerequisites, env vars, run)
+    │   └── bridge/
+    │       └── hermes_lcm_bridge.py   JSON-line bridge: initialize/ingest/search/clear
+    ├── utils/
+    │   └── cli-llm.ts       CLI-backed (codex|claude) answerer/judge transport
+    └── judges/
+        └── cli.ts           Judge implementation wired to cli-llm.ts
+```
+
+These are byte-identical copies of the files at the commit above — no header
+comments were added to any of them so they stay diffable against the fork.
+
+## Clone + install
+
+```bash
+git clone https://github.com/electricsheephq/memorybench-benchmark-tool.git
+cd memorybench-benchmark-tool
+git checkout b249c9bf9441a351e32595da3bf84f0c734e49e6   # or the current adapter/hermes-lcm tip
+bun install
+```
+
+## Environment
+
+hermes-lcm's embedding path needs `fastembed` in a dedicated venv (the plugin
+itself has no pip deps — it's imported via `sys.path`, never installed):
+
+```bash
+uv venv --python 3.13 /path/to/hermes-lcm/.venv-fastembed
+uv pip install --python /path/to/hermes-lcm/.venv-fastembed/bin/python fastembed numpy
+```
+
+| Var | Required | Purpose |
+|---|---|---|
+| `HERMES_LCM_REPO` | yes | Path to the hermes-lcm checkout being benchmarked. |
+| `HERMES_LCM_PYTHON` | yes | Interpreter with `fastembed` installed (the venv above). |
+| `HERMES_MB_WORKDIR` | yes | Base dir for per-container `lcm.db` files. **Use a fresh/empty dir per run** — this is the harness's isolation boundary between containers. |
+| `HERMES_MB_PROVIDER` | no (default `fastembed`) | `fastembed` or `voyage`. |
+| `HERMES_MB_MODEL` | no | Embedding model id; defaults to `BAAI/bge-small-en-v1.5` (fastembed) or `voyage-context-3` (voyage). |
+| `LCM_LONGMEMEVAL_FASTEMBED_CACHE` | no | Redirect the FastEmbed model cache (e.g. to a roomy volume). |
+| `VOYAGE_API_KEY` | only if `HERMES_MB_PROVIDER=voyage` | — |
+| `HERMES_MB_LLM_CLI` | no (enables the CLI-backed transport) | `codex` or `claude`. When set, the answer and judge phases route through a subscription-authenticated CLI instead of a metered API SDK. |
+| `HERMES_MB_CODEX_MODEL` | no | Overrides the codex default model. |
+| `HERMES_MB_CODEX_EFFORT` | no (default `low`) | `model_reasoning_effort` passed to `codex exec`. |
+| `HERMES_MB_CLAUDE_MODEL` | no (default `claude-sonnet-5`) | Model passed to `claude -p`. |
+| `HERMES_MB_CLI_TIMEOUT_MS` | no (default `180000`) | Per-call timeout for the CLI transport. |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` | only if **not** using `HERMES_MB_LLM_CLI` | Harness-level answerer/judge key (hermes-lcm itself needs no provider key — retrieval is fully local). |
+
+## Run
+
+```bash
+export HERMES_LCM_REPO=/path/to/hermes-lcm
+export HERMES_LCM_PYTHON=$HERMES_LCM_REPO/.venv-fastembed/bin/python
+export HERMES_MB_WORKDIR=/fresh/empty/workdir
+export HERMES_MB_PROVIDER=fastembed
+export LCM_LONGMEMEVAL_FASTEMBED_CACHE=/path/to/fastembed-cache
+export HERMES_MB_LLM_CLI=codex   # or: claude
+
+bun run src/index.ts run -p hermes-lcm -b longmemeval \
+  -j gpt-4o -m gpt-4o \
+  -r hermes-lcm-fastembed-<run-label> \
+  --concurrency-answer 4 --concurrency-evaluate 4
+```
+
+`-j`/`-m` are recorded on the run's checkpoint as labels even when
+`HERMES_MB_LLM_CLI` is set; the model that actually answered/judged is the
+one `cliLlmModelId()` reports (disclose that value, not `-j`/`-m`, in the
+results writeup). Add `-l <n>` to limit the question count for a smoke run
+before committing to a full 500q pass.
+
+### Resume semantics
+
+Re-running the **identical command with the same `-r <run-id>`** (no
+`--force`) resumes from the last completed phase — the orchestrator finds the
+existing checkpoint, validates provider/benchmark match, and continues.
+Passing `--force` clears that checkpoint and starts over. Check progress at
+any time with:
+
+```bash
+bun run src/index.ts status -r <run-id>
+```
+
+### Where results land
+
+Relative to the harness repo root: `./data/runs/<run-id>/checkpoint.json`
+(run state, resumable) and `./data/runs/<run-id>/results/` (per-question and
+aggregate output).
+
+## What we changed and why
+
+The `adapter/hermes-lcm` branch adds three things on top of upstream
+`supermemoryai/memorybench`, none of which touch how any other provider is
+scored:
+
+- **`hermes-lcm` provider + Python bridge.** hermes-lcm is Python/SQLite
+  native and the harness is TypeScript/Bun, so the provider spawns a
+  long-lived Python bridge process and speaks newline-delimited JSON over
+  stdin/stdout — the same "persistent backend handle" shape the harness's Zep
+  provider uses for its SDK client. The bridge is crash-loud: if it exits,
+  the pending call rejects and every later call throws rather than silently
+  degrading.
+- **Fresh, per-container `lcm.db` isolation.** `ingest` accumulates one
+  harness session at a time into a store keyed by `containerTag`, and
+  `search` invokes the **production** `tools.lcm_recall` (never a
+  harness-reimplemented arm) through a `SimpleNamespace` engine with a fresh,
+  dataset-disjoint `current_session_id` — the same scope-prior fairness rule
+  the retrieval harness (`benchmarking/longmemeval.py`) uses, applied per QA
+  container. The bridge imports `benchmarking.longmemeval`'s deterministic
+  session-summary function rather than reimplementing it, so both layers
+  build identical session summaries from identical inputs.
+- **CLI-backed answerer/judge (`cli-llm.ts` + `judges/cli.ts`).** Added so a
+  full 500-question run doesn't require a funded per-token API key: it routes
+  the answer and judge phases through a subscription-authenticated CLI
+  (`codex exec` or `claude -p`) instead. Prompts are piped over stdin (avoids
+  an argv/`E2BIG` failure mode on long contexts) and the transport is
+  crash-loud (nonzero exit or empty output rejects) with **one retry** on a
+  transient failure — added after a measured burst of simultaneous transient
+  CLI failures killed an otherwise-healthy run partway through. This is a
+  transport swap only: the judge still grades with the harness's standard
+  LongMemEval per-question-type prompts (`buildJudgePrompt` /
+  `parseJudgeResponse`), the same as every SDK-backed judge.
+
+**Fairness held constant:** the adapter/bridge only ever receives what the
+harness gives every provider (session messages + query, no evidence
+peeking); `tools.lcm_recall`'s single-shot snippet payload (≤25 hits, 300
+chars each) is scored as-is, with no agentic re-expansion of a hit.

--- a/benchmarks/qa-harness/src/judges/cli.ts
+++ b/benchmarks/qa-harness/src/judges/cli.ts
@@ -1,0 +1,38 @@
+import type { LanguageModel } from "ai"
+import type { Judge, JudgeConfig, JudgeInput, JudgeResult } from "../types/judge"
+import type { ProviderPrompts } from "../types/prompts"
+import { buildJudgePrompt, parseJudgeResponse, getJudgePrompt } from "./base"
+import { logger } from "../utils/logger"
+import { cliComplete, cliLlmModelId } from "../utils/cli-llm"
+
+/**
+ * Judge backed by a subscription-authenticated CLI (Codex/Claude) instead of a
+ * metered API. Same prompts as the SDK judges (LongMemEval per-type prompts via
+ * `buildJudgePrompt`), verdict parsed by the shared `parseJudgeResponse`.
+ */
+export class CliJudge implements Judge {
+  name = "cli"
+
+  async initialize(_config: JudgeConfig): Promise<void> {
+    logger.info(`Initialized CLI judge (${cliLlmModelId()})`)
+  }
+
+  async evaluate(input: JudgeInput): Promise<JudgeResult> {
+    const prompt = buildJudgePrompt(input)
+    const text = await cliComplete(prompt)
+    return parseJudgeResponse(text)
+  }
+
+  getPromptForQuestionType(questionType: string, providerPrompts?: ProviderPrompts): string {
+    return getJudgePrompt(questionType, providerPrompts)
+  }
+
+  getModel(): LanguageModel {
+    // The CLI backend has no ai-sdk LanguageModel. The evaluate phase skips the
+    // LLM-graded retrieval-metrics pass when the CLI backend is active, so this
+    // is never called; throw loudly if that assumption is ever violated.
+    throw new Error("CliJudge.getModel() is not available under the CLI LLM backend")
+  }
+}
+
+export default CliJudge

--- a/benchmarks/qa-harness/src/providers/hermes-lcm/README.md
+++ b/benchmarks/qa-harness/src/providers/hermes-lcm/README.md
@@ -1,0 +1,95 @@
+# hermes-lcm provider
+
+Scores [hermes-lcm](https://github.com/) — a Python/SQLite lossless
+context-management memory plugin — on this harness's full
+ingest → search → answer → judge → report pipeline, for leaderboard-comparable
+LongMemEval_S QA accuracy.
+
+## How it works
+
+hermes-lcm is Python-native, so the provider (`index.ts`) drives a long-lived
+Python bridge (`bridge/hermes_lcm_bridge.py`) over newline-delimited JSON on
+stdin/stdout — the same "persistent backend handle" shape as the Zep provider's
+SDK client. Requests are serialized (one line in flight at a time) and the
+provider is crash-loud: if the bridge exits, the pending call rejects and every
+later call throws.
+
+| Provider method | Bridge behavior |
+|---|---|
+| `initialize` | Warms the embedding model once (so the model load happens here, not inside a per-question path). |
+| `ingest` | Accumulates ONE harness session at a time into a per-container LCM store on disk: appends the messages to `MessageStore` (session ids/order preserved), builds the **same** deterministic per-session summary the in-house harness uses (`benchmarking.longmemeval.deterministic_session_summary`, imported — never reimplemented), records the summary embedding + conversational-chunk embeddings (batched). |
+| `awaitIndexing` | No-op — ingest is fully synchronous. |
+| `search` | Calls the **production** `tools.lcm_recall` over the container store through a `SimpleNamespace` engine with a fresh, dataset-disjoint `current_session_id`, then maps each hit → `{content, metadata}` and returns the top-k the harness asks for. |
+| `clear` | Deletes the container's db + date sidecar. |
+
+The hermes-lcm plugin repo is **never modified**: it is made importable via the
+same `sys.path` + package-spec bootstrap the repo's own harness uses.
+
+**Fairness:** the adapter only ever sees what the harness gives every provider
+(the session messages + the query). No dataset-specific logic, no evidence
+peeking. `tools.lcm_recall`'s snippet (300 chars/hit, ≤25 hits) is the honest
+single-shot production payload — the adapter does not agentically re-expand hits.
+
+**Session dates:** the plugin's `append_batch` stamps ingest wall-clock time and
+takes no per-message timestamp (and must not be modified), so the
+harness-provided session date — data every provider receives — is preserved in a
+per-container sidecar and surfaced onto each search hit's `metadata.date` for
+temporal questions.
+
+## Prerequisites
+
+hermes-lcm's embedding path needs `fastembed` (optional dep). Create a dedicated
+venv once (the plugin itself has no pip deps — it is imported via `sys.path`):
+
+```bash
+uv venv --python 3.13 /path/to/hermes-lcm/.venv-fastembed
+uv pip install --python /path/to/hermes-lcm/.venv-fastembed/bin/python fastembed numpy
+```
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `HERMES_LCM_REPO` | `/Volumes/LEXAR/hermes-work/hermes-lcm` | Path to the hermes-lcm checkout. |
+| `HERMES_LCM_PYTHON` | `$HERMES_LCM_REPO/.venv-fastembed/bin/python` | Python interpreter that has `fastembed`. |
+| `HERMES_MB_WORKDIR` | `$TMPDIR/hermes-lcm-mb` | Base dir for per-container LCM dbs. |
+| `HERMES_MB_PROVIDER` | `fastembed` | Embedding provider: `fastembed` or `voyage`. |
+| `HERMES_MB_MODEL` | `BAAI/bge-small-en-v1.5` (fastembed) / `voyage-context-3` (voyage) | Embedding model id. |
+| `LCM_LONGMEMEVAL_FASTEMBED_CACHE` | fastembed default | FastEmbed model cache dir (point at a roomy volume). |
+| `VOYAGE_API_KEY` | — | Required only when `HERMES_MB_PROVIDER=voyage`. |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` | — | Answerer + judge key (harness-level, not provider-level). |
+
+hermes-lcm needs **no provider API key** — retrieval is fully local.
+
+## Run
+
+```bash
+export HERMES_LCM_REPO=/Volumes/LEXAR/hermes-work/hermes-lcm
+export HERMES_LCM_PYTHON=$HERMES_LCM_REPO/.venv-fastembed/bin/python
+export HERMES_MB_WORKDIR=/Volumes/LEXAR/hermes-work/mb-workdir
+export HERMES_MB_PROVIDER=fastembed
+export LCM_LONGMEMEVAL_FASTEMBED_CACHE=/Volumes/LEXAR/hermes-work/fastembed-cache
+export OPENAI_API_KEY=sk-...            # answerer + judge
+
+# 5-question smoke
+bun run src/index.ts run -p hermes-lcm -b longmemeval -j gpt-4o -m gpt-4o -l 5 -r smoke-hermes-lcm-5q --force
+
+# full LongMemEval_S (500q)
+bun run src/index.ts run -p hermes-lcm -b longmemeval -j gpt-4o -m gpt-4o -r hermes-lcm-fastembed-500q
+```
+
+Swap `-j sonnet-4 -m sonnet-4` (Anthropic) or `-j gemini-2.5-flash -m
+gemini-2.5-flash` (Google) to change the judge/answerer.
+
+## ⚠ Result-comparability disclosures
+
+Bake these into any numbers reported from a hermes-lcm run:
+
+- **Judge/answerer = `gemini-2.5-flash`** in the runs produced so far (no funded
+  OpenAI/Anthropic key was available: the OpenAI key was `insufficient_quota` and
+  no `ANTHROPIC_API_KEY` existed). This is **non-standard** vs the usual `gpt-4o`
+  LongMemEval leaderboard judge, so the accuracy numbers are **directional until a
+  judge-parity rerun** with `-j gpt-4o -m gpt-4o`.
+- **Retrieval = production `tools.lcm_recall` single-shot snippets** (≤25 hits,
+  300 chars each). The adapter does not agentically re-expand hits, so this scores
+  hermes-lcm's one-shot recall payload — not a multi-hop recall→expand agent loop.

--- a/benchmarks/qa-harness/src/providers/hermes-lcm/bridge/hermes_lcm_bridge.py
+++ b/benchmarks/qa-harness/src/providers/hermes-lcm/bridge/hermes_lcm_bridge.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""JSON-line bridge exposing hermes-lcm as a memorybench Provider backend.
+
+The TypeScript ``HermesLcmProvider`` spawns this script in ``serve`` mode and
+speaks newline-delimited JSON over stdin/stdout: one request object per line,
+one response object per line. It implements the four stateful provider methods
+(initialize / ingest / search / clear); ``awaitIndexing`` is a no-op on the TS
+side because ingest is fully synchronous here.
+
+Design contract (faithful to ``benchmarking/longmemeval.py`` in the hermes-lcm
+repo, which this imports rather than reimplements):
+
+* ``ingest`` accumulates ONE harness session at a time into a per-container LCM
+  store on disk (the harness calls ``provider.ingest([session], ...)`` in a loop),
+  preserving session ids/order, building the SAME deterministic per-session
+  summary the in-house harness uses, recording summary + conversational-chunk
+  embeddings. Embeds are batched per call.
+* ``search`` invokes the PRODUCTION ``tools.lcm_recall`` over that store through a
+  ``SimpleNamespace`` engine with a fresh, dataset-disjoint ``current_session_id``
+  (so the scope prior never silently lifts an evidence session), then maps each
+  hit -> ``{content, metadata}`` and returns the top-k the harness asks for.
+
+Fairness: the bridge only ever sees what the harness hands it (the session
+messages + the query). No dataset-specific logic, no evidence peeking.
+
+The hermes-lcm plugin repo is NEVER modified: it is made importable via the same
+``sys.path`` + package-spec bootstrap the repo's own harness uses.
+
+Environment:
+    HERMES_LCM_REPO                path to the hermes-lcm checkout (required)
+    HERMES_MB_WORKDIR              base dir for per-container LCM dbs (required)
+    HERMES_MB_PROVIDER            embedding provider: fastembed (default) | voyage
+    HERMES_MB_MODEL              embedding model id (default per provider)
+    LCM_LONGMEMEVAL_FASTEMBED_CACHE  fastembed model cache dir
+    VOYAGE_API_KEY               required when HERMES_MB_PROVIDER=voyage
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sys
+import traceback
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_DEFAULT_MODELS = {
+    "fastembed": "BAAI/bge-small-en-v1.5",
+    "voyage": "voyage-context-3",
+}
+
+# Preserve the real stdout for protocol responses, then redirect stdout to
+# stderr so any library chatter (model downloads, warnings) can never corrupt
+# the newline-delimited JSON channel.
+_RESPONSE_OUT = sys.stdout
+sys.stdout = sys.stderr
+
+
+def _log(message: str) -> None:
+    print(f"[hermes-lcm-bridge] {message}", file=sys.stderr, flush=True)
+
+
+def _safe(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value)).strip("-._") or "container"
+
+
+class Bridge:
+    def __init__(self) -> None:
+        repo = os.environ.get("HERMES_LCM_REPO")
+        if not repo:
+            raise RuntimeError("HERMES_LCM_REPO is not set")
+        self.repo_root = Path(repo).resolve()
+        if not self.repo_root.is_dir():
+            raise RuntimeError(f"HERMES_LCM_REPO does not exist: {self.repo_root}")
+
+        workdir = os.environ.get("HERMES_MB_WORKDIR")
+        if not workdir:
+            raise RuntimeError("HERMES_MB_WORKDIR is not set")
+        self.workdir = Path(workdir).resolve()
+        self.workdir.mkdir(parents=True, exist_ok=True)
+
+        self.provider_name = (os.environ.get("HERMES_MB_PROVIDER") or "fastembed").strip().lower()
+        if self.provider_name in {"fast-embed"}:
+            self.provider_name = "fastembed"
+        self.model = os.environ.get("HERMES_MB_MODEL") or _DEFAULT_MODELS.get(
+            self.provider_name, ""
+        )
+        if not self.model:
+            raise RuntimeError(f"no embedding model for provider {self.provider_name!r}")
+
+        # Make the plugin importable exactly the way the repo's own harness does.
+        if str(self.repo_root) not in sys.path:
+            sys.path.insert(0, str(self.repo_root))
+        from benchmarking.longmemeval import (  # noqa: E402
+            _ensure_hermes_lcm_package,
+            deterministic_session_summary,
+            resolve_harness_provider,
+        )
+
+        _ensure_hermes_lcm_package()
+        self._deterministic_session_summary = deterministic_session_summary
+        self._resolve_harness_provider = resolve_harness_provider
+
+        # Lazily populated on initialize().
+        self.embedder: Any = None
+        self.dim: int = 0
+        # Per-container monotonic session order (recency prior in lcm_recall).
+        self._order: dict[str, int] = {}
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def initialize(self, _req: dict[str, Any]) -> dict[str, Any]:
+        if self.provider_name == "voyage" and not os.environ.get("VOYAGE_API_KEY"):
+            raise RuntimeError("HERMES_MB_PROVIDER=voyage but VOYAGE_API_KEY is unset")
+        # Warm the embedder once so the model download/load happens here, not
+        # inside a per-question path, and .dim is populated.
+        self.embedder = self._resolve_harness_provider(self.provider_name, self.model)
+        self.dim = int(self.embedder.dim)
+        self.model = self.embedder.model_id
+        _log(
+            f"initialized provider={self.provider_name} model={self.model} dim={self.dim} "
+            f"workdir={self.workdir}"
+        )
+        return {
+            "ok": True,
+            "provider": self.provider_name,
+            "model": self.model,
+            "dim": self.dim,
+            "embeddings_enabled": True,
+        }
+
+    # -- helpers --------------------------------------------------------------
+
+    def _db_path(self, container_tag: str) -> Path:
+        return self.workdir / f"{_safe(container_tag)}.db"
+
+    def _dates_path(self, container_tag: str) -> Path:
+        # A sidecar mapping session_id -> harness-provided session date. The
+        # plugin's append_batch stamps ingest wall-clock time (it takes no
+        # per-message timestamp and must not be modified), so the real session
+        # date -- data the harness gives EVERY provider -- is preserved here and
+        # surfaced onto each search hit's metadata for temporal questions.
+        return self.workdir / f"{_safe(container_tag)}.dates.json"
+
+    def _load_dates(self, container_tag: str) -> dict[str, Any]:
+        path = self._dates_path(container_tag)
+        if path.exists():
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _config(self, db_path: Path):
+        from hermes_lcm.config import LCMConfig
+
+        return LCMConfig(
+            database_path=str(db_path),
+            embeddings_enabled=True,
+            embedding_provider=self.provider_name,
+            embedding_model=self.model,
+        )
+
+    # -- ingest ---------------------------------------------------------------
+
+    def ingest(self, req: dict[str, Any]) -> dict[str, Any]:
+        if self.embedder is None:
+            raise RuntimeError("ingest before initialize")
+        container_tag = str(req["containerTag"])
+        session = req["session"]
+        session_id = str(session["sessionId"])
+        session_meta = session.get("metadata") or {}
+        session_date = session_meta.get("date") or session_meta.get("formattedDate")
+        messages = [
+            {
+                "role": str(m.get("role", "user")),
+                "content": str(m.get("content", "")),
+            }
+            for m in session.get("messages", [])
+        ]
+
+        from hermes_lcm.chunking import iter_message_chunks
+        from hermes_lcm.dag import SummaryDAG, SummaryNode
+        from hermes_lcm.store import MessageStore
+        from hermes_lcm.vector_store import EmbeddingIdentity, VectorStore
+
+        db_path = self._db_path(container_tag)
+        config = self._config(db_path)
+        # Opening these bootstraps the schema on first touch and re-opens
+        # idempotently thereafter, so successive sessions accumulate.
+        store = MessageStore(str(db_path), ingest_protection_config=config)
+        dag = SummaryDAG(str(db_path))
+        vector_store = VectorStore(str(db_path), config=config)
+        try:
+            vector_store.register_profile(self.model, self.provider_name, self.dim)
+            identity = vector_store.capture_identity(self.model, provider=self.provider_name)
+            vector_store.register_profile(self.model, self.provider_name, self.dim, task="chunk")
+            chunk_identity = EmbeddingIdentity.canonical(
+                self.provider_name, self.model, "", self.dim, "float32", "little", "chunk"
+            )
+
+            store_ids: list[int] = []
+            if messages:
+                store_ids = store.append_batch(
+                    session_id, messages, source="benchmark", conversation_id=session_id
+                )
+                rows = [
+                    {"store_id": sid, "role": m["role"], "content": m["content"]}
+                    for sid, m in zip(store_ids, messages)
+                ]
+                chunk_texts: list[str] = []
+                chunk_meta: list[Any] = []
+                for chunk in iter_message_chunks(rows, policy="conversational"):
+                    chunk_texts.append(chunk.text)
+                    chunk_meta.append(chunk)
+                if chunk_texts:
+                    chunk_vectors = self.embedder.embed_documents(chunk_texts)
+                    for chunk, vector in zip(chunk_meta, chunk_vectors):
+                        vector_store.record_chunk_embedding(
+                            chunk.chunk_id, self.model, vector,
+                            store_id=chunk.store_id, chunk_index=chunk.chunk_index,
+                            char_start=chunk.char_start, char_end=chunk.char_end,
+                            token_estimate=chunk.token_estimate, identity=chunk_identity,
+                        )
+
+            summary_text = self._deterministic_session_summary(messages)
+            order = self._order.get(container_tag, 0) + 1
+            self._order[container_tag] = order
+            node_id = dag.add_node(
+                SummaryNode(
+                    session_id=session_id,
+                    depth=0,
+                    summary=summary_text,
+                    token_count=len(summary_text.split()),
+                    source_token_count=sum(len(m["content"].split()) for m in messages),
+                    source_type="messages",
+                    created_at=float(order),
+                )
+            )
+            summary_vector = self.embedder.embed_documents([summary_text])[0]
+            vector_store.record_embedding(
+                str(node_id), "summary", self.model, summary_vector, identity=identity
+            )
+        finally:
+            vector_store.close()
+            dag.close()
+            store.close()
+
+        if session_date:
+            dates = self._load_dates(container_tag)
+            dates[session_id] = session_date
+            self._dates_path(container_tag).write_text(
+                json.dumps(dates), encoding="utf-8"
+            )
+
+        return {"ok": True, "documentIds": [str(sid) for sid in store_ids] or [session_id]}
+
+    # -- search ---------------------------------------------------------------
+
+    def search(self, req: dict[str, Any]) -> dict[str, Any]:
+        if self.embedder is None:
+            raise RuntimeError("search before initialize")
+        container_tag = str(req["containerTag"])
+        query = str(req.get("query", ""))
+        limit = int(req.get("limit", 25))
+
+        import hermes_lcm.tools as lcm_tools
+        from hermes_lcm.dag import SummaryDAG
+        from hermes_lcm.store import MessageStore
+        from hermes_lcm.vector_store import VectorStore
+
+        db_path = self._db_path(container_tag)
+        config = self._config(db_path)
+        store = MessageStore(str(db_path), ingest_protection_config=config)
+        dag = SummaryDAG(str(db_path))
+        vector_store = VectorStore(str(db_path), config=config)  # noqa: F841 (keeps db warm)
+        try:
+            # A probe current-session id disjoint from any dataset session id
+            # (the harness uses "<qid>-session-<i>"); the scope prior may boost
+            # the current conversation, so it must NOT be an evidence session.
+            fresh_session = f"__hermes_lcm_recall_probe__{container_tag}"
+            engine = SimpleNamespace(
+                _config=config,
+                _store=store,
+                _dag=dag,
+                _hermes_home=str(self.workdir),
+                current_session_id=fresh_session,
+            )
+            cache_key = (self.provider_name.strip().lower(), str(self.embedder.model_id).strip())
+            engine._lcm_embedding_provider_cache = (cache_key, self.embedder)
+
+            payload = json.loads(
+                lcm_tools.lcm_recall({"query": query, "limit": limit}, engine=engine)
+            )
+        finally:
+            vector_store.close()
+            dag.close()
+            store.close()
+
+        if "error" in payload:
+            raise RuntimeError(f"lcm_recall error: {payload['error']}")
+
+        dates = self._load_dates(container_tag)
+        results: list[dict[str, Any]] = []
+        for hit in payload.get("hits", []):
+            session_id = hit.get("session_id")
+            metadata = {
+                "session_id": session_id,
+                "date": dates.get(str(session_id)),
+                "kind": hit.get("kind"),
+                "score": hit.get("score"),
+                "arms": hit.get("arms"),
+                "from_current_session": hit.get("from_current_session"),
+            }
+            if hit.get("kind") == "summary":
+                metadata["node_id"] = hit.get("node_id")
+            else:
+                metadata["store_id"] = hit.get("store_id")
+                if hit.get("chunk_span"):
+                    metadata["chunk_span"] = hit.get("chunk_span")
+            results.append({"content": hit.get("snippet") or "", "metadata": metadata})
+
+        return {
+            "ok": True,
+            "results": results[:limit],
+            "degraded": payload.get("degraded", False),
+            "degraded_reason": payload.get("degraded_reason"),
+        }
+
+    # -- clear ----------------------------------------------------------------
+
+    def clear(self, req: dict[str, Any]) -> dict[str, Any]:
+        container_tag = str(req["containerTag"])
+        db_path = self._db_path(container_tag)
+        for suffix in ("", "-wal", "-shm"):
+            candidate = Path(str(db_path) + suffix)
+            if candidate.exists():
+                candidate.unlink()
+        dates_path = self._dates_path(container_tag)
+        if dates_path.exists():
+            dates_path.unlink()
+        self._order.pop(container_tag, None)
+        return {"ok": True}
+
+    # -- dispatch -------------------------------------------------------------
+
+    def handle(self, req: dict[str, Any]) -> dict[str, Any]:
+        cmd = req.get("cmd")
+        if cmd == "initialize":
+            return self.initialize(req)
+        if cmd == "ingest":
+            return self.ingest(req)
+        if cmd == "search":
+            return self.search(req)
+        if cmd == "clear":
+            return self.clear(req)
+        if cmd == "ping":
+            return {"ok": True}
+        raise RuntimeError(f"unknown cmd: {cmd!r}")
+
+
+def main() -> int:
+    bridge = Bridge()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(json.dumps({"ok": False, "error": f"bad json: {exc}"}), file=_RESPONSE_OUT, flush=True)
+            continue
+        try:
+            response = bridge.handle(req)
+        except Exception as exc:  # noqa: BLE001 - report every failure loudly
+            traceback.print_exc(file=sys.stderr)
+            response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        print(json.dumps(response), file=_RESPONSE_OUT, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/qa-harness/src/providers/hermes-lcm/index.ts
+++ b/benchmarks/qa-harness/src/providers/hermes-lcm/index.ts
@@ -1,0 +1,216 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type {
+  Provider,
+  ProviderConfig,
+  IngestOptions,
+  IngestResult,
+  SearchOptions,
+  IndexingProgressCallback,
+} from "../../types/provider"
+import type { UnifiedSession } from "../../types/unified"
+import { logger } from "../../utils/logger"
+import { HERMES_LCM_PROMPTS } from "./prompts"
+
+const DEFAULT_REPO = "/Volumes/LEXAR/hermes-work/hermes-lcm"
+const INITIALIZE_TIMEOUT_MS = 300_000 // model download/load on first warmup can be slow
+const REQUEST_TIMEOUT_MS = 120_000
+
+interface BridgeResponse {
+  ok: boolean
+  error?: string
+  [key: string]: unknown
+}
+
+/**
+ * hermes-lcm memory provider.
+ *
+ * hermes-lcm is a Python/SQLite lossless-context-management plugin, so the
+ * provider drives a long-lived Python bridge (`bridge/hermes_lcm_bridge.py`)
+ * over newline-delimited JSON on stdin/stdout — the same "persistent backend
+ * handle" shape as the Zep provider's SDK client. Ingest accumulates each
+ * harness session into a per-container LCM store; search calls the PRODUCTION
+ * `tools.lcm_recall` and returns its hits as `{content, metadata}`.
+ *
+ * Requests are serialized (single pipe, single in-flight request) and the
+ * provider is crash-loud: if the bridge exits, the pending call rejects and
+ * every subsequent call throws rather than silently degrading.
+ */
+export class HermesLcmProvider implements Provider {
+  name = "hermes-lcm"
+  prompts = HERMES_LCM_PROMPTS
+  // Single Python process + SQLite + one pipe => run every phase sequentially.
+  concurrency = { default: 1 }
+
+  private proc: ChildProcessWithoutNullStreams | null = null
+  private stdoutBuffer = ""
+  private pending: {
+    resolve: (r: BridgeResponse) => void
+    reject: (e: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  } | null = null
+  private queue: Promise<unknown> = Promise.resolve()
+  private deadError: Error | null = null
+
+  async initialize(_config: ProviderConfig): Promise<void> {
+    const repo = process.env.HERMES_LCM_REPO || DEFAULT_REPO
+    const python =
+      process.env.HERMES_LCM_PYTHON || join(repo, ".venv-fastembed", "bin", "python")
+    const script = join(import.meta.dir, "bridge", "hermes_lcm_bridge.py")
+
+    if (!existsSync(python)) {
+      throw new Error(
+        `hermes-lcm python not found at ${python}. Set HERMES_LCM_PYTHON or create the fastembed venv (see provider README).`
+      )
+    }
+    if (!existsSync(script)) {
+      throw new Error(`hermes-lcm bridge script not found at ${script}`)
+    }
+
+    const workdir = process.env.HERMES_MB_WORKDIR || join(tmpdir(), "hermes-lcm-mb")
+    const env: Record<string, string> = {
+      ...process.env,
+      HERMES_LCM_REPO: repo,
+      HERMES_MB_WORKDIR: workdir,
+      HERMES_MB_PROVIDER: process.env.HERMES_MB_PROVIDER || "fastembed",
+      PYTHONUNBUFFERED: "1",
+    }
+
+    this.proc = spawn(python, [script, "serve"], { env }) as ChildProcessWithoutNullStreams
+    this.proc.stdout.setEncoding("utf8")
+    this.proc.stderr.setEncoding("utf8")
+
+    this.proc.stdout.on("data", (chunk: string) => this.onStdout(chunk))
+    this.proc.stderr.on("data", (chunk: string) => {
+      for (const line of chunk.split("\n")) {
+        if (line.trim()) logger.debug(`[hermes-lcm] ${line}`)
+      }
+    })
+    this.proc.on("exit", (code, signal) => {
+      this.markDead(new Error(`hermes-lcm bridge exited (code=${code}, signal=${signal})`))
+    })
+    this.proc.on("error", (err) => {
+      this.markDead(new Error(`hermes-lcm bridge process error: ${err.message}`))
+    })
+
+    const resp = await this.request({ cmd: "initialize" }, INITIALIZE_TIMEOUT_MS)
+    logger.info(
+      `Initialized hermes-lcm provider (provider=${resp.provider}, model=${resp.model}, dim=${resp.dim})`
+    )
+  }
+
+  async ingest(sessions: UnifiedSession[], options: IngestOptions): Promise<IngestResult> {
+    const documentIds: string[] = []
+    // The harness calls ingest one session at a time, but honor a batch too.
+    for (const session of sessions) {
+      const resp = await this.request({
+        cmd: "ingest",
+        containerTag: options.containerTag,
+        session,
+      })
+      const ids = (resp.documentIds as string[]) || []
+      documentIds.push(...ids)
+    }
+    return { documentIds }
+  }
+
+  async awaitIndexing(
+    result: IngestResult,
+    _containerTag: string,
+    onProgress?: IndexingProgressCallback
+  ): Promise<void> {
+    // Ingest is fully synchronous (embeddings recorded inline), so indexing is
+    // instant. Report every document as completed for the progress tracker.
+    onProgress?.({
+      completedIds: result.documentIds,
+      failedIds: [],
+      total: result.documentIds.length,
+    })
+  }
+
+  async search(query: string, options: SearchOptions): Promise<unknown[]> {
+    const resp = await this.request({
+      cmd: "search",
+      containerTag: options.containerTag,
+      query,
+      limit: options.limit ?? 25,
+    })
+    if (resp.degraded) {
+      logger.debug(`[hermes-lcm] search degraded: ${resp.degraded_reason}`)
+    }
+    return (resp.results as unknown[]) || []
+  }
+
+  async clear(containerTag: string): Promise<void> {
+    if (this.deadError) return
+    try {
+      await this.request({ cmd: "clear", containerTag })
+    } catch (e) {
+      logger.warn(`Failed to clear hermes-lcm container ${containerTag}: ${e}`)
+    }
+  }
+
+  // -- bridge plumbing ------------------------------------------------------
+
+  private onStdout(chunk: string): void {
+    this.stdoutBuffer += chunk
+    let newlineIndex: number
+    while ((newlineIndex = this.stdoutBuffer.indexOf("\n")) !== -1) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex).trim()
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1)
+      if (!line) continue
+      const pending = this.pending
+      this.pending = null
+      if (!pending) {
+        logger.warn(`[hermes-lcm] unexpected bridge output: ${line}`)
+        continue
+      }
+      clearTimeout(pending.timer)
+      try {
+        pending.resolve(JSON.parse(line) as BridgeResponse)
+      } catch (e) {
+        pending.reject(new Error(`hermes-lcm bridge sent invalid JSON: ${line} (${e})`))
+      }
+    }
+  }
+
+  private markDead(err: Error): void {
+    if (!this.deadError) this.deadError = err
+    if (this.pending) {
+      clearTimeout(this.pending.timer)
+      this.pending.reject(err)
+      this.pending = null
+    }
+  }
+
+  /** Serialize requests: one line on the pipe at a time. */
+  private request(payload: Record<string, unknown>, timeoutMs = REQUEST_TIMEOUT_MS): Promise<BridgeResponse> {
+    const run = async (): Promise<BridgeResponse> => {
+      if (this.deadError) throw this.deadError
+      if (!this.proc) throw new Error("hermes-lcm bridge not started")
+      const resp = await new Promise<BridgeResponse>((resolve, reject) => {
+        const timer = setTimeout(
+          () => this.markDead(new Error(`hermes-lcm bridge timed out after ${timeoutMs}ms on ${payload.cmd}`)),
+          timeoutMs
+        )
+        this.pending = { resolve, reject, timer }
+        this.proc!.stdin.write(JSON.stringify(payload) + "\n")
+      })
+      if (!resp.ok) {
+        throw new Error(`hermes-lcm ${payload.cmd} failed: ${resp.error}`)
+      }
+      return resp
+    }
+    // Chain onto the queue so calls never interleave on the shared pipe.
+    const result = this.queue.then(run, run)
+    this.queue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+}
+
+export default HermesLcmProvider

--- a/benchmarks/qa-harness/src/providers/hermes-lcm/prompts.ts
+++ b/benchmarks/qa-harness/src/providers/hermes-lcm/prompts.ts
@@ -1,0 +1,14 @@
+import type { ProviderPrompts } from "../../types/prompts"
+
+/**
+ * hermes-lcm deliberately ships NO custom answer or judge prompt.
+ *
+ * For leaderboard-comparable LongMemEval_S QA accuracy the harness defaults are
+ * the neutral baseline: the default answer prompt reasons over the raw JSON
+ * search results (which already carry `content` + `metadata.date`), and the
+ * judge falls through to LongMemEval's standard per-question-type prompts
+ * (`getJudgePromptForType`). Handing hermes-lcm a bespoke tuned prompt would
+ * inflate its numbers relative to providers scored under those defaults, so we
+ * intentionally leave both undefined.
+ */
+export const HERMES_LCM_PROMPTS: ProviderPrompts = {}

--- a/benchmarks/qa-harness/src/utils/cli-llm.ts
+++ b/benchmarks/qa-harness/src/utils/cli-llm.ts
@@ -1,0 +1,194 @@
+import { spawn } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { execSync } from "node:child_process"
+
+/**
+ * CLI-backed LLM client: routes the answerer + judge stages through a
+ * subscription-authenticated CLI (Codex or Claude) instead of a per-token
+ * metered API. One process per call; prompt via stdin (sidesteps argv E2BIG);
+ * plain text back on stdout / a last-message file. Crash-loud: a nonzero exit
+ * or empty output rejects.
+ *
+ * Enable with `HERMES_MB_LLM_CLI=codex` (primary) or `claude` (fallback).
+ */
+export type CliLlmBackend = "codex" | "claude"
+
+const CALL_TIMEOUT_MS = Number(process.env.HERMES_MB_CLI_TIMEOUT_MS || 180_000)
+
+export function cliLlmBackend(): CliLlmBackend | null {
+  const b = (process.env.HERMES_MB_LLM_CLI || "").trim().toLowerCase()
+  return b === "codex" || b === "claude" ? b : null
+}
+
+/** Human-readable model id for run-note disclosure. */
+export function cliLlmModelId(): string {
+  const backend = cliLlmBackend()
+  if (backend === "claude") {
+    return `${process.env.HERMES_MB_CLAUDE_MODEL || "claude-sonnet-5"} (via claude -p)`
+  }
+  if (backend === "codex") {
+    return `${process.env.HERMES_MB_CODEX_MODEL || "gpt-5.6-sol (codex default)"} (via codex exec)`
+  }
+  return "n/a"
+}
+
+export async function cliComplete(prompt: string): Promise<string> {
+  const backend = cliLlmBackend()
+  if (!backend) throw new Error("cliComplete called but HERMES_MB_LLM_CLI is not codex|claude")
+  const run = () => (backend === "codex" ? codexComplete(prompt) : claudeComplete(prompt))
+  try {
+    return await run()
+  } catch (first) {
+    // One retry after a short pause: a transient CLI hiccup (observed: a
+    // simultaneous burst of missing codex output files) must not kill an
+    // entire 500-call phase. A second consecutive failure is real.
+    await new Promise((r) => setTimeout(r, 5000))
+    return run()
+  }
+}
+
+function runProcess(
+  command: string,
+  args: string[],
+  prompt: string,
+  env: NodeJS.ProcessEnv,
+  readResult: () => string
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env })
+    let stderr = ""
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      reject(new Error(`${command} timed out after ${CALL_TIMEOUT_MS}ms`))
+    }, CALL_TIMEOUT_MS)
+
+    child.stdout.on("data", () => {}) // agentic/event stdout ignored; result read separately
+    child.stderr.on("data", (d) => {
+      stderr += d.toString()
+    })
+    child.on("error", (e) => {
+      clearTimeout(timer)
+      reject(new Error(`${command} spawn error: ${e.message}`))
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      if (code !== 0) {
+        reject(new Error(`${command} exited ${code}: ${stderr.slice(-600)}`))
+        return
+      }
+      try {
+        const text = readResult().trim()
+        if (!text) {
+          reject(new Error(`${command} produced empty output. stderr: ${stderr.slice(-400)}`))
+          return
+        }
+        resolve(text)
+      } catch (e) {
+        reject(new Error(`${command} output read failed: ${e}`))
+      }
+    })
+    child.stdin.write(prompt)
+    child.stdin.end()
+  })
+}
+
+function codexComplete(prompt: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "codex-llm-"))
+  const outFile = join(dir, "out.txt")
+  const effort = process.env.HERMES_MB_CODEX_EFFORT || "low"
+  const args = [
+    "exec",
+    "--skip-git-repo-check",
+    "-s",
+    "read-only",
+    "--ephemeral",
+    "-c",
+    `model_reasoning_effort=${effort}`,
+    "-o",
+    outFile,
+  ]
+  const model = process.env.HERMES_MB_CODEX_MODEL
+  if (model) args.push("-m", model)
+  args.push("-") // read prompt from stdin
+  const done = () => {
+    try {
+      return readFileSync(outFile, "utf8")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+  return runProcess("codex", args, prompt, process.env, done).catch((e) => {
+    rmSync(dir, { recursive: true, force: true })
+    throw e
+  })
+}
+
+/**
+ * Fallback backend. Uses the documented robust `claude -p` automation pattern
+ * (memory reference_claude_p_automation_auth): an isolated CLAUDE_CONFIG_DIR
+ * with an empty settings.json (so the host settings.json z.ai routing is not
+ * re-applied), the SDK child-session marker vars scrubbed, and an explicit
+ * OAuth credential from the macOS keychain.
+ */
+function claudeComplete(prompt: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "claude-llm-"))
+  try {
+    require("node:fs").writeFileSync(join(dir, "settings.json"), "{}")
+  } catch {
+    /* best effort */
+  }
+  const model = process.env.HERMES_MB_CLAUDE_MODEL || "claude-sonnet-5"
+  const env: NodeJS.ProcessEnv = { ...process.env, CLAUDE_CONFIG_DIR: dir }
+  for (const k of [
+    "CLAUDECODE",
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH",
+    "CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+  ]) {
+    delete env[k]
+  }
+  if (!env.CLAUDE_CODE_OAUTH_TOKEN && !env.ANTHROPIC_API_KEY) {
+    try {
+      const raw = execSync(
+        `security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w`,
+        { encoding: "utf8" }
+      )
+      const token = JSON.parse(raw)?.claudeAiOauth?.accessToken
+      if (token) env.CLAUDE_CODE_OAUTH_TOKEN = token
+    } catch {
+      /* let claude report "Not logged in" loudly */
+    }
+  }
+  // No stdout side file for claude: capture stdout directly.
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn("claude", ["-p", "--model", model, "--output-format", "text"], { env })
+    let stdout = ""
+    let stderr = ""
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      reject(new Error(`claude timed out after ${CALL_TIMEOUT_MS}ms`))
+    }, CALL_TIMEOUT_MS)
+    child.stdout.on("data", (d) => (stdout += d.toString()))
+    child.stderr.on("data", (d) => (stderr += d.toString()))
+    child.on("error", (e) => {
+      clearTimeout(timer)
+      rmSync(dir, { recursive: true, force: true })
+      reject(new Error(`claude spawn error: ${e.message}`))
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      rmSync(dir, { recursive: true, force: true })
+      if (code !== 0) return reject(new Error(`claude exited ${code}: ${stderr.slice(-600)}`))
+      const text = stdout.trim()
+      if (!text) return reject(new Error(`claude produced empty output. stderr: ${stderr.slice(-400)}`))
+      resolve(text)
+    })
+    child.stdin.write(prompt)
+    child.stdin.end()
+  })
+}


### PR DESCRIPTION
## Summary

Adds `benchmarks/METHODOLOGY.md`, documenting the two hermes-lcm memory-quality benchmark layers:

1. **Retrieval quality** — session/turn-level recall@k and NDCG@10 against LongMemEval's labeled evidence, via the in-tree offline harness (`benchmarking/longmemeval.py`, CLI `scripts/lcm_longmemeval.py`): pinned `xiaowu0162/longmemeval` (`LongMemEval_S`) at a fixed revision, fresh per-question temp stores, deterministic non-LLM summaries, and all seven scored arms including the production `lcm_recall` tool.
2. **Judged QA accuracy** — end-task answer correctness through the org's forked benchmarking harness ([electricsheephq/memorybench-benchmark-tool](https://github.com/electricsheephq/memorybench-benchmark-tool), a fork of `supermemoryai/memorybench`), branch `adapter/hermes-lcm`: the `hermes-lcm` Provider drives the production `tools.lcm_recall` through a Python bridge, one fresh `lcm.db` per question-container.

Also adds `benchmarks/qa-harness/` — byte-verbatim vendored copies of the hermes-lcm-authored files from the `adapter/hermes-lcm` branch (provider, prompts, bridge, CLI-backed answerer/judge transport) plus `REPLICATION.md` (clone/install/env/run/resume against the pinned commit SHA), so the judged-QA benchmark is independently replicable without depending on the fork staying up. Cross-linked one line from `benchmarks/README.md`.

This PR is docs-only and deliberately branched off `main` (not the `release-test-*` tags) so it can merge independently of the v1/v2/v3 code trains tracked in #412. **Scores are appended to the results index as runs complete** — the two landed retrieval runs (`longmemeval-v2-500q-fastembed`, `longmemeval-v3-500q-fastembed`) are listed; voyage-embedding retrieval and judged-QA rows are marked `pending` until those results files land with the v2/v3 merges.

Related: #412

## Test plan

- [x] `python3 -m compileall .` — clean (docs-only change; no repo Python files modified)
- [x] Every vendored `qa-harness/` file verified byte-identical (`diff -q`) against `adapter/hermes-lcm` @ `b249c9bf9441a351e32595da3bf84f0c734e49e6` in the memorybench fork
- [x] Dataset revision, CLI flags, env vars, and results paths verified against `benchmarking/longmemeval.py`, `scripts/lcm_longmemeval.py`, and the memorybench orchestrator/CLI source (not taken on faith)