### PR TITLE
fix: lcm_grep crashes on a null/absent query argument

### DIFF
--- a/tests/test_search_tool_arg_coercion.py
+++ b/tests/test_search_tool_arg_coercion.py
@@ -1,0 +1,86 @@
+"""Hostile-argument coercion guards for the search-tool ``query`` argument.
+
+A model is free to emit ``{"query": null}`` (or a number) for any ``lcm_*``
+search tool. Every such tool must answer with the documented
+``{"error": "No query provided"}`` payload rather than letting an
+``AttributeError``/``TypeError`` escape the tool boundary, and must not treat a
+non-string sentinel as a literal search term.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_lcm.tools as lcm_tools
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryDAG
+from hermes_lcm.store import MessageStore
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "coercion.db"))
+    store = MessageStore(config.database_path, ingest_protection_config=config)
+    dag = SummaryDAG(config.database_path)
+    engine = SimpleNamespace(
+        _config=config,
+        _store=store,
+        _dag=dag,
+        current_session_id="session-a",
+    )
+    try:
+        yield engine
+    finally:
+        dag.close()
+        store.close()
+
+
+@pytest.mark.parametrize("mode", ["full_text", "semantic", "hybrid"])
+def test_lcm_grep_null_query_returns_error_payload(engine, mode):
+    payload = json.loads(lcm_tools.lcm_grep({"query": None, "mode": mode}, engine=engine))
+
+    assert payload["error"] == "No query provided"
+
+
+@pytest.mark.parametrize("mode", ["full_text", "semantic", "hybrid"])
+def test_lcm_grep_missing_query_returns_error_payload(engine, mode):
+    payload = json.loads(lcm_tools.lcm_grep({"mode": mode}, engine=engine))
+
+    assert payload["error"] == "No query provided"
+
+
+@pytest.mark.parametrize("mode", ["full_text", "semantic", "hybrid"])
+def test_lcm_grep_whitespace_query_returns_error_payload(engine, mode):
+    payload = json.loads(lcm_tools.lcm_grep({"query": "   ", "mode": mode}, engine=engine))
+
+    assert payload["error"] == "No query provided"
+
+
+def test_lcm_recall_null_query_returns_error_payload(engine):
+    payload = json.loads(lcm_tools.lcm_recall({"query": None}, engine=engine))
+
+    assert payload["error"] == "No query provided"
+
+
+def test_lcm_recall_null_query_does_not_search_for_the_string_none(engine):
+    """``str(None)`` is ``"None"`` — a truthy literal that must never be searched."""
+    payload = json.loads(lcm_tools.lcm_recall({"query": None}, engine=engine))
+
+    assert payload.get("query") != "None"
+
+
+def test_lcm_expand_query_null_prompt_returns_error_payload(engine):
+    payload = json.loads(lcm_tools.lcm_expand_query({"prompt": None}, engine=engine))
+
+    assert payload["error"] == "prompt is required"
+
+
+def test_lcm_grep_non_string_query_is_coerced_not_raised(engine):
+    """A numeric query is a legitimate search term once coerced, not a crash."""
+    payload = json.loads(lcm_tools.lcm_grep({"query": 42}, engine=engine))
+
+    assert "error" not in payload or payload["error"] != "No query provided"
+    assert payload.get("query") == "42"

--- a/tools.py
+++ b/tools.py
@@ -2367,7 +2367,10 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
-    query = args.get("query", "").strip()
+    # Coerce defensively: a model can emit `{"query": null}` (or a number), and
+    # `.strip()` on a non-string escapes the tool as an unhandled AttributeError
+    # instead of the "No query provided" error the sibling tools return.
+    query = str(args.get("query") or "").strip()
     if not query:
         return json.dumps({"error": "No query provided"})
 
@@ -3056,7 +3059,7 @@ def _lcm_grep_semantic(
     mode = str(args.get("mode") or "semantic").lower()
     if time.monotonic() >= deadline:
         return _lcm_grep_deadline_error(mode, "semantic_entry")
-    query = str(args.get("query", "")).strip()
+    query = str(args.get("query") or "").strip()
     if not query:
         return {"error": "No query provided"}
 
@@ -4587,7 +4590,7 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
-    query = str(args.get("query", "")).strip()
+    query = str(args.get("query") or "").strip()
     if not query:
         return json.dumps({"error": "No query provided"})
 


### PR DESCRIPTION
## Summary
- Coerce the `query` argument null-safely in `lcm_grep` (full-text + semantic) and `lcm_recall` so a non-string query returns the documented `{"error": "No query provided"}` payload instead of escaping the tool as an `AttributeError`.
- Adds `tests/test_search_tool_arg_coercion.py` covering all three search tools across `full_text` / `semantic` / `hybrid`.

## Why

**Symptom.** With LCM enabled, a model that calls `lcm_grep` with a null query crashes the tool call:

```
AttributeError: 'NoneType' object has no attribute 'strip'
```

Nothing in the payload tells the model what went wrong, so the turn either aborts or the model retries the same malformed call. This is reachable in normal operation — the `query` field is a free-form model-authored string, and models routinely emit `null` when they are unsure what to search for (particularly right after a compaction, when `lcm_grep` is the recovery path being advertised in the LCM system note).

**Root cause.** `_lcm_grep_full_text` was the one search entry point still calling `.strip()` on the raw argument:

```python
query = args.get("query", "").strip()      # tools.py — full-text path
```

`args.get("query", "")` only supplies the default when the key is *absent*; an explicit `None` (or a number) is returned as-is and `.strip()` raises. `lcm_expand_query` already guards this correctly with `str(args.get("query") or "")`.

The sibling paths had a quieter variant of the same bug:

```python
query = str(args.get("query", "")).strip()  # _lcm_grep_semantic, lcm_recall
```

That does not raise, but `str(None)` is `"None"` — a truthy 4-character string — so the tool silently runs a real search for the literal term `None` and returns a confidently empty (or spuriously matching) result set instead of an error.

Because `mode=semantic` / `mode=hybrid` fall back to the full-text helper, they surfaced the crash as a degraded payload rather than a clean argument error:

```json
{"error": "full-text fallback failed: 'NoneType' object has no attribute 'strip'", "mode": "hybrid"}
```

**Fix.** Use the `str(args.get("query") or "")` form that `lcm_expand_query` already uses, at all three sites. `None`, `""`, and whitespace all fall through to the existing "No query provided" branch; a numeric query is coerced to its string form and searched normally rather than crashing.

## Validation

- [x] Focused validation: `pytest tests/test_search_tool_arg_coercion.py -q` -> `13 passed`
- [x] Regression-proof (fix reverted, tests kept): `6 failed, 7 passed` — the 7 that still pass are the intended controls (missing-key and whitespace cases, which were never broken)
- [x] Neighbour suites: `pytest tests/test_lcm_recall.py tests/test_embedding_search_modes.py tests/test_tool_contracts.py tests/test_search_tool_arg_coercion.py -q` -> `84 passed`
- [x] `ruff check tools.py tests/test_search_tool_arg_coercion.py` -> `All checks passed!`
- [ ] `pytest -q` — not run in full locally; the change is confined to three argument-coercion lines and the suites that exercise those tools are green.

## Notes
- No behaviour change for well-formed queries: for any `str` input, `str(x or "")` is `x` unless `x` is `""`, which already short-circuits to the same error branch.
- `lcm_expand_query`'s `prompt` argument was already null-safe; a test is included to pin that.
