### PR TITLE
fix: add setter for last_compression_status property

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -907,6 +907,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """
         return self._last_compression_status
 
+    @last_compression_status.setter
+    def last_compression_status(self, value: str) -> None:
+        """Allow host to reset status before each compress() pass.
+
+        Without a setter, ``setattr(engine, "last_compression_status", "")``
+        in ``conversation_compression.py`` raises ``AttributeError: property
+        has no setter``, crashing context compression.
+        """
+        self._last_compression_status = value
+
     @property
     def last_compression_noop_reason(self) -> str:
         """Human-readable reason for the latest no-op compression decision."""


### PR DESCRIPTION
## Bug

`LCMEngine.last_compression_status` is defined as a read-only `@property` (engine.py:694), but the Hermes host resets it via `setattr()` before each `compress()` pass to prevent a stale `'noop'` from suppressing a legitimate session split.

**Host code** (`agent/conversation_compression.py`):

```python
for _attr in ("last_compression_status", "_last_compression_status"):
    if hasattr(agent.context_compressor, _attr):
        setattr(agent.context_compressor, _attr, "")
```

**Result:**

```
AttributeError: property 'last_compression_status' of 'LCMEngine' object has no setter
```

This crashes context compression entirely — every compression pass fails with this error.

## Fix

Add a `@last_compression_status.setter` that writes the backing `_last_compression_status` field. 10 lines, surgical.

## Verification

- `python3 -c "import ast; ast.parse(open('engine.py').read())"` — syntax OK
- Stub test confirming `setattr(engine, 'last_compression_status', '')` no longer raises
- Existing tests that read `engine.last_compression_status` are unaffected (getter unchanged)