### PR TITLE
test: isolate plugin registration storage

### DIFF
--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -10,6 +10,17 @@ import subprocess
 import sys
 import types
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_plugin_registration_storage(tmp_path, monkeypatch):
+    """Keep packaging tests away from the live profile's SQLite database."""
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("LCM_DATABASE_PATH", raising=False)
+    return hermes_home
+
 
 EXPECTED_LCM_TOOLS = {
     "lcm_grep",
@@ -369,7 +380,7 @@ def test_lcm_grep_declares_opt_in_externalized_content_scope():
     assert properties["externalized_refs"]["maxItems"] == 256
 
 
-def test_plugin_entrypoint_registers_lcm_context_engine():
+def test_plugin_entrypoint_registers_lcm_context_engine(_isolate_plugin_registration_storage):
     engine = _register_plugin_engine("hermes_lcm_packaging_entrypoint")
 
     assert engine is not None
@@ -379,7 +390,8 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     assert identity["plugin_name"] == "hermes-lcm"
     assert identity["plugin_version"] == "0.21.0-rc2"
     assert Path(identity["plugin_path"]) == repo_root
-    assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
+    assert identity["database_path_source"] == "hermes_home"
+    assert Path(identity["database_path"]) == _isolate_plugin_registration_storage / "lcm.db"
     assert identity["plugin_git_commit"]
     assert identity["plugin_git_commit"] == subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True


### PR DESCRIPTION
## Summary
- isolate packaging tests behind a per-test temporary `HERMES_HOME`
- remove inherited `LCM_DATABASE_PATH` overrides and assert the registered engine binds `<temporary-home>/lcm.db`

## Why
- packaging tests execute the plugin entrypoint, which opens SQLite storage during registration
- without isolation, inherited profile settings can make tests touch or contend with a user's live LCM database

## Validation
- [x] Focused hostile-environment validation: `LCM_DATABASE_PATH=<sentinel> python -m pytest tests/test_packaging_install.py -q` -> `25 passed`; sentinel database was not created
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `1015 passed`
  - [x] `pytest -q` -> `1678 passed, 12 xfailed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `1678 passed, 12 xfailed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Full release validation: `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-packaging-isolation-committed` -> all selected gates passed, including benchmark smoke and smoke/release stress checks
- [ ] Workflow validation, if workflows changed: not applicable; no workflow files changed

## Notes
- test-only change; production code and runtime behavior are unchanged
- independent OpenAI Codex review of commit `d7a1bb10404e433b8440605358e0568bde460278`: `CLEAN`, no findings or missing tests

**AI Assistance:** The implementation, regression tests, and initial analysis were prepared with AI agents.
