### PR TITLE
fix: defer temporal rollup maintenance from session start

### DIFF
--- a/command.py
+++ b/command.py
@@ -2413,18 +2413,18 @@ def _rollups_rebuild_text(tokens: list[str], engine) -> str:
     scope = engine.current_session_id
     targets = _rollup_period_targets(kind, target_date)
     limit = max(0, int(engine._config.rollup_builds_per_pass))
-    store = RollupStore(engine._dag.db_path)
     lease_key = engine.try_acquire_rollup_operator_lease(scope)
     if lease_key is None:
-        store.close()
         return "\n".join([
             "LCM temporal rollup rebuild",
             "status: busy",
             "error: background temporal rollup maintenance is active for this session",
             "note: retry after the current maintenance pass completes",
         ])
+    store = None
     outcomes: list[_RollupRebuildResult] = []
     try:
+        store = RollupStore(engine._dag.db_path)
         if store.connection is None:  # pragma: no cover - RollupStore initialization contract
             raise RuntimeError("temporal rollup store is unavailable")
         # Durably seed a stale row for EVERY requested target BEFORE applying the
@@ -2488,7 +2488,8 @@ def _rollups_rebuild_text(tokens: list[str], engine) -> str:
             f"error: {type(exc).__name__}: {exc}",
         ])
     finally:
-        store.close()
+        if store is not None:
+            store.close()
         engine.release_rollup_operator_lease(lease_key)
 
     # ``complete`` is reserved for attempted targets that all reached ready.

--- a/command.py
+++ b/command.py
@@ -2488,9 +2488,11 @@ def _rollups_rebuild_text(tokens: list[str], engine) -> str:
             f"error: {type(exc).__name__}: {exc}",
         ])
     finally:
-        if store is not None:
-            store.close()
-        engine.release_rollup_operator_lease(lease_key)
+        try:
+            if store is not None:
+                store.close()
+        finally:
+            engine.release_rollup_operator_lease(lease_key)
 
     # ``complete`` is reserved for attempted targets that all reached ready.
     # Explicitly bounded, unattempted queued debt may coexist with complete.

--- a/command.py
+++ b/command.py
@@ -2414,6 +2414,15 @@ def _rollups_rebuild_text(tokens: list[str], engine) -> str:
     targets = _rollup_period_targets(kind, target_date)
     limit = max(0, int(engine._config.rollup_builds_per_pass))
     store = RollupStore(engine._dag.db_path)
+    lease_key = engine.try_acquire_rollup_operator_lease(scope)
+    if lease_key is None:
+        store.close()
+        return "\n".join([
+            "LCM temporal rollup rebuild",
+            "status: busy",
+            "error: background temporal rollup maintenance is active for this session",
+            "note: retry after the current maintenance pass completes",
+        ])
     outcomes: list[_RollupRebuildResult] = []
     try:
         if store.connection is None:  # pragma: no cover - RollupStore initialization contract
@@ -2480,6 +2489,7 @@ def _rollups_rebuild_text(tokens: list[str], engine) -> str:
         ])
     finally:
         store.close()
+        engine.release_rollup_operator_lease(lease_key)
 
     # ``complete`` is reserved for attempted targets that all reached ready.
     # Explicitly bounded, unattempted queued debt may coexist with complete.

--- a/engine.py
+++ b/engine.py
@@ -158,6 +158,7 @@ class _RollupMaintenanceScheduler:
         self._follow_up_key: tuple[str, str] | None = None
         self._follow_up_job: Callable[[], None] | None = None
         self._running_follow_up = False
+        self._exclusive_keys: set[tuple[str, str]] = set()
         self._worker: threading.Thread | None = None
 
     def schedule(
@@ -166,6 +167,14 @@ class _RollupMaintenanceScheduler:
         job: Callable[[], None],
     ) -> bool:
         with self._condition:
+            if key in self._exclusive_keys:
+                logger.info(
+                    "LCM temporal rollup maintenance deferred while an operator "
+                    "rebuild owns database=%s scope=%s",
+                    key[0],
+                    key[1],
+                )
+                return False
             if key in self._queued_keys:
                 return True
             if key in self._active_keys and not self._running_follow_up:
@@ -194,6 +203,28 @@ class _RollupMaintenanceScheduler:
             self._condition.notify_all()
             return True
 
+    def try_acquire_exclusive(self, key: tuple[str, str]) -> bool:
+        """Reserve one idle key for a synchronous operator rebuild.
+
+        This is intentionally non-blocking: a manual rebuild must not race a
+        provider-backed maintenance pass, but it also must not wait behind one
+        on the gateway thread. The caller can ask the operator to retry once the
+        background pass completes.
+        """
+        with self._condition:
+            busy_keys = self._queued_keys | self._active_keys | self._exclusive_keys
+            if key in busy_keys or self._follow_up_key == key:
+                return False
+            if len(self._exclusive_keys) >= self._max_pending_jobs:
+                return False
+            self._exclusive_keys.add(key)
+            return True
+
+    def release_exclusive(self, key: tuple[str, str]) -> None:
+        with self._condition:
+            self._exclusive_keys.discard(key)
+            self._condition.notify_all()
+
     def drain(
         self,
         keys: set[tuple[str, str]],
@@ -205,6 +236,7 @@ class _RollupMaintenanceScheduler:
             while keys & (
                 self._queued_keys
                 | self._active_keys
+                | self._exclusive_keys
                 | ({self._follow_up_key} if self._follow_up_key else set())
             ):
                 if deadline is None:
@@ -1464,6 +1496,27 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     # -- ContextEngine optional methods ------------------------------------
 
+    def _rollup_maintenance_key(self, scope: str) -> tuple[str, str]:
+        raw_database_path = str(self._dag.db_path)
+        if raw_database_path == ":memory:":
+            database_identity = f":memory:{id(self._dag)}"
+        else:
+            database_identity = str(Path(raw_database_path).resolve())
+        return database_identity, str(scope)
+
+    def try_acquire_rollup_operator_lease(
+        self,
+        scope: str,
+    ) -> tuple[str, str] | None:
+        """Reserve this database/scope for a synchronous rollup rebuild."""
+        key = self._rollup_maintenance_key(scope)
+        if not _ROLLUP_MAINTENANCE_SCHEDULER.try_acquire_exclusive(key):
+            return None
+        return key
+
+    def release_rollup_operator_lease(self, key: tuple[str, str]) -> None:
+        _ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
+
     def _schedule_rollup_maintenance(self, scope: str) -> None:
         """Enqueue one best-effort rollup pass using private SQLite helpers."""
         try:
@@ -1475,7 +1528,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 )
                 return
             database_path = Path(raw_database_path).resolve()
-            key = (str(database_path), str(scope))
+            key = self._rollup_maintenance_key(scope)
             config = copy.deepcopy(self._config)
             circuit_breaker = self._summary_circuit_breaker
             spend_guard = self._summary_spend_guard

--- a/engine.py
+++ b/engine.py
@@ -4,6 +4,7 @@ Implements the ContextEngine ABC. Replaces the built-in ContextCompressor
 with a DAG-based summarization system that preserves every message.
 """
 
+import asyncio
 import copy
 import hashlib
 import json
@@ -260,7 +261,7 @@ class _RollupMaintenanceScheduler:
             while True:
                 try:
                     job()
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     logger.warning(
                         "LCM background temporal rollup maintenance failed for database=%s scope=%s",
                         key[0],

--- a/engine.py
+++ b/engine.py
@@ -160,12 +160,42 @@ class _RollupMaintenanceScheduler:
         self._follow_up_job: Callable[[], None] | None = None
         self._running_follow_up = False
         self._exclusive_keys: set[tuple[str, str]] = set()
+        self._owned_keys: dict[object, set[tuple[str, str]]] = {}
+        self._key_owners: dict[tuple[str, str], set[object]] = {}
         self._worker: threading.Thread | None = None
+
+    def _track_owner_locked(
+        self,
+        key: tuple[str, str],
+        owner: object | None,
+    ) -> None:
+        if owner is None:
+            return
+        self._owned_keys.setdefault(owner, set()).add(key)
+        self._key_owners.setdefault(key, set()).add(owner)
+
+    def _release_key_owners_if_idle_locked(self, key: tuple[str, str]) -> None:
+        if (
+            key in self._queued_keys
+            or key in self._active_keys
+            or key in self._exclusive_keys
+            or self._follow_up_key == key
+        ):
+            return
+        for owner in self._key_owners.pop(key, set()):
+            owned = self._owned_keys.get(owner)
+            if owned is None:
+                continue
+            owned.discard(key)
+            if not owned:
+                self._owned_keys.pop(owner, None)
 
     def schedule(
         self,
         key: tuple[str, str],
         job: Callable[[], None],
+        *,
+        owner: object | None = None,
     ) -> bool:
         with self._condition:
             if key in self._exclusive_keys:
@@ -177,10 +207,12 @@ class _RollupMaintenanceScheduler:
                 )
                 return False
             if key in self._queued_keys:
+                self._track_owner_locked(key, owner)
                 return True
             if key in self._active_keys and not self._running_follow_up:
                 self._follow_up_key = key
                 self._follow_up_job = job
+                self._track_owner_locked(key, owner)
                 self._condition.notify_all()
                 return True
             if len(self._jobs) >= self._max_pending_jobs:
@@ -201,6 +233,7 @@ class _RollupMaintenanceScheduler:
                 self._worker = worker
             self._jobs.append((key, job))
             self._queued_keys.add(key)
+            self._track_owner_locked(key, owner)
             self._condition.notify_all()
             return True
 
@@ -249,6 +282,24 @@ class _RollupMaintenanceScheduler:
                 self._condition.wait(remaining)
             return True
 
+    def drain_owner(
+        self,
+        owner: object,
+        timeout: float | None = None,
+    ) -> bool:
+        """Wait until every outstanding key accepted for ``owner`` is idle."""
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while self._owned_keys.get(owner):
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
     def _run(self) -> None:
         while True:
             with self._condition:
@@ -278,6 +329,7 @@ class _RollupMaintenanceScheduler:
                         continue
                     self._active_keys.discard(key)
                     self._running_follow_up = False
+                    self._release_key_owners_if_idle_locked(key)
                     self._condition.notify_all()
                     break
 
@@ -528,9 +580,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._host_fallback_compressor: Any = None
         self._host_fallback_session_id = ""
         self._host_fallback_import_warning_logged = False
-        # Keys scheduled by this engine are retained for deterministic test and
-        # diagnostic drains. Jobs themselves never use this engine's SQLite helpers.
-        self._rollup_maintenance_keys: set[tuple[str, str]] = set()
+        # The scheduler associates this identity only with outstanding work, so
+        # diagnostic drains do not retain every historical session key forever.
+        self._rollup_maintenance_owner = object()
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -1547,8 +1599,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 finally:
                     private_dag.close()
 
-            if _ROLLUP_MAINTENANCE_SCHEDULER.schedule(key, maintain):
-                self._rollup_maintenance_keys.add(key)
+            _ROLLUP_MAINTENANCE_SCHEDULER.schedule(
+                key,
+                maintain,
+                owner=self._rollup_maintenance_owner,
+            )
         except Exception:
             # Maintenance is opportunistic; a scheduler/setup failure must never
             # turn a successful foreground session bind into a host failure.
@@ -1559,8 +1614,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def drain_rollup_maintenance(self, timeout: float | None = None) -> bool:
         """Wait for rollup jobs scheduled by this engine (tests and diagnostics)."""
-        return _ROLLUP_MAINTENANCE_SCHEDULER.drain(
-            set(self._rollup_maintenance_keys),
+        return _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(
+            self._rollup_maintenance_owner,
             timeout=timeout,
         )
 

--- a/engine.py
+++ b/engine.py
@@ -13,8 +13,9 @@ import re
 import sqlite3
 import threading
 import time
+from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.context_engine import ContextEngine
 
@@ -131,6 +132,124 @@ from .tokens import count_message_tokens, count_messages_tokens, count_tokens
 from . import tools as lcm_tools
 
 logger = logging.getLogger(__name__)
+
+
+class _RollupMaintenanceScheduler:
+    """Run deduplicated rollup jobs on one process-wide worker.
+
+    Session binding only enqueues work. The worker is shared by every engine so
+    rapid gateway binds cannot create one thread per session. A key that is
+    already queued is ignored; a key requested while active gets at most one
+    follow-up pass, which preserves eventual progress when new staleness arrives
+    during an in-flight build without allowing concurrent duplicate builds.
+    """
+
+    def __init__(self, max_pending_jobs: int = 64) -> None:
+        self._condition = threading.Condition()
+        self._max_pending_jobs = max(1, int(max_pending_jobs))
+        self._jobs: deque[
+            tuple[tuple[str, str], Callable[[], None]]
+        ] = deque()
+        self._queued_keys: set[tuple[str, str]] = set()
+        self._active_keys: set[tuple[str, str]] = set()
+        # One worker means at most one active key. Keep its requested rerun in
+        # a literal single slot so queue saturation cannot discard the
+        # documented active-pass follow-up guarantee or grow hidden state.
+        self._follow_up_key: tuple[str, str] | None = None
+        self._follow_up_job: Callable[[], None] | None = None
+        self._running_follow_up = False
+        self._worker: threading.Thread | None = None
+
+    def schedule(
+        self,
+        key: tuple[str, str],
+        job: Callable[[], None],
+    ) -> bool:
+        with self._condition:
+            if key in self._queued_keys:
+                return True
+            if key in self._active_keys and not self._running_follow_up:
+                self._follow_up_key = key
+                self._follow_up_job = job
+                self._condition.notify_all()
+                return True
+            if len(self._jobs) >= self._max_pending_jobs:
+                logger.warning(
+                    "LCM temporal rollup maintenance queue is full; "
+                    "deferring database=%s scope=%s until a later bind",
+                    key[0],
+                    key[1],
+                )
+                return False
+            if self._worker is None or not self._worker.is_alive():
+                worker = threading.Thread(
+                    target=self._run,
+                    name="lcm-rollup-maintenance",
+                    daemon=True,
+                )
+                worker.start()
+                self._worker = worker
+            self._jobs.append((key, job))
+            self._queued_keys.add(key)
+            self._condition.notify_all()
+            return True
+
+    def drain(
+        self,
+        keys: set[tuple[str, str]],
+        timeout: float | None = None,
+    ) -> bool:
+        """Wait until none of ``keys`` is queued or active."""
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while keys & (
+                self._queued_keys
+                | self._active_keys
+                | ({self._follow_up_key} if self._follow_up_key else set())
+            ):
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                while not self._jobs:
+                    self._condition.wait()
+                key, job = self._jobs.popleft()
+                self._queued_keys.discard(key)
+                self._active_keys.add(key)
+                self._running_follow_up = False
+            while True:
+                try:
+                    job()
+                except Exception:
+                    logger.warning(
+                        "LCM background temporal rollup maintenance failed for database=%s scope=%s",
+                        key[0],
+                        key[1],
+                        exc_info=True,
+                    )
+                with self._condition:
+                    if self._follow_up_key == key and self._follow_up_job is not None:
+                        job = self._follow_up_job
+                        self._follow_up_key = None
+                        self._follow_up_job = None
+                        self._running_follow_up = True
+                        self._condition.notify_all()
+                        continue
+                    self._active_keys.discard(key)
+                    self._running_follow_up = False
+                    self._condition.notify_all()
+                    break
+
+
+_ROLLUP_MAINTENANCE_SCHEDULER = _RollupMaintenanceScheduler()
 
 _SESSION_END_BUSY_TIMEOUT_MS = 50
 _CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
@@ -376,6 +495,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._host_fallback_compressor: Any = None
         self._host_fallback_session_id = ""
         self._host_fallback_import_warning_logged = False
+        # Keys scheduled by this engine are retained for deterministic test and
+        # diagnostic drains. Jobs themselves never use this engine's SQLite helpers.
+        self._rollup_maintenance_keys: set[tuple[str, str]] = set()
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -1342,6 +1464,52 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     # -- ContextEngine optional methods ------------------------------------
 
+    def _schedule_rollup_maintenance(self, scope: str) -> None:
+        """Enqueue one best-effort rollup pass using private SQLite helpers."""
+        try:
+            raw_database_path = str(self._dag.db_path)
+            if raw_database_path == ":memory:":
+                logger.warning(
+                    "LCM cannot run background temporal rollup maintenance for "
+                    "an isolated in-memory SQLite database; maintenance skipped"
+                )
+                return
+            database_path = Path(raw_database_path).resolve()
+            key = (str(database_path), str(scope))
+            config = copy.deepcopy(self._config)
+            circuit_breaker = self._summary_circuit_breaker
+            spend_guard = self._summary_spend_guard
+
+            def maintain() -> None:
+                private_dag = SummaryDAG(database_path)
+                try:
+                    run_rollup_maintenance(
+                        private_dag,
+                        config,
+                        scope,
+                        circuit_breaker=circuit_breaker,
+                        spend_guard=spend_guard,
+                    )
+                finally:
+                    private_dag.close()
+
+            if _ROLLUP_MAINTENANCE_SCHEDULER.schedule(key, maintain):
+                self._rollup_maintenance_keys.add(key)
+        except Exception:
+            # Maintenance is opportunistic; a scheduler/setup failure must never
+            # turn a successful foreground session bind into a host failure.
+            logger.warning(
+                "LCM could not schedule background temporal rollup maintenance",
+                exc_info=True,
+            )
+
+    def drain_rollup_maintenance(self, timeout: float | None = None) -> bool:
+        """Wait for rollup jobs scheduled by this engine (tests and diagnostics)."""
+        return _ROLLUP_MAINTENANCE_SCHEDULER.drain(
+            set(self._rollup_maintenance_keys),
+            timeout=timeout,
+        )
+
     def _bind_lifecycle_state(
         self,
         session_id: str,
@@ -1393,11 +1561,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             and not self._session_ignored
             and not self._session_stateless
         ):
-            run_rollup_maintenance(
-                self._dag, self._config, session_id,
-                circuit_breaker=self._summary_circuit_breaker,
-                spend_guard=self._summary_spend_guard,
-            )
+            self._schedule_rollup_maintenance(session_id)
 
     def _invalidate_rollups_for_published_node(self, node: "SummaryNode") -> None:
         """Stale the rollups covering EVERY UTC day a just-published node spans.

--- a/escalation.py
+++ b/escalation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import inspect
 import logging
 import re
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
@@ -70,6 +71,11 @@ class SummaryCircuitBreaker:
     cooldown_seconds: int = 300
     _failures: dict[str, int] = field(default_factory=dict)
     _open_until: dict[str, float] = field(default_factory=dict)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        repr=False,
+        compare=False,
+    )
 
     def _key(self, model: str | None) -> str:
         return (model or "").strip() or _DEFAULT_ROUTE_KEY
@@ -77,33 +83,36 @@ class SummaryCircuitBreaker:
     def allows(self, model: str | None, *, now: float | None = None) -> bool:
         key = self._key(model)
         current_time = time.monotonic() if now is None else now
-        opened_until = self._open_until.get(key, 0.0)
-        if opened_until <= current_time:
-            if key in self._open_until:
-                self._open_until.pop(key, None)
-            return True
-        return False
+        with self._lock:
+            opened_until = self._open_until.get(key, 0.0)
+            if opened_until <= current_time:
+                if key in self._open_until:
+                    self._open_until.pop(key, None)
+                return True
+            return False
 
     def record_success(self, model: str | None) -> None:
         key = self._key(model)
-        self._failures.pop(key, None)
-        self._open_until.pop(key, None)
+        with self._lock:
+            self._failures.pop(key, None)
+            self._open_until.pop(key, None)
 
     def record_failure(self, model: str | None, *, now: float | None = None) -> None:
         key = self._key(model)
-        failures = self._failures.get(key, 0) + 1
-        self._failures[key] = failures
-        threshold = max(1, int(self.failure_threshold or 1))
-        if failures >= threshold:
-            current_time = time.monotonic() if now is None else now
-            cooldown = max(0, int(self.cooldown_seconds or 0))
-            self._open_until[key] = current_time + cooldown
-            logger.warning(
-                "LCM summary route circuit opened for %s after %d failure(s); cooldown=%ss",
-                key,
-                failures,
-                cooldown,
-            )
+        with self._lock:
+            failures = self._failures.get(key, 0) + 1
+            self._failures[key] = failures
+            threshold = max(1, int(self.failure_threshold or 1))
+            if failures >= threshold:
+                current_time = time.monotonic() if now is None else now
+                cooldown = max(0, int(self.cooldown_seconds or 0))
+                self._open_until[key] = current_time + cooldown
+                logger.warning(
+                    "LCM summary route circuit opened for %s after %d failure(s); cooldown=%ss",
+                    key,
+                    failures,
+                    cooldown,
+                )
 
 
 @dataclass
@@ -123,6 +132,11 @@ class SummarySpendGuard:
     backoff_seconds: float = 1800.0
     _calls: list[float] = field(default_factory=list)
     _backoff_until: float = 0.0
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        repr=False,
+        compare=False,
+    )
 
     def _prune(self, current_time: float) -> None:
         cutoff = current_time - self.window_seconds
@@ -133,16 +147,27 @@ class SummarySpendGuard:
         if self.max_calls <= 0:
             return True
         current_time = time.monotonic() if now is None else now
-        if current_time < self._backoff_until:
-            return False
-        self._prune(current_time)
-        return len(self._calls) < self.max_calls
+        with self._lock:
+            if current_time < self._backoff_until:
+                return False
+            self._prune(current_time)
+            return len(self._calls) < self.max_calls
 
-    def record_call(self, *, now: float | None = None) -> None:
+    def try_record_call(self, *, now: float | None = None) -> bool:
+        """Atomically reserve one provider call if the budget allows it."""
         if self.max_calls <= 0:
-            return
+            return True
         current_time = time.monotonic() if now is None else now
-        self._prune(current_time)
+        with self._lock:
+            if current_time < self._backoff_until:
+                return False
+            self._prune(current_time)
+            if len(self._calls) >= self.max_calls:
+                return False
+            self._record_call_locked(current_time)
+            return True
+
+    def _record_call_locked(self, current_time: float) -> None:
         self._calls.append(current_time)
         if len(self._calls) >= self.max_calls and self._backoff_until <= current_time:
             self._backoff_until = current_time + max(0.0, self.backoff_seconds)
@@ -157,9 +182,18 @@ class SummarySpendGuard:
                 self.backoff_seconds,
             )
 
+    def record_call(self, *, now: float | None = None) -> None:
+        if self.max_calls <= 0:
+            return
+        current_time = time.monotonic() if now is None else now
+        with self._lock:
+            self._prune(current_time)
+            self._record_call_locked(current_time)
+
     def clear(self) -> None:
-        self._calls.clear()
-        self._backoff_until = 0.0
+        with self._lock:
+            self._calls.clear()
+            self._backoff_until = 0.0
 
 
 def _strip_reasoning_blocks(text: str) -> str:
@@ -350,14 +384,12 @@ def _invoke_summary_llm_chain(
             continue
         # Check the spend guard per-route so a mid-chain trip stops the
         # remaining fallbacks instead of over-spending by up to len(chain)-1.
-        if spend_guard is not None and not spend_guard.allows():
+        if spend_guard is not None and not spend_guard.try_record_call():
             logger.warning(
                 "LCM summary spend guard active; skipping LLM summarization and "
                 "deferring to deterministic fallback"
             )
             break
-        if spend_guard is not None:
-            spend_guard.record_call()
         try:
             result = _invoke_summary_llm(
                 prompt,

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -463,6 +463,33 @@ class TestProviderPrefixedAuxiliaryCalls:
             disabled.record_call(now=0)
         assert disabled.allows(now=0) is True
 
+    def test_spend_guard_reservation_is_atomic_across_threads(self):
+        from hermes_lcm.escalation import SummarySpendGuard
+
+        guard = SummarySpendGuard(
+            max_calls=3,
+            window_seconds=100,
+            backoff_seconds=50,
+        )
+        barrier = threading.Barrier(12)
+        reservations: list[bool] = []
+        result_lock = threading.Lock()
+
+        def reserve():
+            barrier.wait()
+            accepted = guard.try_record_call(now=1000.0)
+            with result_lock:
+                reservations.append(accepted)
+
+        threads = [threading.Thread(target=reserve) for _ in range(12)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert sum(reservations) == 3
+
     def test_summarize_falls_to_l3_when_spend_guard_backs_off(self, monkeypatch):
         from hermes_lcm import escalation
         from hermes_lcm.escalation import SummarySpendGuard

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+import time
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
@@ -285,8 +286,8 @@ def test_empty_builds_have_zero_store_side_effects(rollup_parts):
 
 def test_publication_staleness_and_bounded_bind_maintenance(tmp_path, monkeypatch):
     # Raw ingest ALONE must not stale rollups (maintainer #388 P1): a period is
-    # staled only when a covering summary node is PUBLISHED. Then bind-time
-    # maintenance rebuilds up to rollup_builds_per_pass targets, leaving the rest
+    # staled only when a covering summary node is PUBLISHED. Then background
+    # bind maintenance rebuilds up to rollup_builds_per_pass targets, leaving the rest
     # durably stale for the next pass.
     db_path = tmp_path / "engine-rollups.db"
     config = LCMConfig(
@@ -301,6 +302,7 @@ def test_publication_staleness_and_bounded_bind_maintenance(tmp_path, monkeypatc
     month_start = today.replace(day=1)
     try:
         engine.on_session_start(scope, conversation_id="temporal-conversation")
+        assert engine.drain_rollup_maintenance(timeout=2)
         node_id = _add_node(engine._dag, scope, today, "today source node")
         store = RollupStore(db_path)
         try:
@@ -340,6 +342,7 @@ def test_publication_staleness_and_bounded_bind_maintenance(tmp_path, monkeypatc
                 lambda _text, **_kwargs: ("rebuilt rollup", 1),
             )
             engine._bind_lifecycle_state(scope, conversation_id="temporal-conversation")
+            assert engine.drain_rollup_maintenance(timeout=2)
 
             statuses = [
                 store.get_rollup(kind, start.isoformat(), scope)["status"]
@@ -426,6 +429,336 @@ def test_maintenance_budget_stops_before_starting_next_build(rollup_parts, monke
     assert statuses == ["ready", "stale"]
 
 
+def test_session_start_does_not_wait_for_slow_rollup_provider(tmp_path, monkeypatch):
+    db_path = tmp_path / "async-session-start.db"
+    config = LCMConfig(
+        database_path=str(db_path),
+        temporal_rollups_enabled=True,
+        rollup_builds_per_pass=1,
+    )
+    engine = LCMEngine(config=config)
+    scope = "slow-rollup-session"
+    target_day = date(2026, 7, 15)
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+
+    def slow_summarizer(_text, **_kwargs):
+        provider_started.set()
+        if not release_provider.wait(timeout=2):
+            raise AssertionError("test did not release slow rollup provider")
+        return "completed in background", 1
+
+    try:
+        _add_node(engine._dag, scope, target_day, "source for slow rollup")
+        store = RollupStore(db_path)
+        try:
+            store.mark_stale_for_day(target_day, scope)
+            monkeypatch.setattr(
+                builder_module,
+                "summarize_with_escalation",
+                slow_summarizer,
+            )
+
+            started_at = time.monotonic()
+            engine.on_session_start(scope, conversation_id="slow-rollup-conversation")
+            bind_elapsed = time.monotonic() - started_at
+
+            assert bind_elapsed < 0.15
+            assert provider_started.wait(timeout=1)
+            release_provider.set()
+            assert engine.drain_rollup_maintenance(timeout=2)
+            assert store.get_rollup("day", target_day.isoformat(), scope)["status"] == "ready"
+        finally:
+            store.close()
+    finally:
+        release_provider.set()
+        engine.shutdown()
+
+
+def test_rollup_background_maintenance_deduplicates_rapid_scope_binds(
+    tmp_path,
+    monkeypatch,
+):
+    config = LCMConfig(
+        database_path=str(tmp_path / "deduplicated-maintenance.db"),
+        temporal_rollups_enabled=True,
+    )
+    engine = LCMEngine(config=config)
+    scope = "deduplicated-scope"
+    first_pass_started = threading.Event()
+    release_first_pass = threading.Event()
+    call_threads: list[int] = []
+    active_calls = 0
+    maximum_active_calls = 0
+    calls_lock = threading.Lock()
+
+    def controlled_maintenance(dag, _config, called_scope, **_kwargs):
+        nonlocal active_calls, maximum_active_calls
+        assert dag is not engine._dag
+        assert dag.connection is not engine._dag.connection
+        assert called_scope == scope
+        with calls_lock:
+            call_threads.append(threading.get_ident())
+            active_calls += 1
+            maximum_active_calls = max(maximum_active_calls, active_calls)
+            call_number = len(call_threads)
+        try:
+            if call_number == 1:
+                first_pass_started.set()
+                if not release_first_pass.wait(timeout=2):
+                    raise AssertionError("test did not release first maintenance pass")
+            return 0
+        finally:
+            with calls_lock:
+                active_calls -= 1
+
+    monkeypatch.setattr(
+        engine_module,
+        "run_rollup_maintenance",
+        controlled_maintenance,
+    )
+    try:
+        engine.on_session_start(scope, conversation_id="deduplicated-conversation")
+        assert first_pass_started.wait(timeout=1)
+
+        for _ in range(20):
+            engine._bind_lifecycle_state(
+                scope,
+                conversation_id="deduplicated-conversation",
+            )
+
+        release_first_pass.set()
+        assert engine.drain_rollup_maintenance(timeout=2)
+        assert len(call_threads) == 2
+        assert len(set(call_threads)) == 1
+        assert maximum_active_calls == 1
+    finally:
+        release_first_pass.set()
+        engine.shutdown()
+
+
+def test_rollup_background_scheduler_bounds_distinct_pending_scopes():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=2)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    completed: list[str] = []
+
+    def blocking_first():
+        first_started.set()
+        if not release_first.wait(timeout=2):
+            raise AssertionError("test did not release first scheduler job")
+        completed.append("active")
+
+    try:
+        assert scheduler.schedule(("db", "active"), blocking_first)
+        assert first_started.wait(timeout=1)
+        assert scheduler.schedule(
+            ("db", "queued-1"),
+            lambda: completed.append("queued-1"),
+        )
+        assert scheduler.schedule(
+            ("db", "queued-2"),
+            lambda: completed.append("queued-2"),
+        )
+        assert not scheduler.schedule(
+            ("db", "overflow"),
+            lambda: completed.append("overflow"),
+        )
+    finally:
+        release_first.set()
+
+    assert scheduler.drain(
+        {
+            ("db", "active"),
+            ("db", "queued-1"),
+            ("db", "queued-2"),
+        },
+        timeout=2,
+    )
+    assert completed == ["active", "queued-1", "queued-2"]
+
+    # Rejection is bounded deferral, not a poisoned key: a later session bind
+    # can offer the same durable stale scope again once capacity is available.
+    assert scheduler.schedule(
+        ("db", "overflow"),
+        lambda: completed.append("overflow"),
+    )
+    assert scheduler.drain({("db", "overflow")}, timeout=2)
+    assert completed == ["active", "queued-1", "queued-2", "overflow"]
+
+
+def test_rollup_scheduler_reserves_active_follow_up_when_queue_is_full():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=1)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    completed: list[str] = []
+
+    def blocking_first():
+        first_started.set()
+        if not release_first.wait(timeout=2):
+            raise AssertionError("test did not release first scheduler job")
+        completed.append("active-1")
+
+    try:
+        assert scheduler.schedule(("db", "active"), blocking_first)
+        assert first_started.wait(timeout=1)
+        assert scheduler.schedule(
+            ("db", "queued"),
+            lambda: completed.append("queued"),
+        )
+        assert scheduler.schedule(
+            ("db", "active"),
+            lambda: completed.append("active-2"),
+        )
+    finally:
+        release_first.set()
+
+    assert scheduler.drain(
+        {("db", "active"), ("db", "queued")},
+        timeout=2,
+    )
+    assert completed == ["active-1", "active-2", "queued"]
+
+
+def test_rollup_scheduler_follow_up_slot_is_single_and_queue_fair():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=1)
+    a1_started = threading.Event()
+    release_a1 = threading.Event()
+    a2_started = threading.Event()
+    release_a2 = threading.Event()
+    b1_started = threading.Event()
+    release_b1 = threading.Event()
+    completed: list[str] = []
+
+    def blocking(label, started, release):
+        def run():
+            started.set()
+            if not release.wait(timeout=2):
+                raise AssertionError(f"test did not release {label}")
+            completed.append(label)
+
+        return run
+
+    try:
+        assert scheduler.schedule(
+            ("db", "a"),
+            blocking("a-1", a1_started, release_a1),
+        )
+        assert a1_started.wait(timeout=1)
+        assert scheduler.schedule(
+            ("db", "b"),
+            blocking("b-1", b1_started, release_b1),
+        )
+        assert scheduler.schedule(
+            ("db", "a"),
+            blocking("a-2", a2_started, release_a2),
+        )
+
+        release_a1.set()
+        assert a2_started.wait(timeout=1)
+        # The immediate follow-up is already consuming the one literal slot;
+        # another request is subject to the normal bounded queue instead of
+        # accumulating hidden follow-up state.
+        assert not scheduler.schedule(
+            ("db", "a"),
+            lambda: completed.append("a-3"),
+        )
+        assert scheduler._follow_up_key is None
+        assert scheduler._follow_up_job is None
+
+        release_a2.set()
+        assert b1_started.wait(timeout=1)
+        assert scheduler.schedule(
+            ("db", "c"),
+            lambda: completed.append("c"),
+        )
+        assert scheduler.schedule(
+            ("db", "b"),
+            lambda: completed.append("b-2"),
+        )
+    finally:
+        release_a1.set()
+        release_a2.set()
+        release_b1.set()
+
+    assert scheduler.drain(
+        {("db", "a"), ("db", "b"), ("db", "c")},
+        timeout=2,
+    )
+    assert completed == ["a-1", "a-2", "b-1", "b-2", "c"]
+    assert scheduler._follow_up_key is None
+    assert scheduler._follow_up_job is None
+
+
+def test_rollup_background_failure_is_logged_without_breaking_bind(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    config = LCMConfig(
+        database_path=str(tmp_path / "failed-background-maintenance.db"),
+        temporal_rollups_enabled=True,
+    )
+    engine = LCMEngine(config=config)
+
+    def fail_maintenance(*_args, **_kwargs):
+        raise RuntimeError("forced background maintenance failure")
+
+    monkeypatch.setattr(engine_module, "run_rollup_maintenance", fail_maintenance)
+    caplog.set_level("WARNING", logger="hermes_lcm.engine")
+    try:
+        engine.on_session_start(
+            "failed-maintenance-scope",
+            conversation_id="failed-maintenance-conversation",
+        )
+        assert engine.drain_rollup_maintenance(timeout=2)
+        assert engine.bound_session_id == "failed-maintenance-scope"
+        assert "background temporal rollup maintenance failed" in caplog.text
+        assert "forced background maintenance failure" in caplog.text
+    finally:
+        engine.shutdown()
+
+
+def test_engine_shutdown_does_not_wait_for_background_rollup_provider(
+    tmp_path,
+    monkeypatch,
+):
+    config = LCMConfig(
+        database_path=str(tmp_path / "shutdown-background-maintenance.db"),
+        temporal_rollups_enabled=True,
+    )
+    engine = LCMEngine(config=config)
+    maintenance_started = threading.Event()
+    release_maintenance = threading.Event()
+
+    def blocking_maintenance(*_args, **_kwargs):
+        maintenance_started.set()
+        if not release_maintenance.wait(timeout=2):
+            raise AssertionError("test did not release background maintenance")
+        return 0
+
+    monkeypatch.setattr(
+        engine_module,
+        "run_rollup_maintenance",
+        blocking_maintenance,
+    )
+    try:
+        engine.on_session_start(
+            "shutdown-maintenance-scope",
+            conversation_id="shutdown-maintenance-conversation",
+        )
+        assert maintenance_started.wait(timeout=1)
+
+        started_at = time.monotonic()
+        engine.shutdown()
+        shutdown_elapsed = time.monotonic() - started_at
+
+        assert shutdown_elapsed < 0.15
+    finally:
+        release_maintenance.set()
+        assert engine.drain_rollup_maintenance(timeout=2)
+
+
 def test_pending_maintenance_query_uses_partial_index(rollup_parts):
     store, _dag, _config = rollup_parts
     store.mark_stale_for_day("2026-07-15", "query-plan")
@@ -449,6 +782,7 @@ def test_session_reset_stales_rollups_referencing_deleted_nodes(tmp_path):
     scope = "reset-session"
     try:
         engine.on_session_start(scope, conversation_id="reset-conversation")
+        assert engine.drain_rollup_maintenance(timeout=2)
         node_id = _add_node(engine._dag, scope, date(2026, 7, 15), "deleted source")
         store = RollupStore(db_path)
         try:
@@ -527,6 +861,7 @@ def test_engine_invalidates_rollups_when_a_node_is_published(tmp_path):
     target_day = date(2026, 7, 15)
     try:
         engine.on_session_start(scope, conversation_id="publish-hook-conversation")
+        assert engine.drain_rollup_maintenance(timeout=2)
         node_id = _add_node(engine._dag, scope, target_day, "published node")
         store = RollupStore(db_path)
         try:
@@ -707,6 +1042,7 @@ def test_raw_ingest_does_not_prebuild_then_publication_drives_stale(tmp_path, mo
     day = datetime.now(timezone.utc).date()
     try:
         engine.on_session_start(scope, conversation_id="p1-conv")
+        assert engine.drain_rollup_maintenance(timeout=2)
         store = RollupStore(db_path)
         try:
             engine.ingest([{"role": "user", "content": "raw only, no summary yet"}])
@@ -723,6 +1059,7 @@ def test_raw_ingest_does_not_prebuild_then_publication_drives_stale(tmp_path, mo
             assert store.get_rollup("day", day.isoformat(), scope)["status"] == "stale"
 
             engine._bind_lifecycle_state(scope, conversation_id="p1-conv")
+            assert engine.drain_rollup_maintenance(timeout=2)
             built = store.get_rollup("day", day.isoformat(), scope)
             assert built["status"] == "ready"
             assert node_id in built["source_node_ids"]
@@ -746,19 +1083,23 @@ def test_bypassed_session_skips_rollup_maintenance(tmp_path, monkeypatch):
     engine = LCMEngine(config=config)
     try:
         engine.on_session_start("bypass-session", conversation_id="bypass-conv")
+        assert engine.drain_rollup_maintenance(timeout=2)
         calls.clear()
 
         engine._session_stateless = True
         engine._bind_lifecycle_state("bypass-session", conversation_id="bypass-conv")
+        assert engine.drain_rollup_maintenance(timeout=2)
         assert calls == []
 
         engine._session_stateless = False
         engine._session_ignored = True
         engine._bind_lifecycle_state("bypass-session", conversation_id="bypass-conv")
+        assert engine.drain_rollup_maintenance(timeout=2)
         assert calls == []
 
         engine._session_ignored = False
         engine._bind_lifecycle_state("bypass-session", conversation_id="bypass-conv")
+        assert engine.drain_rollup_maintenance(timeout=2)
         assert calls == ["maintenance"]
     finally:
         engine.shutdown()

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -691,6 +691,25 @@ def test_rollup_scheduler_follow_up_slot_is_single_and_queue_fair():
     assert scheduler._follow_up_job is None
 
 
+def test_rollup_scheduler_releases_completed_owner_keys():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=2)
+    owner = object()
+    completed: list[int] = []
+
+    for index in range(128):
+        key = ("db", f"ephemeral-{index}")
+        assert scheduler.schedule(
+            key,
+            lambda index=index: completed.append(index),
+            owner=owner,
+        )
+        assert scheduler.drain_owner(owner, timeout=2)
+        assert owner not in scheduler._owned_keys
+        assert key not in scheduler._key_owners
+
+    assert completed == list(range(128))
+
+
 def test_rollup_scheduler_runs_same_key_after_cancelled_job():
     scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=1)
     key = ("db", "cancelled")

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -1091,6 +1091,7 @@ def test_raw_ingest_does_not_prebuild_then_publication_drives_stale(tmp_path, mo
         try:
             engine.ingest([{"role": "user", "content": "raw only, no summary yet"}])
             engine._bind_lifecycle_state(scope, conversation_id="p1-conv")
+            assert engine.drain_rollup_maintenance(timeout=2)
             assert store.get_rollup("day", day.isoformat(), scope) is None
 
             node_id = _add_node(engine._dag, scope, day, "published leaf summary")

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import threading
@@ -688,6 +689,25 @@ def test_rollup_scheduler_follow_up_slot_is_single_and_queue_fair():
     assert completed == ["a-1", "a-2", "b-1", "b-2", "c"]
     assert scheduler._follow_up_key is None
     assert scheduler._follow_up_job is None
+
+
+def test_rollup_scheduler_runs_same_key_after_cancelled_job():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=1)
+    key = ("db", "cancelled")
+    first_started = threading.Event()
+    second_ran = threading.Event()
+
+    def cancelled_job():
+        first_started.set()
+        raise asyncio.CancelledError("forced maintenance cancellation")
+
+    assert scheduler.schedule(key, cancelled_job)
+    assert first_started.wait(timeout=1)
+    assert scheduler.drain({key}, timeout=1)
+
+    assert scheduler.schedule(key, second_ran.set)
+    assert scheduler.drain({key}, timeout=2)
+    assert second_ran.is_set()
 
 
 def test_rollup_scheduler_operator_exclusion_is_bounded_and_defers_maintenance():

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -690,6 +690,30 @@ def test_rollup_scheduler_follow_up_slot_is_single_and_queue_fair():
     assert scheduler._follow_up_job is None
 
 
+def test_rollup_scheduler_operator_exclusion_is_bounded_and_defers_maintenance():
+    scheduler = engine_module._RollupMaintenanceScheduler(max_pending_jobs=1)
+    operator_key = ("db", "operator")
+    completed: list[str] = []
+
+    assert scheduler.try_acquire_exclusive(operator_key)
+    assert not scheduler.try_acquire_exclusive(operator_key)
+    assert not scheduler.try_acquire_exclusive(("db", "second-operator"))
+    assert not scheduler.schedule(
+        operator_key,
+        lambda: completed.append("raced"),
+    )
+    assert not scheduler.drain({operator_key}, timeout=0)
+
+    scheduler.release_exclusive(operator_key)
+    assert scheduler.drain({operator_key}, timeout=0)
+    assert scheduler.schedule(
+        operator_key,
+        lambda: completed.append("after-release"),
+    )
+    assert scheduler.drain({operator_key}, timeout=2)
+    assert completed == ["after-release"]
+
+
 def test_rollup_background_failure_is_logged_without_breaking_bind(
     tmp_path,
     monkeypatch,

--- a/tests/test_rollup_introspection.py
+++ b/tests/test_rollup_introspection.py
@@ -230,6 +230,27 @@ def test_rollups_rebuild_releases_operator_lease_when_store_open_fails(
     engine_module._ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
 
 
+def test_rollups_rebuild_releases_operator_lease_when_store_close_fails(
+    engine,
+    monkeypatch,
+):
+    scope = engine.current_session_id
+    key = engine._rollup_maintenance_key(scope)
+
+    class CloseFailRollupStore(RollupStore):
+        def close(self):
+            super().close()
+            raise RuntimeError("forced store-close failure")
+
+    monkeypatch.setattr(command_module, "RollupStore", CloseFailRollupStore)
+
+    with pytest.raises(RuntimeError, match="forced store-close failure"):
+        handle_lcm_command("rollups rebuild day 2026-07-15", engine)
+
+    assert engine_module._ROLLUP_MAINTENANCE_SCHEDULER.try_acquire_exclusive(key)
+    engine_module._ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
+
+
 def test_rollups_rebuild_all_durably_seeds_unattempted_targets(engine, monkeypatch):
     # Regression for maintainer #391: targets beyond the per-pass budget must be
     # durably seeded as 'stale' rows (not absent) so later maintenance builds

--- a/tests/test_rollup_introspection.py
+++ b/tests/test_rollup_introspection.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+import hermes_lcm.command as command_module
 import hermes_lcm.engine as engine_module
 import hermes_lcm.rollup_builder as builder_module
 from hermes_lcm import tools as lcm_tools
@@ -172,7 +173,10 @@ def test_rollups_rebuild_marks_all_targets_stale_and_builds_bounded(engine, monk
         store.close()
 
 
-def test_rollups_rebuild_refuses_while_background_maintenance_is_active(engine):
+def test_rollups_rebuild_refuses_while_background_maintenance_is_active(
+    engine,
+    monkeypatch,
+):
     scope = engine.current_session_id
     key = engine._rollup_maintenance_key(scope)
     started = threading.Event()
@@ -189,6 +193,13 @@ def test_rollups_rebuild_refuses_while_background_maintenance_is_active(engine):
     )
     assert started.wait(timeout=2)
     try:
+        monkeypatch.setattr(
+            command_module,
+            "RollupStore",
+            lambda *_args, **_kwargs: pytest.fail(
+                "busy operator rebuild touched SQLite before acquiring its lease"
+            ),
+        )
         result = handle_lcm_command("rollups rebuild day 2026-07-15", engine)
 
         assert "status: busy" in result
@@ -197,6 +208,26 @@ def test_rollups_rebuild_refuses_while_background_maintenance_is_active(engine):
     finally:
         release.set()
         assert engine_module._ROLLUP_MAINTENANCE_SCHEDULER.drain({key}, timeout=5)
+
+
+def test_rollups_rebuild_releases_operator_lease_when_store_open_fails(
+    engine,
+    monkeypatch,
+):
+    scope = engine.current_session_id
+    key = engine._rollup_maintenance_key(scope)
+
+    def fail_store_open(*_args, **_kwargs):
+        raise RuntimeError("forced store-open failure")
+
+    monkeypatch.setattr(command_module, "RollupStore", fail_store_open)
+
+    result = handle_lcm_command("rollups rebuild day 2026-07-15", engine)
+
+    assert "status: error" in result
+    assert "forced store-open failure" in result
+    assert engine_module._ROLLUP_MAINTENANCE_SCHEDULER.try_acquire_exclusive(key)
+    engine_module._ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
 
 
 def test_rollups_rebuild_all_durably_seeds_unattempted_targets(engine, monkeypatch):

--- a/tests/test_rollup_introspection.py
+++ b/tests/test_rollup_introspection.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from datetime import datetime, timezone
 
 import pytest
 
+import hermes_lcm.engine as engine_module
 import hermes_lcm.rollup_builder as builder_module
 from hermes_lcm import tools as lcm_tools
 from hermes_lcm.command import handle_lcm_command
@@ -25,6 +27,7 @@ def engine(tmp_path):
     )
     instance = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
     instance.on_session_start("rollup-session", conversation_id="rollup-conversation")
+    assert instance.drain_rollup_maintenance(timeout=5.0)
     try:
         yield instance
     finally:
@@ -167,6 +170,33 @@ def test_rollups_rebuild_marks_all_targets_stale_and_builds_bounded(engine, monk
         assert "- month 2026-07-01: stale (bounded; not attempted)" in result
     finally:
         store.close()
+
+
+def test_rollups_rebuild_refuses_while_background_maintenance_is_active(engine):
+    scope = engine.current_session_id
+    key = engine._rollup_maintenance_key(scope)
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_maintenance():
+        started.set()
+        if not release.wait(timeout=5):
+            raise AssertionError("test did not release background maintenance")
+
+    assert engine_module._ROLLUP_MAINTENANCE_SCHEDULER.schedule(
+        key,
+        blocking_maintenance,
+    )
+    assert started.wait(timeout=2)
+    try:
+        result = handle_lcm_command("rollups rebuild day 2026-07-15", engine)
+
+        assert "status: busy" in result
+        assert "background temporal rollup maintenance is active" in result
+        assert "retry" in result.lower()
+    finally:
+        release.set()
+        assert engine_module._ROLLUP_MAINTENANCE_SCHEDULER.drain({key}, timeout=5)
 
 
 def test_rollups_rebuild_all_durably_seeds_unattempted_targets(engine, monkeypatch):


### PR DESCRIPTION
## Summary
- Move temporal rollup maintenance out of the synchronous session-start path.
- Run maintenance through one bounded, process-wide worker with per-database/scope deduplication and one literal active-key follow-up slot.
- Give worker jobs independent SQLite-backed helpers instead of using an engine's live connections across threads.
- Track only scheduler keys that are still outstanding for each engine, releasing completed historical session keys without weakening deterministic drains.
- Serialize synchronous operator rebuilds against same-key background maintenance with a bounded, fail-closed process-wide lease.
- Make the shared summary circuit breaker and spend guard thread-safe, including atomic provider-call budget reservation.

## Why
A session bind currently calls temporal rollup maintenance inline. Day/week/month rollups can invoke the configured summary provider, so a slow provider call can hold the host gateway event loop for tens of seconds and delay unrelated platform work.

The configured model is not the problem: provider-backed maintenance simply should not run synchronously inside a lifecycle hook. This keeps the existing fidelity/model choice while making session startup prompt and bounded.

This is the plugin-side root-cause companion to [NousResearch/hermes-agent#71376](https://github.com/NousResearch/hermes-agent/pull/71376), which adds a generic host-side resilience boundary around context-engine startup.

## Validation
- [x] Behavioral RED on `49e99a2`: a blocked rollup provider held session start for about 2 seconds; the new contract requires startup to return in under 150 ms.
- [x] CI-found operator/background race reproduced: same-key manual rebuild could contend on SQLite, mark one target failed, and leave another building.
- [x] Maintainer cleanup regressions demonstrated RED before the repair: `CancelledError` stranded the active key and a forced store-close failure stranded the operator lease.
- [x] Exact-head affected rollup tests: `72 passed`.
- [x] Historical-key retention regression: 128 sequential ephemeral scheduler keys complete, drain, and leave no owner/key associations behind.
- [x] Prior-head CI exposed a missing async-test drain on Python 3.14 (`1 failed, 2309 passed, 12 xfailed`); the synchronized current test preserves the raw-ingest/stale/ready assertions.
- [x] Exact-head Python 3.11 and 3.14 full CI shapes, each with isolated `HOME`/`HERMES_HOME` and `ulimit -n 1024`: `2311 passed, 12 xfailed`.
- [x] `ruff check .`, `python -m compileall -q .`, script/shell static checks, and `git diff --check`.
- [x] Final bounded independent repair/delta rereviews: `CLEAN`.
- [x] Workflow validation: N/A, no workflow files changed.

## Risk / impact
- Session start now schedules eventual rollup maintenance instead of completing it inline.
- The global queue is bounded to 64 pending keys. If full, maintenance is deferred until a later bind rather than blocking the caller or growing memory without bound.
- The current active key may reserve one immediate follow-up pass; requests arriving during that pass use the ordinary bounded FIFO queue.
- A same-key manual `rollups rebuild` returns `status: busy` before opening SQLite when background maintenance is queued, active, or awaiting its immediate follow-up; the operator can retry after that pass.
- Operator leases are process-wide, bounded, included in drain bookkeeping, and released even when opening or closing the rebuild store fails.
- `:memory:` SQLite databases skip background rollups because a worker-owned connection would address a different database.
- Engine shutdown does not wait for a slow provider call; detached jobs own private resources and close them in the worker.
- Per-engine drain ownership exists only while a key is queued, active, exclusive, or follow-up-reserved; idle historical keys are removed under the scheduler lock.

## Scope boundaries
- No model, prompt, rollup policy, schema, migration, or user-facing config change.
- No change to context compression itself.
- No host/gateway special casing; that resilience layer lives in the companion Hermes Agent PR.

## Rollout / operator notes
No migration or config change is required. Existing temporal-rollup settings and model selection continue to apply.

## Reviewer focus
- Scheduler deduplication, queue bounds, FIFO fairness, single follow-up semantics, and bounded owner/key bookkeeping.
- Atomic operator/background exclusion, busy-before-SQLite behavior, and lease cleanup on exceptions.
- Worker resource ownership across shutdown/rebind.
- Shared circuit-breaker/spend-guard concurrency.
- Eventual progress versus bounded overload behavior.

## Notes
- Companion host-side PR: [NousResearch/hermes-agent#71376](https://github.com/NousResearch/hermes-agent/pull/71376)
- No merge-order dependency is intended; each PR improves its own ownership boundary independently.
