### PR TITLE
fix: recover primary writes from stale SQLite snapshots

### DIFF
--- a/dag.py
+++ b/dag.py
@@ -49,6 +49,7 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .store import _normalize_source_value, _UNKNOWN_SOURCE, _legacy_blank_source_clause
+from .sqlite_util import _run_sqlite_write_with_snapshot_retry
 
 
 logger = logging.getLogger(__name__)
@@ -246,27 +247,39 @@ class SummaryDAG:
     def add_node(self, node: SummaryNode) -> int:
         """Insert a summary node and return its node_id."""
         with self._db_lock:
-            cur = self._conn.execute(
-                """INSERT INTO summary_nodes
-                   (session_id, depth, summary, token_count, source_token_count,
-                    source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    node.session_id,
-                    node.depth,
-                    node.summary,
-                    node.token_count,
-                    node.source_token_count,
-                    json.dumps(node.source_ids),
-                    node.source_type,
-                    node.created_at or time.time(),
-                    node.earliest_at,
-                    node.latest_at,
-                    node.expand_hint,
-                ),
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("SummaryDAG connection is closed")
+
+            def insert_node() -> int:
+                cur = conn.execute(
+                    """INSERT INTO summary_nodes
+                       (session_id, depth, summary, token_count, source_token_count,
+                        source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        node.session_id,
+                        node.depth,
+                        node.summary,
+                        node.token_count,
+                        node.source_token_count,
+                        json.dumps(node.source_ids),
+                        node.source_type,
+                        node.created_at or time.time(),
+                        node.earliest_at,
+                        node.latest_at,
+                        node.expand_hint,
+                    ),
+                )
+                if cur.lastrowid is None:
+                    raise RuntimeError("SQLite did not return a summary node id")
+                return int(cur.lastrowid)
+
+            node.node_id = _run_sqlite_write_with_snapshot_retry(
+                conn,
+                insert_node,
+                operation_name="summary_dag.add_node",
             )
-            self._conn.commit()
-            node.node_id = cur.lastrowid
             return node.node_id
 
     @staticmethod

--- a/sqlite_util.py
+++ b/sqlite_util.py
@@ -8,10 +8,15 @@ example the session-end timeout budget).
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from contextlib import contextmanager
-from typing import Iterator, List
+from typing import Callable, Iterator, List, TypeVar
+
+
+_T = TypeVar("_T")
+logger = logging.getLogger(__name__)
 
 
 def _is_sqlite_locked_error(exc: BaseException) -> bool:
@@ -25,6 +30,59 @@ def _is_sqlite_locked_error(exc: BaseException) -> bool:
             return True
         current = current.__cause__ or current.__context__
     return False
+
+
+def _is_sqlite_busy_snapshot_error(exc: BaseException) -> bool:
+    """Return True only for SQLite's stale read-snapshot write-upgrade error."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if (
+            isinstance(current, sqlite3.Error)
+            and getattr(current, "sqlite_errorcode", None)
+            == sqlite3.SQLITE_BUSY_SNAPSHOT
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _run_sqlite_write_with_snapshot_retry(
+    conn: sqlite3.Connection,
+    operation: Callable[[], _T],
+    *,
+    operation_name: str,
+) -> _T:
+    """Run one write transaction, retrying one stale-snapshot upgrade.
+
+    ``SQLITE_BUSY_SNAPSHOT`` cannot be fixed by waiting: the connection must
+    roll back its old read snapshot and begin the write from current state.
+    Retrying the complete transaction once is safe for bounded deterministic
+    LCM writes. Ordinary ``SQLITE_BUSY`` already receives SQLite's configured
+    busy timeout and is not multiplied here.
+    """
+    for attempt in range(2):
+        try:
+            with conn:
+                return operation()
+        except sqlite3.Error as exc:
+            # ``Connection.__exit__`` normally rolled back already. Keep this
+            # explicit so every error path leaves a reusable clean connection.
+            if conn.in_transaction:
+                conn.rollback()
+            if attempt == 0 and _is_sqlite_busy_snapshot_error(exc):
+                continue
+            if _is_sqlite_locked_error(exc):
+                logger.warning(
+                    "SQLite write lock recovery exhausted "
+                    "(operation=%s, code=%s, name=%s)",
+                    operation_name,
+                    getattr(exc, "sqlite_errorcode", None),
+                    getattr(exc, "sqlite_errorname", None),
+                )
+            raise
+    raise AssertionError("unreachable SQLite write retry state")
 
 
 def _sqlite_busy_timeout_ms(conn: sqlite3.Connection) -> int:

--- a/store.py
+++ b/store.py
@@ -46,6 +46,7 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .message_content import normalize_content_value as _normalize_content_value
+from .sqlite_util import _run_sqlite_write_with_snapshot_retry
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -379,13 +380,17 @@ class MessageStore:
         if token_estimates is None:
             token_estimates = [0] * len(messages)
 
-        ids = []
-        with self._write_lock, self._conn:
+        conn = self._conn
+        if conn is None:
+            raise RuntimeError("MessageStore connection is closed")
+
+        def insert_messages() -> List[int]:
+            ids: List[int] = []
             for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
                 ts = time.time()
-                cur = self._conn.execute(
+                cur = conn.execute(
                     """INSERT INTO messages
                        (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,
                         tool_name, timestamp, token_estimate, pinned)
@@ -404,8 +409,17 @@ class MessageStore:
                         0,
                     ),
                 )
-                ids.append(cur.lastrowid)
-        return ids
+                if cur.lastrowid is None:
+                    raise RuntimeError("SQLite did not return a message id")
+                ids.append(int(cur.lastrowid))
+            return ids
+
+        with self._write_lock:
+            return _run_sqlite_write_with_snapshot_retry(
+                conn,
+                insert_messages,
+                operation_name="message_store.append_protected_batch",
+            )
 
     def reassign_session_messages(self, old_session_id: str, new_session_id: str) -> int:
         """Move all persisted messages from one session_id to another."""

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -29,6 +29,7 @@ from hermes_lcm.db_bootstrap import (
     ensure_external_content_fts,
 )
 from hermes_lcm.search_query import sanitize_fts5_query
+from hermes_lcm.sqlite_util import _run_sqlite_write_with_snapshot_retry
 from hermes_lcm.session_patterns import (
     build_session_match_keys,
     compile_session_pattern,
@@ -1287,6 +1288,65 @@ class TestMessageStore:
         ids = store.append_batch("sess1", msgs, [1, 2, 3])
         assert len(ids) == 3
         assert ids[0] < ids[1] < ids[2]
+
+    def test_append_batch_retries_after_stale_read_snapshot(self, tmp_path):
+        db_path = tmp_path / "append-snapshot-retry.db"
+        store = MessageStore(db_path)
+        writer = sqlite3.connect(db_path)
+        try:
+            store.connection.execute("BEGIN")
+            store.connection.execute("SELECT COUNT(*) FROM messages").fetchone()
+            writer.execute(
+                "INSERT OR REPLACE INTO metadata(key, value) VALUES('other-writer', 'advanced')"
+            )
+            writer.commit()
+
+            ids = store._append_protected_batch(
+                "snapshot",
+                [{"role": "user", "content": "retry on a fresh transaction"}],
+            )
+
+            assert len(ids) == 1
+            assert store.connection.in_transaction is False
+            assert store.get(ids[0])["content"] == "retry on a fresh transaction"
+        finally:
+            writer.close()
+            store.close()
+
+    def test_write_snapshot_retry_does_not_retry_ordinary_busy(self, tmp_path, caplog):
+        db_path = tmp_path / "append-ordinary-busy.db"
+        store = MessageStore(db_path)
+        store.connection.execute("PRAGMA busy_timeout=25")
+        holder = sqlite3.connect(db_path, timeout=0.025)
+        holder.execute("PRAGMA busy_timeout=25")
+        holder.execute("BEGIN IMMEDIATE")
+        attempts = 0
+
+        def blocked_write():
+            nonlocal attempts
+            attempts += 1
+            store.connection.execute(
+                "INSERT OR REPLACE INTO metadata(key, value) VALUES('victim', 'blocked')"
+            )
+
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked") as exc_info:
+                _run_sqlite_write_with_snapshot_retry(
+                    store.connection,
+                    blocked_write,
+                    operation_name="test.ordinary_busy",
+                )
+
+            assert exc_info.value.sqlite_errorcode == sqlite3.SQLITE_BUSY
+            assert attempts == 1
+            assert store.connection.in_transaction is False
+            assert "operation=test.ordinary_busy" in caplog.text
+            assert "code=5" in caplog.text
+            assert "name=SQLITE_BUSY" in caplog.text
+        finally:
+            holder.rollback()
+            holder.close()
+            store.close()
 
     def test_append_batch_accepts_content_parts(self, store):
         msgs = [
@@ -3222,6 +3282,64 @@ class TestSummaryDAG:
         self._assert_write_lock_obtainable(db_path)
 
         dag.close()
+
+    def test_add_node_lock_failure_rolls_back_connection(self, tmp_path, caplog):
+        db_path = tmp_path / "add-node-lock-cleanup.db"
+        dag = SummaryDAG(db_path)
+        dag.connection.execute("PRAGMA busy_timeout=25")
+        holder = sqlite3.connect(db_path, timeout=0.025)
+        holder.execute("PRAGMA busy_timeout=25")
+        holder.execute("BEGIN IMMEDIATE")
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                dag.add_node(
+                    SummaryNode(
+                        session_id="locked",
+                        depth=0,
+                        summary="must roll back",
+                        token_count=3,
+                        source_ids=[1],
+                        source_type="messages",
+                    )
+                )
+            assert dag.connection.in_transaction is False
+            assert "operation=summary_dag.add_node" in caplog.text
+            assert "code=5" in caplog.text
+            assert "name=SQLITE_BUSY" in caplog.text
+        finally:
+            holder.rollback()
+            holder.close()
+            dag.close()
+
+    def test_add_node_retries_after_stale_read_snapshot(self, tmp_path):
+        db_path = tmp_path / "add-node-snapshot-retry.db"
+        dag = SummaryDAG(db_path)
+        writer = sqlite3.connect(db_path)
+        try:
+            dag.connection.execute("BEGIN")
+            dag.connection.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()
+            writer.execute(
+                "INSERT OR REPLACE INTO metadata(key, value) VALUES('other-writer', 'advanced')"
+            )
+            writer.commit()
+
+            node_id = dag.add_node(
+                SummaryNode(
+                    session_id="snapshot",
+                    depth=0,
+                    summary="retry on a fresh transaction",
+                    token_count=6,
+                    source_ids=[1],
+                    source_type="messages",
+                )
+            )
+
+            assert node_id > 0
+            assert dag.connection.in_transaction is False
+            assert dag.get_node(node_id).summary == "retry on a fresh transaction"
+        finally:
+            writer.close()
+            dag.close()
 
     def test_add_and_get(self, dag):
         node = SummaryNode(


### PR DESCRIPTION
## Summary

Recover the two gateway-critical SQLite write paths from stale WAL read snapshots without broadening ordinary lock retry behavior.

- retries the complete write transaction once for `SQLITE_BUSY_SNAPSHOT` only
- explicitly leaves the connection out of transaction after every SQLite failure
- keeps the existing `busy_timeout` as the sole policy for ordinary `SQLITE_BUSY`
- adds operation/code/name logging when lock recovery is exhausted
- covers message batch persistence and summary-node publication

## Why

While tracing #421 on a production-sized LCM database, I reproduced two different SQLite lock modes:

1. ordinary competing-writer `SQLITE_BUSY` (`5`), where the configured busy timeout is the right wait policy;
2. stale read-snapshot `SQLITE_BUSY_SNAPSHOT` (`517`), where waiting cannot help because the connection must roll back the old snapshot before retrying the write.

The second mode could fail `SummaryDAG.add_node()` or message batch persistence and leave the caller dealing with a stale transaction state. This patch resets that snapshot and retries the whole bounded transaction once.

This is complementary to #425. That PR releases TEMP staging transactions before compaction writes; this one handles stale-snapshot upgrade failure in the primary Store/DAG publication paths themselves.

@stephenschoettler @100yenadmin, could you sanity-check the transaction boundary and whether this is the right narrow follow-up for #421?

## Validation

Exact restacked candidate `f209f5ed792dbddce4fdaa9947c1713751ad9466` on current `main` `23d5adcd6acf6a6b7e175f99e172a19727b60ae1`, including merged #425:

- full suite: `2301 passed, 12 xfailed`
- post-#425 Store/DAG/engine/rollup regression suite: `1195 passed`
- new lock-mode regressions: `4 passed`
- `ruff`, `compileall`, shell syntax, and `git diff --check`: passed
- independent bounded #425 × #429 transaction review: approved with no related blocker

A deterministic WAL probe also confirms:

- stale snapshot retries successfully from a fresh transaction
- ordinary `SQLITE_BUSY` is not retried and still raises after `busy_timeout`
- every observed success/failure path ends with `in_transaction = false`
- `PRAGMA quick_check = ok`

## Risk / impact

Low and intentionally bounded:

- no schema, config, public API, scoring, or feature-default changes
- no generic retry/backoff loop
- no retry for ordinary `SQLITE_BUSY`
- both retried callbacks are local deterministic SQLite transactions with no external side effects

## Scope

Changed only:

- `sqlite_util.py`
- `store.py`
- `dag.py`
- `tests/test_lcm_core.py`

## Rollout

No live deployment is included here. After review/merge, verify the next lock event logs the operation plus SQLite code/name, and confirm conversation persistence no longer fails on code `517`.

## Reviewer focus

- `with conn:` commit/rollback semantics when returning from the callback
- whole-transaction idempotency on the single snapshot retry
- exact distinction between `SQLITE_BUSY` and `SQLITE_BUSY_SNAPSHOT`
- clean reusable connection state after exhausted contention
