### PR TITLE
fix: guard expand-query LLM response access; degrade instead of raising

### DIFF
--- a/tests/test_expand_query_degradation.py
+++ b/tests/test_expand_query_degradation.py
@@ -1,0 +1,160 @@
+"""``lcm_expand_query`` degradation guards for unusable aux-LLM responses.
+
+The expansion synthesis call is made through ``agent.auxiliary_client.call_llm``,
+which can hand back an error-shaped or partial object under load. Reading
+``response.choices[0].message.content`` unguarded turns that into an opaque
+``TypeError``/``AttributeError`` that kills the whole tool call; the tool should
+instead degrade to the same payload it already returns on a synthesis timeout,
+so the caller keeps its node and raw matches.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import hermes_lcm.tools as lcm_tools
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryDAG, SummaryNode
+from hermes_lcm.store import MessageStore
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "expand.db"))
+    store = MessageStore(config.database_path, ingest_protection_config=config)
+    dag = SummaryDAG(config.database_path)
+    engine = SimpleNamespace(
+        _config=config,
+        _store=store,
+        _dag=dag,
+        current_session_id="session-a",
+    )
+    store.append_batch(
+        "session-a", [{"role": "user", "content": "the widget recovery code is ZX-9"}]
+    )
+    dag.add_node(
+        SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="discussed the widget recovery code",
+            token_count=8,
+            source_token_count=16,
+            source_ids=[1],
+            source_type="messages",
+            created_at=1.0,
+            earliest_at=1.0,
+            latest_at=1.0,
+            expand_hint="widget recovery code",
+        )
+    )
+    try:
+        yield engine
+    finally:
+        dag.close()
+        store.close()
+
+
+def _stub_call_llm(monkeypatch, response):
+    """Point ``agent.auxiliary_client.call_llm`` at a canned response object."""
+    agent_module = sys.modules.get("agent")
+    if agent_module is None:
+        agent_module = ModuleType("agent")
+        agent_module.__path__ = []
+        monkeypatch.setitem(sys.modules, "agent", agent_module)
+
+    auxiliary = ModuleType("agent.auxiliary_client")
+    auxiliary.call_llm = lambda **kwargs: response
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", auxiliary)
+    monkeypatch.setattr(agent_module, "auxiliary_client", auxiliary, raising=False)
+
+
+class _NonSubscriptableChoices:
+    """Error-shaped response: ``choices`` is present but cannot be indexed.
+
+    Mirrors an error envelope where the provider populated ``choices`` with a
+    scalar/sentinel rather than a list of completions.
+    """
+
+    choices = object()
+
+
+def _expand(engine):
+    return json.loads(
+        lcm_tools.lcm_expand_query(
+            {"prompt": "what is the widget code?", "query": "widget"}, engine=engine
+        )
+    )
+
+
+def test_none_choices_degrades_instead_of_raising(engine, monkeypatch):
+    _stub_call_llm(monkeypatch, SimpleNamespace(choices=None))
+
+    payload = _expand(engine)
+
+    assert payload["degraded"] is True
+    assert "synthesis unavailable" in payload["error"]
+
+
+def test_missing_choices_attribute_degrades(engine, monkeypatch):
+    _stub_call_llm(monkeypatch, SimpleNamespace())
+
+    payload = _expand(engine)
+
+    assert payload["degraded"] is True
+    assert "synthesis unavailable" in payload["error"]
+
+
+def test_empty_choices_list_degrades(engine, monkeypatch):
+    _stub_call_llm(monkeypatch, SimpleNamespace(choices=[]))
+
+    payload = _expand(engine)
+
+    assert payload["degraded"] is True
+    assert "synthesis unavailable" in payload["error"]
+
+
+def test_non_subscriptable_choices_degrades(engine, monkeypatch):
+    _stub_call_llm(monkeypatch, _NonSubscriptableChoices())
+
+    payload = _expand(engine)
+
+    assert payload["degraded"] is True
+    assert "synthesis unavailable" in payload["error"]
+
+
+def test_choice_without_message_degrades(engine, monkeypatch):
+    _stub_call_llm(monkeypatch, SimpleNamespace(choices=[SimpleNamespace()]))
+
+    payload = _expand(engine)
+
+    assert payload["degraded"] is True
+
+
+def test_degraded_payload_still_carries_matches(engine, monkeypatch):
+    """Degrading must not throw away the retrieval work already done."""
+    _stub_call_llm(monkeypatch, SimpleNamespace(choices=None))
+
+    payload = _expand(engine)
+
+    assert "matches" in payload
+    assert "raw_matches" in payload
+    assert "node_ids" in payload
+
+
+def test_well_formed_response_still_answers(engine, monkeypatch):
+    """Control: the guard must not perturb the happy path."""
+    _stub_call_llm(
+        monkeypatch,
+        SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="The code is ZX-9."))]
+        ),
+    )
+
+    payload = _expand(engine)
+
+    assert payload.get("degraded") is not True
+    assert payload["answer"] == "The code is ZX-9."

--- a/tools.py
+++ b/tools.py
@@ -1678,6 +1678,17 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
     return total
 
 
+class _ExpansionSynthesisError(RuntimeError):
+    """Raised when the expansion aux-LLM call returns an unusable response.
+
+    ``call_llm`` can hand back an error-shaped or partial object whose
+    ``choices`` is missing, ``None``, or otherwise non-subscriptable. Surfacing
+    that as a typed error lets ``lcm_expand_query`` degrade the same way it
+    already degrades on a synthesis timeout, instead of leaking an opaque
+    ``TypeError``/``AttributeError`` out of the tool call.
+    """
+
+
 def _synthesize_expansion_answer(
     *,
     prompt: str,
@@ -1709,7 +1720,26 @@ def _synthesize_expansion_answer(
     }
     apply_lcm_model_route(call_kwargs, model)
     response = call_llm(**call_kwargs)
-    content = response.choices[0].message.content
+    # ``call_llm`` can return an error-shaped or partial object (e.g. when the
+    # auxiliary lane collides with the foreground model's own in-flight calls),
+    # in which case ``choices`` may be absent, ``None``, empty, or a
+    # non-subscriptable sentinel. Guard the access so an unusable response
+    # degrades cleanly at the call site instead of raising an opaque
+    # ``TypeError``/``AttributeError`` that kills the whole expand call.
+    choices = getattr(response, "choices", None)
+    first = None
+    if choices is not None:
+        try:
+            first = choices[0]
+        except (TypeError, IndexError, KeyError):
+            first = None
+    if first is None:
+        raise _ExpansionSynthesisError(
+            "expansion synthesis returned no usable choices "
+            f"(response type={type(response).__name__})"
+        )
+    message = getattr(first, "message", None)
+    content = getattr(message, "content", None)
     if not isinstance(content, str):
         content = str(content) if content else ""
     from .escalation import _strip_reasoning_blocks
@@ -5736,6 +5766,12 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             f"lcm_expand_query synthesis timed out after {timeout:.3g}s",
             include_timeout=True,
         )
+    except _ExpansionSynthesisError as exc:
+        # Unusable aux-LLM response. Degrade the same way a timeout does: the
+        # caller still receives the node/raw matches it asked for, only the
+        # synthesized prose answer is unavailable.
+        logger.warning("LCM expand_query synthesis failed: %s", exc)
+        return _degraded_payload(f"lcm_expand_query synthesis unavailable: {exc}")
 
     answer = str(answer).strip() if answer is not None else ""
     if not answer:


### PR DESCRIPTION
## Summary
- Guard the aux-LLM response read in `_synthesize_expansion_answer` so an unusable response degrades `lcm_expand_query` the same way a synthesis timeout already does, instead of leaking a `TypeError`/`AttributeError` out of the tool call.
- Adds `tests/test_expand_query_degradation.py` covering the malformed-response shapes plus a happy-path control.

## Why

**Symptom.** `lcm_expand_query` intermittently dies mid-call with an error that has nothing to do with the query:

```
TypeError: 'NoneType' object is not subscriptable
```

It is intermittent and load-correlated — it shows up when the auxiliary lane is contended (several expansions in flight, or the aux provider rate-limiting), and never reproduces on a quiet system. The retrieval half of the tool has already finished successfully at that point, so the caller loses a complete set of node and raw matches to a failure in the optional prose-synthesis step.

**Root cause.** The synthesis path reads the completion unguarded:

```python
response = call_llm(**call_kwargs)
content = response.choices[0].message.content   # tools.py
```

`call_llm` does not guarantee a well-formed completion. When the auxiliary provider returns an error-shaped or partial envelope, `choices` can be `None`, absent, an empty list, or a non-list sentinel, and each shape raises a different opaque exception from that one line:

| response shape | raised |
|---|---|
| `choices=None` | `TypeError: 'NoneType' object is not subscriptable` |
| `choices` attribute missing | `AttributeError` |
| `choices=[]` | `IndexError` |
| `choices=<non-list sentinel>` | `TypeError` |
| choice present, no `.message` | `AttributeError` |

`lcm_expand_query` wraps the synthesis call, but its `except` clause only catches `TimeoutError`, so all of the above propagate out of `handle_tool_call` uncaught.

**Fix.** Read `choices` / `[0]` / `.message` / `.content` defensively and raise a typed `_ExpansionSynthesisError` when the response yields no usable choice. `lcm_expand_query` catches that alongside the existing timeout branch and returns the same `_degraded_payload(...)`.

This deliberately reuses the existing degradation path rather than adding a new one: the tool already has a well-defined answer for "retrieval succeeded, synthesis didn't," and an unusable response is the same situation as a timed-out one from the caller's perspective. The caller keeps `matches`, `raw_matches`, and `node_ids`; only the synthesized prose is missing, and `degraded: true` says so explicitly.

## Validation

- [x] RED-proof — fix reverted, tests kept: `6 failed, 1 passed`. The one pass is the happy-path control, which must pass in both states.
- [x] GREEN: `pytest tests/test_expand_query_degradation.py -q` -> `7 passed`
- [x] Neighbour suites: `pytest tests/ -q -k "expand or tool_contract or recall"` -> `139 passed, 2177 deselected`
- [x] `ruff check tools.py tests/test_expand_query_degradation.py` -> `All checks passed!`

## Notes
- No behaviour change on well-formed responses — `test_well_formed_response_still_answers` pins that the guard is transparent on the happy path.
- The typed private exception keeps the guard from swallowing unrelated `TypeError`s raised deeper inside the call; only the "no usable choice" condition is converted into a degraded payload.
