### PR TITLE
feat: add LCM_ABSOLUTE_THRESHOLD_TOKENS for absolute compaction threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Most installs only need `plugins.enabled` and `context.engine: lcm`.
 | Variable | Default | Use |
 |----------|---------|-----|
 | `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
+| `LCM_ABSOLUTE_THRESHOLD_TOKENS` | `0` | If `> 0`, force compaction at this absolute prompt-token count instead of `context_length × LCM_CONTEXT_THRESHOLD`. Cross-model context-health setpoint (common coding default: `130000`) so large windows do not delay compaction and degrade recall |
 | `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
 | `LCM_FRESH_TAIL_MAX_TOKENS` | `0` | Optional token cap for the protected fresh tail (`0` disables it); always retains the newest message and complete assistant/tool-result groups |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
@@ -413,6 +414,14 @@ threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
 compressor. Hermes core `compression.enabled` is still the global gate that
 allows compaction, so leave it enabled when using LCM.
 
+If `LCM_ABSOLUTE_THRESHOLD_TOKENS` is set to a positive integer, it overrides the
+ratio-derived trigger after window math runs. Use this when you want a fixed
+context-health setpoint across model switches (for example `130000` for coding
+agents) so a larger window does not silently delay compaction, lower recall, or
+let long sessions accumulate more noise before LCM intervenes. Leave it at `0`
+to keep ratio-based behavior. When the absolute override is active, Codex
+GPT-5.5 ratio auto-raise is suppressed so the absolute setpoint stays pinned.
+
 If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the
 session.
@@ -422,11 +431,14 @@ session.
 Long-context models change the tuning problem. A 1M-token model does not mean
 you always want to spend 750k prompt tokens before LCM starts compacting. Start
 with the active prompt budget you are willing to pay for, then tune the threshold
-around that budget.
+around that budget. If the budget itself should stay fixed across models, set
+`LCM_ABSOLUTE_THRESHOLD_TOKENS` instead of recomputing a ratio per window.
 
 ```text
 compaction trigger = effective context window * LCM_CONTEXT_THRESHOLD
 LCM_CONTEXT_THRESHOLD = desired compaction trigger / effective context window
+# or, model-independent:
+# LCM_ABSOLUTE_THRESHOLD_TOKENS = desired compaction trigger
 ```
 
 Examples, as math rather than universal recommendations:

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -138,6 +138,7 @@ environment variables:
 | Variable | Default | Use |
 |----------|---------|-----|
 | `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
+| `LCM_ABSOLUTE_THRESHOLD_TOKENS` | `0` | If `> 0`, force compaction at this absolute prompt-token count instead of `context_length × LCM_CONTEXT_THRESHOLD`. Cross-model context-health setpoint (common coding default: `130000`) so large windows do not delay compaction and degrade recall |
 | `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
 | `LCM_FRESH_TAIL_MAX_TOKENS` | `0` | Optional token cap for the protected fresh tail (`0` disables it); always retains the newest message and complete assistant/tool-result groups |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
@@ -295,6 +296,14 @@ When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
 threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
 compressor. Hermes core `compression.enabled` is still the global gate that
 allows compaction, so leave it enabled when using LCM.
+
+If `LCM_ABSOLUTE_THRESHOLD_TOKENS` is set to a positive integer, it overrides the
+ratio-derived trigger after window math runs. Use this when you want a fixed
+context-health setpoint across model switches (for example `130000` for coding
+agents) so a larger window does not silently delay compaction, lower recall, or
+let long sessions accumulate more noise before LCM intervenes. Leave it at `0`
+to keep ratio-based behavior. When the absolute override is active, Codex
+GPT-5.5 ratio auto-raise is suppressed so the absolute setpoint stays pinned.
 
 If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the

--- a/engine.py
+++ b/engine.py
@@ -666,6 +666,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.threshold_tokens = self._effective_threshold_tokens(
             context_threshold_tokens
         )
+        # Absolute override: pin the compaction trigger to a fixed token budget
+        # so model-window switches do not move the operator's context-health
+        # setpoint (e.g. ~130K for high-quality coding recall). Ratio-based
+        # LCM_CONTEXT_THRESHOLD alone drifts with context_length.
+        try:
+            absolute_threshold_tokens = int(
+                os.environ.get("LCM_ABSOLUTE_THRESHOLD_TOKENS", "0") or 0
+            )
+        except (TypeError, ValueError):
+            absolute_threshold_tokens = 0
+        if absolute_threshold_tokens > 0:
+            self.threshold_tokens = absolute_threshold_tokens
+            # Keep route-specific ratio auto-raise from re-climbing the
+            # intermediate ratio on later recomputes; absolute still wins
+            # above, but disabling auto-raise keeps status/percent honest.
+            self._config.codex_gpt55_autoraise_enabled = False
         return True
 
     def _session_metadata_matches_active_runtime(

--- a/tests/test_absolute_threshold.py
+++ b/tests/test_absolute_threshold.py
@@ -1,0 +1,101 @@
+"""Absolute compaction threshold override tests."""
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+
+
+class TestAbsoluteThresholdTokens:
+    def test_absolute_threshold_pins_across_model_windows(self, tmp_path, monkeypatch):
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setenv("LCM_ABSOLUTE_THRESHOLD_TOKENS", "130000")
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        config = LCMConfig(database_path=str(tmp_path / "abs-threshold.db"))
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        try:
+            for window in (262_144, 500_000, 1_000_000):
+                engine.update_model(
+                    model="coding-model",
+                    context_length=window,
+                    provider="custom",
+                    base_url="https://example.invalid/v1",
+                    api_key="test-secret",
+                    api_mode="chat",
+                )
+                assert engine.threshold_tokens == 130_000, (
+                    f"window={window} expected absolute 130000, got {engine.threshold_tokens}"
+                )
+                assert engine.context_length == window
+        finally:
+            engine.shutdown()
+
+    def test_unset_absolute_keeps_ratio_behavior(self, tmp_path, monkeypatch):
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.delenv("LCM_ABSOLUTE_THRESHOLD_TOKENS", raising=False)
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.35")
+
+        config = LCMConfig.from_env()
+        config.database_path = str(tmp_path / "ratio-threshold.db")
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        try:
+            engine.update_model(
+                model="coding-model",
+                context_length=200_000,
+                provider="custom",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="chat",
+            )
+            assert engine.threshold_tokens == int(200_000 * 0.35)
+        finally:
+            engine.shutdown()
+
+    def test_absolute_suppresses_codex_gpt55_autoraise(self, tmp_path, monkeypatch):
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setenv("LCM_ABSOLUTE_THRESHOLD_TOKENS", "130000")
+        monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+        config = LCMConfig(
+            database_path=str(tmp_path / "abs-autoraise.db"),
+            codex_gpt55_autoraise_enabled=True,
+        )
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        try:
+            engine.update_model(
+                model="gpt-5.5",
+                context_length=400_000,
+                provider="openai-codex",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="responses",
+            )
+            assert engine.threshold_tokens == 130_000
+            assert engine._config.codex_gpt55_autoraise_enabled is False
+        finally:
+            engine.shutdown()
+
+    def test_invalid_absolute_env_falls_back_to_ratio(self, tmp_path, monkeypatch):
+        from hermes_lcm.engine import LCMEngine
+
+        monkeypatch.setenv("LCM_ABSOLUTE_THRESHOLD_TOKENS", "not-a-number")
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.40")
+
+        config = LCMConfig.from_env()
+        config.database_path = str(tmp_path / "bad-abs.db")
+        engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        try:
+            engine.update_model(
+                model="coding-model",
+                context_length=100_000,
+                provider="custom",
+                base_url="https://example.invalid/v1",
+                api_key="test-secret",
+                api_mode="chat",
+            )
+            assert engine.threshold_tokens == int(100_000 * 0.40)
+        finally:
+            engine.shutdown()


### PR DESCRIPTION
## Summary
- Add `LCM_ABSOLUTE_THRESHOLD_TOKENS` env var. When `> 0`, pin `threshold_tokens` to that absolute prompt-token count after ratio math in `_set_context_length()`.
- Suppress Codex GPT-5.5 ratio auto-raise while the absolute override is active so the setpoint cannot climb back.
- Document the knob in `README.md` and `docs/operator-guide.md` as a cross-model **context-health** control (common coding default: `130000`).
- Add focused unit tests for cross-window pinning, ratio fallback, invalid env, and auto-raise suppression.

## Why
LCM's compaction trigger is currently ratio-only:

```text
threshold_tokens = context_threshold × context_length
```

Switching models silently moves the compaction point even when the task and quality target have not changed:

| Model window | Ratio 0.35 | Ratio 0.50 |
|---|---:|---:|
| 262K | ~91K | ~131K |
| 500K | ~175K | ~250K |
| 1M | ~350K | ~500K |

For coding agents this is the wrong coupling. Compaction should keep the **working context inside a healthy band**, not maximize window utilization:

1. **Recall stays high** — the model can still find the right file, API, constraint, and prior decision.
2. **Context corruption stays low** — long multi-file sessions accumulate noise; past a point more tokens reduce reasoning quality ("lost in the middle", instruction dilution, contradictory mid-session state).
3. **Coding quality stays stable across models** — the same repo/task should get comparable context hygiene on a 262K or 500K/1M backend.

~130K active tokens is a strong default **context-health setpoint for highest-quality programming effect**: enough room for system prompt, skills, multi-file diffs, tool results, and a useful fresh tail; early enough that LCM can still summarize while session structure is recoverable; independent of which model is selected.

Existing knobs are insufficient:
- `LCM_CONTEXT_THRESHOLD` drifts with `context_length`.
- `LCM_MAX_ASSEMBLY_TOKENS` / `LCM_RESERVE_TOKENS_FLOOR` limit assembly cap, not the compaction trigger.

## Proposed behavior
```python
# end of _set_context_length(), after ratio-derived threshold_tokens
_abs = int(os.environ.get("LCM_ABSOLUTE_THRESHOLD_TOKENS", "0") or 0)
if _abs > 0:
    self.threshold_tokens = _abs
    self._config.codex_gpt55_autoraise_enabled = False
```

- Unset / `0` → identical to today (ratio-based).
- No API or config-schema break; follows existing `LCM_*` env pattern.

## Validation
- [x] Focused validation: `pytest tests/test_absolute_threshold.py -q` → `4 passed`
- [x] Related command surface: `pytest tests/test_absolute_threshold.py tests/test_lcm_command.py -q` → `81 passed`
- [x] `git diff --check` clean on committed files
- [ ] Default full suite (optional CI): `pytest -q`
- [ ] Release script (optional CI): `scripts/validate_release.sh --full --keep-going ...`

## Test plan
- [x] `LCM_ABSOLUTE_THRESHOLD_TOKENS=130000` → `threshold_tokens == 130000` for windows 262K / 500K / 1M
- [x] unset env → ratio behavior unchanged
- [x] absolute set on Codex GPT-5.5 route → auto-raise disabled, absolute still wins
- [x] invalid env value → falls back to ratio
- [ ] CI green on this PR

## Alternatives considered
1. Companion plugin monkey-patch via `resolve_active_lcm_engine()` — works locally, not discoverable.
2. Config-file key — viable later; env matches other operational LCM knobs for v1.
3. Per-model threshold map — over-engineered for "one health setpoint across models".
4. Only lowering the global ratio — still model-dependent (1M × 0.25 ≈ 250K, already past the coding-health band).