### PR TITLE
fix: query-path embedding spend-guard starves retrieval after 60 calls/min -- make it configurable with a generous default

### DIFF
--- a/config.py
+++ b/config.py
@@ -370,6 +370,9 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("recall_query_timeout_s", "LCM_RECALL_QUERY_TIMEOUT_S", float),
     _EnvFieldSpec("embedding_backfill_timeout_s", "LCM_EMBEDDING_BACKFILL_TIMEOUT_S", float),
     _EnvFieldSpec("embedding_max_batch_items", "LCM_EMBEDDING_MAX_BATCH_ITEMS", int),
+    _EnvFieldSpec("embedding_query_spend_max_calls", "LCM_EMBEDDING_QUERY_SPEND_MAX_CALLS", int),
+    _EnvFieldSpec("embedding_query_spend_window_seconds", "LCM_EMBEDDING_QUERY_SPEND_WINDOW_SECONDS", float),
+    _EnvFieldSpec("embedding_query_spend_backoff_seconds", "LCM_EMBEDDING_QUERY_SPEND_BACKOFF_SECONDS", float),
     _EnvFieldSpec("new_session_retain_depth", "LCM_NEW_SESSION_RETAIN_DEPTH", int),
     _EnvFieldSpec("doctor_clean_apply_enabled", "LCM_DOCTOR_CLEAN_APPLY_ENABLED", bool),
     _EnvFieldSpec("empty_lifecycle_gc_enabled", "LCM_EMPTY_LIFECYCLE_GC_ENABLED", bool),
@@ -636,6 +639,18 @@ class LCMConfig:
     # Voyage caps a single embeddings request at 1000 input items; document
     # batches split at this many items in addition to the token budget.
     embedding_max_batch_items: int = 1000
+    # Sliding-window spend guard for the latency-sensitive QUERY embedding path
+    # (resolve_provider(for_backfill=False)). The historical hardcoded default
+    # was 60 calls / 60s window / 60s backoff -- a backfill-economy control that
+    # silently gutted retrieval when a tight query loop (e.g. a benchmark firing
+    # hundreds of query embeds in a minute) crossed 60 calls and every further
+    # call was rejected pre-network with ProviderRateLimited (~9k tokens for 451
+    # query embeds is negligible spend, so the low ceiling bought nothing). The
+    # default is now generous; max_calls=0 disables the guard entirely. Backfill
+    # keeps its own bulk contract (max_calls=0) and is unaffected.
+    embedding_query_spend_max_calls: int = 600
+    embedding_query_spend_window_seconds: float = 60.0
+    embedding_query_spend_backoff_seconds: float = 60.0
 
     # -- Session carry-over ---
     # Depth retained after /new (-1 = all, 0 = nothing, 2 = keep d2+)

--- a/embedding_provider.py
+++ b/embedding_provider.py
@@ -1682,6 +1682,16 @@ def resolve_provider(
     nor a normal document batch/local model load should be governed by the
     latency-sensitive query policy. The backfill worker retains its own
     operation budget and renewable lease.
+
+    The query path (``for_backfill=False``) gets an explicit, configurable
+    sliding-window guard from ``embedding_query_spend_{max_calls,window_seconds,
+    backoff_seconds}`` (env ``LCM_EMBEDDING_QUERY_SPEND_*``), defaulting to a
+    generous ceiling. The historical implicit default here was the strict
+    ``EmbeddingSpendGuard()`` (60/60s/60s) -- a backfill-economy control that
+    silently gutted retrieval when a tight query loop crossed 60 calls/window
+    and every further call was rejected pre-network with ``ProviderRateLimited``
+    (451 query embeds ≈ 9k tokens ≈ negligible spend). ``max_calls=0`` disables
+    the guard entirely; the circuit breaker still trips on real failures.
     """
     provider = str(getattr(config, "embedding_provider", "") or "").strip().lower()
     model = str(getattr(config, "embedding_model", "") or "").strip()
@@ -1693,7 +1703,18 @@ def resolve_provider(
         )
     # max_calls=0 disables the sliding-window guard (allows() always True,
     # record_call() a no-op); the circuit breaker still trips on failures.
-    spend_guard = EmbeddingSpendGuard(max_calls=0) if for_backfill else None
+    if for_backfill:
+        spend_guard = EmbeddingSpendGuard(max_calls=0)
+    else:
+        spend_guard = EmbeddingSpendGuard(
+            max_calls=int(getattr(config, "embedding_query_spend_max_calls", 600)),
+            window_seconds=float(
+                getattr(config, "embedding_query_spend_window_seconds", 60.0)
+            ),
+            backoff_seconds=float(
+                getattr(config, "embedding_query_spend_backoff_seconds", 60.0)
+            ),
+        )
     timeout_field = (
         "embedding_backfill_timeout_s"
         if for_backfill

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -773,6 +773,87 @@ def test_spend_guard_rate_limits_provider_calls():
     assert len(transport.calls) == 1
 
 
+def test_resolve_provider_query_path_guard_is_generous_and_unthrottled():
+    # Regression for #123: the query path (for_backfill=False) must NOT inherit
+    # the strict 60/60s default that gutted retrieval; it gets the generous
+    # configurable guard and survives a tight loop of 100+ back-to-back embeds.
+    config = LCMConfig(embedding_provider="voyage", embedding_model="voyage-4")
+    provider = resolve_provider(config, for_backfill=False)
+    guard = provider.spend_guard
+    assert guard.max_calls == 600
+    assert guard.window_seconds == 60.0
+    assert guard.backoff_seconds == 60.0
+
+    now = 0.0
+    for _ in range(120):
+        assert guard.allows(now=now) is True
+        guard.record_call(now=now)
+        now += 0.001  # 120 calls inside one 60s window, as the benchmark does
+    assert guard.allows(now=now) is True
+
+
+def test_resolve_provider_query_guard_is_configurable():
+    # Constructor-arg surface: the LCMConfig fields thread straight into the
+    # query-path guard so a benchmark harness can widen or disable it.
+    config = LCMConfig(
+        embedding_provider="voyage",
+        embedding_model="voyage-4",
+        embedding_query_spend_max_calls=5,
+        embedding_query_spend_window_seconds=30.0,
+        embedding_query_spend_backoff_seconds=15.0,
+    )
+    provider = resolve_provider(config, for_backfill=False)
+    assert provider.spend_guard.max_calls == 5
+    assert provider.spend_guard.window_seconds == 30.0
+    assert provider.spend_guard.backoff_seconds == 15.0
+
+
+def test_query_guard_env_override(monkeypatch):
+    # Env surface: LCM_EMBEDDING_QUERY_SPEND_* overrides the defaults.
+    monkeypatch.setenv("LCM_EMBEDDING_PROVIDER", "voyage")
+    monkeypatch.setenv("LCM_EMBEDDING_MODEL", "voyage-4")
+    monkeypatch.setenv("LCM_EMBEDDING_QUERY_SPEND_MAX_CALLS", "1200")
+    monkeypatch.setenv("LCM_EMBEDDING_QUERY_SPEND_WINDOW_SECONDS", "90")
+    monkeypatch.setenv("LCM_EMBEDDING_QUERY_SPEND_BACKOFF_SECONDS", "45")
+    config = LCMConfig.from_env()
+    assert config.embedding_query_spend_max_calls == 1200
+    assert config.embedding_query_spend_window_seconds == 90.0
+    assert config.embedding_query_spend_backoff_seconds == 45.0
+    provider = resolve_provider(config, for_backfill=False)
+    assert provider.spend_guard.max_calls == 1200
+
+
+def test_resolve_provider_backfill_path_stays_exempt():
+    # Backfill's bulk contract is unchanged: max_calls=0 => allows() always
+    # True, record_call() a no-op, even after many calls.
+    config = LCMConfig(embedding_provider="voyage", embedding_model="voyage-4")
+    provider = resolve_provider(config, for_backfill=True)
+    guard = provider.spend_guard
+    assert guard.max_calls == 0
+    for _ in range(100):
+        guard.record_call()
+    assert guard.allows() is True
+
+
+def test_query_path_rate_limit_surfaces_typed_reason(monkeypatch):
+    # Zero-discard: when the guard does trip, the caller receives the TYPED
+    # ProviderRateLimited with the exact operator-readable message the live
+    # probe recorded -- never a bare swallowed counter bump. The rejection is
+    # pre-network (no transport call is made for the throttled attempt).
+    monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
+    guard = EmbeddingSpendGuard(max_calls=1, window_seconds=100, backoff_seconds=50)
+    transport = FakeTransport(_voyage_success(1))
+    provider = VoyageProvider("voyage", transport=transport, spend_guard=guard)
+
+    assert provider.embed_query("first")
+    with pytest.raises(
+        ProviderRateLimited,
+        match="voyage embedding call-rate guard is cooling down",
+    ):
+        provider.embed_query("second")
+    assert len(transport.calls) == 1
+
+
 def test_voyage_document_splits_share_one_absolute_deadline(monkeypatch):
     monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
     monkeypatch.setattr(provider_mod, "count_tokens", lambda _text: 1)


### PR DESCRIPTION
## Summary

- Make the query-path embedding spend guard explicit and configurable instead of implicitly inheriting the strict backfill default.
- Default query-path guard to a generous 600 calls/60s (env-overridable via `LCM_EMBEDDING_QUERY_SPEND_*`).
- Leave the backfill path's exempt bulk contract (`max_calls=0`) unchanged.

## Why

`resolve_provider(for_backfill=False)` (the query embedding path) implicitly used the strict default `EmbeddingSpendGuard()` (60 calls/60s, 60s backoff) -- a control meant for backfill economy, not interactive query traffic. Once a query loop crossed 60 calls in a 60s window, every further call was rejected pre-network with `ProviderRateLimited`, silently starving retrieval well within normal query volume.

A live probe against the query path reproduced this directly: calls 1-60 returned HTTP 200 as expected, and every call from 61 onward was rejected instantly and pre-network, with no retry or backoff recovering it within the window. The failure mode was silent -- retrieval simply degraded rather than erroring loudly.

## Fix

- `resolve_provider` now passes an explicit, configurable `EmbeddingSpendGuard` on the query path instead of falling through to the strict default.
- New `embedding_query_spend_*` config knobs (env `LCM_EMBEDDING_QUERY_SPEND_*`) default to 600 calls/60s/60s -- generous enough that normal query volume never trips it, while still bounding runaway loops.
- Backfill path is untouched: it keeps its exempt bulk contract (`max_calls=0`).
- A tripped guard still surfaces the typed `ProviderRateLimited` pre-network (zero-discard), never a silently swallowed counter.

## Tests

- `tests/test_embedding_provider.py` -- new coverage: query path stays unthrottled at 120 back-to-back embeds (root-cause repro), guard is configurable via constructor args and env, backfill stays exempt, and a tripped guard surfaces the typed rate-limit reason with the exact message.
- `tests/test_lcm_core.py` -- full existing suite, unaffected by this change, run alongside as a regression check.
- Both files green: `uv run pytest tests/test_embedding_provider.py tests/test_lcm_core.py` -- 355 passed.

## Risk and impact

Query-path behavior only; backfill's spend contract is unchanged. Default is deliberately generous so no currently-passing query workload should newly hit the guard.
