### PR TITLE
fix: release SQLite TEMP staging snapshots before compaction writes

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -351,6 +351,23 @@ class CompactionMixin:
                  current_tokens: int = None,
                  focus_topic: Optional[str] = None,
                  force: bool = False) -> List[Dict[str, Any]]:
+        """Run compaction and leave a terminal public status on every failure."""
+        try:
+            return self._compress_impl(
+                messages,
+                current_tokens=current_tokens,
+                focus_topic=focus_topic,
+                force=force,
+            )
+        except BaseException:
+            self._last_compression_status = "error"
+            self._last_compression_noop_reason = ""
+            raise
+
+    def _compress_impl(self, messages: List[Dict[str, Any]],
+                       current_tokens: int = None,
+                       focus_topic: Optional[str] = None,
+                       force: bool = False) -> List[Dict[str, Any]]:
         """Main compaction entry point.
 
         1. Ingest any new messages into the store

--- a/rollup_builder.py
+++ b/rollup_builder.py
@@ -15,6 +15,7 @@ from .dag import SummaryDAG
 from .escalation import _deterministic_truncate, summarize_with_escalation
 from .rollup_periods import CoverageNode, canonical_frontier, load_source_lineage
 from .rollup_store import RollupBuildToken, RollupStore
+from .sqlite_util import _sqlite_savepoint
 from .tokens import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,18 @@ def _stable_hash(value: object) -> str:
 
 
 def _scope_frontier(dag: SummaryDAG, scope: str) -> list[dict[str, object]]:
+    """Load a scope frontier without retaining its TEMP-staging snapshot."""
+    with dag._db_lock:
+        connection = dag.connection
+        if connection is None:
+            return []
+        with _sqlite_savepoint(connection):
+            return _scope_frontier_staged(dag, scope)
+
+
+def _scope_frontier_staged(
+    dag: SummaryDAG, scope: str
+) -> list[dict[str, object]]:
     """The scope's canonical frontier nodes with normalized interval bounds.
 
     Loads every summary node for ``scope`` and applies the shared interval-aware
@@ -449,6 +462,18 @@ def _rollup_source_ids(store: RollupStore, rollup_ids: Sequence[int]) -> list[in
 
 
 def _canonical_aggregate_sources(
+    dag: SummaryDAG, source_ids: Sequence[int]
+) -> list[dict[str, object]]:
+    """Resolve aggregate sources without retaining a TEMP-staging snapshot."""
+    with dag._db_lock:
+        connection = dag.connection
+        if connection is None:
+            return []
+        with _sqlite_savepoint(connection):
+            return _canonical_aggregate_sources_staged(dag, source_ids)
+
+
+def _canonical_aggregate_sources_staged(
     dag: SummaryDAG, source_ids: Sequence[int]
 ) -> list[dict[str, object]]:
     """Resolve one bounded canonical node frontier for aggregate publication."""

--- a/rollup_periods.py
+++ b/rollup_periods.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Mapping, Sequence
 
+from .sqlite_util import _sqlite_savepoint
+
 
 @dataclass(frozen=True)
 class CoverageNode:
@@ -31,6 +33,21 @@ class CanonicalFrontierOverlapError(RuntimeError):
 
 
 def load_source_lineage(
+    connection: Any,
+    root_node_ids: Sequence[int],
+    *,
+    limit: int,
+) -> dict[int, tuple[int, ...]]:
+    """Load lineage without leaking the TEMP-staging transaction to callers."""
+    with _sqlite_savepoint(connection):
+        return _load_source_lineage_staged(
+            connection,
+            root_node_ids,
+            limit=limit,
+        )
+
+
+def _load_source_lineage_staged(
     connection: Any,
     root_node_ids: Sequence[int],
     *,

--- a/sqlite_util.py
+++ b/sqlite_util.py
@@ -1,15 +1,15 @@
 """SQLite lock-contention helpers shared by the LCM engine.
 
-Isolated from ``engine.py`` (WS5 seam): detecting SQLite lock-contention error
-chains and temporarily bounding ``busy_timeout`` on gateway-critical paths are a
-cohesive, pure SQLite concern with no engine state. ``engine.py`` imports the
-two entry points it calls; the busy-timeout probe travels with them. Callers
-keep their own policy constants (for example the session-end timeout budget).
+Isolated from ``engine.py`` (WS5 seam): lock-contention detection, bounded
+``busy_timeout`` changes, and transaction-preserving savepoints are pure SQLite
+concerns with no engine state. Callers keep their own policy constants (for
+example the session-end timeout budget).
 """
 
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from contextlib import contextmanager
 from typing import Iterator, List
 
@@ -30,6 +30,25 @@ def _is_sqlite_locked_error(exc: BaseException) -> bool:
 def _sqlite_busy_timeout_ms(conn: sqlite3.Connection) -> int:
     row = conn.execute("PRAGMA busy_timeout").fetchone()
     return int(row[0]) if row and row[0] is not None else 0
+
+
+@contextmanager
+def _sqlite_savepoint(conn: sqlite3.Connection) -> Iterator[None]:
+    """Isolate helper writes without taking ownership of a caller transaction."""
+    # UUID hex contains only identifier-safe characters and keeps every nested
+    # helper's SAVEPOINT name unique with a fixed upper bound on name length.
+    name = f"lcm_{uuid.uuid4().hex}"
+    conn.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
+        finally:
+            conn.execute(f"RELEASE SAVEPOINT {name}")
+        raise
+    else:
+        conn.execute(f"RELEASE SAVEPOINT {name}")
 
 
 @contextmanager

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -311,6 +311,27 @@ def test_lcm_tool_status_includes_optional_cache_usage_metrics(engine):
     assert payload["config"]["summary_timeout_ms"] == 60_000
 
 
+def test_compress_exception_sets_terminal_error_status_and_reraises_same_exception(
+    engine,
+    monkeypatch,
+):
+    original = RuntimeError("forced compaction failure")
+    engine._last_compression_status = "noop"
+    engine._last_compression_noop_reason = "stale no-op reason"
+
+    def fail_ingest(_messages):
+        raise original
+
+    monkeypatch.setattr(engine, "_ingest_messages", fail_ingest)
+    with pytest.raises(RuntimeError) as caught:
+        engine.compress([{"role": "user", "content": "trigger"}])
+
+    assert caught.value is original
+    assert engine.last_compression_status == "error"
+    assert engine.last_compression_noop_reason == ""
+    assert engine.last_compression_was_noop is False
+
+
 def test_update_model_updates_runtime_metadata_and_context_window(engine):
     engine.update_model(
         model="deepseek-v4-flash",

--- a/tests/test_lcm_recent.py
+++ b/tests/test_lcm_recent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -684,3 +685,74 @@ def test_recent_fallback_candidate_work_is_sql_bounded(recent_parts, monkeypatch
     assert result["mode"] == "leaf_summary_fallback"
     assert result["sections"] == []
     assert frontier_calls == []
+
+
+def test_recent_fallback_releases_snapshot_before_later_dag_write(recent_parts):
+    engine, _store = recent_parts
+    scope = engine.current_session_id
+    day = date(2026, 7, 15)
+    first_id = _add_leaf(engine._dag, scope, day, "recent staged source")
+    connection = engine._dag.connection
+    assert connection is not None
+    window = parse_recent_period("date:2026-07-15", now=NOW)
+
+    sections = tools_module._recent_leaf_sections(
+        engine, window, "conversation", 10
+    )
+
+    assert [section["node_id"] for section in sections] == [first_id]
+    assert connection.in_transaction is False
+    with sqlite3.connect(engine._dag.db_path) as independent:
+        independent.execute(
+            "INSERT OR REPLACE INTO metadata(key, value) VALUES(?, ?)",
+            ("recent-independent", "committed"),
+        )
+
+    # A leaked read snapshot fails here with SQLITE_BUSY_SNAPSHOT.
+    assert _add_leaf(engine._dag, scope, day, "recent write after staging") > first_id
+
+
+def test_recent_fallback_preserves_outer_transaction(recent_parts):
+    engine, _store = recent_parts
+    scope = engine.current_session_id
+    day = date(2026, 7, 15)
+    _add_leaf(engine._dag, scope, day, "recent outer source")
+    connection = engine._dag.connection
+    assert connection is not None
+    window = parse_recent_period("date:2026-07-15", now=NOW)
+
+    connection.execute("BEGIN")
+    connection.execute(
+        "INSERT INTO metadata(key, value) VALUES('recent-caller-write', 'active')"
+    )
+    tools_module._recent_leaf_sections(engine, window, "conversation", 10)
+
+    assert connection.in_transaction is True
+    assert connection.execute(
+        "SELECT value FROM metadata WHERE key='recent-caller-write'"
+    ).fetchone()[0] == "active"
+    connection.rollback()
+    assert connection.execute(
+        "SELECT value FROM metadata WHERE key='recent-caller-write'"
+    ).fetchone() is None
+
+
+def test_recent_fallback_releases_transaction_on_lineage_exception(
+    recent_parts,
+    monkeypatch,
+):
+    engine, _store = recent_parts
+    day = date(2026, 7, 15)
+    _add_leaf(engine._dag, engine.current_session_id, day, "recent exception source")
+    connection = engine._dag.connection
+    assert connection is not None
+    window = parse_recent_period("date:2026-07-15", now=NOW)
+
+    def fail_lineage(*_args, **_kwargs):
+        raise RuntimeError("forced recent lineage failure")
+
+    monkeypatch.setattr(tools_module, "load_source_lineage", fail_lineage)
+    assert tools_module._recent_leaf_sections(
+        engine, window, "conversation", 10
+    ) == []
+    assert connection.in_transaction is False

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 from datetime import date, datetime, timedelta, timezone
 
@@ -1269,3 +1270,122 @@ def test_committed_mutation_event_survives_hook_gap_and_reconciles(rollup_parts)
         assert reopened.get_rollup("day", day.isoformat(), scope)["status"] == "stale"
     finally:
         reopened.close()
+
+
+@pytest.mark.parametrize("staging_helper", ["scope", "aggregate", "lineage"])
+def test_dag_temp_staging_releases_snapshot_before_later_write(
+    rollup_parts,
+    staging_helper,
+):
+    _store, dag, _config = rollup_parts
+    scope = f"transaction-hygiene-{staging_helper}"
+    day = date(2026, 7, 15)
+    node_id = _add_node(dag, scope, day, "staged source")
+    connection = dag.connection
+    assert connection is not None
+    assert connection.in_transaction is False
+
+    if staging_helper == "scope":
+        builder_module._scope_frontier(dag, scope)
+    elif staging_helper == "aggregate":
+        builder_module._canonical_aggregate_sources(dag, [node_id])
+    else:
+        periods_module.load_source_lineage(connection, [node_id], limit=10)
+
+    assert connection.in_transaction is False
+    with sqlite3.connect(dag.db_path) as independent:
+        independent.execute(
+            "INSERT OR REPLACE INTO metadata(key, value) VALUES(?, ?)",
+            (f"independent-{staging_helper}", "committed"),
+        )
+
+    # A leaked read snapshot makes this fail immediately with
+    # SQLITE_BUSY_SNAPSHOT after the independent commit above.
+    assert _add_node(dag, scope, day, "write after staging") > node_id
+
+
+@pytest.mark.parametrize("staging_helper", ["scope", "aggregate", "lineage"])
+def test_dag_temp_staging_preserves_caller_owned_transaction(
+    rollup_parts,
+    staging_helper,
+):
+    _store, dag, _config = rollup_parts
+    scope = f"outer-transaction-{staging_helper}"
+    day = date(2026, 7, 15)
+    node_id = _add_node(dag, scope, day, "outer transaction source")
+    connection = dag.connection
+    assert connection is not None
+
+    connection.execute("BEGIN")
+    connection.execute(
+        "INSERT INTO metadata(key, value) VALUES(?, ?)",
+        (f"caller-write-{staging_helper}", "still active"),
+    )
+    if staging_helper == "scope":
+        builder_module._scope_frontier(dag, scope)
+    elif staging_helper == "aggregate":
+        builder_module._canonical_aggregate_sources(dag, [node_id])
+    else:
+        periods_module.load_source_lineage(connection, [node_id], limit=10)
+
+    assert connection.in_transaction is True
+    assert connection.execute(
+        "SELECT value FROM metadata WHERE key = ?",
+        (f"caller-write-{staging_helper}",),
+    ).fetchone()[0] == "still active"
+    connection.rollback()
+    assert connection.execute(
+        "SELECT value FROM metadata WHERE key = ?",
+        (f"caller-write-{staging_helper}",),
+    ).fetchone() is None
+
+
+def test_scope_and_aggregate_staging_release_transaction_on_exception(
+    rollup_parts,
+    monkeypatch,
+):
+    _store, dag, _config = rollup_parts
+    scope = "staging-exception"
+    day = date(2026, 7, 15)
+    node_id = _add_node(dag, scope, day, "exception source")
+    connection = dag.connection
+    assert connection is not None
+
+    def fail_lineage(*_args, **_kwargs):
+        raise RuntimeError("forced lineage failure")
+
+    monkeypatch.setattr(builder_module, "load_source_lineage", fail_lineage)
+    with pytest.raises(builder_module.RollupWorkLimitExceeded):
+        builder_module._scope_frontier(dag, scope)
+    assert connection.in_transaction is False
+
+    with pytest.raises(builder_module.RollupWorkLimitExceeded):
+        builder_module._canonical_aggregate_sources(dag, [node_id])
+    assert connection.in_transaction is False
+
+
+def test_source_lineage_releases_transaction_on_exception(rollup_parts):
+    _store, dag, _config = rollup_parts
+    day = date(2026, 7, 15)
+    child_id = _add_node(dag, "lineage-exception", day, "child")
+    parent_id = dag.add_node(
+        SummaryNode(
+            session_id="lineage-exception",
+            depth=1,
+            summary="parent",
+            token_count=1,
+            source_token_count=2,
+            source_ids=[child_id],
+            source_type="nodes",
+            created_at=_timestamp(day),
+            earliest_at=_timestamp(day),
+            latest_at=_timestamp(day),
+        )
+    )
+    connection = dag.connection
+    assert connection is not None
+
+    with pytest.raises(RuntimeError, match="bounded work limit"):
+        periods_module.load_source_lineage(connection, [parent_id], limit=1)
+
+    assert connection.in_transaction is False

--- a/tools.py
+++ b/tools.py
@@ -69,6 +69,7 @@ from .retrieval_core import (
 from .rollup_store import RollupStore
 from .search_query import AGE_DECAY_RATE, normalize_search_sort
 from .session_patterns import build_session_match_keys, compile_session_pattern
+from .sqlite_util import _sqlite_savepoint
 from .store import build_message_fts_spec
 from .vector_store import VectorStore
 
@@ -1393,6 +1394,26 @@ def _recent_conversation_scope_session_ids(engine: "LCMEngine") -> list[str]:
 
 
 def _recent_leaf_sections(
+    engine: "LCMEngine",
+    window: RecentPeriodWindow,
+    requested_scope: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Load fallback nodes without retaining their TEMP-staging snapshot."""
+    with engine._dag._db_lock:
+        connection = engine._dag.connection
+        if connection is None:
+            return []
+        with _sqlite_savepoint(connection):
+            return _recent_leaf_sections_staged(
+                engine,
+                window,
+                requested_scope,
+                limit,
+            )
+
+
+def _recent_leaf_sections_staged(
     engine: "LCMEngine",
     window: RecentPeriodWindow,
     requested_scope: str,


### PR DESCRIPTION
## Summary
- Wrap rc1 temporal-rollup and recent-fallback TEMP staging in transaction-preserving SQLite savepoints.
- Release helper-created read snapshots before later DAG writes while preserving caller-owned outer transactions.
- Mark escaped compaction failures as terminal `error` instead of leaving status stuck on `running`.

## Why
`v0.20.0-rc1` introduced TEMP-table staging on the shared DAG connection for temporal rollups and recent fallback. Those helper writes could leave an implicit transaction open. If another connection committed afterwards, the next DAG publication on the stale snapshot could fail with `SQLITE_BUSY_SNAPSHOT`, surfaced by Python as `sqlite3.OperationalError: database is locked`, and abort the conversation compression turn.

This was reproduced from the exact rc1 base (`ad337660`) and then observed on a real rc1 Hermes runtime. After loading this exact patch and restarting the gateway, the affected older conversations became usable again and the direct stale-snapshot regression stayed green.

This is intended as a focused candidate for rc2. It fixes one concrete rc1 regression; it is not a broad cross-process locking redesign.

Refs #421

## Validation
- [x] Regression tests confirmed the rc1 staging-snapshot failure before the fix.
- [x] Affected surface: `pytest -q tests/test_lcm_engine.py tests/test_lcm_recent.py tests/test_rollup_builder.py` -> `847 passed`
- [x] Full suite: `pytest -q` -> `2297 passed, 12 xfailed`
- [x] Low-FD full suite -> `2297 passed, 12 xfailed`
- [x] Full release gate: `scripts/validate_release.sh --full --keep-going --output <temp-dir>` -> `PASS`
- [x] Release stress tier -> 6/6 cases passed, 0 failures
- [x] Exact candidate review -> no verified related blockers
- [x] Runtime smoke on rc1 -> patched engine loaded, direct `SQLITE_BUSY_SNAPSHOT` regression passed, database/FTS checks passed, and affected older conversations opened successfully
- [x] `git diff --check origin/main...HEAD`

## Risk / impact
The change is limited to transaction ownership around existing TEMP staging and terminal status reporting. There are no schema, migration, configuration, API, or dependency changes.

Savepoints intentionally preserve an outer transaction owned by the caller. They do not repair a transaction that was already stale before entering the helper.

## Scope boundaries
- No global/inter-process mutex.
- No broad SQLite retry policy.
- No vector-store behavior changes.
- This does not claim to resolve every possible long-held writer scenario discussed in #421.

## Rollout / operator notes
No migration or configuration change is required. The plugin/gateway must be restarted after updating so the new engine code is loaded.

## Reviewer focus
Please look closely at nested transaction ownership, TEMP-table lifetime under the DAG reentrant lock, and the rc1-to-rc2 scope boundary.

Looping in @100yenadmin and @stephenschoettler because this is a candidate for rc2 and touches the temporal-rollup paths introduced in rc1.
