### PR TITLE
fix: reconcile partial tool tail replay after restart

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -4027,6 +4027,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             scan_start=scan_start,
             ignored_messages=ignored_original_messages,
         )
+        reconciled_existing_session = self._ingest_cursor_needs_reconcile
+        reconcile_messages = replay_messages
         if self._ingest_cursor_needs_reconcile:
             reconcile_messages = [
                 original_msg
@@ -4049,6 +4051,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
             self._ingest_cursor_needs_reconcile = False
         cursor = min(max(self._ingest_cursor, 0), n)
+        replayed_tool_segment_indexes = (
+            self._replayed_tool_segment_indexes_after_cursor(reconcile_messages, cursor)
+            if reconciled_existing_session
+            else set()
+        )
         if cursor > 0:
             cached_source_identities = getattr(self, "_last_active_replay_source_identities", None)
             cached_active_replay_messages = getattr(self, "_last_active_replay_messages", None)
@@ -4158,6 +4165,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
             for offset, (original_msg, replay_msg) in enumerate(zip(original_new_messages, new_messages)):
                 absolute_idx = cursor + offset
+                if absolute_idx in replayed_tool_segment_indexes:
+                    continue
                 replay_text = text_content_for_pattern_matching(replay_msg.get("content")) or ""
                 original_text = text_content_for_pattern_matching(original_msg.get("content")) or ""
                 volatile_placeholder = self._is_volatile_ignored_quarantine_placeholder(

--- a/reconcile.py
+++ b/reconcile.py
@@ -445,6 +445,12 @@ class ReconcileMixin:
                     "tool_calls": decoded_tool_calls,
                 })
         effective_fresh_tail_count = self._fresh_tail_boundary(boundary_messages).count
+        stored_tool_identities = {
+            identity
+            for identity in stored_tail
+            for role, _content, tool_call_id, _tool_calls in [identity]
+            if role == "tool" and tool_call_id
+        }
         empty_prefix_cursor: int | None = None
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
@@ -509,6 +515,47 @@ class ReconcileMixin:
                 and self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix)
             )
             matches_raw_tail = self._matches_store_tail_suffix(stored_tail, candidate_prefix)
+            candidate_has_tool_anchor = any(
+                role == "tool" and bool(tool_call_id)
+                for role, _content, tool_call_id, _tool_calls in candidate_prefix
+            )
+            candidate_tool_anchor_indexes = [
+                index
+                for index, (role, _content, tool_call_id, _tool_calls) in enumerate(candidate_prefix)
+                if role == "tool" and bool(tool_call_id)
+            ]
+            candidate_tool_identities = {
+                candidate_prefix[index]
+                for index in candidate_tool_anchor_indexes
+            }
+            candidate_ends_with_replayed_tool_result = (
+                len(candidate_tool_anchor_indexes) == 1
+                and candidate_tool_identities.issubset(stored_tool_identities)
+                and candidate_tool_anchor_indexes[0] == len(candidate_prefix) - 1
+                and all(
+                    identity[0] == "assistant" and not identity[1]
+                    for identity in candidate_prefix[: candidate_tool_anchor_indexes[0]]
+                )
+            )
+            candidate_has_user_after_tool_anchor = any(
+                identity[0] == "user"
+                for identity in candidate_prefix[candidate_tool_anchor_indexes[-1] + 1 :]
+            ) if candidate_tool_anchor_indexes else False
+            matches_tool_anchored_stale_window = (
+                candidate_has_tool_anchor
+                and not candidate_has_user_after_tool_anchor
+                and (
+                    any(
+                        sanitized_replay_tail[start : start + len(candidate_prefix)] == candidate_prefix
+                        for start in range(len(sanitized_replay_tail) - len(candidate_prefix) + 1)
+                    )
+                    or any(
+                        stored_tail[start : start + len(candidate_prefix)] == candidate_prefix
+                        for start in range(len(stored_tail) - len(candidate_prefix) + 1)
+                    )
+                )
+            )
+
             matches_visible_sanitized_tail = (
                 filtered_candidate_placeholders
                 and bool(candidate_visible_prefix)
@@ -573,6 +620,8 @@ class ReconcileMixin:
             if (
                 not matches_sanitized_tail
                 and not matches_raw_tail
+                and not candidate_ends_with_replayed_tool_result
+                and not matches_tool_anchored_stale_window
                 and not matches_inline_generation_cleanup_tail
                 and not matches_durable_persisted_output_full_replay
             ):
@@ -673,19 +722,22 @@ class ReconcileMixin:
                 and matches_raw_tail
                 and candidate_prefix == stored_tail[-len(candidate_prefix) :]
             )
-            # Tool-call IDs are stable execution identities. If an exact durable
-            # suffix includes the same non-empty tool result ID after a process
-            # restart, it is proven replay even when the host only retained a
-            # partial active window shorter than the full durable session. A
-            # genuinely new delta cannot reuse an already persisted call ID.
-            has_tool_anchored_suffix_replay = (
+            # Tool results carry stable execution identities. A stale exact
+            # window may be skipped through matching assistant rows, but never
+            # through a user turn after the final tool anchor. If surrounding
+            # content changed, only skip through the final durable tool result;
+            # later assistant/user messages may be genuinely new after recovery.
+            has_tool_id_anchored_replay = (
                 not candidate_has_persisted_marker
-                and (matches_sanitized_tail or matches_raw_tail)
-                and any(
-                    role == "tool" and bool(tool_call_id)
-                    for role, _content, tool_call_id, _tool_calls in candidate_prefix
+                and candidate_has_tool_anchor
+                and (
+                    matches_sanitized_tail
+                    or matches_raw_tail
+                    or matches_tool_anchored_stale_window
+                    or candidate_ends_with_replayed_tool_result
                 )
             )
+
             has_persisted_marker_specific_replay_evidence = (
                 not candidate_has_persisted_marker
                 or has_durable_persisted_marker_suffix_replay
@@ -747,7 +799,7 @@ class ReconcileMixin:
                 or matches_durable_persisted_output_full_replay
                 or has_inline_generation_cleanup_replay
                 or has_inline_persisted_generation_suffix_replay
-                or has_tool_anchored_suffix_replay
+                or has_tool_id_anchored_replay
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay

--- a/reconcile.py
+++ b/reconcile.py
@@ -673,6 +673,19 @@ class ReconcileMixin:
                 and matches_raw_tail
                 and candidate_prefix == stored_tail[-len(candidate_prefix) :]
             )
+            # Tool-call IDs are stable execution identities. If an exact durable
+            # suffix includes the same non-empty tool result ID after a process
+            # restart, it is proven replay even when the host only retained a
+            # partial active window shorter than the full durable session. A
+            # genuinely new delta cannot reuse an already persisted call ID.
+            has_tool_anchored_suffix_replay = (
+                not candidate_has_persisted_marker
+                and (matches_sanitized_tail or matches_raw_tail)
+                and any(
+                    role == "tool" and bool(tool_call_id)
+                    for role, _content, tool_call_id, _tool_calls in candidate_prefix
+                )
+            )
             has_persisted_marker_specific_replay_evidence = (
                 not candidate_has_persisted_marker
                 or has_durable_persisted_marker_suffix_replay
@@ -734,6 +747,7 @@ class ReconcileMixin:
                 or matches_durable_persisted_output_full_replay
                 or has_inline_generation_cleanup_replay
                 or has_inline_persisted_generation_suffix_replay
+                or has_tool_anchored_suffix_replay
                 or has_raw_full_replay
                 or has_scaffold_suffix_replay
                 or has_raw_cleanup_replay

--- a/reconcile.py
+++ b/reconcile.py
@@ -1010,6 +1010,60 @@ class ReconcileMixin:
         )
         return 0
 
+    def _replayed_tool_segment_indexes_after_cursor(
+        self,
+        messages: List[Dict[str, Any]],
+        cursor: int,
+    ) -> set[int]:
+        """Find exact durable tool pairs replayed after a preserved new delta."""
+        if not self._session_id or cursor >= len(messages):
+            return set()
+        session_count = self._store.get_session_count(self._session_id)
+        if session_count <= 0:
+            return set()
+        tail_limit = min(max(len(messages) * 4, 64), session_count)
+        stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)
+        stored_identities = {
+            self._message_replay_identity(row, stored_row=True)
+            for row in stored_rows
+            if not self._matches_ignore_message_patterns(row, stored_row=True)
+        }
+        replayed: set[int] = set()
+        index = max(0, cursor)
+        while index < len(messages):
+            assistant = messages[index]
+            if str(assistant.get("role") or "") != "assistant" or not assistant.get("tool_calls"):
+                index += 1
+                continue
+            assistant_identity = self._message_replay_identity(assistant)
+            call_ids = {
+                str(call.get("id") or "")
+                for call in assistant.get("tool_calls") or []
+                if isinstance(call, dict) and str(call.get("id") or "")
+            }
+            result_indexes: dict[str, int] = {}
+            probe = index + 1
+            while probe < len(messages) and str(messages[probe].get("role") or "") == "tool":
+                result = messages[probe]
+                tool_call_id = str(result.get("tool_call_id") or "")
+                content = normalize_content_value(result.get("content")) or ""
+                if (
+                    tool_call_id in call_ids
+                    and not _is_hermes_persisted_output_marker(content)
+                    and self._message_replay_identity(result) in stored_identities
+                ):
+                    result_indexes[tool_call_id] = probe
+                probe += 1
+            if (
+                call_ids
+                and assistant_identity in stored_identities
+                and call_ids.issubset(result_indexes)
+            ):
+                replayed.add(index)
+                replayed.update(result_indexes.values())
+            index = max(index + 1, probe)
+        return replayed
+
     def _raw_externalized_placeholder_replay_identity(self, msg: Dict[str, Any]) -> tuple[str, str, str, str]:
         return (
             str(msg.get("role") or "unknown"),

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4254,6 +4254,47 @@ class TestAssemblyBudgetSelection:
         assert [row["content"] for row in rows].count("repeat user intent") == 1
         assert rows[-1]["content"] == "new user after restart"
 
+    def test_partial_tool_anchored_tail_replay_after_restart_does_not_duplicate_rows(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        persisted_messages = [{"role": "system", "content": "sys"}]
+        for idx in range(40):
+            persisted_messages.extend([
+                {"role": "user", "content": f"historical user {idx}"},
+                {"role": "assistant", "content": f"historical answer {idx}"},
+            ])
+        tool_call = {
+            "id": "call_restart_anchor",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": "{}"},
+        }
+        replayed_tail = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_restart_anchor",
+                "tool_name": "search_files",
+                "content": "durable tool result",
+            },
+            {"role": "assistant", "content": "durable answer"},
+        ]
+        persisted_messages.extend(replayed_tail)
+        engine._ingest_messages(persisted_messages)
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(
+            replayed_tail + [{"role": "user", "content": "new user after restart"}]
+        )
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 1
+        assert [row["tool_call_id"] for row in rows].count("call_restart_anchor") == 1
+        assert rows[-1]["content"] == "new user after restart"
+
     def test_non_contiguous_preserved_prompt_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
         engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
         messages = [

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4463,6 +4463,9 @@ class TestAssemblyBudgetSelection:
         ])
 
         rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 2
+        assert [row["tool_call_id"] for row in rows].count("call_multi_anchor_a") == 1
+        assert [row["tool_call_id"] for row in rows].count("call_multi_anchor_b") == 1
         assert any(row["content"] == "brand-new assistant between tools" for row in rows[original_count:])
         assert rows[-1]["content"] == "new user after multiple tools"
 
@@ -4501,6 +4504,45 @@ class TestAssemblyBudgetSelection:
         assert len(rows) == original_count + 1
         assert [row["tool_call_id"] for row in rows].count("call_repeated_user_anchor") == 1
         assert rows[-1]["content"] == "repeat me"
+
+    def test_reconcile_filters_later_exact_tool_pair_after_preserved_new_assistant(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        call_a = {"id": "call_multi_a", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}
+        call_b = {"id": "call_multi_b", "type": "function", "function": {"name": "search_files", "arguments": "{}"}}
+        pair_a = [
+            {"role": "assistant", "content": "", "tool_calls": [call_a]},
+            {"role": "tool", "tool_call_id": "call_multi_a", "tool_name": "read_file", "content": "A"},
+        ]
+        pair_b = [
+            {"role": "assistant", "content": "", "tool_calls": [call_b]},
+            {"role": "tool", "tool_call_id": "call_multi_b", "tool_name": "search_files", "content": "B"},
+        ]
+        engine._ingest_messages([
+            {"role": "system", "content": "sys"},
+            *pair_a,
+            {"role": "assistant", "content": "old durable assistant"},
+            *pair_b,
+            {"role": "user", "content": "intervening durable user"},
+        ])
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages([
+            *pair_a,
+            {"role": "assistant", "content": "genuinely new assistant"},
+            *pair_b,
+            {"role": "user", "content": "new user"},
+        ])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 2
+        assert [row["tool_call_id"] for row in rows].count("call_multi_a") == 1
+        assert [row["tool_call_id"] for row in rows].count("call_multi_b") == 1
+        assert [row["content"] for row in rows[-2:]] == ["genuinely new assistant", "new user"]
 
     def test_non_contiguous_preserved_prompt_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
         engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4295,6 +4295,213 @@ class TestAssemblyBudgetSelection:
         assert [row["tool_call_id"] for row in rows].count("call_restart_anchor") == 1
         assert rows[-1]["content"] == "new user after restart"
 
+    def test_tool_anchored_stale_window_replay_after_restart_does_not_duplicate_rows(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        tool_call = {
+            "id": "call_stale_window_anchor",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": "{}"},
+        }
+        replayed_window = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_stale_window_anchor",
+                "tool_name": "search_files",
+                "content": "durable tool result",
+            },
+            {"role": "assistant", "content": "durable answer"},
+        ]
+        persisted_messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "historical objective"},
+            *replayed_window,
+            {"role": "user", "content": "intervening durable user"},
+            {"role": "assistant", "content": "intervening durable answer"},
+        ]
+        engine._ingest_messages(persisted_messages)
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(
+            replayed_window + [{"role": "user", "content": "new user after stale window"}]
+        )
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 1
+        assert [row["tool_call_id"] for row in rows].count("call_stale_window_anchor") == 1
+        assert rows[-1]["content"] == "new user after stale window"
+
+    def test_tool_result_anchored_noncontiguous_replay_preserves_changed_assistant_rows(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        tool_call = {
+            "id": "call_transformed_restart_anchor",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+        engine._ingest_messages([
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "historical objective"},
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_transformed_restart_anchor",
+                "tool_name": "read_file",
+                "content": "original durable tool result",
+            },
+            {"role": "assistant", "content": "durable answer"},
+            {"role": "user", "content": "intervening durable user"},
+        ])
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages([
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_transformed_restart_anchor",
+                "tool_name": "read_file",
+                "content": "original durable tool result",
+            },
+            {"role": "assistant", "content": "transformed assistant replay representation"},
+            {"role": "user", "content": "new user after noncontiguous replay"},
+        ])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 2
+        assert [row["tool_call_id"] for row in rows].count("call_transformed_restart_anchor") == 1
+        assert [row["content"] for row in rows[-2:]] == [
+            "transformed assistant replay representation",
+            "new user after noncontiguous replay",
+        ]
+
+    def test_tool_anchored_stale_replay_does_not_consume_new_assistant_after_tool(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        tool_call = {
+            "id": "call_resumed_answer_anchor",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+        replayed_tool_pair = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_resumed_answer_anchor",
+                "tool_name": "read_file",
+                "content": "durable tool result",
+            },
+        ]
+        engine._ingest_messages([
+            {"role": "system", "content": "sys"},
+            *replayed_tool_pair,
+            {"role": "assistant", "content": "old durable answer"},
+            {"role": "user", "content": "intervening durable user"},
+        ])
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(
+            replayed_tool_pair + [{"role": "assistant", "content": "brand-new resumed answer"}]
+        )
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 1
+        assert [row["tool_call_id"] for row in rows].count("call_resumed_answer_anchor") == 1
+        assert rows[-1]["content"] == "brand-new resumed answer"
+
+    def test_tool_anchored_replay_does_not_consume_changed_assistant_between_tools(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        tool_a = {
+            "id": "call_multi_anchor_a",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+        tool_b = {
+            "id": "call_multi_anchor_b",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": "{}"},
+        }
+        tool_a_pair = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_a]},
+            {"role": "tool", "tool_call_id": "call_multi_anchor_a", "tool_name": "read_file", "content": "result A"},
+        ]
+        tool_b_pair = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_b]},
+            {"role": "tool", "tool_call_id": "call_multi_anchor_b", "tool_name": "search_files", "content": "result B"},
+        ]
+        engine._ingest_messages([
+            {"role": "system", "content": "sys"},
+            *tool_a_pair,
+            {"role": "assistant", "content": "old assistant between tools"},
+            *tool_b_pair,
+            {"role": "user", "content": "intervening durable user"},
+        ])
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages([
+            *tool_a_pair,
+            {"role": "assistant", "content": "brand-new assistant between tools"},
+            *tool_b_pair,
+            {"role": "user", "content": "new user after multiple tools"},
+        ])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert any(row["content"] == "brand-new assistant between tools" for row in rows[original_count:])
+        assert rows[-1]["content"] == "new user after multiple tools"
+
+    def test_tool_anchored_stale_replay_does_not_consume_repeated_new_user_turn(self, tmp_path, monkeypatch):
+        engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
+        tool_call = {
+            "id": "call_repeated_user_anchor",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": "{}"},
+        }
+        replayed_window = [
+            {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_repeated_user_anchor",
+                "tool_name": "search_files",
+                "content": "durable tool result",
+            },
+        ]
+        engine._ingest_messages([
+            {"role": "system", "content": "sys"},
+            *replayed_window,
+            {"role": "user", "content": "repeat me"},
+            {"role": "assistant", "content": "old response"},
+        ])
+        original_count = engine._store.get_session_count("assembly-session")
+
+        from hermes_lcm.engine import LCMEngine
+
+        replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        replay._session_id = "assembly-session"
+        replay._ingest_cursor_needs_reconcile = True
+        replay._ingest_messages(replayed_window + [{"role": "user", "content": "repeat me"}])
+
+        rows = replay._store.get_session_messages("assembly-session")
+        assert len(rows) == original_count + 1
+        assert [row["tool_call_id"] for row in rows].count("call_repeated_user_anchor") == 1
+        assert rows[-1]["content"] == "repeat me"
+
     def test_non_contiguous_preserved_prompt_replay_does_not_duplicate_durable_rows(self, tmp_path, monkeypatch):
         engine = self._engine(tmp_path, monkeypatch, max_assembly_tokens=450)
         messages = [


### PR DESCRIPTION
## Summary
- treat an exact durable suffix containing an existing non-empty tool-call ID as restart replay
- avoid requiring a partial active snapshot to span the full durable session
- preserve existing persisted-output marker semantics
- add a regression reproducing duplicate suffix ingestion after restart

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_lcm_core.py`
- [x] 292 passed