### PR TITLE
feat(recall): make Voyage reranker configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -352,6 +352,7 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("database_path", "LCM_DATABASE_PATH", str),
     _EnvFieldSpec("embeddings_enabled", "LCM_EMBEDDINGS_ENABLED", bool),
     _EnvFieldSpec("rerank_enabled", "LCM_RERANK_ENABLED", bool),
+    _EnvFieldSpec("rerank_model", "LCM_RERANK_MODEL", str),
     _EnvFieldSpec("recall_scan_rows", "LCM_RECALL_SCAN_ROWS", int),
     _EnvFieldSpec("proactive_recall_enabled", "LCM_PROACTIVE_RECALL_ENABLED", bool),
     _EnvFieldSpec("proactive_recall_min_score", "LCM_PROACTIVE_RECALL_MIN_SCORE", float),
@@ -555,10 +556,13 @@ class LCMConfig:
 
     # -- Embeddings (default-off until a provider/model are configured) ---
     embeddings_enabled: bool = False
-    # lcm_recall cross-encoder rerank stage (voyage rerank-2.5-lite over the top
-    # fused candidates). Default-off: recall ships value on RRF order alone, and
-    # rerank is one extra billable API call the operator opts into.
+    # lcm_recall cross-encoder rerank stage over the top fused candidates.
+    # Default-off: recall ships value on RRF order alone, and rerank is one extra
+    # billable API call the operator opts into. The lite default preserves the
+    # established latency/cost posture; operators may explicitly select Voyage's
+    # quality-oriented rerank-2.5 model.
     rerank_enabled: bool = False
+    rerank_model: str = "rerank-2.5-lite"
     embedding_bounded_scan_rows: int = 2_000
     # Vector storage dtype for NEWLY-registered embedding profiles: float32
     # (default; a stock install keeps summary vectors byte-identical) or int8
@@ -602,12 +606,11 @@ class LCMConfig:
     # otherwise have to lcm_recall by hand. Default-off => byte-identical
     # assembly; when disabled the whole path is skipped before any work.
     proactive_recall_enabled: bool = False
-    # Relevance floor on the lcm_recall composite score. Two regimes:
-    #  - rerank OFF (default): the score is RRF-scale (~0.014-0.05); a single
-    #    top-ranked arm hit is ~0.016, so this floor mainly drops ancient or
-    #    low-ranked hits. The default keeps fresh top-of-arm hits.
-    #  - rerank ON: a cross-encoder relevance in [0,1] dominates the score;
-    #    raise this floor (e.g. ~0.3) for a true semantic gate.
+    # Relevance floor on lcm_recall's RRF/composite score (~0.014-0.05); a single
+    # top-ranked arm hit is ~0.016, so this floor mainly drops ancient or
+    # low-ranked hits. Reranking only reorders the bounded candidate window and
+    # deliberately does not replace this score with Voyage's incompatible 0..1
+    # relevance scale, so this threshold keeps the same meaning in both modes.
     proactive_recall_min_score: float = 0.01
     # Hard token budget for the single injected "relevant memories" block.
     proactive_recall_budget_tokens: int = 500

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -181,8 +181,10 @@ environment variables:
 | `LCM_EMBEDDING_STORE_DIM` | `0` | Optional Matryoshka truncation dimension for newly-registered profiles (`0` = full profile dim); truncated vectors are renormalized and are also a distinct profile identity |
 | `LCM_EMBEDDING_BINARY_PRESCREEN` | `false` | Write the sign-bit prescreen for float32 identities too (int8 identities always write it), unlocking the full-corpus two-stage KNN; flipping it on an already-populated identity mints a new, distinct identity rather than mutating the existing one |
 | `LCM_KNN_PRESCREEN_MULTIPLIER` | `4` | Stage-1 prescreen breadth for two-stage KNN: `M = multiplier × k` lowest-Hamming-distance survivors are exact-rescored |
+| `LCM_RERANK_ENABLED` | `false` | Let `lcm_recall` ask Voyage to rerank its bounded fused candidate window. Failures preserve the incoming RRF order; `lcm_grep` is unaffected |
+| `LCM_RERANK_MODEL` | `rerank-2.5-lite` | Voyage reranker model used by `lcm_recall`; set `rerank-2.5` for the quality-oriented model |
 | `LCM_PROACTIVE_RECALL_ENABLED` | `false` | Opt in to proactive memory injection: at assembly, embed the newest user message and inject one budget-capped "relevant memories" block (needs `LCM_EMBEDDINGS_ENABLED`). Default-off keeps assembly byte-identical |
-| `LCM_PROACTIVE_RECALL_MIN_SCORE` | `0.01` | Relevance floor for an injected memory. RRF-scale by default (a top-of-arm hit is ~0.016); with `LCM_RERANK_ENABLED` the score is a `[0,1]` cross-encoder relevance, so raise this (e.g. `0.3`) for a strict semantic gate |
+| `LCM_PROACTIVE_RECALL_MIN_SCORE` | `0.01` | Relevance floor for an injected memory on the RRF/composite scale (a top-of-arm hit is ~0.016). Reranking changes candidate order only and does not replace this score with Voyage's incompatible `0..1` relevance score |
 | `LCM_PROACTIVE_RECALL_BUDGET_TOKENS` | `500` | Hard token budget for the single injected block (1-3 items) |
 | `LCM_PROACTIVE_RECALL_PROVIDER` | empty | Embedding-provider override for the injection query only (e.g. keep a local `fastembed` provider offline even when search uses `voyage`). Empty reuses the main provider. The override provider must have embedded the corpus for its arms to return hits |
 | `LCM_DOCTOR_CLEAN_APPLY_ENABLED` | `false` | Permit destructive `/lcm doctor clean apply` in trusted operator contexts |

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -150,6 +150,14 @@ erroring the tool. `lcm_grep`'s hybrid RRF is unaffected: it keeps implicit
 actually applied to the arms that ran are echoed back under
 `provenance.arm_weights`.
 
+`LCM_RERANK_ENABLED=true` optionally lets Voyage reorder the bounded top fused
+window after the scope/recency prior. `LCM_RERANK_MODEL` selects the Voyage
+model (`rerank-2.5-lite` by default; `rerank-2.5` for the quality-oriented
+model). Reranking is deliberately order-only: Voyage's `0..1` relevance values
+are not spliced into the much smaller RRF/composite score scale. Provider,
+network, or deadline failures keep the incoming order and are reported under
+`provenance.rerank`. This stage applies to `lcm_recall`, not `lcm_grep`.
+
 If the summary or chunk arm ran under `coverage='bounded'` (recency-truncated
 candidate scan) or `coverage='full_approx'` (two-stage binary-prescreen KNN,
 see [vector storage scale options](operator-guide.md#vector-storage-scale-options-v3)),

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -327,6 +327,7 @@ def test_rerank_skips_silently_on_non_voyage_provider(recall_engine, monkeypatch
 
 def test_rerank_applies_and_reorders_with_voyage_provider(recall_engine, monkeypatch):
     recall_engine._config.rerank_enabled = True
+    recall_engine._config.rerank_model = "rerank-2.5"
     a = _add_summary(recall_engine, "kanban alpha", session_id="session-a", created_at=5.0)
     b = _add_summary(recall_engine, "kanban beta", session_id="session-b", created_at=5.0)
     # a is RRF rank 1, b rank 2 (seeded under the voyage identity the rerank
@@ -335,19 +336,23 @@ def test_rerank_applies_and_reorders_with_voyage_provider(recall_engine, monkeyp
 
     class RerankProvider(MockProvider):
         provider_id = "voyage"
+        observed_model = None
 
         def rerank(self, query, documents, *, top_k=None, timeout, model="rerank-2.5-lite"):
+            self.observed_model = model
             # Flip relevance: the LAST document scores highest (index i -> score i),
             # returned in descending-relevance order as the real API does.
             return sorted(
                 ((i, float(i)) for i in range(len(documents))), key=lambda item: -item[1]
             )
 
+    provider = RerankProvider()
     payload = _recall(
-        recall_engine, monkeypatch, provider=RerankProvider(), include="summaries", scope_bias=0.0, limit=5
+        recall_engine, monkeypatch, provider=provider, include="summaries", scope_bias=0.0, limit=5
     )
     assert payload["provenance"]["rerank"] == "applied"
     assert payload["hits"][0]["node_id"] == b
+    assert provider.observed_model == "rerank-2.5"
 
 
 def test_rerank_failure_falls_back_to_rrf_order(recall_engine, monkeypatch):
@@ -458,6 +463,13 @@ def test_recall_query_timeout_has_its_own_budget(monkeypatch, tmp_path):
     cfg = LCMConfig.from_env()
     assert cfg.recall_query_timeout_s == 12.5
     assert cfg.embedding_query_timeout_s == 3.0  # grep's deadline untouched
+
+
+def test_rerank_model_default_and_env_override(monkeypatch):
+    assert LCMConfig().rerank_model == "rerank-2.5-lite"
+
+    monkeypatch.setenv("LCM_RERANK_MODEL", "rerank-2.5")
+    assert LCMConfig.from_env().rerank_model == "rerank-2.5"
 
 
 def test_recall_arm_weights_default_and_env_lenient(monkeypatch, tmp_path):

--- a/tests/test_proactive_recall_injection.py
+++ b/tests/test_proactive_recall_injection.py
@@ -217,6 +217,29 @@ def test_min_score_floor_drops_weak_hits(tmp_path, provider):
     assert engine._proactive_recall_skipped_count == 1
 
 
+def test_rerank_keeps_proactive_floor_on_reported_rrf_score(tmp_path, monkeypatch, provider):
+    """Reranking changes order only; proactive recall still filters the score
+    reported by lcm_recall, which remains on the RRF/composite scale."""
+    engine = _make_engine(
+        tmp_path,
+        rerank_enabled=True,
+        proactive_recall_min_score=0.01,
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "lcm_recall",
+        lambda *a, **k: (
+            '{"hits":[{"snippet":"useful older context",'
+            '"score":0.016,"from_current_session":false}]}'
+        ),
+    )
+
+    msg = engine._build_proactive_recall_message(_tail(), "user", set())
+
+    assert msg is not None
+    assert "useful older context" in msg["content"]
+
+
 # ── Budget cap ──
 
 

--- a/tools.py
+++ b/tools.py
@@ -3050,6 +3050,10 @@ def _lcm_recall_rerank(
                 documents,
                 top_k=len(documents),
                 timeout=max(0.001, deadline - time.monotonic()),
+                model=(
+                    str(getattr(config, "rerank_model", "") or "").strip()
+                    or "rerank-2.5-lite"
+                ),
             ),
             remaining_s=deadline - time.monotonic(),
             name="lcm-recall-rerank",


### PR DESCRIPTION
## Summary

Make the Voyage reranker model configurable through `LCM_RERANK_MODEL`.

The compatibility default remains `rerank-2.5-lite`; quality-oriented deployments can select `rerank-2.5` without changing source code.

## Why

This came from rc1 rollout testing. The rerank model was hard-coded even though reranking itself is already operator-configurable and opt-in. That prevented a clean quality-versus-latency evaluation of Voyage `rerank-2.5`.

## Validation

- focused recall/provider/proactive suites: 110 passed
- full suite: 2287 passed, 12 xfailed
- `ruff check` on changed Python files
- `git diff --check`
- `python -m py_compile` on changed Python files
- real non-sensitive Voyage smoke: `rerank-2.5` accepted and correctly ranked the relevant document first
- independent exact-diff review: no related blocker

## Risk / impact

Default behavior is unchanged. The setting only affects Voyage reranking when `LCM_RERANK_ENABLED=true`. Empty or whitespace configuration defensively falls back to `rerank-2.5-lite`.

Reranking remains order-only: Voyage relevance scores do not replace the existing RRF/composite scores used by recall and proactive-recall thresholds.

## Scope boundaries

- No change to embeddings, vector storage, `lcm_grep`, or raw-chunk handling
- No automatic rerank activation
- No score-fusion redesign
- No provider credentials or deployment-specific values in source

## Rollout / operator notes

Operators can use:

```env
LCM_RERANK_ENABLED=true
LCM_RERANK_MODEL=rerank-2.5
```

The existing `rerank-2.5-lite` default remains the lower-cost/lower-latency option.

## Reviewer focus

Please focus on config parsing, Voyage model forwarding, defensive fallback, and preservation of proactive-recall score semantics.

Review requested from @stephenschoettler and @100yenadmin.