### PR TITLE
test: batch large-ID fixture setup

### DIFF
--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -624,6 +624,7 @@ def test_large_id_metadata_resolve_scales_past_variable_limit(stores):
     now = 1.0
     vec = array("f", store._normalized([1.0, 0.0], expected_dim=2)).tobytes()
     identity = store._current_profile()["identity_hash"]
+    conn.execute("BEGIN")
     for node_id in range(1, 40_001):
         conn.execute(
             "INSERT INTO summary_nodes(node_id, session_id, depth, summary, "


### PR DESCRIPTION
## Summary
- Batch the existing 40,000-row large-ID metadata fixture in one explicit SQLite transaction.
- Keep production code, fixture cardinality, and assertions unchanged.

## Why
- `VectorStore` uses autocommit, so the fixture otherwise performs 40,000 durable transactions before reaching the behavior under test.
- On unchanged base `424a6b2`, the focused test times out during fixture setup under Python 3.13.14, SQLite 3.46.1, and `ulimit -n 1024`; this candidate passes under the same environment.

## Validation
- [x] RED → GREEN: unchanged base -> timeout after 15.11s; candidate focused test -> `1 passed in 3.76s`
- [x] Relevant module: `tests/test_vector_store.py` -> `53 passed in 26.47s`
- [x] Supported interpreter legs: Python 3.11.14, 3.12.12, and 3.14.6 with `ulimit -n 1024`, `tests/test_vector_store.py` -> `53 passed` on each leg
- [x] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [x] `pytest -q` -> `2297 passed, 12 xfailed in 239.55s` on Python 3.13.14 / SQLite 3.46.1 / `ulimit -n 1024`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `2297 passed, 12 xfailed in 239.55s`
  - [x] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- The candidate changes only `tests/test_vector_store.py`: one fixture-only insertion immediately before the unchanged 40,000-row loop.
- No workflow files changed.
