### PR TITLE
test: batch embedding backfill fixture setup

### DIFF
--- a/tests/test_embedding_backfill.py
+++ b/tests/test_embedding_backfill.py
@@ -1026,12 +1026,16 @@ def test_inflight_maintenance_processes_only_one_bounded_chunk(tmp_path):
         conn = store.connection
         command_mod._ensure_inflight_table(conn)
         identity = "identity"
+        # VectorStore connections use autocommit, so batch this large fixture
+        # explicitly instead of forcing one durable transaction per row.
+        conn.execute("BEGIN")
         conn.executemany(
             "INSERT INTO lcm_embedding_backfill_inflight("
             "embedded_id, identity_hash, lease_id, generation, claimed_at, "
             "state, updated_at) VALUES (?, ?, 'stale', 1, 1, 'claimed', 1)",
             ((str(index), identity) for index in range(250_001)),
         )
+        conn.commit()
         lease = command_mod._acquire_embedding_backfill_lease(
             conn, ttl_s=600.0, heartbeat_s=60.0
         )


### PR DESCRIPTION
## Summary
- Batch the existing 250,001-row embedding backfill fixture in one explicit SQLite transaction.
- Keep the fixture cardinality, assertions, and production code unchanged.

## Why
- `VectorStore` uses autocommit, so the fixture's `executemany` otherwise performs 250,001 durable transactions before the test reaches the behavior under test.
- The unchanged `49e99a2` base times out during fixture setup under Python 3.13.14, SQLite 3.46.1, and `ulimit -n 1024`; this candidate passes under the same environment.
- This baseline prerequisite unblocks exact-head CI for PR #399. It does not address or claim to fix PR #399's correctness findings.

## Validation
- [x] Focused validation: Python 3.13.14 / SQLite 3.46.1 / `ulimit -n 1024`, `test_inflight_maintenance_processes_only_one_bounded_chunk` -> `1 passed in 1.52s`
- [x] Relevant module: Python 3.13.14 / SQLite 3.46.1 / `ulimit -n 1024`, `tests/test_embedding_backfill.py` -> `40 passed in 4.57s`
- [x] Supported interpreter legs: Python 3.11.14, 3.12.12, and 3.14.6 with `ulimit -n 1024`, `tests/test_embedding_backfill.py` -> `40 passed` on each leg
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- The candidate changes only `tests/test_embedding_backfill.py`: four fixture-only insertions, with no assertion or cardinality changes.
- PR #426 is adjacent same-file work for blank-summary discovery, but its hunks and root cause do not overlap this fixture setup change.
- The full default suite was not duplicated locally for this test-only fixture correction; exact-head GitHub CI is expected to provide repository-wide validation. No workflow files changed.

Refs #399
