### PR TITLE
feat: expand summary DAGs across sessions

### DIFF
--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -4,18 +4,19 @@ Use this page when you need the exact LCM tool contract or archive-migration not
 
 ## Agent Tools
 
-Use these tools for current-session recall after compaction. Use `session_search`
-for earlier separate sessions or broad cross-session history.
+These tools default to current-session recall after compaction. Use `session_search`
+to discover earlier sessions; known LCM session and node ids can then be retrieved
+through the explicit cross-session arguments below.
 
 | Tool | Use |
 |------|-----|
 | `lcm_grep` | Search current-session raw messages and summaries. `mode='full_text'` is the byte-compatible default; `mode='semantic'` searches embedded summaries; `mode='hybrid'` combines full-text and semantic ranks with RRF. Opt into `content_scope='externalized'` or `'both'` for bounded literal search over recoverable payload prefixes owned by the active session. Opt into `session_scope='all'` or `session_scope='session'` (with `session_id`) for bounded archive recovery over rows already present in `lcm.db`, including externally backfilled rows that may carry source strings such as `openclaw-lcm:*`; broader scopes return raw-message hits only in full-text mode and cannot search externalized payloads. Raw-message filters `role`, `time_from`, `time_to`, `source`, and `conversation_id` are pushed into the full-text query; when any is supplied, externalized payload results are omitted, and summary hits are omitted for the role/time filters so the filter contract stays exact. Use `session_search` for earlier separate sessions or broad cross-session recall. |
-| `lcm_recall` | Search the agent's entire memory across ALL conversations and all time by meaning. Runs three arms over the whole local database — full-text raw messages, embedded summary KNN, and verbatim chunk KNN (all cross-session, no filter) — fuses them with RRF, dedupes chunk hits against FTS by `store_id`, and applies a soft prior `final_score = rank_score × (1 + scope_bias × is_current_conversation) × recency_boost(half_life=30d, floor 0.5)`. `scope_bias` (0..1, default 0.5) and recency are ranking BOOSTS, never filters. `include` selects `all`/`summaries`/`verbatim`. An optional voyage `rerank-2.5-lite` stage (`LCM_RERANK_ENABLED`, default off) reorders the top window of candidates AFTER the scope/recency prior, as a pure rank-reorder (voyage relevance is never spliced onto the RRF scale); any failure skips silently to RRF order. When embeddings are disabled or the vector corpora are empty the tool degrades to the full-text arm — including for `include='summaries'`, whose only vector arm is dead in that state, so a summaries request still returns full-text hits rather than nothing. Each hit carries an `expand_hint`: verbatim/current-session hits get an `lcm_expand(...)` handle, while cross-session summary hits get an `lcm_load_session(...)` handle (`lcm_expand`'s `node_id` mode is current-session only). Use `lcm_grep(mode='full_text')` for exact text in a known range and `lcm_load_session` for full transcripts. |
+| `lcm_recall` | Search the agent's entire memory across ALL conversations and all time by meaning. Runs three arms over the whole local database — full-text raw messages, embedded summary KNN, and verbatim chunk KNN (all cross-session, no filter) — fuses them with RRF, dedupes chunk hits against FTS by `store_id`, and applies a soft prior `final_score = rank_score × (1 + scope_bias × is_current_conversation) × recency_boost(half_life=30d, floor 0.5)`. `scope_bias` (0..1, default 0.5) and recency are ranking BOOSTS, never filters. `include` selects `all`/`summaries`/`verbatim`. An optional voyage `rerank-2.5-lite` stage (`LCM_RERANK_ENABLED`, default off) reorders the top window of candidates AFTER the scope/recency prior, as a pure rank-reorder (voyage relevance is never spliced onto the RRF scale); any failure skips silently to RRF order. When embeddings are disabled or the vector corpora are empty the tool degrades to the full-text arm — including for `include='summaries'`, whose only vector arm is dead in that state, so a summaries request still returns full-text hits rather than nothing. Each hit carries an `expand_hint`: verbatim/current-session hits get an `lcm_expand(...)` handle, while cross-session summary hits retain an `lcm_load_session(...)` transcript handle. If both ids are known, the summary DAG can instead be opened with `lcm_expand(node_id=..., session_id=...)`. Use `lcm_grep(mode='full_text')` for exact text in a known range and `lcm_load_session` for full transcripts. |
 | `lcm_recent` | Retrieve recent summaries with natural UTC periods. Ready temporal rollups are preferred; missing, stale, disabled, and sub-day windows transparently use leaf summaries instead. |
 | `lcm_load_session` | Load one ordered raw-message transcript page for an explicit `session_id`. This is not search: it returns raw rows in `store_id` order, bounded by `limit`, with per-message content bounded by `max_content_chars`, and continues with `after_store_id` from `next_cursor`. |
-| `lcm_describe` | Inspect the current-session DAG or preview an `externalized_ref` without loading full content. |
-| `lcm_expand` | Recover source messages, child summaries, or externalized payloads with pagination. Use `store_id` to fetch a single raw message regardless of session, suitable for drilling into a cross-session `lcm_grep` result. |
-| `lcm_expand_query` | Answer a question using expanded current-session LCM context while returning a bounded answer. |
+| `lcm_describe` | Inspect the active-session DAG by default, or pass `session_id` with a known node/overview target. `externalized_ref` remains active-session only. |
+| `lcm_expand` | Recover source messages or child summaries with pagination. Node lookup defaults to the active session; explicit cross-session lookup requires matching `node_id` and `session_id`. `externalized_ref` remains active-session only; `store_id` fetches a raw message regardless of session. |
+| `lcm_expand_query` | Retrieve from the active session by default or up to 20 explicit `session_ids`. `output='answer'` runs bounded synthesis; `output='evidence'` returns bounded serialized context without an LLM call. |
 | `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
 | `lcm_inspect` | Read-only operator inventory for current-session lineage, message/frontier metadata, fresh tail, externalized refs/readability, compaction skip/no-op reasons, and matched ignore/stateless patterns. It returns metadata only; use `lcm_load_session`/`lcm_expand` when you need content. |
 | `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
@@ -28,6 +29,19 @@ bounded archive search over rows already present in `lcm.db` (raw-message hits
 only). Once a session id is known, `lcm_load_session` can enumerate that session's
 raw transcript in chronological `store_id` pages without a search query. Use
 Hermes `session_search` for broad cross-session history outside the LCM database.
+
+`lcm_describe` and `lcm_expand` keep their existing active-session behavior when
+`session_id` is omitted. An explicit id must be a non-empty string and must match
+the requested node; `lcm_expand` rejects `session_id` in `store_id` and
+`externalized_ref` modes. `lcm_expand_query` accepts a non-empty list of at most
+20 `session_ids`; omitted means active session. Explicit `node_ids` are admitted
+only when they belong to one of those sessions. Search results from multiple
+sessions are merged and bounded by `max_results` before context expansion.
+
+`lcm_expand_query(output='evidence')` uses the same `context_max_tokens` budget,
+recursive DAG traversal, raw-hit deduplication, and pagination metadata as answer
+mode, but returns the serialized blocks under `evidence` before synthesis. This
+path makes no auxiliary LLM call. `output='answer'` remains the default.
 
 Within the current session, `source` filters raw rows directly and filters
 summary nodes by descendant raw-message source lineage. `unknown` is a real
@@ -225,11 +239,11 @@ Tool responses are bounded so one retrieval call cannot flood the main context.
 Lossless recovery means raw content is stored with stable source lineage and can
 be recovered in deterministic pages.
 
-- `lcm_expand(node_id=...)` pages immediate sources with `source_offset` and `source_limit`
+- `lcm_expand(node_id=..., session_id=...)` pages immediate sources with `source_offset` and `source_limit`; omit `session_id` for the active-session default
 - `lcm_load_session(session_id=...)` pages ordered raw session rows with `after_store_id` and `next_cursor`; each row includes bounded content plus truncation metadata, and large individual rows can be recovered with `lcm_expand(store_id=...)` using `content_offset`
 - oversized raw messages continue with `content_offset`
 - `lcm_expand(externalized_ref=...)` pages payload content with `content_offset`
-- `lcm_expand_query` uses `context_max_tokens` for auxiliary context and reports truncation/pagination hints when needed
+- `lcm_expand_query` uses `context_max_tokens` for answer or evidence context and reports truncation/pagination hints when needed
 
 ### Searching externalized payloads
 
@@ -286,7 +300,7 @@ The script is intentionally conservative:
 - changing `--agent`, `--namespace`, or `--session-identity` under the same `--import-id` is treated as the same import and will skip already-tracked source messages; use a new `--import-id` for a different mapping
 - no OpenClaw config or separate secret tables are imported, but raw transcripts and tool payloads are imported and may contain sensitive user data
 
-This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
+This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the default current-session retrieval contract for agent tools.
 
 ## Related references
 

--- a/schemas.py
+++ b/schemas.py
@@ -136,8 +136,8 @@ LCM_RECALL = {
         "Returns the most relevant memories — summaries and verbatim excerpts — ranked by relevance, "
         "recency, and relatedness to the current conversation, each with an expand_hint handle to the "
         "original content: verbatim/current-session hits get lcm_expand(...), while cross-session summary "
-        "hits get lcm_load_session(...) (lcm_expand's node_id mode is current-session only, so it cannot "
-        "expand a cross-session summary). Not for retrieving exact/verbatim text within a known time range — "
+        "hits retain lcm_load_session(...) transcript handles. A known cross-session summary node can also "
+        "be expanded with lcm_expand(node_id=..., session_id=...). Not for retrieving exact/verbatim text within a known time range — "
         "use lcm_grep(mode='full_text') for that. Not for full transcripts — after locating the right "
         "conversation, use lcm_load_session(session_id). Recency and current-conversation preference are soft "
         "ranking boosts, not filters; for hard time bounds use lcm_grep time_from/time_to."
@@ -225,7 +225,7 @@ LCM_LOAD_SESSION = {
         "and orders rows chronologically by store_id. Use this after session_search or lcm_grep has identified a session_id "
         "that already exists in lcm.db. Output is bounded by limit, per-row content is bounded by max_content_chars, "
         "and row pagination uses after_store_id/next_cursor. "
-        "It returns raw rows only; cross-session summary/DAG expansion remains out of scope."
+        "It returns raw rows only; use lcm_describe/lcm_expand with both node_id and session_id for summary DAGs."
     ),
     "parameters": {
         "type": "object",
@@ -279,14 +279,12 @@ LCM_LOAD_SESSION = {
 LCM_DESCRIBE = {
     "name": "lcm_describe",
     "description": (
-        "Inspect a current-session summary node's subtree metadata WITHOUT loading full "
-        "content, or inspect an externalized payload ref without opening the "
-        "full payload. Returns token counts, child manifest, expand hints, "
-        "or externalized payload metadata/preview. Use this to plan retrieval "
-        "strategy before spending tokens on lcm_expand inside the active conversation. "
-        "For cross-session recall, use session_search first. If called with no "
-        "node_id or externalized_ref, returns the top-level DAG overview for "
-        "the current session."
+        "Inspect a summary node's subtree metadata WITHOUT loading full content. "
+        "Node and overview lookup default to the active session; pass an explicit session_id "
+        "to inspect a known node or DAG from another LCM session. A node must belong to the "
+        "requested session. externalized_ref remains active-session only. Returns token counts, "
+        "child manifest, expand hints, or externalized payload metadata/preview. If called with "
+        "no node_id or externalized_ref, returns the top-level overview for the selected session."
     ),
     "parameters": {
         "type": "object",
@@ -294,6 +292,13 @@ LCM_DESCRIBE = {
             "node_id": {
                 "type": "integer",
                 "description": "Summary node ID to inspect. Omit for session overview.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": (
+                    "Optional explicit LCM session id for node or overview lookup. "
+                    "Omit to preserve active-session scope; an explicit id must be non-empty and match the node."
+                ),
             },
             "externalized_ref": {
                 "type": "string",
@@ -308,8 +313,9 @@ LCM_EXPAND = {
     "name": "lcm_expand",
     "description": (
         "Recover the original detail behind a summary node, externalized payload, or raw message. "
-        "Mode selection (exactly one): node_id (current session only) returns the source messages "
-        "or lower-depth summaries that were compacted into a summary node; externalized_ref "
+        "Mode selection (exactly one): node_id returns the source messages or lower-depth summaries "
+        "that were compacted into a summary node, defaulting to the active session unless an explicit "
+        "matching session_id is supplied; externalized_ref "
         "(current session only) returns a stored externalized payload's content; store_id returns "
         "a single raw message by store_id and works across sessions, suitable for drilling into "
         "cross-session lcm_grep results. Output is bounded by max_tokens; raw recovery is pageable "
@@ -322,8 +328,15 @@ LCM_EXPAND = {
             "node_id": {
                 "type": "integer",
                 "description": (
-                    "Summary node ID to expand. Current-session only — cross-session DAG expansion "
-                    "is not supported in this version."
+                    "Summary node ID to expand. Omit session_id for active-session lookup or pair it "
+                    "with an explicit matching session_id for cross-session DAG expansion."
+                ),
+            },
+            "session_id": {
+                "type": "string",
+                "description": (
+                    "Optional explicit LCM session id for node_id mode only. Must be non-empty and "
+                    "match the node; it is rejected with externalized_ref or store_id mode."
                 ),
             },
             "externalized_ref": {
@@ -425,11 +438,10 @@ LCM_DOCTOR = {
 LCM_EXPAND_QUERY = {
     "name": "lcm_expand_query",
     "description": (
-        "Answer a natural-language question using expanded LCM context from the current session. Provide a prompt, and either "
-        "query matching summaries/raw messages to expand or explicit node_ids to inspect. Uses the expansion path "
-        "instead of the summarization path so retrieval/synthesis can use a different model or timeout. "
-        "When expanding parent summary nodes, it recursively descends the DAG under the context budget to include leaf evidence where possible. "
-        "Prefer this for questions about the active conversation after compaction; for cross-session recall, use session_search first."
+        "Retrieve expanded LCM context from the active session by default or from up to 20 explicit session_ids. "
+        "Provide a prompt and either a query matching summaries/raw messages or explicit node_ids. output='answer' "
+        "(default) synthesizes a bounded answer with the expansion model; output='evidence' returns the same bounded "
+        "serialized context directly without an LLM call. Parent summaries are recursively descended under the context budget."
     ),
     "parameters": {
         "type": "object",
@@ -445,7 +457,26 @@ LCM_EXPAND_QUERY = {
             "node_ids": {
                 "type": "array",
                 "items": {"type": "integer"},
-                "description": "Optional explicit summary node IDs to expand instead of searching",
+                "description": "Optional summary node IDs to expand instead of searching. IDs must belong to the selected sessions.",
+            },
+            "session_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 20,
+                "description": (
+                    "Optional non-empty LCM session ids to search or authorize for node_ids. "
+                    "Omit for the active session. At most 20 entries are accepted."
+                ),
+            },
+            "output": {
+                "type": "string",
+                "enum": ["answer", "evidence"],
+                "description": (
+                    "'answer' runs bounded synthesis (default); 'evidence' returns bounded serialized "
+                    "context and pagination metadata without calling an LLM."
+                ),
+                "default": "answer",
             },
             "max_results": {
                 "type": "integer",
@@ -459,7 +490,7 @@ LCM_EXPAND_QUERY = {
             },
             "context_max_tokens": {
                 "type": "integer",
-                "description": "Expanded serialized summary/raw/child-source/externalized fresh context budget for the auxiliary LLM before it returns the bounded answer (default max(answer max_tokens, 32000 or LCM_EXPANSION_CONTEXT_TOKENS))",
+                "description": "Expanded serialized summary/raw/child-source/externalized fresh context budget. Answer mode sends this context to the auxiliary LLM; evidence mode returns it directly (default max(answer max_tokens, 32000 or LCM_EXPANSION_CONTEXT_TOKENS))",
                 "default": 32000,
             },
         },

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -22,7 +22,7 @@ from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryNode
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.externalize import externalize_ingest_payload
-from hermes_lcm.tokens import count_message_tokens, count_messages_tokens
+from hermes_lcm.tokens import count_message_tokens, count_messages_tokens, count_tokens
 
 
 @pytest.fixture
@@ -1499,7 +1499,13 @@ class TestEngineABC:
         assert "session_id" in grep_props
         assert "session_scope='session'" in grep_props["session_id"]["description"]
         assert "role" in grep_props
-        assert grep_props["role"]["enum"] == ["system", "user", "assistant", "tool", "unknown"]
+        assert grep_props["role"]["enum"] == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "unknown",
+        ]
         assert "time_from" in grep_props
         assert "time_to" in grep_props
         assert "source" in grep_props
@@ -1518,17 +1524,26 @@ class TestEngineABC:
         # The schema now documents the broader scopes — assert by enumerating them in the
         # session_scope description rather than enforcing the legacy current-only wording.
         scope_description = grep_props["session_scope"]["description"]
-        assert "all" in scope_description and "session" in scope_description and "current" in scope_description
+        assert (
+            "all" in scope_description
+            and "session" in scope_description
+            and "current" in scope_description
+        )
         assert "session_search" in scope_description
         # Cross-session search is positioned as plugin-local archive recovery, not memory.
-        assert "archive" in grep_schema["description"].lower() or "plugin-local" in grep_schema["description"].lower()
+        assert (
+            "archive" in grep_schema["description"].lower()
+            or "plugin-local" in grep_schema["description"].lower()
+        )
 
         describe_schema = next(s for s in schemas if s["name"] == "lcm_describe")
         expand_schema = next(s for s in schemas if s["name"] == "lcm_expand")
-        expand_query_schema = next(s for s in schemas if s["name"] == "lcm_expand_query")
+        expand_query_schema = next(
+            s for s in schemas if s["name"] == "lcm_expand_query"
+        )
 
-        assert "current session" in describe_schema["description"].lower()
-        assert "session_search" in describe_schema["description"]
+        describe_props = describe_schema["parameters"]["properties"]
+        assert describe_props["session_id"]["type"] == "string"
         # lcm_expand picked up a third mode (store_id); its description must surface that.
         assert "store_id" in expand_schema["description"]
         assert "session_search" in expand_schema["description"]
@@ -1537,7 +1552,11 @@ class TestEngineABC:
         assert "source_limit" in expand_props
         assert "content_offset" in expand_props
         assert "store_id" in expand_props
-        assert "across sessions" in expand_props["store_id"]["description"].lower() or "cross-session" in expand_props["store_id"]["description"].lower()
+        assert expand_props["session_id"]["type"] == "string"
+        assert (
+            "across sessions" in expand_props["store_id"]["description"].lower()
+            or "cross-session" in expand_props["store_id"]["description"].lower()
+        )
         assert "pagination" in expand_props["source_offset"]["description"].lower()
         load_schema = next(s for s in schemas if s["name"] == "lcm_load_session")
         load_props = load_schema["parameters"]["properties"]
@@ -1548,11 +1567,16 @@ class TestEngineABC:
         assert "roles" in load_props
         assert "time_from" in load_props
         assert "time_to" in load_props
-        assert "current session" in expand_query_schema["description"].lower()
-        assert "session_search" in expand_query_schema["description"]
         expand_query_props = expand_query_schema["parameters"]["properties"]
         assert "context_max_tokens" in expand_query_props
-        assert "fresh context budget" in expand_query_props["context_max_tokens"]["description"]
+        assert (
+            "fresh context budget"
+            in expand_query_props["context_max_tokens"]["description"]
+        )
+        assert expand_query_props["session_ids"]["minItems"] == 1
+        assert expand_query_props["session_ids"]["maxItems"] == 20
+        assert expand_query_props["output"]["enum"] == ["answer", "evidence"]
+        assert expand_query_props["output"]["default"] == "answer"
 
     def test_readme_documents_session_scope_contract(self):
         readme = Path(__file__).resolve().parents[1].joinpath("README.md").read_text()
@@ -24647,7 +24671,9 @@ class TestEngineTools:
             for item in result["context_pagination"]
         )
 
-    def test_handle_expand_query_externalized_truncation_returns_ref_in_context_pagination(self, tmp_path, monkeypatch):
+    def test_handle_expand_query_externalized_truncation_returns_ref_in_context_pagination(
+        self, tmp_path, monkeypatch
+    ):
         captured = {}
 
         def fake_synthesize(*, prompt, context_blocks, model, max_tokens, timeout):
@@ -24663,9 +24689,9 @@ class TestEngineTools:
         engine = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
         engine._session_id = "test-session"
         content = "EXTERNALIZED RAW DETAIL " + ("abcdef" * 1000)
-        engine._serialize_messages([
-            {"role": "tool", "tool_call_id": "call_ext", "content": content}
-        ])
+        engine._serialize_messages(
+            [{"role": "tool", "tool_call_id": "call_ext", "content": content}]
+        )
         ref = next((tmp_path / "hermes" / "lcm-large-outputs").glob("*.json")).name
         placeholder = f"[GC'd externalized tool output: tool_call_id=call_ext; chars={len(content)}; ref={ref}]"
         store_id = engine._store.append(
@@ -24697,7 +24723,9 @@ class TestEngineTools:
             )
         )
 
-        message_block = next(block for block in captured["context_blocks"] if block["type"] == "messages")
+        message_block = next(
+            block for block in captured["context_blocks"] if block["type"] == "messages"
+        )
         assert message_block["messages"][0]["content_source"] == "externalized_payload"
         assert message_block["messages"][0]["content_truncated"] is True
         assert result["context_truncated"] is True
@@ -24707,11 +24735,37 @@ class TestEngineTools:
             and item["content_source"] == "externalized_payload"
             and item["externalized_ref"] == ref
             and item["pagination"]["has_more"] is True
-            and item["expand_args"] == {
+            and item["expand_args"]
+            == {
                 "externalized_ref": ref,
                 "content_offset": item["pagination"]["next_content_offset"],
             }
             for item in result["context_pagination"]
+        )
+
+        captured.clear()
+        engine._session_id = "new-session"
+        cross_session_result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What externalized detail exists?",
+                    "node_ids": [node_id],
+                    "session_ids": ["test-session"],
+                    "max_tokens": 5,
+                    "context_max_tokens": 20,
+                },
+            )
+        )
+        cross_session_block = next(
+            block for block in captured["context_blocks"] if block["type"] == "messages"
+        )
+        assert cross_session_block["messages"][0]["content_source"] != (
+            "externalized_payload"
+        )
+        assert all(
+            "externalized_ref" not in item.get("expand_args", {})
+            for item in cross_session_result["context_pagination"]
         )
 
     def test_handle_expand_query_counts_externalized_transcript_content_against_context_budget(self, tmp_path, monkeypatch):
@@ -25791,6 +25845,336 @@ class TestEngineTools:
         fts_check = next(c for c in result["checks"] if c["check"] == "fts_index_sync")
         assert fts_check["status"] == "pass"
         assert fts_check["detail"] == "1 session FTS rows, 1 session messages"
+
+    def test_handle_describe_and_expand_accept_explicit_cross_session_node(
+        self, engine
+    ):
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "historical expanded evidence"},
+        )
+        child_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="historical child summary",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=1,
+                summary="historical parent summary",
+                token_count=5,
+                source_token_count=10,
+                source_ids=[child_id],
+                source_type="nodes",
+                created_at=2,
+            )
+        )
+
+        describe = json.loads(
+            engine.handle_tool_call(
+                "lcm_describe",
+                {"node_id": node_id, "session_id": "old-session"},
+            )
+        )
+        mismatched = json.loads(
+            engine.handle_tool_call(
+                "lcm_describe",
+                {"node_id": node_id, "session_id": "wrong-session"},
+            )
+        )
+        expanded = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": node_id, "session_id": "old-session"},
+            )
+        )
+
+        assert describe["node_id"] == node_id
+        assert describe["session_id"] == "old-session"
+        assert describe["expand_hint"] == (
+            f"lcm_expand(node_id={node_id}, session_id='old-session')"
+        )
+        assert describe["children"][0]["expand_hint"] == (
+            f"lcm_expand(node_id={child_id}, session_id='old-session')"
+        )
+        assert (
+            mismatched["error"] == f"Node {node_id} not found in session wrong-session"
+        )
+        assert expanded["session_id"] == "old-session"
+        assert expanded["expanded"][0]["node_id"] == child_id
+        assert expanded["expanded"][0]["expand_hint"] == (
+            f"lcm_expand(node_id={child_id}, session_id='old-session')"
+        )
+        child_expanded = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand",
+                {"node_id": child_id, "session_id": "old-session"},
+            )
+        )
+        assert (
+            child_expanded["expanded"][0]["content"] == "historical expanded evidence"
+        )
+
+    def test_handle_expand_query_merges_sessions_by_relevance(
+        self, engine, monkeypatch
+    ):
+        strong_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="older-session",
+                depth=0,
+                summary="strong needle match",
+                token_count=20,
+                source_token_count=20,
+                source_ids=[],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+        weak_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="newer-session",
+                depth=0,
+                summary="weak needle match",
+                token_count=1,
+                source_token_count=1,
+                source_ids=[],
+                source_type="messages",
+                created_at=2,
+            )
+        )
+
+        def fake_node_search(query, session_id=None, limit=20):
+            del query, limit
+            node = engine._dag.get_node(
+                strong_id if session_id == "older-session" else weak_id
+            )
+            node.search_rank = -4.0 if session_id == "older-session" else -3.0
+            return [node]
+
+        monkeypatch.setattr(engine._dag, "search", fake_node_search)
+        monkeypatch.setattr(engine._store, "search", lambda *args, **kwargs: [])
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Find the strongest match",
+                    "query": "needle",
+                    "session_ids": ["older-session", "newer-session"],
+                    "max_results": 1,
+                    "output": "evidence",
+                },
+            )
+        )
+
+        assert result["node_ids"] == [strong_id]
+
+    def test_handle_expand_query_searches_bounded_explicit_sessions(
+        self, engine, monkeypatch
+    ):
+        captured = {}
+        old_store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "NEEDLE historical raw evidence"},
+        )
+        engine._store.append(
+            "other-session",
+            {"role": "user", "content": "NEEDLE excluded raw evidence"},
+        )
+        old_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="NEEDLE historical summary evidence",
+                token_count=5,
+                source_token_count=5,
+                source_ids=[old_store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        def fake_synthesize(**kwargs):
+            captured["context_blocks"] = kwargs["context_blocks"]
+            return "cross-session answer"
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fake_synthesize)
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "What is the historical evidence?",
+                    "query": "NEEDLE",
+                    "session_ids": ["old-session"],
+                    "context_max_tokens": 1000,
+                },
+            )
+        )
+
+        assert result["answer"] == "cross-session answer"
+        assert result["node_ids"] == [old_node_id]
+        assert result["matches"][0]["session_id"] == "old-session"
+        serialized_context = json.dumps(captured["context_blocks"])
+        assert "NEEDLE historical raw evidence" in serialized_context
+        assert "NEEDLE excluded raw evidence" not in serialized_context
+
+    def test_handle_expand_query_rejects_more_than_twenty_session_ids(self, engine):
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Find evidence",
+                    "query": "anything",
+                    "session_ids": [f"session-{index}" for index in range(21)],
+                },
+            )
+        )
+
+        assert result["error"] == "session_ids accepts at most 20 entries"
+
+    def test_handle_expand_query_evidence_skips_synthesis_and_stays_bounded(
+        self, engine, monkeypatch
+    ):
+        store_id = engine._store.append(
+            "old-session",
+            {"role": "user", "content": "bounded evidence " * 200},
+        )
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="bounded evidence summary",
+                token_count=5,
+                source_token_count=400,
+                source_ids=[store_id],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        def fail_synthesis(**kwargs):
+            raise AssertionError("evidence output must not call the synthesis model")
+
+        monkeypatch.setattr(lcm_tools, "_synthesize_expansion_answer", fail_synthesis)
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Return the evidence",
+                    "node_ids": [node_id],
+                    "session_ids": ["old-session"],
+                    "output": "evidence",
+                    "context_max_tokens": 200,
+                },
+            )
+        )
+
+        assert result["output"] == "evidence"
+        assert "answer" not in result
+        assert result["node_ids"] == [node_id]
+        serialized_evidence = json.dumps(result["evidence"], ensure_ascii=False)
+        assert count_tokens(serialized_evidence) <= 200
+        assert result["context_tokens"] == count_tokens(serialized_evidence)
+        assert result["evidence"][0]["session_id"] == "old-session"
+
+    def test_handle_expand_query_evidence_drops_metadata_over_budget(self, engine):
+        node_ids = [
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="old-session",
+                    depth=0,
+                    summary="",
+                    token_count=0,
+                    source_token_count=0,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=index,
+                )
+            )
+            for index in range(100)
+        ]
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Return bounded evidence",
+                    "node_ids": node_ids,
+                    "session_ids": ["old-session"],
+                    "output": "evidence",
+                    "max_results": 100,
+                    "context_max_tokens": 1,
+                },
+            )
+        )
+
+        serialized_evidence = json.dumps(result["evidence"], ensure_ascii=False)
+        assert count_tokens(serialized_evidence) <= 1
+        assert result["context_tokens"] == count_tokens(serialized_evidence)
+        assert result["context_truncated"] is True
+
+    def test_handle_expand_query_evidence_counts_emitted_json_spacing(self, engine):
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="old-session",
+                depth=0,
+                summary="",
+                token_count=0,
+                source_token_count=0,
+                source_ids=[],
+                source_type="messages",
+                created_at=1,
+            )
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Return bounded evidence",
+                    "node_ids": [node_id],
+                    "session_ids": ["old-session"],
+                    "output": "evidence",
+                    "context_max_tokens": 36,
+                },
+            )
+        )
+
+        serialized_evidence = json.dumps(result["evidence"], ensure_ascii=False)
+        assert count_tokens(serialized_evidence) <= 36
+        assert result["context_tokens"] == count_tokens(serialized_evidence)
+        assert result["context_truncated"] is True
+
+    @pytest.mark.parametrize("invalid_output", ["", 0, []])
+    def test_handle_expand_query_rejects_explicit_invalid_output(
+        self, engine, monkeypatch, invalid_output
+    ):
+        monkeypatch.setattr(
+            lcm_tools,
+            "_synthesize_expansion_answer",
+            lambda **kwargs: pytest.fail("invalid output must not invoke synthesis"),
+        )
+
+        result = json.loads(
+            engine.handle_tool_call(
+                "lcm_expand_query",
+                {
+                    "prompt": "Return evidence",
+                    "query": "anything",
+                    "output": invalid_output,
+                },
+            )
+        )
+
+        assert result["error"] == "output must be one of: answer, evidence"
 
 
 class TestHandleGrepCrossSession:

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -23,6 +23,18 @@ from hermes_lcm.vector_store import EmbeddingIdentity, VectorStore
 CURRENT = "session-cur"
 
 
+def test_cross_session_summary_hint_targets_explicit_node_expansion():
+    hint = lcm_tools._lcm_recall_summary_expand_hint(
+        {
+            "node_id": 42,
+            "session_id": "archived-session",
+            "from_current_session": False,
+        }
+    )
+
+    assert hint == "lcm_expand(node_id=42, session_id='archived-session')"
+
+
 class MockProvider:
     provider_id = "mock"
     model_id = "mock-model"

--- a/tools.py
+++ b/tools.py
@@ -128,11 +128,16 @@ def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
     return engine if engine is not None else None
 
 
-def _get_session_node(engine: "LCMEngine", node_id: int):
+def _get_session_node(engine: "LCMEngine", node_id: int, session_id: str | None = None):
+    target_session_id = engine.current_session_id if session_id is None else session_id
     node = engine._dag.get_node(node_id)
-    if node is None or node.session_id != engine.current_session_id:
+    if node is None or node.session_id != target_session_id:
         return None
     return node
+
+
+def _session_expand_hint(node_id: int, session_id: str) -> str:
+    return f"lcm_expand(node_id={node_id}, session_id={session_id!r})"
 
 
 def _get_externalized_payload(
@@ -279,6 +284,7 @@ _LCM_LOAD_SESSION_HARD_MAX_CONTENT_CHARS = 20_000
 _LCM_RECENT_MAX_RESPONSE_CHARS = _LCM_LOAD_SESSION_HARD_MAX_CONTENT_CHARS
 _LCM_INSPECT_DEFAULT_LIMIT = 20
 _LCM_INSPECT_HARD_LIMIT_CAP = 200
+_LCM_EXPAND_QUERY_SESSION_ID_CAP = 20
 _LCM_INSPECT_REF_SCAN_MESSAGE_LIMIT = 10_000
 _LCM_INSPECT_PAYLOAD_METADATA_READ_BYTES = 16_384
 _LCM_INSPECT_MAX_RESPONSE_CHARS = 20_000
@@ -698,11 +704,11 @@ def _expand_child_nodes(
         source_limit = remaining_source_count
     else:
         source_limit = min(max(0, source_limit), remaining_source_count)
-    selected_source_ids = node.source_ids[source_offset:source_offset + source_limit]
+    selected_source_ids = node.source_ids[source_offset : source_offset + source_limit]
     children: list[tuple[int, Any]] = []
     for relative_index, child_id in enumerate(selected_source_ids):
         child = engine._dag.get_node(child_id)
-        if child is None or child.session_id != engine.current_session_id:
+        if child is None or child.session_id != node.session_id:
             continue
         children.append((source_offset + relative_index, child))
 
@@ -719,14 +725,17 @@ def _expand_child_nodes(
                 next_source_offset = source_index
                 has_more = True
                 break
-            summary, summary_truncated = _truncate_text_to_token_budget(summary, remaining_tokens)
+            summary, summary_truncated = _truncate_text_to_token_budget(
+                summary, remaining_tokens
+            )
         expanded.append(
             {
                 "node_id": child.node_id,
                 "source_index": source_index,
                 "depth": child.depth,
                 "summary": summary[:1000] if max_tokens is None else summary,
-                "summary_truncated": summary_truncated or (max_tokens is None and len(child.summary) > 1000),
+                "summary_truncated": summary_truncated
+                or (max_tokens is None and len(child.summary) > 1000),
                 "token_count": child.token_count,
                 "source_token_count": child.source_token_count,
                 "expand_hint": child.expand_hint,
@@ -805,14 +814,17 @@ def _collect_descendant_evidence_blocks(
         stack.append((current, current_path, current_visited, source_index + 1))
         child_id = current.source_ids[source_index]
         child = engine._dag.get_node(child_id)
-        if child is None or child.session_id != engine.current_session_id:
+        if child is None or child.session_id != current.session_id:
             continue
         child_node_id = int(child.node_id)
         if child_node_id in current_visited:
             continue
 
         remaining_node_visits[0] -= 1
-        child_path = [*current_path, {"node_id": int(current.node_id), "source_index": source_index}]
+        child_path = [
+            *current_path,
+            {"node_id": int(current.node_id), "source_index": source_index},
+        ]
         remaining_tokens = max(0, max_tokens - budget_used)
         if child.source_type == "messages":
             messages, pagination = _expand_message_sources(
@@ -837,7 +849,9 @@ def _collect_descendant_evidence_blocks(
             continue
 
         if child.source_type == "nodes":
-            children, pagination = _expand_child_nodes(engine, child, max_tokens=remaining_tokens)
+            children, pagination = _expand_child_nodes(
+                engine, child, max_tokens=remaining_tokens
+            )
             if children or pagination.get("has_more"):
                 block = {
                     "type": "descendant_child_nodes",
@@ -1034,6 +1048,12 @@ def _context_content_token_count(blocks: list[dict[str, Any]]) -> int:
         elif block.get("type") in {"child_nodes", "descendant_child_nodes"}:
             total += sum(count_tokens(str(child.get("summary") or "")) for child in block.get("children", []))
     return total
+
+
+def _serialized_context_token_count(blocks: list[dict[str, Any]]) -> int:
+    from .tokens import count_tokens
+
+    return count_tokens(json.dumps(blocks, ensure_ascii=False))
 
 
 def _synthesize_expansion_answer(
@@ -2815,12 +2835,12 @@ def _lcm_recall_recency_boost(timestamp: Any, *, now: float) -> float:
 
 
 def _lcm_recall_summary_expand_hint(hit: dict[str, Any]) -> str:
-    # Cross-session summary/DAG expansion is deferred (lcm_expand node_id is
-    # current-session only), so a cross-session summary points at the session
-    # loader instead of a node handle it cannot expand.
     if hit.get("from_current_session"):
         return f"lcm_expand(node_id={hit.get('node_id')})"
-    return f"lcm_load_session(session_id='{hit.get('session_id') or ''}')"
+    return (
+        f"lcm_expand(node_id={hit.get('node_id')}, "
+        f"session_id='{hit.get('session_id') or ''}')"
+    )
 
 
 def _lcm_recall_excerpt_expand_hint(hit: dict[str, Any]) -> str:
@@ -3425,7 +3445,11 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
         if payload is None:
-            return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
+            return json.dumps(
+                {
+                    "error": f"Externalized payload {externalized_ref} not found in current session"
+                }
+            )
         return json.dumps(
             {
                 "externalized_ref": externalized_ref,
@@ -3442,13 +3466,30 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
         )
 
     node_id = args.get("node_id")
-    session_id = engine.current_session_id
+    session_id_explicit = "session_id" in args
+    session_id_arg = args.get("session_id")
+    if session_id_explicit:
+        if not isinstance(session_id_arg, str) or not session_id_arg.strip():
+            return json.dumps({"error": "session_id must be a non-empty string"})
+        session_id = session_id_arg.strip()
+    else:
+        session_id = engine.current_session_id
 
     if node_id is not None:
-        node = _get_session_node(engine, node_id)
+        node = _get_session_node(engine, node_id, session_id)
         if node is None:
-            return json.dumps({"error": f"Node {node_id} not found in current session"})
+            scope = (
+                f"session {session_id}" if session_id_explicit else "current session"
+            )
+            return json.dumps({"error": f"Node {node_id} not found in {scope}"})
         info = engine._dag.describe_subtree(node_id)
+        if session_id_explicit:
+            info["session_id"] = node.session_id
+            info["expand_hint"] = _session_expand_hint(node.node_id, node.session_id)
+            for child in info.get("children", []):
+                child["expand_hint"] = _session_expand_hint(
+                    child["node_id"], node.session_id
+                )
         return json.dumps(info)
 
     depth_stats = engine._dag.get_session_depth_stats(session_id)
@@ -3473,7 +3514,11 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
                 {
                     "node_id": node.node_id,
                     "token_count": node.token_count,
-                    "expand_hint": node.expand_hint,
+                    "expand_hint": (
+                        _session_expand_hint(node.node_id, node.session_id)
+                        if session_id_explicit
+                        else node.expand_hint
+                    ),
                 }
                 for node in nodes
             ],
@@ -3488,11 +3533,10 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
     Mode selection (exactly one is required):
     - ``externalized_ref``: open a stored externalized payload by ref filename (current session only)
     - ``store_id``: fetch a single raw message by store_id; works across sessions
-    - ``node_id``: expand a summary node to its source content (current session only)
+    - ``node_id``: expand a summary node to its source content (explicit ``session_id`` required cross-session)
 
-    Only ``store_id`` mode accepts an arbitrary cross-session target. ``node_id``
-    stays current-session scoped, but carried-over current-session nodes may
-    reference raw source rows that still belong to the previous session.
+    Omitting ``session_id`` preserves current-session node lookup. Carried-over
+    current-session nodes may reference raw source rows from the previous session.
     """
     engine = _require_engine(kwargs)
     if engine is None:
@@ -3511,27 +3555,50 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         modes_provided.append("node_id")
 
     if len(modes_provided) > 1:
-        return json.dumps({
-            "error": (
-                "Provide only one of node_id, externalized_ref, store_id "
-                f"(got {', '.join(modes_provided)})"
-            ),
-        })
+        return json.dumps(
+            {
+                "error": (
+                    "Provide only one of node_id, externalized_ref, store_id "
+                    f"(got {', '.join(modes_provided)})"
+                ),
+            }
+        )
     if not modes_provided:
-        return json.dumps({
-            "error": "node_id, externalized_ref, or store_id is required",
-        })
+        return json.dumps(
+            {
+                "error": "node_id, externalized_ref, or store_id is required",
+            }
+        )
+
+    session_id_explicit = "session_id" in args
+    session_id_arg = args.get("session_id")
+    if session_id_explicit and "node_id" not in modes_provided:
+        return json.dumps({"error": "session_id is only valid with node_id"})
+    if session_id_explicit:
+        if not isinstance(session_id_arg, str) or not session_id_arg.strip():
+            return json.dumps({"error": "session_id must be a non-empty string"})
+        session_id = session_id_arg.strip()
+    else:
+        session_id = engine.current_session_id
 
     max_tokens = _parse_positive_int(args.get("max_tokens", 4000), 4000)
     source_offset = _parse_non_negative_int(args.get("source_offset", 0), 0)
     source_limit_arg = args.get("source_limit")
-    source_limit = _parse_positive_int(source_limit_arg, 0) if source_limit_arg is not None else None
+    source_limit = (
+        _parse_positive_int(source_limit_arg, 0)
+        if source_limit_arg is not None
+        else None
+    )
     content_offset = _parse_non_negative_int(args.get("content_offset", 0), 0)
 
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
         if payload is None:
-            return json.dumps({"error": f"Externalized payload {externalized_ref} not found in current session"})
+            return json.dumps(
+                {
+                    "error": f"Externalized payload {externalized_ref} not found in current session"
+                }
+            )
         content = payload.get("content", "")
         sliced = _slice_content_for_response(content, max_tokens, content_offset)
         return json.dumps(
@@ -3563,7 +3630,9 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         if stored is None:
             return json.dumps({"error": f"Message store_id {store_id} not found"})
         transcript_content = stored.get("content", "") or ""
-        sliced = _slice_content_for_response(transcript_content, max_tokens, content_offset)
+        sliced = _slice_content_for_response(
+            transcript_content, max_tokens, content_offset
+        )
         engine_session_id = engine.current_session_id
         stored_session_id = stored.get("session_id", "")
         result: Dict[str, Any] = {
@@ -3575,7 +3644,8 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             "role": stored.get("role"),
             "timestamp": stored.get("timestamp", 0),
             "tool_call_id": stored.get("tool_call_id") or "",
-            "from_current_session": bool(engine_session_id) and stored_session_id == engine_session_id,
+            "from_current_session": bool(engine_session_id)
+            and stored_session_id == engine_session_id,
             "content": sliced["content"],
             "content_chars": sliced["content_chars"],
             "content_offset": sliced["content_offset"],
@@ -3592,7 +3662,11 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
         ref_values = [transcript_content]
         if stored.get("tool_calls"):
             try:
-                ref_values.append(json.dumps(stored.get("tool_calls"), ensure_ascii=False, sort_keys=True))
+                ref_values.append(
+                    json.dumps(
+                        stored.get("tool_calls"), ensure_ascii=False, sort_keys=True
+                    )
+                )
             except (TypeError, ValueError):
                 ref_values.append(str(stored.get("tool_calls")))
         refs: list[str] = []
@@ -3627,11 +3701,12 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
                 )
         return json.dumps(result)
 
+    assert raw_node_id_arg is not None
     node_id = raw_node_id_arg
-
-    node = _get_session_node(engine, node_id)
+    node = _get_session_node(engine, node_id, session_id)
     if node is None:
-        return json.dumps({"error": f"Node {node_id} not found in current session"})
+        scope = f"session {session_id}" if session_id_explicit else "current session"
+        return json.dumps({"error": f"Node {node_id} not found in {scope}"})
 
     if node.source_type == "messages":
         messages, pagination = _expand_message_sources(
@@ -3642,15 +3717,16 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             source_limit=source_limit,
             content_offset=content_offset,
         )
-        return json.dumps(
-            {
-                "node_id": node_id,
-                "depth": node.depth,
-                "source_type": "messages",
-                "expanded": messages,
-                "pagination": pagination,
-            }
-        )
+        result = {
+            "node_id": node_id,
+            "depth": node.depth,
+            "source_type": "messages",
+            "expanded": messages,
+            "pagination": pagination,
+        }
+        if session_id_explicit:
+            result["session_id"] = node.session_id
+        return json.dumps(result)
 
     if node.source_type == "nodes":
         children, pagination = _expand_child_nodes(
@@ -3660,15 +3736,20 @@ def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
             source_offset=source_offset,
             source_limit=source_limit,
         )
-        return json.dumps(
-            {
-                "node_id": node_id,
-                "depth": node.depth,
-                "source_type": "nodes",
-                "expanded": children,
-                "pagination": pagination,
-            }
-        )
+        result = {
+            "node_id": node_id,
+            "depth": node.depth,
+            "source_type": "nodes",
+            "expanded": children,
+            "pagination": pagination,
+        }
+        if session_id_explicit:
+            result["session_id"] = node.session_id
+            for child in result["expanded"]:
+                child["expand_hint"] = _session_expand_hint(
+                    child["node_id"], node.session_id
+                )
+        return json.dumps(result)
 
     return json.dumps({"error": f"Unknown source_type: {node.source_type}"})
 
@@ -3683,6 +3764,32 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     if not prompt:
         return json.dumps({"error": "prompt is required"})
 
+    raw_output = args.get("output", "answer")
+    if not isinstance(raw_output, str):
+        return json.dumps({"error": "output must be one of: answer, evidence"})
+    output = raw_output.strip().lower()
+    if output not in {"answer", "evidence"}:
+        return json.dumps({"error": "output must be one of: answer, evidence"})
+
+    session_ids_explicit = "session_ids" in args
+    raw_session_ids = args.get("session_ids")
+    if not session_ids_explicit:
+        session_ids = [engine.current_session_id]
+    elif not isinstance(raw_session_ids, list) or not raw_session_ids:
+        return json.dumps({"error": "session_ids must be a non-empty array of strings"})
+    elif len(raw_session_ids) > _LCM_EXPAND_QUERY_SESSION_ID_CAP:
+        return json.dumps({"error": "session_ids accepts at most 20 entries"})
+    else:
+        session_ids = []
+        for raw_session_id in raw_session_ids:
+            if not isinstance(raw_session_id, str) or not raw_session_id.strip():
+                return json.dumps(
+                    {"error": "session_ids must contain only non-empty strings"}
+                )
+            session_id = raw_session_id.strip()
+            if session_id not in session_ids:
+                session_ids.append(session_id)
+
     def _parse_int_arg(name: str, default: int) -> tuple[int | None, str | None]:
         raw_value = args.get(name, default)
         try:
@@ -3694,8 +3801,13 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     if max_tokens_error:
         return json.dumps({"error": max_tokens_error})
     max_tokens = max(1, max_tokens)
-    context_default = max(max_tokens, int(getattr(engine._config, "expansion_context_tokens", 32_000) or 32_000))
-    context_max_tokens, context_max_tokens_error = _parse_int_arg("context_max_tokens", context_default)
+    context_default = max(
+        max_tokens,
+        int(getattr(engine._config, "expansion_context_tokens", 32_000) or 32_000),
+    )
+    context_max_tokens, context_max_tokens_error = _parse_int_arg(
+        "context_max_tokens", context_default
+    )
     if context_max_tokens_error:
         return json.dumps({"error": context_max_tokens_error})
     context_max_tokens = max(1, context_max_tokens)
@@ -3711,26 +3823,77 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
     nodes = []
     raw_results: list[dict[str, Any]] = []
     if raw_node_ids:
+        allowed_session_ids = set(session_ids)
         for node_id in raw_node_ids:
             try:
                 parsed_node_id = int(node_id)
             except (TypeError, ValueError):
                 return json.dumps({"error": "node_ids must contain only integers"})
-            node = _get_session_node(engine, parsed_node_id)
-            if node is not None:
+            node = engine._dag.get_node(parsed_node_id)
+            if node is not None and node.session_id in allowed_session_ids:
                 nodes.append(node)
     elif query:
-        nodes = engine._dag.search(query, session_id=engine.current_session_id, limit=max_results)
-        raw_results = engine._store.search(query, session_id=engine.current_session_id, limit=max_results)
+        for session_id in session_ids:
+            nodes.extend(
+                engine._dag.search(query, session_id=session_id, limit=max_results)
+            )
+            raw_results.extend(
+                engine._store.search(query, session_id=session_id, limit=max_results)
+            )
+        if len(session_ids) > 1:
+            nodes.sort(
+                key=lambda node: (
+                    float(node.search_rank)
+                    if node.search_rank is not None
+                    else float("inf"),
+                    -float(node.search_directness or 0),
+                    -float(node.latest_at or node.created_at or 0),
+                )
+            )
+            raw_results.sort(
+                key=lambda row: _combined_result_sort_key(
+                    {
+                        "type": "message",
+                        "role": row.get("role"),
+                        "_sort_rank": row.get("search_rank"),
+                        "_sort_directness": row.get("_directness_score"),
+                        "_sort_ts": row.get("timestamp"),
+                    },
+                    "relevance",
+                )
+            )
+        nodes = nodes[:max_results]
+        raw_results = raw_results[:max_results]
     else:
         return json.dumps({"error": "Provide either query or node_ids"})
 
     if not nodes and not raw_results:
+        if output == "evidence":
+            payload = {
+                "prompt": prompt,
+                "query": query,
+                "output": "evidence",
+                "evidence": [],
+                "context_max_tokens": context_max_tokens,
+                "context_tokens": 0,
+                "context_truncated": False,
+                "context_pagination": [],
+                "node_ids": [],
+                "matches": [],
+                "raw_matches": [],
+            }
+            if session_ids_explicit:
+                payload["session_ids"] = session_ids
+            return json.dumps(payload)
         return json.dumps(
             {
                 "prompt": prompt,
                 "query": query,
-                "answer": "No matching summaries or raw messages found in the current session.",
+                "answer": (
+                    "No matching summaries or raw messages found in the requested sessions."
+                    if session_ids_explicit
+                    else "No matching summaries or raw messages found in the current session."
+                ),
                 "node_ids": [],
                 "matches": [],
                 "raw_matches": [],
@@ -3739,19 +3902,40 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
 
     context_blocks = []
     context_budget_used = 0
+    context_budget_truncated = False
     for node in nodes[:max_results]:
         remaining_context_tokens = max(0, context_max_tokens - context_budget_used)
+        if output == "evidence" and remaining_context_tokens <= 0:
+            context_budget_truncated = True
+            break
         node_blocks = _collect_context_blocks_for_node(
             engine,
             node,
             max_tokens=remaining_context_tokens,
-            hydrate_externalized_content=True,
+            hydrate_externalized_content=(
+                not session_ids_explicit or node.session_id == engine.current_session_id
+            ),
         )
-        context_blocks.extend(node_blocks)
-        context_budget_used += _context_content_token_count(node_blocks)
+        if session_ids_explicit:
+            for block in node_blocks:
+                block["session_id"] = node.session_id
+        if output == "evidence":
+            for block in node_blocks:
+                candidate_blocks = [*context_blocks, block]
+                candidate_tokens = _serialized_context_token_count(candidate_blocks)
+                if candidate_tokens > context_max_tokens:
+                    context_budget_truncated = True
+                    break
+                context_blocks.append(block)
+                context_budget_used = candidate_tokens
+            if context_budget_truncated:
+                break
+        else:
+            context_blocks.extend(node_blocks)
+            context_budget_used += _context_content_token_count(node_blocks)
 
     raw_matches: list[dict[str, Any]] = []
-    if raw_results:
+    if raw_results and context_budget_used < context_max_tokens:
         seen_store_ids = _collect_store_ids_from_context_blocks(context_blocks)
         remaining_context_tokens = max(0, context_max_tokens - context_budget_used)
         raw_block, raw_matches = _collect_raw_match_context_block(
@@ -3762,8 +3946,19 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             exclude_store_ids=seen_store_ids,
         )
         if raw_block is not None:
-            context_blocks.append(raw_block)
-            context_budget_used += _context_content_token_count([raw_block])
+            if output == "evidence":
+                candidate_blocks = [*context_blocks, raw_block]
+                candidate_tokens = _serialized_context_token_count(candidate_blocks)
+                if candidate_tokens <= context_max_tokens:
+                    context_blocks.append(raw_block)
+                    context_budget_used = candidate_tokens
+                else:
+                    context_budget_truncated = True
+            else:
+                context_blocks.append(raw_block)
+                context_budget_used += _context_content_token_count([raw_block])
+    elif raw_results:
+        context_budget_truncated = True
 
     context_pagination = []
     for block in context_blocks:
@@ -3771,30 +3966,36 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             continue
         block_type = block.get("type")
         if block_type == "summary" and block.get("summary_truncated"):
-            context_pagination.append(
-                {
-                    "node_id": block.get("node_id"),
-                    "type": "summary",
-                    "summary_truncated": True,
-                    "expand_args": {"node_id": block.get("node_id")},
-                }
-            )
+            item = {
+                "node_id": block.get("node_id"),
+                "type": "summary",
+                "summary_truncated": True,
+                "expand_args": {"node_id": block.get("node_id")},
+            }
+            if block.get("session_id") is not None:
+                item["session_id"] = block["session_id"]
+                item["expand_args"]["session_id"] = block["session_id"]
+            context_pagination.append(item)
             continue
 
         if block_type in {"child_nodes", "descendant_child_nodes"}:
             for child in block.get("children", []):
                 if child.get("summary_truncated"):
                     child_node_id = child.get("node_id")
-                    context_pagination.append(
-                        {
-                            "node_id": block.get("node_id"),
-                            "type": "child_summary" if block_type == "child_nodes" else "descendant_child_summary",
-                            "child_node_id": child_node_id,
-                            "source_index": child.get("source_index"),
-                            "summary_truncated": True,
-                            "expand_args": {"node_id": child_node_id},
-                        }
-                    )
+                    item = {
+                        "node_id": block.get("node_id"),
+                        "type": "child_summary"
+                        if block_type == "child_nodes"
+                        else "descendant_child_summary",
+                        "child_node_id": child_node_id,
+                        "source_index": child.get("source_index"),
+                        "summary_truncated": True,
+                        "expand_args": {"node_id": child_node_id},
+                    }
+                    if block.get("session_id") is not None:
+                        item["session_id"] = block["session_id"]
+                        item["expand_args"]["session_id"] = block["session_id"]
+                    context_pagination.append(item)
 
         pagination = block.get("pagination")
         if not pagination or not pagination.get("has_more"):
@@ -3805,9 +4006,15 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
             "type": block_type,
             "pagination": pagination,
         }
+        if block.get("session_id") is not None:
+            item["session_id"] = block.get("session_id")
         if block_type in {"messages", "child_messages"}:
             truncated_message = next(
-                (message for message in block.get("messages", []) if message.get("content_truncated")),
+                (
+                    message
+                    for message in block.get("messages", [])
+                    if message.get("content_truncated")
+                ),
                 None,
             )
             if truncated_message:
@@ -3818,7 +4025,10 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                 if externalized_ref:
                     item["externalized_ref"] = externalized_ref
                     item["tool_call_id"] = externalized.get("tool_call_id")
-                if truncated_message.get("content_source") == "externalized_payload" and externalized_ref:
+                if (
+                    truncated_message.get("content_source") == "externalized_payload"
+                    and externalized_ref
+                ):
                     item["expand_args"] = {
                         "externalized_ref": externalized_ref,
                         "content_offset": pagination.get("next_content_offset") or 0,
@@ -3837,7 +4047,11 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                 }
         elif block_type == "raw_messages":
             truncated_message = next(
-                (message for message in block.get("messages", []) if message.get("content_truncated")),
+                (
+                    message
+                    for message in block.get("messages", [])
+                    if message.get("content_truncated")
+                ),
                 None,
             )
             if truncated_message:
@@ -3855,10 +4069,15 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
                 "node_id": block.get("node_id"),
                 "source_offset": pagination.get("next_source_offset") or 0,
             }
+        if item.get("session_id") is not None and "node_id" in item.get(
+            "expand_args", {}
+        ):
+            item["expand_args"]["session_id"] = item["session_id"]
         context_pagination.append(item)
 
-    context_truncated = any(
-        bool(item.get("summary_truncated")) or bool(item.get("pagination", {}).get("has_more"))
+    context_truncated = context_budget_truncated or any(
+        bool(item.get("summary_truncated"))
+        or bool(item.get("pagination", {}).get("has_more"))
         for item in context_pagination
     )
 
@@ -3872,7 +4091,29 @@ def lcm_expand_query(args: Dict[str, Any], **kwargs) -> str:
         }
         for node in selected_nodes
     ]
+    if session_ids_explicit:
+        for match, node in zip(matches, selected_nodes):
+            match["session_id"] = node.session_id
+            match["expand_hint"] = _session_expand_hint(node.node_id, node.session_id)
     node_ids = [node.node_id for node in selected_nodes]
+
+    if output == "evidence":
+        payload = {
+            "prompt": prompt,
+            "query": query,
+            "output": "evidence",
+            "evidence": context_blocks,
+            "context_max_tokens": context_max_tokens,
+            "context_tokens": _serialized_context_token_count(context_blocks),
+            "context_truncated": context_truncated,
+            "context_pagination": context_pagination,
+            "node_ids": node_ids,
+            "matches": matches,
+            "raw_matches": raw_matches,
+        }
+        if session_ids_explicit:
+            payload["session_ids"] = session_ids
+        return json.dumps(payload)
 
     def _degraded_payload(reason: str, *, include_timeout: bool = False) -> str:
         payload: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- allow `lcm_describe` and `lcm_expand` to target an explicit historical `session_id`
- add bounded multi-session evidence retrieval to `lcm_expand_query` for up to 20 explicit sessions
- preserve relevance ordering and emit session-aware provenance and expansion hints
- document the cross-session recovery path and cover it with regression tests

## Why
- cross-session recall can find historical summary nodes, but previously could not directly expand their DAG lineage or supporting evidence
- sending users to a whole-session transcript loses the selected node context and makes historical claims harder to verify
- explicit bounded expansion closes that recovery gap without turning archive access into an unbounded scan

## Validation
- [x] Focused validation: `pytest -q tests/test_lcm_engine.py tests/test_lcm_recall.py -o addopts=` -> `795 passed, 1 skipped`
- [x] Default focused validation: `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q -o addopts=` -> `1076 passed, 1 skipped`
- [ ] `pytest -q` -> `2305 passed, 1 skipped, 12 xfailed, 2 failed`; the failures are existing macOS `/tmp` vs `/private/tmp` string-prefix assertions in `test_path_containment_within_allowed_base` and `test_configured_externalization_path_inside_allowed_base_accepted`
- [ ] low-fd full pytest -> same two unrelated macOS path-prefix failures
- [x] release validator compile, shell, focused-pytest, benchmark-smoke, stress-smoke, and stress-release gates passed
- [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [ ] Workflow validation: not run; no workflow files changed

## Notes
- current-session defaults are unchanged
- historical externalized payloads are not hydrated when they are not accessible to the active session
- full validation artifacts: `/tmp/hermes-lcm-release-validation-cross-session-dag-isolated`

Closes #448