### PR TITLE
fix: keep FTS from starving semantic recall

### DIFF
--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -498,6 +498,117 @@ def test_recall_uses_recall_timeout_budget(recall_engine, monkeypatch):
     assert payload["hits"]
 
 
+def test_slow_fts_arm_cannot_starve_semantic_recall_and_rerank(recall_engine, monkeypatch):
+    """A slow first arm degrades alone instead of consuming the whole recall budget."""
+    recall_engine._config.recall_query_timeout_s = 8.0
+    recall_engine._config.embedding_provider = "voyage"
+    recall_engine._config.embedding_model = "voyage-4-large"
+    recall_engine._config.rerank_enabled = True
+
+    clock = [100.0]
+    captured: dict[str, float] = {}
+
+    class VoyageProvider(MockProvider):
+        provider_id = "voyage"
+        model_id = "voyage-4-large"
+
+        def rerank(self, _query, documents, *, top_k=None, timeout, model="rerank-2.5-lite"):
+            return [(index, 1.0) for index, _document in enumerate(documents)]
+
+    provider = VoyageProvider()
+
+    def slow_fts(_engine, _query, *, candidate_limit, deadline):
+        del candidate_limit
+        captured["fts_deadline"] = deadline
+        clock[0] = deadline
+        return [], {"error": "full-text deadline exhausted", "timeout": True}
+
+    def summary_arm(_engine, **_kwargs):
+        return (
+            [
+                {
+                    "kind": "summary",
+                    "node_id": 1,
+                    "session_id": "session-a",
+                    "timestamp": 1.0,
+                    "snippet": "semantic result survives slow full-text search",
+                    "from_current_session": False,
+                    "expand_hint": "lcm_expand(node_id=1)",
+                }
+            ],
+            "full",
+            1,
+            1,
+        )
+
+    monkeypatch.setattr(lcm_tools.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(lcm_tools, "resolve_provider", lambda _config: provider)
+    monkeypatch.setattr(lcm_tools, "_resolve_recall_chunk_provider", lambda *_a, **_k: provider)
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", slow_fts)
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_summary_arm", summary_arm)
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_chunk_arm", lambda *_a, **_k: ([], "none", 0, 0))
+
+    payload = json.loads(
+        lcm_tools.lcm_recall(
+            {"query": "semantic deadline fairness", "include": "all", "limit": 5},
+            engine=recall_engine,
+        )
+    )
+
+    assert captured["fts_deadline"] < 108.0
+    assert payload["provenance"]["arms_run"] == ["summary"]
+    assert payload["provenance"]["coverage"] == {
+        "fts": "none",
+        "summary": "full",
+        "chunk": "none",
+    }
+    assert payload["provenance"]["rerank"] == "applied"
+    assert payload["hits"][0]["node_id"] == 1
+    assert payload["degraded"] is True
+    assert payload["timeout"] is True
+
+
+@pytest.mark.parametrize(
+    ("embeddings_enabled", "provider_name", "model_name"),
+    [
+        (False, "voyage", "voyage-4-large"),
+        (True, "", ""),
+    ],
+)
+def test_fts_fallback_keeps_full_recall_budget_without_semantic_route(
+    recall_engine,
+    monkeypatch,
+    embeddings_enabled,
+    provider_name,
+    model_name,
+):
+    recall_engine._config.recall_query_timeout_s = 8.0
+    recall_engine._config.embeddings_enabled = embeddings_enabled
+    recall_engine._config.embedding_provider = provider_name
+    recall_engine._config.embedding_model = model_name
+
+    clock = [100.0]
+    captured: dict[str, float] = {}
+
+    def fts_arm(_engine, _query, *, candidate_limit, deadline):
+        del candidate_limit
+        captured["fts_deadline"] = deadline
+        return [], None
+
+    monkeypatch.setattr(lcm_tools.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(lcm_tools, "resolve_provider", lambda _config: None)
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", fts_arm)
+
+    json.loads(
+        lcm_tools.lcm_recall(
+            {"query": "fts fallback budget", "include": "all", "limit": 5},
+            engine=recall_engine,
+        )
+    )
+
+    assert captured["fts_deadline"] == 108.0
+
+
 def test_bounded_chunk_coverage_surfaces_as_degraded(recall_engine, monkeypatch):
     """SCAN-1: a recency-bounded chunk arm reports a degraded_reasons entry naming
     the arm + scanned/total, instead of silently truncating."""

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -581,6 +581,57 @@ def test_slow_fts_arm_cannot_starve_semantic_recall_and_rerank(recall_engine, mo
 
 
 @pytest.mark.parametrize(
+    ("configured_provider", "canonical_provider"),
+    [("voyageai", "voyage"), ("fast-embed", "fastembed")],
+)
+def test_provider_alias_uses_existing_vector_corpus_for_fts_fairness(
+    recall_engine,
+    monkeypatch,
+    configured_provider,
+    canonical_provider,
+):
+    """Supported provider aliases select the same corpus as provider resolution."""
+    recall_engine._config.recall_query_timeout_s = 8.0
+    recall_engine._config.embedding_provider = configured_provider
+    node = _add_summary(
+        recall_engine,
+        "semantic result behind the provider alias",
+        session_id="session-a",
+        created_at=1.0,
+    )
+    _seed_summary_vectors(
+        recall_engine,
+        [(node, [1.0, 0.0])],
+        provider=canonical_provider,
+    )
+
+    provider = MockProvider()
+    provider.provider_id = canonical_provider
+    clock = [100.0]
+    captured: dict[str, float] = {}
+
+    def fts_arm(_engine, _query, *, candidate_limit, deadline):
+        del candidate_limit
+        captured["fts_deadline"] = deadline
+        return [], None
+
+    monkeypatch.setattr(lcm_tools.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(lcm_tools, "resolve_provider", lambda _config: provider)
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", fts_arm)
+
+    payload = json.loads(
+        lcm_tools.lcm_recall(
+            {"query": "provider alias", "include": "all", "limit": 5},
+            engine=recall_engine,
+        )
+    )
+
+    assert captured["fts_deadline"] == 102.0
+    assert payload["provenance"]["coverage"]["summary"] == "full"
+    assert payload["hits"][0]["node_id"] == node
+
+
+@pytest.mark.parametrize(
     ("embeddings_enabled", "provider_name", "model_name"),
     [
         (False, "voyage", "voyage-4-large"),

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -80,13 +80,13 @@ def _add_summary(engine, summary, *, session_id, created_at, latest_at=None):
     )
 
 
-def _seed_summary_vectors(engine, rows, *, provider="mock"):
+def _seed_summary_vectors(engine, rows, *, provider="mock", model="mock-model"):
     store = VectorStore(engine._store.db_path, config=engine._config)
     try:
-        store.register_profile("mock-model", provider, 2)
-        identity = store.capture_identity("mock-model", provider=provider)
+        store.register_profile(model, provider, 2)
+        identity = store.capture_identity(model, provider=provider)
         for node_id, vector in rows:
-            store.record_embedding(str(node_id), "summary", "mock-model", vector, identity=identity)
+            store.record_embedding(str(node_id), "summary", model, vector, identity=identity)
     finally:
         store.close()
 
@@ -504,6 +504,18 @@ def test_slow_fts_arm_cannot_starve_semantic_recall_and_rerank(recall_engine, mo
     recall_engine._config.embedding_provider = "voyage"
     recall_engine._config.embedding_model = "voyage-4-large"
     recall_engine._config.rerank_enabled = True
+    node = _add_summary(
+        recall_engine,
+        "semantic result survives slow full-text search",
+        session_id="session-a",
+        created_at=1.0,
+    )
+    _seed_summary_vectors(
+        recall_engine,
+        [(node, [1.0, 0.0])],
+        provider="voyage",
+        model="voyage-4-large",
+    )
 
     clock = [100.0]
     captured: dict[str, float] = {}
@@ -607,6 +619,36 @@ def test_fts_fallback_keeps_full_recall_budget_without_semantic_route(
     )
 
     assert captured["fts_deadline"] == 108.0
+
+
+def test_fts_keeps_full_budget_when_requested_vector_corpus_is_unbackfilled(
+    recall_engine,
+    monkeypatch,
+):
+    """Configured embeddings without requested vectors are still an FTS-only route."""
+    recall_engine._config.recall_query_timeout_s = 8.0
+
+    clock = [100.0]
+    captured: dict[str, float] = {}
+
+    def fts_arm(_engine, _query, *, candidate_limit, deadline):
+        del candidate_limit
+        captured["fts_deadline"] = deadline
+        return [], None
+
+    monkeypatch.setattr(lcm_tools.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(lcm_tools, "resolve_provider", lambda _config: MockProvider())
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", fts_arm)
+
+    payload = json.loads(
+        lcm_tools.lcm_recall(
+            {"query": "fts fallback budget", "include": "verbatim", "limit": 5},
+            engine=recall_engine,
+        )
+    )
+
+    assert captured["fts_deadline"] == 108.0
+    assert payload["provenance"]["coverage"]["chunk"] == "none"
 
 
 def test_bounded_chunk_coverage_surfaces_as_degraded(recall_engine, monkeypatch):

--- a/tools.py
+++ b/tools.py
@@ -266,6 +266,11 @@ _LCM_RECALL_DEFAULT_SCOPE_BIAS = 0.5
 _LCM_RECALL_SNIPPET_CHARS = 300
 _LCM_RECALL_RESPONSE_CHAR_CAP = 64_000
 _LCM_RECALL_VALID_INCLUDE = frozenset({"all", "summaries", "verbatim"})
+# A slow first FTS arm must not consume the whole shared recall deadline when a
+# real semantic route is configured. FTS-only/degraded installs keep the full
+# budget; hybrid recall reserves the remainder for provider resolution, vector
+# arms, hydration, fusion, and optional reranking.
+_LCM_RECALL_FTS_MAX_BUDGET_FRACTION = 0.25
 # Recency boost half-life (30 days) and its floor: a memory's rank_score is
 # multiplied by 2**(-age/half_life), clamped so age never zeroes an otherwise
 # strong hit — it only nudges toward newer memories.
@@ -3130,9 +3135,24 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
 
     # -- FTS arm (the default-on value: works with embeddings disabled) --
     if run_fts:
+        fts_deadline = deadline
+        semantic_configured = (
+            embeddings_enabled
+            and (run_summary or run_chunk)
+            and bool(str(getattr(engine._config, "embedding_provider", "") or "").strip())
+            and bool(str(getattr(engine._config, "embedding_model", "") or "").strip())
+        )
+        if semantic_configured:
+            now = time.monotonic()
+            remaining_s = max(0.0, deadline - now)
+            fts_budget_s = min(
+                remaining_s,
+                max(0.001, remaining_s * _LCM_RECALL_FTS_MAX_BUDGET_FRACTION),
+            )
+            fts_deadline = now + fts_budget_s
         try:
             hits, fts_error = _lcm_recall_fts_arm(
-                engine, query, candidate_limit=candidate_limit, deadline=deadline
+                engine, query, candidate_limit=candidate_limit, deadline=fts_deadline
             )
         except (_WorkerCapacityError, TimeoutError) as exc:
             hits, fts_error = [], {"error": str(exc)}

--- a/tools.py
+++ b/tools.py
@@ -3076,6 +3076,103 @@ def _lcm_recall_rerank(
     return reordered, "applied"
 
 
+def _lcm_recall_has_usable_vector_corpus(
+    engine: "LCMEngine",
+    *,
+    run_summary: bool,
+    run_chunk: bool,
+    provider_name: str,
+    model_name: str,
+    deadline: float,
+) -> bool:
+    """Return whether a requested semantic arm has vectors for its selected profile.
+
+    This read-only preflight mirrors ``VectorStore`` profile ordering and requires
+    a live metadata+vector pair. Merely configuring embeddings or registering an
+    empty profile therefore cannot shorten the only usable FTS fallback. Missing
+    or partial optional schema fails closed without materializing feature tables.
+    """
+    provider_name = str(provider_name or "").strip().lower()
+    model_name = str(model_name or "").strip()
+    if not provider_name or not model_name or time.monotonic() >= deadline:
+        return False
+
+    conn: sqlite3.Connection | None = None
+    try:
+        db_path = Path(engine._store.db_path).resolve()
+        remaining_s = max(0.001, deadline - time.monotonic())
+        conn = sqlite3.connect(
+            f"{db_path.as_uri()}?mode=ro",
+            uri=True,
+            timeout=min(0.05, remaining_s),
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only=ON")
+        conn.set_progress_handler(
+            lambda: 1 if time.monotonic() >= deadline else 0,
+            1000,
+        )
+
+        def corpus_has_vectors(
+            *,
+            task: str,
+            selected_model: str,
+            meta_table: str,
+            vector_table: str,
+            id_column: str,
+        ) -> bool:
+            profile = conn.execute(
+                """
+                SELECT identity_hash
+                FROM lcm_embedding_profile
+                WHERE model_name = ? AND provider = ? AND task = ?
+                ORDER BY (active = 1 AND archived_at IS NULL) DESC,
+                         registered_at DESC, identity_hash DESC
+                LIMIT 1
+                """,
+                (selected_model, provider_name, task),
+            ).fetchone()
+            if profile is None:
+                return False
+            identity_hash = str(profile["identity_hash"])
+            row = conn.execute(
+                f"""
+                SELECT 1
+                FROM {meta_table} m
+                JOIN {vector_table} v
+                  ON v.{id_column} = m.{id_column}
+                 AND v.identity_hash = m.identity_hash
+                WHERE m.identity_hash = ? AND m.archived = 0
+                LIMIT 1
+                """,
+                (identity_hash,),
+            ).fetchone()
+            return row is not None
+
+        if run_summary and corpus_has_vectors(
+            task="summary",
+            selected_model=model_name,
+            meta_table="lcm_embedding_meta",
+            vector_table="lcm_embedding_vectors",
+            id_column="embedded_id",
+        ):
+            return True
+        if run_chunk and corpus_has_vectors(
+            task="chunk",
+            selected_model=default_chunk_model(provider_name, model_name),
+            meta_table="lcm_chunk_meta",
+            vector_table="lcm_chunk_vectors",
+            id_column="chunk_id",
+        ):
+            return True
+        return False
+    except (OSError, ValueError, sqlite3.Error):
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     """Search the agent's entire memory (all conversations, all time) by meaning.
 
@@ -3132,17 +3229,30 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     degraded_reasons: list[str] = []
     timed_out = False
     provider: Any = None
+    provider_override = str(kwargs.get("provider_override") or "").strip()
 
     # -- FTS arm (the default-on value: works with embeddings disabled) --
     if run_fts:
         fts_deadline = deadline
-        semantic_configured = (
+        configured_provider = provider_override or str(
+            getattr(engine._config, "embedding_provider", "") or ""
+        ).strip()
+        configured_model = str(
+            getattr(engine._config, "embedding_model", "") or ""
+        ).strip()
+        semantic_available = (
             embeddings_enabled
             and (run_summary or run_chunk)
-            and bool(str(getattr(engine._config, "embedding_provider", "") or "").strip())
-            and bool(str(getattr(engine._config, "embedding_model", "") or "").strip())
+            and _lcm_recall_has_usable_vector_corpus(
+                engine,
+                run_summary=run_summary,
+                run_chunk=run_chunk,
+                provider_name=configured_provider,
+                model_name=configured_model,
+                deadline=deadline,
+            )
         )
-        if semantic_configured:
+        if semantic_available:
             now = time.monotonic()
             remaining_s = max(0.0, deadline - now)
             fts_budget_s = min(
@@ -3179,7 +3289,6 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
             query_vector: list[float] | None = None
             chunk_provider: Any = None
             chunk_query_vector: list[float] | None = None
-            provider_override = kwargs.get("provider_override")
             try:
                 provider = _run_within_deadline(
                     lambda: _resolve_recall_provider(

--- a/tools.py
+++ b/tools.py
@@ -3093,6 +3093,10 @@ def _lcm_recall_has_usable_vector_corpus(
     or partial optional schema fails closed without materializing feature tables.
     """
     provider_name = str(provider_name or "").strip().lower()
+    provider_name = {
+        "voyageai": "voyage",
+        "fast-embed": "fastembed",
+    }.get(provider_name, provider_name)
     model_name = str(model_name or "").strip()
     if not provider_name or not model_name or time.monotonic() >= deadline:
         return False


### PR DESCRIPTION
## Summary

- Cap the first FTS arm at 25% of the remaining recall budget when a requested semantic corpus actually has vectors.
- Keep the full deadline for FTS-only, unconfigured, and unbackfilled fallback paths.
- Add orchestration-level regressions for both sides of that contract.

## Why

On a production-size rc1 database, `lcm_recall(include="all")` could spend the complete shared 8-second deadline in FTS before provider resolution, summary/chunk retrieval, or reranking got a chance to run.

The resulting response looked like a Voyage/reranker problem, but summary-only recall on the same runtime worked normally. The actual issue was sequential deadline allocation: FTS received the whole request budget even when other configured arms still had work to do.

This keeps FTS useful while preventing it from starving the rest of the recall pipeline.

## Validation

The regression was RED before the fix:

```text
assert captured["fts_deadline"] < 108.0
E assert 108.0 < 108.0
```

Exact candidate results:

```text
new fairness regression: 1 passed
focused recall suite:     41 passed
full suite:               2291 passed, 12 xfailed
ruff / diff-check / compile: passed
```

The regression exercises `lcm_recall()` itself and verifies that:

- FTS times out and degrades independently;
- summary retrieval still returns a hit;
- reranking still runs;
- provenance reports the partial result honestly;
- embeddings-off, missing provider/model, or an empty requested vector corpus keeps the full FTS deadline;
- supported provider aliases select the same vector corpus as provider resolution.

## Risk and impact

This only changes internal deadline scheduling in `lcm_recall()`.

No schema, provider, scoring, RRF, response shape, feature default, or configuration surface changes. The global recall deadline is unchanged.

One deliberate trade-off remains: if matching vectors exist but the configured provider is unavailable at runtime, recall still uses the hybrid schedule and FTS gets 25% rather than the full deadline. Detecting provider health before FTS would move expensive provider resolution ahead of the cheap fallback and is outside this focused fix.

## Scope

In scope:

- FTS-first starvation in `include="all"` / hybrid recall;
- requested-corpus availability before applying the hybrid FTS cap;
- accurate partial-result timeout and provenance behavior;
- preserving full-budget FTS fallback where no semantic route is configured.

Out of scope:

- redesigning all recall arms into a parallel scheduler;
- changing provider retries or reranker behavior;
- runtime deployment or config changes.

## Rollout

No deployment is included in this PR. After review and merge, the production canary is the same `include="all"` query that reproduced the rc1 symptom, with arm provenance checked to confirm that a slow FTS arm no longer suppresses semantic retrieval and reranking.

## Reviewer focus

Please check the child-deadline math, the read-only corpus preflight, provider-alias normalization, and the fallback tests that preserve the original full FTS budget.

@stephenschoettler @100yenadmin this came directly from the rc1 production-size recall path. The Voyage/reranker route itself was healthy; FTS was simply eating the clock before it could run.
