### PR TITLE
fix(backfill): skip empty summaries

### DIFF
--- a/command.py
+++ b/command.py
@@ -2679,6 +2679,16 @@ def _embedding_current_profile(conn: sqlite3.Connection) -> sqlite3.Row | None:
         raise
 
 
+def _register_summary_has_text(conn: sqlite3.Connection) -> None:
+    """Expose Python's Unicode whitespace semantics to summary discovery SQL."""
+    conn.create_function(
+        "lcm_summary_has_text",
+        1,
+        lambda value: int(isinstance(value, str) and bool(value.strip())),
+        deterministic=True,
+    )
+
+
 def _embedding_pending_rows(
     conn: sqlite3.Connection,
     identity_hash: str,
@@ -2688,6 +2698,7 @@ def _embedding_pending_rows(
     # A dispatched/uncertain row may already have been accepted remotely, so it
     # must never be silently resent; only explicit --retry-uncertain operator
     # authorization can return it to discovery.
+    _register_summary_has_text(conn)
     inflight_exists = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' "
         "AND name='lcm_embedding_backfill_inflight'"
@@ -2705,6 +2716,7 @@ def _embedding_pending_rows(
     )
     where = """
         n.depth = 0
+        AND lcm_summary_has_text(n.summary) = 1
         AND NOT EXISTS (
             SELECT 1
             FROM lcm_embedding_meta AS m
@@ -2739,10 +2751,12 @@ def _embedding_authorized_uncertain_rows(
     limit: int,
 ) -> tuple[int, list[sqlite3.Row]]:
     """Select exact uncertain rows without consuming their durable markers."""
+    _register_summary_has_text(conn)
     where = """
         f.identity_hash = ?
         AND f.state = 'uncertain'
         AND n.depth = 0
+        AND lcm_summary_has_text(n.summary) = 1
         AND NOT EXISTS (
             SELECT 1
             FROM lcm_embedding_meta AS m

--- a/tests/test_embedding_backfill.py
+++ b/tests/test_embedding_backfill.py
@@ -200,6 +200,97 @@ def test_dry_run_reports_counts_tokens_and_cost_without_calls_or_writes(
     assert provider.calls == []
 
 
+def test_empty_leaf_summaries_are_not_pending_or_sent_to_provider(monkeypatch, tmp_path):
+    engine = _engine(tmp_path)
+    dag = SummaryDAG(engine._store.db_path)
+    try:
+        dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="",
+            created_at=3.0,
+            latest_at=3.0,
+        ))
+        dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="   \n\t",
+            created_at=2.0,
+            latest_at=2.0,
+        ))
+        dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="\v\f",
+            created_at=1.5,
+            latest_at=1.5,
+        ))
+        valid_id = dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="useful summary",
+            created_at=1.0,
+            latest_at=1.0,
+        ))
+    finally:
+        dag.close()
+    store = VectorStore(engine._store.db_path, config=engine._config)
+    try:
+        store.register_profile("model-a", "ollama", 2)
+    finally:
+        store.close()
+    provider = FakeProvider()
+    monkeypatch.setattr(command_mod, "resolve_provider", lambda _config, **_kw: provider)
+
+    preview = handle_lcm_command("embed backfill", engine)
+    applied = handle_lcm_command("embed backfill --apply", engine)
+
+    assert "pending: 1" in preview
+    assert "selected: 1" in preview
+    assert "embedded: 1" in applied
+    assert "remaining: 0" in applied
+    assert provider.calls == [["useful summary"]]
+    assert _meta_ids(engine) == [str(valid_id)]
+
+
+def test_retry_uncertain_does_not_resend_empty_summary(monkeypatch, tmp_path):
+    engine = _engine(tmp_path)
+    dag = SummaryDAG(engine._store.db_path)
+    try:
+        blank_id = dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="\t\n",
+            created_at=2.0,
+            latest_at=2.0,
+        ))
+        valid_id = dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="retry this summary",
+            created_at=1.0,
+            latest_at=1.0,
+        ))
+    finally:
+        dag.close()
+    store = VectorStore(engine._store.db_path, config=engine._config)
+    try:
+        store.register_profile("model-a", "ollama", 2)
+    finally:
+        store.close()
+    _mark_uncertain(engine, [blank_id, valid_id])
+    provider = FakeProvider()
+    monkeypatch.setattr(command_mod, "resolve_provider", lambda _config, **_kw: provider)
+
+    result = handle_lcm_command("embed backfill --apply --retry-uncertain", engine)
+
+    assert "selected: 1" in result
+    assert "embedded: 1" in result
+    assert provider.calls == [["retry this summary"]]
+    assert _meta_ids(engine) == [str(valid_id)]
+    assert _inflight_rows(engine) == [(str(blank_id), "uncertain")]
+
+
 def test_apply_batches_records_correct_meta_and_is_idempotent(monkeypatch, tmp_path):
     engine = _engine(tmp_path)
     node_ids = _seed(engine, 35)


### PR DESCRIPTION
## Summary

Skip null, empty, and Unicode-whitespace-only leaf summaries during embedding backfill discovery.

## Why

This came from an rc1 production finding. A summary-only Voyage backfill admitted a blank leaf summary into a mixed provider batch. Voyage rejected the batch with HTTP 400, so valid neighboring summaries were marked failed alongside the blank row.

Filtering at discovery keeps dry-run counts truthful and prevents both ordinary apply and explicit `--retry-uncertain` from sending blank text.

## Validation

- `tests/test_embedding_backfill.py`: 42 passed
- full suite: 2287 passed, 12 xfailed
- `ruff check command.py tests/test_embedding_backfill.py`
- `git diff --check`
- `python -m py_compile command.py tests/test_embedding_backfill.py`
- independent targeted delta review: closed, no remaining related blocker

## Risk / impact

Low and bounded to summary-backfill selection. Python `str.strip()` defines whitespace consistently, including Unicode whitespace that SQLite `TRIM` does not cover. Valid summaries continue normally. Existing durable `uncertain` markers for excluded blank rows are preserved rather than silently cleared.

## Scope boundaries

- Summary corpus only
- No raw-chunk behavior change
- No provider, vector schema, lease, retry, or uncertain-publication redesign
- No live data or credentials in this change

## Rollout / operator notes

Found while running the v0.20.0-rc1 summary-only Voyage backfill. The corrected discovery path was exercised against that workflow before publication.

## Reviewer focus

Please focus on normal pending discovery, explicit uncertain retry discovery, and the decision to preserve excluded uncertain markers.

Review requested from @stephenschoettler and @100yenadmin.