### PR TITLE
fix: bind lcm slash commands to active runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,9 +717,12 @@ Hermes host discovery/status mismatch, not an LCM storage or compaction failure.
 
 ### `/lcm status` looks unbound after restart
 
-After a fresh Hermes restart, `/lcm status` may show `session_id: (unbound)` or
-`threshold_tokens: (uninitialized)`. Send one normal Hermes message first, then
-run `lcm_status` or `/lcm status` again for live per-session fields.
+Compatible Hermes gateway hosts expose task-local lane metadata while
+dispatching `/lcm`. Once that lane has constructed an agent, `/lcm status`
+resolves the same active LCM runtime as `lcm_status`, including its foreground
+view while an ignored or stateless side channel is bound. Before the first
+normal message constructs an agent, or in a genuinely sessionless process,
+`session_id: (unbound)` and `threshold_tokens: (uninitialized)` remain expected.
 
 ## Architecture
 

--- a/__init__.py
+++ b/__init__.py
@@ -78,6 +78,55 @@ def _ensure_engine_bound_to_session(
         )
 
 
+def _session_context_value(name: str) -> str:
+    """Read task-local host session metadata with legacy env compatibility."""
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:
+        return str(os.environ.get(name, "") or "")
+    try:
+        return str(get_session_env(name, "") or "")
+    except Exception:
+        # Once a concurrent host exposes task-local session context, never fall
+        # back to process-global env after a read failure: it may name another
+        # lane. Unbound is safer than cross-session command dispatch.
+        logger.debug("LCM plugin command could not read %s", name, exc_info=True)
+        return ""
+
+
+def _command_engine_for_current_session(engine, resolve_active_lcm_engine):
+    """Resolve the runtime serving the current plugin-command invocation.
+
+    Gateway hosts bind task-local session/lane metadata before dispatching a
+    plugin slash command. Prefer the already-active AIAgent clone registered for
+    that lane. If no clone exists yet, keep the process-wide prototype's genuine
+    ``(unbound)`` cold-start status rather than mutating shared runtime state.
+    """
+    session_id = _session_context_value("HERMES_SESSION_ID")
+    conversation_id = _session_context_value("HERMES_SESSION_KEY")
+    if session_id or conversation_id:
+        active_engine = resolve_active_lcm_engine(
+            session_id=session_id,
+            conversation_id=conversation_id,
+        )
+        if active_engine is not None:
+            return active_engine
+    return engine
+
+
+def _make_command_handler(handle_lcm_command, engine, resolve_active_lcm_engine):
+    def _handler(raw_args: str):
+        return handle_lcm_command(
+            raw_args,
+            _command_engine_for_current_session(
+                engine,
+                resolve_active_lcm_engine,
+            ),
+        )
+
+    return _handler
+
+
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
@@ -188,7 +237,11 @@ def register(ctx):
 
         register_command(
             "lcm",
-            lambda raw_args: handle_lcm_command(raw_args, engine),
+            _make_command_handler(
+                handle_lcm_command,
+                engine,
+                resolve_active_lcm_engine,
+            ),
             description="LCM status and diagnostics",
         )
     elif callable(register_command):

--- a/engine_registry.py
+++ b/engine_registry.py
@@ -44,6 +44,39 @@ def _engine_matches_conversation_binding(engine: Any, conversation_id: str) -> b
     )
 
 
+def _engine_matches_foreground_binding(
+    engine: Any,
+    session_id: str,
+    conversation_id: str,
+) -> bool:
+    """Return whether an engine's operator-facing foreground matches the lane.
+
+    A stateless/ignored side channel can temporarily own the engine's bound
+    session while ``current_session_id`` and ``current_conversation_id`` keep
+    pointing at the foreground conversation. The direct registries intentionally
+    follow the bound session for ingest dispatch, so operator commands need this
+    bounded fallback scan to recover the same clone without rebinding it.
+    """
+    if not _is_usable_lcm_engine(engine) or not (session_id or conversation_id):
+        return False
+    try:
+        foreground_session_id = str(
+            getattr(engine, "current_session_id", "") or ""
+        )
+        foreground_conversation_id = str(
+            getattr(engine, "current_conversation_id", "") or ""
+        )
+    except Exception:
+        return False
+    return bool(
+        (not session_id or foreground_session_id == session_id)
+        and (
+            not conversation_id
+            or foreground_conversation_id == conversation_id
+        )
+    )
+
+
 def _remove_registry_entries_for_engine(
     engine: Any,
     *,
@@ -92,4 +125,24 @@ def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -
                 return engine
             if engine is not None and not conversation_matches:
                 _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
+        # Direct lookups above follow the engine's actively-bound ingest lane.
+        # If that lane is a side channel, find the same engine by its stable
+        # operator-facing foreground view. Registry size is bounded by live
+        # AIAgent clones and values are weak, so this scan does not retain stale
+        # runtimes or grow with historical sessions.
+        seen: set[int] = set()
+        for engine in (
+            list(_ACTIVE_ENGINES_BY_SESSION_ID.values())
+            + list(_ACTIVE_ENGINES_BY_CONVERSATION_ID.values())
+        ):
+            engine_id = id(engine)
+            if engine_id in seen:
+                continue
+            seen.add(engine_id)
+            if _engine_matches_foreground_binding(
+                engine,
+                session_id,
+                conversation_id,
+            ):
+                return engine
     return None

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import importlib.util
+import json
 import logging
 import os
 import shutil
@@ -53,6 +54,54 @@ def _register_plugin_engine(module_name: str):
     ctx = _Ctx()
     module.register(ctx)
     return ctx.engine
+
+
+def _register_plugin_with_command(
+    monkeypatch,
+    tmp_path,
+    module_name: str,
+    session_values: dict[str, str],
+):
+    """Register the plugin against a host-shaped slash-command context."""
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    fake_session_context = types.SimpleNamespace(
+        get_session_env=lambda name, default="": session_values.get(name, default)
+    )
+    fake_gateway = types.SimpleNamespace(session_context=fake_session_context)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setitem(sys.modules, "gateway", fake_gateway)
+    monkeypatch.setitem(sys.modules, "gateway.session_context", fake_session_context)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / module_name))
+    monkeypatch.setenv("LCM_ENABLE_SLASH_COMMAND", "1")
+
+    module = _load_plugin_entrypoint_module(module_name)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+            self.commands = {}
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_command(self, name, handler, description=""):
+            self.commands[name] = handler
+
+    ctx = _Ctx()
+    module.register(ctx)
+    return ctx
+
+
+def _slash_status_fields(text: str) -> dict[str, str]:
+    return {
+        key.strip(): value.strip()
+        for line in text.splitlines()
+        if ":" in line
+        for key, value in [line.split(":", 1)]
+    }
 
 
 def test_standalone_install_scripts_exist_and_are_shell_scripts():
@@ -610,6 +659,95 @@ def test_registered_tool_handler_forwards_messages_to_engine_handle_tool_call(mo
         assert "messages" in kwargs, f"{name}: messages kwarg not forwarded"
         # Depending on whether engine passes it through, at minimum verify it arrived
         assert kwargs["messages"] == test_messages, f"{name}: messages content mismatch"
+
+
+def test_slash_status_matches_active_tool_clone_after_rebind_and_side_channel(
+    monkeypatch,
+    tmp_path,
+):
+    session_values = {
+        "HERMES_SESSION_KEY": "agent:main:discord:dm:42",
+    }
+    monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "side-channel")
+    ctx = _register_plugin_with_command(
+        monkeypatch,
+        tmp_path,
+        "hermes_lcm_slash_active_clone",
+        session_values,
+    )
+    prototype = ctx.engine
+    clone = prototype.clone_for_agent()
+    try:
+        clone.update_model("gpt-active", 372000, provider="openai-codex")
+        clone.on_session_start(
+            "discord-session-a",
+            platform="discord",
+            conversation_id="agent:main:discord:dm:42",
+        )
+
+        tool_status = json.loads(clone.handle_tool_call("lcm_status", {}))
+        slash_status = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert slash_status["session_id"] == tool_status["session_id"]
+        assert (
+            slash_status["conversation_id"]
+            == tool_status["runtime_identity"]["conversation_id"]
+        )
+        assert slash_status["model"] == tool_status["model"]
+        assert slash_status["provider"] == tool_status["provider"]
+        assert int(slash_status["context_length"]) == tool_status["context_length"]
+        assert int(slash_status["threshold_tokens"]) == tool_status["threshold_tokens"]
+        assert prototype.current_session_id == ""
+
+        clone.on_session_start(
+            "discord-session-b",
+            platform="discord",
+            conversation_id="agent:main:discord:dm:84",
+        )
+        session_values.update({
+            "HERMES_SESSION_KEY": "agent:main:discord:dm:84",
+        })
+        rebound = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert rebound["session_id"] == "discord-session-b"
+        assert rebound["conversation_id"] == "agent:main:discord:dm:84"
+
+        clone.on_session_start(
+            "side-channel",
+            platform="cron",
+            conversation_id="agent:main:cron:tick:1",
+        )
+        assert clone.bound_session_id == "side-channel"
+        assert clone.current_session_id == "discord-session-b"
+        side_channel = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert side_channel["session_id"] == "discord-session-b"
+        assert side_channel["conversation_id"] == "agent:main:discord:dm:84"
+        assert side_channel["side_channel_active"] == "yes"
+    finally:
+        clone.shutdown()
+        prototype.shutdown()
+
+
+def test_slash_status_stays_unbound_until_lane_has_an_active_runtime(
+    monkeypatch,
+    tmp_path,
+):
+    session_values = {
+        "HERMES_SESSION_KEY": "agent:main:discord:dm:42",
+    }
+    ctx = _register_plugin_with_command(
+        monkeypatch,
+        tmp_path,
+        "hermes_lcm_slash_host_context",
+        session_values,
+    )
+    try:
+        cold = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert cold["session_id"] == "(unbound)"
+        assert cold["model"] == "(uninitialized)"
+        assert cold["context_length"] == "(uninitialized)"
+        assert cold["threshold_tokens"] == "(uninitialized)"
+        assert ctx.engine.current_session_id == ""
+    finally:
+        ctx.engine.shutdown()
 
 
 def test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- route `/lcm` through the active per-agent LCM runtime registered for the task-local gateway lane instead of the process-wide plugin prototype
- preserve the operator-facing foreground runtime while an ignored or stateless side channel owns the engine's ingest binding
- keep genuinely cold or sessionless command invocations unbound rather than mutating shared runtime state

## Why
- after per-agent engine isolation, the plugin command closure still captures the process-wide prototype while `lcm_status` runs on the active agent clone
- this makes `/lcm status` report `(unbound)` or stale runtime fields even when the lane has an initialized LCM engine
- the active-engine registry already tracks live clones; plugin command dispatch should resolve through that same boundary

## Validation
- [x] Focused validation: `python -m pytest -q tests/test_packaging_install.py::test_slash_status_matches_active_tool_clone_after_rebind_and_side_channel tests/test_packaging_install.py::test_slash_status_stays_unbound_until_lane_has_an_active_runtime --tb=short` -> `2 passed`
- [x] Default validation:
  - [x] `python -m pytest -q tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py --tb=short` -> `1069 passed`
  - [x] `python -m pytest -q --tb=short` -> `2299 passed, 12 xfailed`
  - [x] low-FD full pytest via `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-slash-active-runtime` -> passed
  - [x] `python -m compileall -q .` via full release validation -> passed
  - [x] script `py_compile` via full release validation -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh` via full release validation -> passed
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check` -> passed
- [x] Additional validation: `python -m ruff check __init__.py engine_registry.py tests/test_packaging_install.py` -> passed
- [ ] Workflow validation, if workflows changed: not applicable; no workflow files changed

## Notes
- Draft pending independent review of the active-runtime resolver and foreground side-channel fallback.
- Revalidated against Hermes Agent `main` at `a61183b56fdb45b9d2a0f2f6b8482e665ccf702f`: gateway plugin commands execute with task-local session/lane context, and per-agent plugin engines are deep-copied before model/session binding. Current gateway context does not expose task-local model/provider/context-length fields, so this intentionally excludes the source commit's unsupported cold-lane ephemeral initialization path.
- Duplicate/overlap check: no direct open PR was found. #243 is the parent shared-runtime issue; merged #247 added per-agent LCM isolation and explicitly called out slash/status routing as follow-up. Historical #14 and #56 own command creation/opt-in, not runtime selection. Open #418 only isolates packaging-test storage; #423 and #436 touch some of the same files but implement separate retrieval/trajectory work.
- Adapted from Stephen's local commit `8c8bd6115d2b3cbcef63122ee4c70e26b668dd56` onto current `origin/main` `49e99a272d2d461e5c90732e7ef2bc20e96f0826`.
- AI assistance: implementation revalidation, test execution, and PR preparation were performed with Hermes agents.

Refs #243
