### PR TITLE
fix: preserve caller-supplied timestamps on single-message ingest

### DIFF
--- a/store.py
+++ b/store.py
@@ -11,6 +11,7 @@ row identity (`store_id`) for DAG/source lookup.
 
 import json
 import logging
+import math
 import sqlite3
 import threading
 import time
@@ -49,6 +50,31 @@ from .message_content import normalize_content_value as _normalize_content_value
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_ingest_timestamp(value: Any) -> float:
+    """Resolve a message's stored timestamp at ingest.
+
+    A caller that is re-ingesting messages it has already seen — restoring a
+    durable transcript, importing a prior session, replaying after a restart —
+    knows each message's real arrival time and passes it as ``timestamp``.
+    Preserve it, so re-ingest does not collapse the whole history onto the
+    instant of the import.
+
+    A genuinely new live message carries no usable ``timestamp`` and falls back
+    to now. Anything unusable (absent, ``None``, non-numeric, non-positive,
+    NaN/inf) is treated as absent rather than raising or writing a 1970 epoch —
+    ingest must never fail on a malformed optional field.
+    """
+    if value is None:
+        return time.time()
+    try:
+        ts = float(value)
+    except (TypeError, ValueError):
+        return time.time()
+    if ts > 0 and math.isfinite(ts):
+        return ts
+    return time.time()
 
 
 _MESSAGE_ROLE_BIAS_SQL = "CASE m.role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 WHEN 'tool' THEN 2 ELSE 1 END"
@@ -336,7 +362,7 @@ class MessageStore:
                     msg.get("tool_call_id"),
                     tc_json,
                     msg.get("tool_name"),
-                    time.time(),
+                    _resolve_ingest_timestamp(msg.get("timestamp")),
                     token_estimate,
                     0,
                 ),
@@ -384,7 +410,7 @@ class MessageStore:
             for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
-                ts = time.time()
+                ts = _resolve_ingest_timestamp(msg.get("timestamp"))
                 cur = self._conn.execute(
                     """INSERT INTO messages
                        (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,

--- a/tests/test_ingest_timestamp_preservation.py
+++ b/tests/test_ingest_timestamp_preservation.py
@@ -1,0 +1,150 @@
+"""Ingest must preserve a caller-supplied per-message ``timestamp``.
+
+A caller re-ingesting messages it has already seen — restoring a durable
+transcript, importing a prior session, replaying after a restart — knows each
+message's real arrival time and passes it as ``timestamp``. Stamping ingest
+wall-clock time over it collapses the entire restored history onto the instant
+of the import, which breaks date-range queries and recency ordering.
+
+Live messages carry no ``timestamp`` and must keep getting a fresh per-row
+clock reading; ``test_lcm_core.py::test_append_batch_timestamps_are_unique_per_row``
+pins that invariant and must stay green.
+"""
+
+import time
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.store import MessageStore
+
+REPLAY_BASE = 1_700_000_000.0
+
+
+@pytest.fixture
+def store(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "ts.db"))
+    store = MessageStore(config.database_path, ingest_protection_config=config)
+    try:
+        yield store
+    finally:
+        store.close()
+
+
+def _replayed(n, base=REPLAY_BASE):
+    return [
+        {"role": "user", "content": f"replayed message {i}", "timestamp": base + i}
+        for i in range(n)
+    ]
+
+
+def test_append_batch_preserves_supplied_timestamps(store):
+    messages = _replayed(4)
+
+    ids = store.append_batch("replay", messages)
+
+    assert [store.get(i)["timestamp"] for i in ids] == [m["timestamp"] for m in messages]
+
+
+def test_append_preserves_supplied_timestamp(store):
+    store_id = store.append(
+        "replay", {"role": "user", "content": "one", "timestamp": REPLAY_BASE}
+    )
+
+    assert store.get(store_id)["timestamp"] == REPLAY_BASE
+
+
+def test_replayed_batch_is_not_collapsed_onto_import_time(store):
+    """The user-visible symptom: a restored history must not all land at 'now'."""
+    before = time.time()
+
+    ids = store.append_batch("replay", _replayed(5))
+
+    stamps = [store.get(i)["timestamp"] for i in ids]
+    assert all(ts < before for ts in stamps)
+    assert len(set(stamps)) == 5
+
+
+def test_supplied_timestamps_survive_time_bounds(store):
+    """``get_time_bounds`` is a real consumer of these values — journal/date
+    range features read the earliest/latest stamps of a set of rows."""
+    day = 86_400.0
+    ids = store.append_batch(
+        "replay",
+        [
+            {"role": "user", "content": "old", "timestamp": REPLAY_BASE},
+            {"role": "user", "content": "newer", "timestamp": REPLAY_BASE + day},
+        ],
+    )
+
+    earliest, latest = store.get_time_bounds(ids)
+
+    assert earliest == REPLAY_BASE
+    assert latest == REPLAY_BASE + day
+
+
+def test_live_messages_without_timestamp_still_get_now(store):
+    """Control: the live-ingest path is unchanged."""
+    before = time.time()
+
+    ids = store.append_batch(
+        "live", [{"role": "user", "content": f"m{i}"} for i in range(3)]
+    )
+
+    after = time.time()
+    for store_id in ids:
+        assert before <= store.get(store_id)["timestamp"] <= after
+
+
+def test_live_batch_timestamps_remain_unique(store):
+    """Control: preserves the existing per-row-clock invariant for live ingest."""
+    ids = store.append_batch(
+        "live", [{"role": "user", "content": f"m{i}"} for i in range(50)]
+    )
+
+    stamps = [store.get(i)["timestamp"] for i in ids]
+
+    assert len(set(stamps)) == len(stamps)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [None, "", "not-a-number", float("nan"), float("inf"), float("-inf"), 0, -1, [], {}],
+)
+def test_unusable_timestamp_falls_back_to_now_without_raising(store, bad):
+    """A malformed optional field must never fail ingest or write a 1970 epoch."""
+    before = time.time()
+
+    store_id = store.append("live", {"role": "user", "content": "x", "timestamp": bad})
+
+    after = time.time()
+    assert before <= store.get(store_id)["timestamp"] <= after
+
+
+def test_integer_and_string_timestamps_are_coerced(store):
+    """Transcript formats routinely carry epochs as ints or numeric strings."""
+    ids = store.append_batch(
+        "replay",
+        [
+            {"role": "user", "content": "int", "timestamp": int(REPLAY_BASE)},
+            {"role": "user", "content": "str", "timestamp": str(REPLAY_BASE)},
+        ],
+    )
+
+    assert [store.get(i)["timestamp"] for i in ids] == [REPLAY_BASE, REPLAY_BASE]
+
+
+def test_mixed_batch_preserves_supplied_and_stamps_the_rest(store):
+    before = time.time()
+
+    ids = store.append_batch(
+        "mixed",
+        [
+            {"role": "user", "content": "replayed", "timestamp": REPLAY_BASE},
+            {"role": "user", "content": "live"},
+        ],
+    )
+
+    replayed_ts, live_ts = (store.get(i)["timestamp"] for i in ids)
+    assert replayed_ts == REPLAY_BASE
+    assert live_ts >= before


### PR DESCRIPTION
## Summary
- Preserve a caller-supplied per-message `timestamp` at ingest instead of overwriting it with ingest wall-clock time, on both `append()` and `append_batch()`.
- Adds `tests/test_ingest_timestamp_preservation.py` (18 tests), including controls that pin the existing live-ingest behaviour.

## Why

**Symptom.** Any caller that re-ingests messages it has already seen — restoring a durable transcript, importing a prior session, replaying after a restart — has the entire restored history land at the instant of the import:

```python
>>> msgs = [{"role": "user", "content": f"m{i}", "timestamp": 1700000000.0 + i}
...         for i in range(4)]
>>> ids = store.append_batch("replay", msgs)
>>> [store.get(i)["timestamp"] for i in ids]
[1785002269.65, 1785002269.65, 1785002269.65, 1785002269.65]   # all "now"
```

Every restored message reads as having arrived seconds ago. Date-range and journal-style queries over restored history return nothing for the period the conversation actually happened, `get_time_bounds` reports the import moment rather than the conversation's real span, and recency ordering across a restore boundary is meaningless.

**Root cause.** Both write paths in `store.py` ignore the message's own `timestamp` and stamp the clock:

```python
# append()
msg.get("tool_name"),
time.time(),                 # <- supplied timestamp discarded
token_estimate,

# _append_protected_batch()
ts = time.time()             # <- same
```

The field is available at both sites: `protect_message_for_ingest` / `protect_messages_for_ingest` pass `timestamp` through unchanged, so `msg.get("timestamp")` is present and correct by the time these lines run. It is simply never read.

This is distinct from the already-fixed batch-sharing bug (where one `time.time()` before the loop gave every row in a batch the *same* stamp). Moving the call inside the loop made live stamps unique, but a caller-supplied stamp is still discarded.

**Fix.** `_resolve_ingest_timestamp(value)` returns the supplied timestamp when it is usable and falls back to `time.time()` otherwise. Both write sites call it.

The fallback is deliberately permissive: absent, `None`, non-numeric, non-positive, and NaN/inf all degrade to "now" rather than raising. `timestamp` is an optional field on a caller-provided dict, so a malformed value must not fail ingest or write a 1970 epoch that would poison the same date queries this change is meant to fix. Ints and numeric strings are coerced, since transcript formats routinely carry epochs that way.

## Validation

- [x] RED-proof — fix reverted, tests kept: `6 failed, 12 passed`. The 12 that pass in both states are the live-ingest controls.
- [x] GREEN: `pytest tests/test_ingest_timestamp_preservation.py -q` -> `18 passed`
- [x] **Existing invariant preserved** — `pytest tests/test_lcm_core.py -k "timestamp or batch or recency or sort"` -> `22 passed`, including `test_append_batch_timestamps_are_unique_per_row`.
- [x] Full suite: `pytest tests/ -q` -> see below.
- [x] `ruff check store.py tests/test_ingest_timestamp_preservation.py` -> `All checks passed!`

## Notes
- **No behaviour change for live ingest.** Live messages carry no `timestamp`, so they take the same `time.time()` path as before — `test_live_messages_without_timestamp_still_get_now` and `test_live_batch_timestamps_remain_unique` pin that, and the latter is the same 50-row uniqueness property your existing test asserts.
- `test_mixed_batch_preserves_supplied_and_stamps_the_rest` covers a batch containing both replayed and live messages, since the resolution is per-row.
- Adds `import math` to `store.py` for the `isfinite` check.
- Related: `benchmarks/qa-harness/.../hermes_lcm_bridge.py` currently keeps a sidecar `*.dates.json` mapping to work around this, noting the plugin "takes no per-message timestamp and must not be modified." With this change that workaround could be retired, though I've left the bridge untouched here to keep the diff focused.
