### PR TITLE
fix: repair stale FTS triggers left by schema migrations

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -2907,8 +2907,50 @@ def _fts_missing_triggers(conn: sqlite3.Connection, spec: ExternalContentFtsSpec
     return bool(expected - existing)
 
 
+def _normalize_trigger_sql(sql: str) -> str:
+    """Canonicalize a CREATE TRIGGER statement for body comparison.
+
+    SQLite stores a trigger's source with ``IF NOT EXISTS`` stripped and the
+    trailing ``;`` removed, so a byte compare against the spec's SQL always
+    mismatches. Normalize both sides (drop ``IF NOT EXISTS``, collapse
+    whitespace, strip the terminator, casefold) so that the only differences
+    which survive are real ones — e.g. a body that still references a column
+    that has since been renamed.
+    """
+    text = re.sub(r"(?i)\bIF\s+NOT\s+EXISTS\s+", "", sql or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text.rstrip(";").strip().lower()
+
+
+def _fts_stale_triggers(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
+    """True if a trigger exists by name but its body has drifted from the spec.
+
+    ``_fts_missing_triggers`` only checks existence by name, so a trigger left
+    behind by an older schema passes that check while aborting every write to
+    the content table at runtime.
+    """
+    for trigger_sql in spec.trigger_sqls:
+        name = _extract_trigger_name(trigger_sql)
+        if not name:
+            continue
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='trigger' AND name = ?",
+            (name,),
+        ).fetchone()
+        if row is None or row[0] is None:
+            # Absent entirely — that is _fts_missing_triggers' job, not "stale".
+            continue
+        if _normalize_trigger_sql(str(row[0])) != _normalize_trigger_sql(trigger_sql):
+            return True
+    return False
+
+
 def external_content_fts_needs_repair(conn: sqlite3.Connection, spec: ExternalContentFtsSpec) -> bool:
-    return _fts_needs_rebuild_structural(conn, spec) or _fts_missing_triggers(conn, spec)
+    return (
+        _fts_needs_rebuild_structural(conn, spec)
+        or _fts_missing_triggers(conn, spec)
+        or _fts_stale_triggers(conn, spec)
+    )
 
 
 def repair_external_content_fts(
@@ -2953,6 +2995,12 @@ def repair_external_content_fts(
         rebuilt = True
 
     triggers_were_missing = _fts_missing_triggers(conn, spec)
+    triggers_were_stale = _fts_stale_triggers(conn, spec)
+    if triggers_were_stale:
+        # A stale trigger exists by name with a drifted body, so the spec's bare
+        # `CREATE TRIGGER IF NOT EXISTS` would no-op and leave the broken trigger
+        # in place. Drop first so the body is guaranteed to be recreated fresh.
+        _drop_fts_triggers(conn, spec.trigger_sqls)
     for trigger_sql in spec.trigger_sqls:
         conn.execute(trigger_sql)
     if rebuilt:
@@ -2965,7 +3013,11 @@ def repair_external_content_fts(
     # full interval). Without this an explicit `repair apply` left the flag stuck.
     _clear_integrity_failed(conn, spec)
     conn.commit()
-    return {"rebuilt": rebuilt, "degraded": degraded, "triggers_recreated": triggers_were_missing}
+    return {
+        "rebuilt": rebuilt,
+        "degraded": degraded,
+        "triggers_recreated": triggers_were_missing or triggers_were_stale,
+    }
 
 
 def ensure_external_content_fts(

--- a/tests/test_fts_trigger_drift.py
+++ b/tests/test_fts_trigger_drift.py
@@ -1,0 +1,195 @@
+"""Detection and repair of content-drifted external-content FTS triggers.
+
+``_fts_missing_triggers`` only checks that each expected trigger exists *by
+name*. A trigger left behind by an older schema — one whose body still
+references a since-renamed column — therefore passes the health check while
+aborting every write to the content table at runtime, and a repair pass cannot
+fix it because the spec's ``CREATE TRIGGER IF NOT EXISTS`` no-ops against the
+existing name.
+
+These tests pin both halves: the drift must be *detected*, and a repair must
+actually *replace* the drifted body.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_lcm import db_bootstrap
+from hermes_lcm.db_bootstrap import (
+    ensure_external_content_fts,
+    external_content_fts_needs_repair,
+    repair_external_content_fts,
+)
+from hermes_lcm.store import build_message_fts_spec
+
+
+def _make_db(tmp_path, name="drift.db"):
+    """A messages table with the real message-FTS spec applied."""
+    conn = sqlite3.connect(str(tmp_path / name))
+    conn.executescript(
+        """
+        CREATE TABLE messages (
+            store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT
+        );
+        INSERT INTO messages(content) VALUES ('hello world');
+        """
+    )
+    spec = build_message_fts_spec()
+    ensure_external_content_fts(conn, spec)
+    conn.commit()
+    return conn, spec
+
+
+def _drift_insert_trigger(conn):
+    """Replace msg_fts_insert with an older-schema body (renamed column)."""
+    conn.execute("DROP TRIGGER msg_fts_insert")
+    conn.execute(
+        """
+        CREATE TRIGGER msg_fts_insert AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts(rowid, content)
+                VALUES (new.store_id, new.body_text);
+        END;
+        """
+    )
+    conn.commit()
+
+
+def _trigger_body(conn, name):
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' AND name = ?", (name,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def test_healthy_triggers_are_not_reported_as_stale(tmp_path):
+    """Control: the freshly-created triggers must compare equal to the spec."""
+    conn, spec = _make_db(tmp_path)
+    try:
+        assert db_bootstrap._fts_stale_triggers(conn, spec) is False
+        assert external_content_fts_needs_repair(conn, spec) is False
+    finally:
+        conn.close()
+
+
+def test_drifted_trigger_body_is_detected_as_needing_repair(tmp_path):
+    conn, spec = _make_db(tmp_path)
+    try:
+        _drift_insert_trigger(conn)
+
+        # Present by name, so the name-only check is satisfied...
+        assert db_bootstrap._fts_missing_triggers(conn, spec) is False
+        # ...but the body has drifted and every write now aborts.
+        assert external_content_fts_needs_repair(conn, spec) is True
+    finally:
+        conn.close()
+
+
+def test_drifted_trigger_aborts_writes_until_repaired(tmp_path):
+    conn, spec = _make_db(tmp_path)
+    try:
+        _drift_insert_trigger(conn)
+
+        with pytest.raises(sqlite3.OperationalError, match="body_text"):
+            conn.execute("INSERT INTO messages(content) VALUES ('blocked')")
+            conn.commit()
+        conn.rollback()
+
+        repair_external_content_fts(conn, spec, throttle=False)
+
+        conn.execute("INSERT INTO messages(content) VALUES ('recovered')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_repair_replaces_the_drifted_trigger_body(tmp_path):
+    conn, spec = _make_db(tmp_path)
+    try:
+        _drift_insert_trigger(conn)
+        assert "body_text" in _trigger_body(conn, "msg_fts_insert")
+
+        repair_external_content_fts(conn, spec, throttle=False)
+
+        body = _trigger_body(conn, "msg_fts_insert")
+        assert "body_text" not in body
+        assert "new.content" in body
+    finally:
+        conn.close()
+
+
+def test_repair_reports_triggers_recreated_for_stale_triggers(tmp_path):
+    conn, spec = _make_db(tmp_path)
+    try:
+        _drift_insert_trigger(conn)
+
+        result = repair_external_content_fts(conn, spec, throttle=False)
+
+        assert result["triggers_recreated"] is True
+    finally:
+        conn.close()
+
+
+def test_missing_trigger_still_reported_and_recreated(tmp_path):
+    """The pre-existing missing-by-name path must keep working unchanged."""
+    conn, spec = _make_db(tmp_path)
+    try:
+        conn.execute("DROP TRIGGER msg_fts_insert")
+        conn.commit()
+
+        assert db_bootstrap._fts_missing_triggers(conn, spec) is True
+        assert external_content_fts_needs_repair(conn, spec) is True
+
+        result = repair_external_content_fts(conn, spec, throttle=False)
+
+        assert result["triggers_recreated"] is True
+        assert _trigger_body(conn, "msg_fts_insert") is not None
+    finally:
+        conn.close()
+
+
+def test_repair_is_idempotent_and_leaves_no_stale_state(tmp_path):
+    conn, spec = _make_db(tmp_path)
+    try:
+        _drift_insert_trigger(conn)
+        repair_external_content_fts(conn, spec, throttle=False)
+
+        second = repair_external_content_fts(conn, spec, throttle=False)
+
+        assert second["triggers_recreated"] is False
+        assert external_content_fts_needs_repair(conn, spec) is False
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "stored, spec_sql",
+    [
+        # SQLite strips IF NOT EXISTS when it stores the trigger source.
+        (
+            "CREATE TRIGGER t AFTER INSERT ON m BEGIN SELECT 1; END",
+            "CREATE TRIGGER IF NOT EXISTS t AFTER INSERT ON m BEGIN SELECT 1; END;",
+        ),
+        # Indentation/newlines in the spec literal are not drift.
+        (
+            "CREATE TRIGGER t AFTER INSERT ON m BEGIN SELECT 1; END",
+            "\n    CREATE TRIGGER t\n        AFTER INSERT ON m BEGIN\n        SELECT 1;\n    END;\n",
+        ),
+        # Keyword case is not drift.
+        (
+            "create trigger t after insert on m begin select 1; end",
+            "CREATE TRIGGER t AFTER INSERT ON m BEGIN SELECT 1; END",
+        ),
+    ],
+)
+def test_normalization_ignores_cosmetic_differences(stored, spec_sql):
+    """Cosmetic storage differences must not be mistaken for real drift."""
+    assert db_bootstrap._normalize_trigger_sql(stored) == db_bootstrap._normalize_trigger_sql(spec_sql)
+
+
+def test_normalization_still_detects_real_body_differences():
+    a = "CREATE TRIGGER t AFTER INSERT ON m BEGIN INSERT INTO f VALUES (new.content); END"
+    b = "CREATE TRIGGER t AFTER INSERT ON m BEGIN INSERT INTO f VALUES (new.body_text); END"
+
+    assert db_bootstrap._normalize_trigger_sql(a) != db_bootstrap._normalize_trigger_sql(b)


### PR DESCRIPTION
## Summary
- Detect external-content FTS triggers that exist **by name** but whose **body has drifted** from the spec, and drop-then-recreate them during repair so the fix actually lands.
- Adds `tests/test_fts_trigger_drift.py` (11 tests).

## Why

**Symptom.** After upgrading across a schema change, LCM can land in a state where **every message write fails** and the health check insists nothing is wrong:

```
sqlite3.OperationalError: no such column: new.body_text
```

Every `INSERT INTO messages` aborts, so the session stops recording. Running a repair reports success and changes nothing:

```python
>>> external_content_fts_needs_repair(conn, spec)
False                                                    # <- claims healthy
>>> repair_external_content_fts(conn, spec, throttle=False)
{'rebuilt': False, 'degraded': False, 'triggers_recreated': False}
>>> conn.execute("INSERT INTO messages(content) VALUES ('x')")
OperationalError: no such column: new.body_text          # <- still broken
```

The database is unusable for writes and there is no in-product way out of it.

**Root cause.** Two independent gaps that compound:

1. **Detection is name-only.** `_fts_missing_triggers` compares the *set of trigger names* in `sqlite_master` against the names in the spec. A trigger left behind by an older schema — whose body still references a column that has since been renamed — is present by name, so the check is satisfied and `external_content_fts_needs_repair` returns `False`.

2. **Repair cannot replace an existing trigger.** `repair_external_content_fts` re-runs the spec's SQL, but those statements are `CREATE TRIGGER IF NOT EXISTS`. Against a trigger that already exists under that name, they no-op. The drifted body survives the repair, and `triggers_recreated: False` is reported.

So the one code path that could fix the problem is also the path that cannot see it.

**Fix.**

- `_fts_stale_triggers(conn, spec)` compares each stored trigger body against the spec's SQL and returns `True` on a real difference. `external_content_fts_needs_repair` now ORs it in alongside the structural and missing-name checks.
- `_normalize_trigger_sql` canonicalizes both sides before comparing. This matters: SQLite stores trigger source with `IF NOT EXISTS` stripped and the trailing `;` removed, so a naive byte compare would flag *every* trigger as stale and force a needless repair on every startup. Normalization drops `IF NOT EXISTS`, collapses whitespace, strips the terminator, and casefolds — so only genuine body differences survive.
- In `repair_external_content_fts`, when stale triggers are detected, `_drop_fts_triggers` runs before the recreate loop so the canonical body is guaranteed to be installed. `triggers_recreated` now reflects missing-or-stale.

The drop is deliberately gated on `triggers_were_stale` rather than done unconditionally, so the common healthy path keeps its existing no-op behaviour.

## Validation

- [x] **Bug reproduced on unmodified `main`** — detection returns `False`, writes abort, repair no-ops. Full transcript in the test-evidence notes.
- [x] RED-proof — fix reverted, tests kept: `9 failed, 2 passed`. The 2 passes are the intended controls (healthy-trigger and missing-trigger paths, which were never broken).
- [x] GREEN: `pytest tests/test_fts_trigger_drift.py -q` -> `11 passed`
- [x] Neighbour suites: `pytest tests/test_db_bootstrap_fts.py tests/test_lcm_core.py tests/test_fts_trigger_drift.py -q` -> `332 passed`
- [x] `ruff check db_bootstrap.py tests/test_fts_trigger_drift.py` -> `All checks passed!`

## Notes
- `test_repair_is_idempotent_and_leaves_no_stale_state` pins that a second repair reports `triggers_recreated: False` — i.e. normalization is not producing perpetual false-positive drift.
- `test_missing_trigger_still_reported_and_recreated` pins the pre-existing missing-by-name path is unchanged.
- The normalization is parametrized against the three cosmetic differences SQLite actually introduces (`IF NOT EXISTS` stripping, whitespace/indentation, keyword case), plus a negative case proving a real column-name difference is still caught.
