### PR TITLE
fix: ignore incidental payload refs in doctor scan

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1833,11 +1833,7 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
         for field, value in (("content", content), ("tool_calls", tool_calls)):
             if not isinstance(value, str):
                 continue
-            refs = _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field)
-            for ref in extract_all_externalized_payload_refs(value):
-                if ref in existing_files and ref not in refs:
-                    refs.append(ref)
-            for ref in refs:
+            for ref in _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field):
                 referenced_refs.add(ref)
                 first_location_by_ref.setdefault(
                     ref,

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -117,6 +117,15 @@ _INGEST_PLACEHOLDER_RE = re.compile(r"\[Externalized LCM ingest payload:.*?;\s*r
 _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE = re.compile(
     r"\[(?:Externalized|GC'd externalized) (?:tool output|payload):.*?;\s*ref=([^;\]\s]+)\]"
 )
+_SOURCE_LITERAL_ASSIGNMENT_RE = re.compile(
+    r"^\s*(?:(?:\d+[|:])|(?:[+-](?![+-])))?\s*"
+    r"[A-Za-z_][A-Za-z0-9_]*(?:\[[^\r\n]+\])?\s*=\s*(?:[rubf]{0,2})?[\"']\s*$",
+    re.IGNORECASE,
+)
+_SOURCE_LITERAL_LINE_RE = re.compile(
+    r"^\s*(?:(?:\d+[|:])|(?:[+-](?![+-])))\s*(?:[rubf]{0,2})?[\"']\s*$",
+    re.IGNORECASE,
+)
 _PERSISTED_OUTPUT_TAG = "<persisted-output>"
 _PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 _PERSISTED_OUTPUT_SAVED_TO_RE = re.compile(r"^Full output saved to:\s*(?P<path>.+?)\s*$", re.MULTILINE)
@@ -1595,9 +1604,10 @@ def _append_unique_refs(target: list[str], refs: list[str]) -> None:
 
 def _walk_string_values(value: Any):
     if isinstance(value, str):
-        yield value
         parsed = _maybe_parse_json_string(value)
-        if parsed is not None and not (isinstance(parsed, str) and parsed == value):
+        if parsed is None:
+            yield value
+        else:
             yield from _walk_string_values(parsed)
     elif isinstance(value, dict):
         for key, nested in value.items():
@@ -1675,12 +1685,35 @@ def _looks_like_example_payload_ref(ref: str) -> bool:
     return name.startswith(("example-", "example_", "fake-", "fake_", "dummy-", "dummy_", "placeholder-", "placeholder_"))
 
 
+def _placeholder_line_prefix(text: str, start: int) -> str:
+    separators = (("\n", 1), ("\r", 1), ("\\n", 2), ("\\r", 2))
+    separator_start, separator_length = max(
+        ((text.rfind(token, 0, start), length) for token, length in separators),
+        key=lambda item: item[0],
+    )
+    prefix = text[separator_start + separator_length:start]
+    return re.sub(r"\\+([\"'])", r"\1", prefix)
+
+
+def _is_incidental_source_placeholder(text: str, start: int) -> bool:
+    """Return true when a placeholder match is quoted source/docs, not a recovery ref."""
+    prefix = _placeholder_line_prefix(text, start)
+    if _SOURCE_LITERAL_ASSIGNMENT_RE.search(prefix) or _SOURCE_LITERAL_LINE_RE.fullmatch(prefix):
+        return True
+    before = text[:start]
+    if before.count("```") % 2:
+        return True
+    return prefix.count("`") % 2 == 1
+
+
 def _extract_unescaped_externalized_payload_refs(text: str, *, ignore_quoted_spans: bool = False) -> list[str]:
     refs: list[str] = []
     for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
         for match in pattern.finditer(text):
             ref = match.group(1).strip()
             if not _is_basename_ref(ref):
+                continue
+            if _is_incidental_source_placeholder(text, match.start()):
                 continue
             if _looks_like_example_payload_ref(ref) and _is_escaped_placeholder_example(text, match.start()):
                 continue
@@ -1712,15 +1745,22 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
     if is_externalized_ingest_placeholder(stripped) or is_externalized_placeholder(stripped):
         return extract_all_externalized_payload_refs(stripped)
     if field == "tool_calls":
-        refs = _extract_unescaped_externalized_payload_refs(value, ignore_quoted_spans=True)
         parsed = _maybe_parse_json_string(value)
         if parsed is None:
-            return refs
+            return _extract_unescaped_externalized_payload_refs(value, ignore_quoted_spans=True)
+        # Raw JSON text erases whether a match came from quoted source. Once the
+        # envelope parses, scan decoded values only and keep raw scanning as the
+        # malformed-envelope fallback above.
+        refs: list[str] = []
         for argument in _walk_tool_call_argument_values(parsed):
             if isinstance(argument, str):
-                _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(argument, ignore_quoted_spans=True))
                 parsed_argument = _maybe_parse_json_string(argument)
-                if parsed_argument is not None:
+                if parsed_argument is None:
+                    _append_unique_refs(
+                        refs,
+                        _extract_unescaped_externalized_payload_refs(argument, ignore_quoted_spans=True),
+                    )
+                else:
                     for nested in _walk_string_values(parsed_argument):
                         nested_stripped = nested.strip()
                         if is_externalized_ingest_placeholder(nested_stripped) or is_externalized_placeholder(nested_stripped):
@@ -1755,7 +1795,7 @@ def _refs_for_externalized_integrity_scan(value: str, *, role: str, field: str) 
                 else:
                     _append_unique_refs(refs, _extract_unescaped_externalized_payload_refs(nested, ignore_quoted_spans=True))
         return refs
-    return extract_all_externalized_payload_refs(value)
+    return _extract_unescaped_externalized_payload_refs(value)
 
 
 def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", limit: int = 5) -> dict[str, Any]:
@@ -1785,7 +1825,11 @@ def scan_externalized_payload_integrity(conn, config, *, hermes_home: str = "", 
         for field, value in (("content", content), ("tool_calls", tool_calls)):
             if not isinstance(value, str):
                 continue
-            for ref in _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field):
+            refs = _refs_for_externalized_integrity_scan(value, role=str(role or ""), field=field)
+            for ref in extract_all_externalized_payload_refs(value):
+                if ref in existing_files and ref not in refs:
+                    refs.append(ref)
+            for ref in refs:
                 referenced_refs.add(ref)
                 first_location_by_ref.setdefault(
                     ref,

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -126,6 +126,10 @@ _SOURCE_LITERAL_LINE_RE = re.compile(
     r"^\s*(?:(?:\d+[|:])|(?:[+-](?![+-])))\s*(?:[rubf]{0,2})?[\"']\s*$",
     re.IGNORECASE,
 )
+_SOURCE_DIFF_LITERAL_RE = re.compile(
+    r"^\s*[+-](?![+-])\s*(?:[rubf]{0,2})?[\"'][^\r\n]*$",
+    re.IGNORECASE,
+)
 _PERSISTED_OUTPUT_TAG = "<persisted-output>"
 _PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 _PERSISTED_OUTPUT_SAVED_TO_RE = re.compile(r"^Full output saved to:\s*(?P<path>.+?)\s*$", re.MULTILINE)
@@ -1698,7 +1702,11 @@ def _placeholder_line_prefix(text: str, start: int) -> str:
 def _is_incidental_source_placeholder(text: str, start: int) -> bool:
     """Return true when a placeholder match is quoted source/docs, not a recovery ref."""
     prefix = _placeholder_line_prefix(text, start)
-    if _SOURCE_LITERAL_ASSIGNMENT_RE.search(prefix) or _SOURCE_LITERAL_LINE_RE.fullmatch(prefix):
+    if (
+        _SOURCE_LITERAL_ASSIGNMENT_RE.search(prefix)
+        or _SOURCE_LITERAL_LINE_RE.fullmatch(prefix)
+        or _SOURCE_DIFF_LITERAL_RE.fullmatch(prefix)
+    ):
         return True
     before = text[:start]
     if before.count("```") % 2:

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2078,7 +2078,13 @@ def test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts(
     missing_ref = "20260719_missing_payload_0123456789ab_abcdef.json"
     braced_ref = "20260719_call-{index}_payload_0123456789ab_abcdef.json"
     orphan_ref = "20260719_orphan_payload_0123456789ab_abcdef.json"
-    for ref in (present_ref, braced_ref, orphan_ref):
+    incidental_existing_refs = (
+        "docs-placeholder.json",
+        "foreign_payload_ref.json",
+        "tool-result.json",
+        "inc-tool-colon.json",
+    )
+    for ref in (present_ref, braced_ref, orphan_ref, *incidental_existing_refs):
         (storage_dir / ref).write_text(json.dumps({"content": "fixture payload"}))
 
     template_source_excerpt = "\n".join(
@@ -2211,9 +2217,10 @@ def test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts(
             "externalized_ref": missing_ref,
         }
     ]
-    assert detail["externalized_payload_files_unreferenced"] == 1
+    assert detail["externalized_payload_files_unreferenced"] == 5
     assert detail["unreferenced_externalized_payload_files"] == [
-        {"externalized_ref": orphan_ref}
+        {"externalized_ref": ref}
+        for ref in sorted((orphan_ref, *incidental_existing_refs))
     ]
     for key in (
         "externalized_payload_refs_total",
@@ -2225,12 +2232,10 @@ def test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts(
     ):
         assert doctor_detail[key] == detail[key]
     encoded = json.dumps(detail)
+    for incidental_ref in incidental_existing_refs:
+        assert {"externalized_ref": incidental_ref} in detail["unreferenced_externalized_payload_files"]
     for incidental_ref in (
         "20260708T120000Z-tool-call-{index}.json",
-        "foreign_payload_ref.json",
-        "tool-result.json",
-        "docs-placeholder.json",
-        "inc-tool-colon.json",
         "inc-tool-pipe.json",
     ):
         assert incidental_ref not in encoded

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2236,6 +2236,76 @@ def test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts(
         assert incidental_ref not in encoded
 
 
+def test_externalized_payload_integrity_scan_ignores_nested_serialized_diff_literals(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    review_diff = "\n".join(
+        [
+            "diff --git a/tests/test_example.py b/tests/test_example.py",
+            "@@ -10,2 +10,3 @@",
+            (
+                "-        'fixture_source = \\\"[Externalized tool output: "
+                "tool_call_id=call_1; chars=1; ref=20260708T120000Z-tool-call-{index}.json]\\\"'"
+            ),
+            (
+                "+        '100: value = \\\"[Externalized payload: kind=raw_payload; "
+                "role=assistant; chars=1; ref=inc-tool-colon.json]\\\"'"
+            ),
+            (
+                "+        '200| value = \\\"[Externalized payload: kind=raw_payload; "
+                "role=assistant; chars=1; ref=inc-tool-pipe.json]\\\"'"
+            ),
+        ]
+    )
+    genuine_placeholder = (
+        "[Externalized LCM ingest payload: kind=ingest_payload; field=content; "
+        "chars=1; bytes=1; ref=missing-genuine.json]"
+    )
+    nested_tool_output = json.dumps(
+        {
+            "output": review_diff.replace("\n", "\\n"),
+            "recoverable_payload": genuine_placeholder,
+        }
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "discord",
+            "tool",
+            nested_tool_output,
+            None,
+            None,
+            None,
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "discord",
+            "role": "tool",
+            "field": "content",
+            "externalized_ref": "missing-genuine.json",
+        }
+    ]
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_content_placeholder_with_trailing_text(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2070,6 +2070,172 @@ def test_externalized_payload_integrity_scan_reports_missing_and_unreferenced_re
     assert "not-counted.json" not in encoded
 
 
+def test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts(tmp_path):
+    engine = _engine(tmp_path)
+    storage_dir = tmp_path / "externalized"
+    storage_dir.mkdir()
+    present_ref = "20260719_present_payload_0123456789ab_abcdef.json"
+    missing_ref = "20260719_missing_payload_0123456789ab_abcdef.json"
+    braced_ref = "20260719_call-{index}_payload_0123456789ab_abcdef.json"
+    orphan_ref = "20260719_orphan_payload_0123456789ab_abcdef.json"
+    for ref in (present_ref, braced_ref, orphan_ref):
+        (storage_dir / ref).write_text(json.dumps({"content": "fixture payload"}))
+
+    template_source_excerpt = "\n".join(
+        [
+            "509:     refs = [",
+            '510:         "[Externalized tool output: tool_call_id=call_"',
+            '511:         f"{index}; chars=120000; bytes=120321; '
+            'ref=20260708T120000Z-tool-call-{index}.json]"',
+            "512:         for index in range(3)",
+        ]
+    )
+    read_file_excerpt = "\n".join(
+        [
+            "8210|        placeholder = (",
+            '8211|            "[GC\'d externalized tool output: tool_call_id=call_abc; "',
+            '8212|            "chars=1234; ref=foreign_payload_ref.json]"',
+            "8213|        )",
+        ]
+    )
+    retrieved_diff = "\n".join(
+        [
+            "diff --git a/tests/test_example.py b/tests/test_example.py",
+            "@@ -10,0 +11,2 @@",
+            "+    tool_result = (",
+            '+        "[Externalized payload: kind=tool_result; role=tool; chars=1; bytes=1; ref=tool-result.json]"',
+            "+    )",
+        ]
+    )
+    docs_excerpt = (
+        "The test fixture uses `[Externalized payload: kind=raw_payload; role=assistant; "
+        "chars=1; bytes=1; ref=docs-placeholder.json]` as an example."
+    )
+    content = "\n".join(
+        [
+            f"[Externalized payload: kind=raw_payload; role=assistant; chars=1; bytes=1; ref={present_ref}]",
+            (
+                '<img src="[Externalized payload: kind=raw_payload; role=assistant; '
+                f'chars=1; bytes=1; ref={missing_ref}]">'
+            ),
+            (
+                'recovery ticket: "[Externalized tool output: '
+                f'tool_call_id=call-braced; chars=1; ref={braced_ref}]"'
+            ),
+        ]
+    )
+    for role, row_content in (
+        ("assistant", content),
+        ("tool", json.dumps({"content": template_source_excerpt})),
+        ("tool", json.dumps({"content": read_file_excerpt})),
+        ("tool", json.dumps({"content": retrieved_diff})),
+        ("tool", json.dumps({"content": docs_excerpt})),
+    ):
+        engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                engine.current_session_id,
+                "test",
+                role,
+                row_content,
+                None,
+                None,
+                None,
+                1.0,
+                1,
+                0,
+            ),
+        )
+    colon_source_excerpt = (
+        '100: value = "[Externalized payload: kind=raw_payload; role=assistant; '
+        'chars=1; bytes=1; ref=inc-tool-colon.json]"'
+    )
+    pipe_source_excerpt = (
+        '200| value = "[Externalized payload: kind=raw_payload; role=assistant; '
+        'chars=1; bytes=1; ref=inc-tool-pipe.json]"'
+    )
+    for stored_tool_calls in (
+        json.dumps([{"function": {"name": "inspect", "arguments": colon_source_excerpt}}]),
+        json.dumps(
+            [
+                {
+                    "function": {
+                        "name": "inspect",
+                        "arguments": json.dumps({"source": pipe_source_excerpt}),
+                    }
+                }
+            ]
+        ),
+    ):
+        engine._store._conn.execute(
+            """INSERT INTO messages
+               (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                engine.current_session_id,
+                "test",
+                "assistant",
+                "calling source inspection tool",
+                None,
+                stored_tool_calls,
+                None,
+                1.0,
+                1,
+                0,
+            ),
+        )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+    doctor_result = json.loads(lcm_tools.lcm_doctor({}, engine=engine))
+    doctor_detail = next(
+        check["detail"] for check in doctor_result["checks"] if check["check"] == "payload_storage"
+    )
+
+    assert detail["externalized_payload_refs_total"] == 3
+    assert detail["externalized_payload_refs_existing"] == 2
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"] == [
+        {
+            "store_id": 1,
+            "session_id": engine.current_session_id,
+            "source": "test",
+            "role": "assistant",
+            "field": "content",
+            "externalized_ref": missing_ref,
+        }
+    ]
+    assert detail["externalized_payload_files_unreferenced"] == 1
+    assert detail["unreferenced_externalized_payload_files"] == [
+        {"externalized_ref": orphan_ref}
+    ]
+    for key in (
+        "externalized_payload_refs_total",
+        "externalized_payload_refs_existing",
+        "externalized_payload_refs_missing",
+        "externalized_payload_files_unreferenced",
+        "missing_externalized_payload_refs",
+        "unreferenced_externalized_payload_files",
+    ):
+        assert doctor_detail[key] == detail[key]
+    encoded = json.dumps(detail)
+    for incidental_ref in (
+        "20260708T120000Z-tool-call-{index}.json",
+        "foreign_payload_ref.json",
+        "tool-result.json",
+        "docs-placeholder.json",
+        "inc-tool-colon.json",
+        "inc-tool-pipe.json",
+    ):
+        assert incidental_ref not in encoded
+
+
 def test_externalized_payload_integrity_scan_detects_embedded_content_placeholder_with_trailing_text(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()


### PR DESCRIPTION
## Summary
- Ignore externalized-payload placeholders that appear as quoted source, docs, line-numbered excerpts, or nested serialized unified diffs instead of treating them as live recovery references.
- Scan decoded values for parseable `tool_calls`, while retaining the raw fallback for malformed envelopes and preserving genuine existing, missing, brace-bearing, and orphan payload diagnostics.
- Add focused regressions for the internal integrity scanner and public `lcm_doctor` detail.

## Why
- On exact current `main` (`49e99a272d2d461e5c90732e7ef2bc20e96f0826`), the committed regressions fail with `9` refs instead of `3` and `4` refs instead of `1` because retained source/example text is classified as missing payload evidence.
- The scanner should report recoverability problems created by LCM storage boundaries, not template filenames or placeholder strings quoted in stored code, docs, tool arguments, or diffs.

## Validation
- [x] Focused validation: `python -m pytest -q tests/test_ingest_protection.py::test_externalized_payload_integrity_scan_ignores_incidental_source_excerpts tests/test_ingest_protection.py::test_externalized_payload_integrity_scan_ignores_nested_serialized_diff_literals` -> `2 passed`
- [x] Scanner selection: `python -m pytest -q tests/test_ingest_protection.py -k externalized_payload_integrity` -> `20 passed, 120 deselected`
- [x] Affected suites: `python -m pytest -q tests/test_ingest_protection.py tests/test_lcm_command.py` -> `217 passed`
- [x] Default validation:
  - [x] `python -m pytest -q tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py` -> pass
  - [x] `python -m pytest -q` -> `2299 passed, 12 xfailed`
  - [x] `(ulimit -n 1024; python -m pytest -q)` -> `2299 passed, 12 xfailed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh`
  - [x] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-doctor-scanner-current-main` -> `PASS: release validation full`
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [x] `ruff check --no-cache .`
- [x] Workflow validation not applicable; no workflow files changed.

## Notes
- This is a clean two-file refresh over current `main`. Its changed-file trees are identical to the previously reviewed cumulative recovered candidate `21071cfd2e7f3c5cbe36b5e831c1ff6d152d6920`; a fresh exact-head reviewer gate for this rebased SHA is tracked separately, so the PR remains draft and no review is requested here.
- Duplicate search found no open PR for the scanner behavior. Closed #398 is the stale template-only predecessor. Open #364/#365 also touch `ingest_protection.py`, but only the unrelated persisted-output file-read path, not the integrity scanner.
- Recovery bundle and two format-patches were generated and independently reapplied from the exact base. Tests used isolated temporary databases/directories; no live database, installed plugin, profile, config, or service was touched.

Refs #398
