### PR TITLE
fix: yield the count-protected fresh tail under sustained threshold pressure (#441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Most installs only need `plugins.enabled` and `context.engine: lcm`.
 | `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
 | `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
 | `LCM_FRESH_TAIL_MAX_TOKENS` | `0` | Optional token cap for the protected fresh tail (`0` disables it); always retains the newest message and complete assistant/tool-result groups |
+| `LCM_FRESH_TAIL_PRESSURE_YIELD_ENABLED` | `true` | Default-on: when compaction is deadlocked because the count-protected tail covers the whole over-threshold session (#441), the tail yields to a derived token bound so compaction can progress; `false` restores the strict count tail (rollback switch) |
+| `LCM_FRESH_TAIL_PRESSURE_YIELD_MIN_OBSERVATIONS` | `3` | Consecutive tail-blocked compaction attempts under host-observed pressure before the yield engages; any attempt not blocked by the tail resets the count; `1` yields on first observation |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Raw-backlog floor before leaf compaction; with dynamic chunking enabled, the base chunk target |
 | `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Enable chunk-sized leaf compaction passes instead of compacting the whole non-tail raw backlog per pass |

--- a/compaction.py
+++ b/compaction.py
@@ -69,6 +69,7 @@ class CompactionMixin:
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
+        self._reset_fresh_tail_pressure_yield()
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
@@ -156,6 +157,7 @@ class CompactionMixin:
                     and self.threshold_tokens > 0
                     and replay_rough >= self.threshold_tokens
                 ),
+                observed_tokens=replay_rough,
             )
             if eligible:
                 return self._mark_preflight_compression_requested()
@@ -185,6 +187,7 @@ class CompactionMixin:
             eligible, reason = self._leaf_compaction_candidate_status(
                 messages,
                 allow_partial_leaf=self._config.threshold_full_sweep_enabled,
+                observed_tokens=rough,
             )
             if eligible:
                 return self._mark_preflight_compression_requested()
@@ -260,6 +263,7 @@ class CompactionMixin:
         *,
         force_overflow: bool = False,
         allow_partial_leaf: bool = False,
+        observed_tokens: Optional[int] = None,
     ) -> tuple[bool, str]:
         """Return whether a normal leaf compaction pass can actually run.
 
@@ -269,7 +273,37 @@ class CompactionMixin:
         backlog outside that tail is still smaller than the configured leaf
         chunk. In that case ``compress()`` would immediately no-op, so preflight
         should not advertise a compaction attempt yet.
+
+        When ``observed_tokens`` reports sustained over-threshold pressure and
+        the protected tail itself is why no pass can run, the fresh-tail
+        pressure yield re-resolves the tail with a derived token bound and the
+        check runs once more (see ``_maybe_engage_fresh_tail_pressure_yield``).
         """
+        eligible, reason = self._leaf_compaction_candidate_status_once(
+            messages,
+            force_overflow=force_overflow,
+            allow_partial_leaf=allow_partial_leaf,
+        )
+        if eligible:
+            return eligible, reason
+        if reason in (
+            "no eligible raw backlog outside fresh tail",
+            "raw backlog outside fresh tail is below leaf chunk threshold",
+        ) and self._maybe_engage_fresh_tail_pressure_yield(messages, observed_tokens):
+            return self._leaf_compaction_candidate_status_once(
+                messages,
+                force_overflow=force_overflow,
+                allow_partial_leaf=allow_partial_leaf,
+            )
+        return eligible, reason
+
+    def _leaf_compaction_candidate_status_once(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        force_overflow: bool = False,
+        allow_partial_leaf: bool = False,
+    ) -> tuple[bool, str]:
         if not messages:
             return False, "empty message list"
         fresh_tail_start = self._fresh_tail_start(messages)
@@ -318,7 +352,10 @@ class CompactionMixin:
             working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
         else:
             working_leaf_chunk_tokens = self._config.leaf_chunk_tokens
-        if raw_tokens_outside_tail < working_leaf_chunk_tokens:
+        if (
+            raw_tokens_outside_tail < working_leaf_chunk_tokens
+            and self._pressure_yield_tail_token_limit <= 0
+        ):
             return False, "raw backlog outside fresh tail is below leaf chunk threshold"
         return True, "eligible raw backlog outside fresh tail"
 
@@ -403,6 +440,7 @@ class CompactionMixin:
                 force=force,
             )
 
+        self._reset_fresh_tail_pressure_yield()
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
         force_overflow = self._should_force_overflow_recovery(
             observed_tokens=observed_prompt_tokens,
@@ -539,6 +577,11 @@ class CompactionMixin:
             # replayed forever as fresh-looking intent.
             leading_anchor_count = self._leading_anchor_count(working_messages)
             if fresh_tail_start <= leading_anchor_count:
+                if not threshold_full_sweep_active and self._maybe_engage_fresh_tail_pressure_yield(
+                    pressure_messages,
+                    observed_prompt_tokens,
+                ):
+                    continue
                 noop_reason = "no eligible raw backlog outside fresh tail"
                 if threshold_full_sweep_active:
                     sweep_raw_drained = True
@@ -655,6 +698,11 @@ class CompactionMixin:
 
             candidate_raw = working_messages[leading_anchor_count:fresh_tail_start]
             if not candidate_raw:
+                if not threshold_full_sweep_active and self._maybe_engage_fresh_tail_pressure_yield(
+                    pressure_messages,
+                    observed_prompt_tokens,
+                ):
+                    continue
                 noop_reason = "no eligible raw backlog outside fresh tail"
                 if threshold_full_sweep_active:
                     sweep_raw_drained = True
@@ -673,8 +721,20 @@ class CompactionMixin:
                 )
             elif self._config.dynamic_leaf_chunk_enabled:
                 working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
-                if raw_tokens_outside_tail < working_leaf_chunk_tokens and not force_overflow:
+                # An armed pressure yield waives the leaf-chunk minimum: the
+                # whole point of the yield is progress, and the freed backlog
+                # can legitimately be smaller than one configured chunk.
+                if (
+                    raw_tokens_outside_tail < working_leaf_chunk_tokens
+                    and not force_overflow
+                    and self._pressure_yield_tail_token_limit <= 0
+                ):
                     if not (deferred_maintenance_active and critical_budget_pressure):
+                        if self._maybe_engage_fresh_tail_pressure_yield(
+                            pressure_messages,
+                            observed_prompt_tokens,
+                        ):
+                            continue
                         noop_reason = (
                             "raw backlog outside fresh tail is below leaf chunk threshold"
                         )
@@ -684,8 +744,17 @@ class CompactionMixin:
                 else:
                     to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
             else:
-                if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
+                if (
+                    raw_tokens_outside_tail < self._config.leaf_chunk_tokens
+                    and not force_overflow
+                    and self._pressure_yield_tail_token_limit <= 0
+                ):
                     if not (deferred_maintenance_active and critical_budget_pressure):
+                        if self._maybe_engage_fresh_tail_pressure_yield(
+                            pressure_messages,
+                            observed_prompt_tokens,
+                        ):
+                            continue
                         noop_reason = (
                             "raw backlog outside fresh tail is below leaf chunk threshold"
                         )

--- a/compaction.py
+++ b/compaction.py
@@ -75,6 +75,9 @@ class CompactionMixin:
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
+            # Bypassed traffic observes nothing about the pressured session's
+            # tail: it must neither extend nor reset the blocked streak.
+            self._pressure_yield_invocation_verdict = "neutral"
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
             rough = count_messages_tokens(messages)
             if self._compression_boundary_cooldown_active():
@@ -452,6 +455,9 @@ class CompactionMixin:
 
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
+            # Bypassed traffic observes nothing about the pressured session's
+            # tail: it must neither extend nor reset the blocked streak.
+            self._pressure_yield_invocation_verdict = "neutral"
             bypass_current_tokens = current_tokens
             if bypass_current_tokens is None or bypass_current_tokens <= 0:
                 auxiliary_session_id = self._thread_context_session_id()
@@ -510,6 +516,7 @@ class CompactionMixin:
             self._ingest_cursor = len(sanitized_messages)
             self._last_compression_status = "sanitized"
             self._last_compression_noop_reason = ""
+            self._note_fresh_tail_pressure_relieved()
             self._write_generated_ignored_placeholder_hash_counts(
                 self._generated_placeholder_digest_budget_for_active_replay(
                     sanitized_messages
@@ -992,6 +999,7 @@ class CompactionMixin:
                 self._ingest_cursor = len(sanitized_messages)
                 self._last_compression_status = "sanitized"
                 self._last_compression_noop_reason = ""
+                self._note_fresh_tail_pressure_relieved()
             else:
                 if dropped_replayed_scaffold_messages:
                     # The active context changed even though no new leaf node was

--- a/compaction.py
+++ b/compaction.py
@@ -68,8 +68,11 @@ class CompactionMixin:
 
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
+        with self._fresh_tail_pressure_yield_invocation():
+            return self._should_compress_preflight_impl(messages)
+
+    def _should_compress_preflight_impl(self, messages):
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
-        self._reset_fresh_tail_pressure_yield()
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
@@ -80,6 +83,8 @@ class CompactionMixin:
                 return True
             return self.threshold_tokens > 0 and rough >= self.threshold_tokens
         rough = count_messages_tokens(messages)
+        if self.threshold_tokens > 0 and rough < self.threshold_tokens:
+            self._note_fresh_tail_pressure_relieved()
         pre_ingest_placeholder_ambiguous_noop = False
         pre_ingest_noop_reason = ""
         if (
@@ -94,9 +99,14 @@ class CompactionMixin:
                 for msg in messages
             )
         ):
+            # Yield-aware (observed_tokens): a persisted-placeholder session
+            # whose only blocker is the fresh tail must not park in the
+            # ambiguous-noop state while compress() would engage the pressure
+            # yield and make progress.
             eligible, reason = self._leaf_compaction_candidate_status(
                 messages,
                 allow_partial_leaf=self._config.threshold_full_sweep_enabled,
+                observed_tokens=rough,
             )
             pre_ingest_placeholder_ambiguous_noop = not eligible
             pre_ingest_noop_reason = reason
@@ -274,12 +284,13 @@ class CompactionMixin:
         chunk. In that case ``compress()`` would immediately no-op, so preflight
         should not advertise a compaction attempt yet.
 
-        When ``observed_tokens`` reports sustained over-threshold pressure and
-        the protected tail itself is why no pass can run, the fresh-tail
+        When ``observed_tokens`` reports host-observed over-threshold pressure
+        and the protected tail itself is why no pass can run, the fresh-tail
         pressure yield re-resolves the tail with a derived token bound and the
-        check runs once more (see ``_maybe_engage_fresh_tail_pressure_yield``).
+        check runs once more (see ``_maybe_engage_fresh_tail_pressure_yield``;
+        the yield arms only once that pressure is sustained).
         """
-        eligible, reason = self._leaf_compaction_candidate_status_once(
+        eligible, reason, filtered_eligible_tokens = self._leaf_compaction_candidate_status_once(
             messages,
             force_overflow=force_overflow,
             allow_partial_leaf=allow_partial_leaf,
@@ -289,8 +300,12 @@ class CompactionMixin:
         if reason in (
             "no eligible raw backlog outside fresh tail",
             "raw backlog outside fresh tail is below leaf chunk threshold",
-        ) and self._maybe_engage_fresh_tail_pressure_yield(messages, observed_tokens):
-            return self._leaf_compaction_candidate_status_once(
+        ) and self._maybe_engage_fresh_tail_pressure_yield(
+            messages,
+            observed_tokens,
+            eligible_tokens=filtered_eligible_tokens,
+        ):
+            eligible, reason, _ = self._leaf_compaction_candidate_status_once(
                 messages,
                 force_overflow=force_overflow,
                 allow_partial_leaf=allow_partial_leaf,
@@ -303,17 +318,25 @@ class CompactionMixin:
         *,
         force_overflow: bool = False,
         allow_partial_leaf: bool = False,
-    ) -> tuple[bool, str]:
+    ) -> tuple[bool, str, int]:
+        """Single candidate-status pass.
+
+        Returns ``(eligible, reason, eligible_tokens)`` where
+        ``eligible_tokens`` is the token count of the FILTERED raw backlog
+        outside the resolved tail — the same view ``compress()`` operates on —
+        so the pressure-yield gate judges tail blockage from the numbers the
+        compaction pass would actually see.
+        """
         if not messages:
-            return False, "empty message list"
+            return False, "empty message list", 0
         fresh_tail_start = self._fresh_tail_start(messages)
         leading_anchor_count = self._leading_anchor_count(messages)
         if fresh_tail_start <= leading_anchor_count:
-            return False, "no eligible raw backlog outside fresh tail"
+            return False, "no eligible raw backlog outside fresh tail", 0
 
         candidate_raw = messages[leading_anchor_count:fresh_tail_start]
         if not candidate_raw:
-            return False, "no eligible raw backlog outside fresh tail"
+            return False, "no eligible raw backlog outside fresh tail", 0
         generated_placeholder_hashes = self._load_generated_ignored_placeholder_hashes()
         if self._compiled_ignore_message_patterns or generated_placeholder_hashes:
             previous_store_id_map = self._current_compress_store_ids_by_message_id
@@ -340,14 +363,14 @@ class CompactionMixin:
                 self._current_compress_store_ids_by_message_id = previous_store_id_map
             candidate_raw = filtered_candidate_raw
             if not candidate_raw:
-                return False, "no eligible raw backlog outside fresh tail"
+                return False, "no eligible raw backlog outside fresh tail", 0
 
         if force_overflow:
-            return True, "forced overflow recovery"
+            return True, "forced overflow recovery", 0
 
         raw_tokens_outside_tail = count_messages_tokens(candidate_raw)
         if allow_partial_leaf:
-            return True, "eligible partial threshold-sweep leaf"
+            return True, "eligible partial threshold-sweep leaf", raw_tokens_outside_tail
         if self._config.dynamic_leaf_chunk_enabled:
             working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(raw_tokens_outside_tail)
         else:
@@ -356,8 +379,12 @@ class CompactionMixin:
             raw_tokens_outside_tail < working_leaf_chunk_tokens
             and self._pressure_yield_tail_token_limit <= 0
         ):
-            return False, "raw backlog outside fresh tail is below leaf chunk threshold"
-        return True, "eligible raw backlog outside fresh tail"
+            return (
+                False,
+                "raw backlog outside fresh tail is below leaf chunk threshold",
+                raw_tokens_outside_tail,
+            )
+        return True, "eligible raw backlog outside fresh tail", raw_tokens_outside_tail
 
     def _working_leaf_chunk_tokens(self, raw_tokens_outside_tail: int) -> int:
         base = max(1, self._config.leaf_chunk_tokens)
@@ -390,12 +417,13 @@ class CompactionMixin:
                  force: bool = False) -> List[Dict[str, Any]]:
         """Run compaction and leave a terminal public status on every failure."""
         try:
-            return self._compress_impl(
-                messages,
-                current_tokens=current_tokens,
-                focus_topic=focus_topic,
-                force=force,
-            )
+            with self._fresh_tail_pressure_yield_invocation():
+                return self._compress_impl(
+                    messages,
+                    current_tokens=current_tokens,
+                    focus_topic=focus_topic,
+                    force=force,
+                )
         except BaseException:
             self._last_compression_status = "error"
             self._last_compression_noop_reason = ""
@@ -440,7 +468,6 @@ class CompactionMixin:
                 force=force,
             )
 
-        self._reset_fresh_tail_pressure_yield()
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
         force_overflow = self._should_force_overflow_recovery(
             observed_tokens=observed_prompt_tokens,
@@ -577,9 +604,14 @@ class CompactionMixin:
             # replayed forever as fresh-looking intent.
             leading_anchor_count = self._leading_anchor_count(working_messages)
             if fresh_tail_start <= leading_anchor_count:
-                if not threshold_full_sweep_active and self._maybe_engage_fresh_tail_pressure_yield(
+                # Also reached with threshold_full_sweep_active: a sweep whose
+                # "drained" raw prefix is really a tail covering the whole
+                # session must yield like any other blocked pass, or the sweep
+                # condenses nothing and the deadlock survives in sweep mode.
+                if self._maybe_engage_fresh_tail_pressure_yield(
                     pressure_messages,
                     observed_prompt_tokens,
+                    eligible_tokens=0,
                 ):
                     continue
                 noop_reason = "no eligible raw backlog outside fresh tail"
@@ -698,9 +730,10 @@ class CompactionMixin:
 
             candidate_raw = working_messages[leading_anchor_count:fresh_tail_start]
             if not candidate_raw:
-                if not threshold_full_sweep_active and self._maybe_engage_fresh_tail_pressure_yield(
+                if self._maybe_engage_fresh_tail_pressure_yield(
                     pressure_messages,
                     observed_prompt_tokens,
+                    eligible_tokens=0,
                 ):
                     continue
                 noop_reason = "no eligible raw backlog outside fresh tail"
@@ -733,6 +766,7 @@ class CompactionMixin:
                         if self._maybe_engage_fresh_tail_pressure_yield(
                             pressure_messages,
                             observed_prompt_tokens,
+                            eligible_tokens=raw_tokens_outside_tail,
                         ):
                             continue
                         noop_reason = (
@@ -753,6 +787,7 @@ class CompactionMixin:
                         if self._maybe_engage_fresh_tail_pressure_yield(
                             pressure_messages,
                             observed_prompt_tokens,
+                            eligible_tokens=raw_tokens_outside_tail,
                         ):
                             continue
                         noop_reason = (
@@ -1033,6 +1068,7 @@ class CompactionMixin:
         )
         self._last_compression_status = "compacted"
         self._last_compression_noop_reason = ""
+        self._note_fresh_tail_pressure_relieved()
         if recovery_assembly_cap is None:
             self._last_overflow_recovery_failed = False
         else:

--- a/config.py
+++ b/config.py
@@ -312,6 +312,11 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("fresh_tail_count", "LCM_FRESH_TAIL_COUNT", int),
     _EnvFieldSpec("fresh_tail_max_tokens", "LCM_FRESH_TAIL_MAX_TOKENS", int),
     _EnvFieldSpec("fresh_tail_pressure_yield_enabled", "LCM_FRESH_TAIL_PRESSURE_YIELD_ENABLED", bool),
+    _EnvFieldSpec(
+        "fresh_tail_pressure_yield_min_observations",
+        "LCM_FRESH_TAIL_PRESSURE_YIELD_MIN_OBSERVATIONS",
+        int,
+    ),
     _EnvFieldSpec("leaf_chunk_tokens", "LCM_LEAF_CHUNK_TOKENS", int),
     _EnvFieldSpec("context_threshold", "LCM_CONTEXT_THRESHOLD", float),
     _EnvFieldSpec("incremental_max_depth", "LCM_INCREMENTAL_MAX_DEPTH", int),
@@ -426,6 +431,13 @@ class LCMConfig:
     # reason compaction cannot make progress. Fires only in a state that
     # otherwise ends at the provider hard limit (see #441).
     fresh_tail_pressure_yield_enabled: bool = True
+    # How many consecutive blocked entry-point invocations (preflight or
+    # compress observing over-threshold pressure with the tail as the only
+    # blocker) it takes before the yield arms. This is what "sustained" means:
+    # below this count fresh_tail_count stays a hard suffix. 1 yields on the
+    # first blocked observation; the evidence streak resets whenever pressure
+    # drops below threshold, a compaction pass succeeds, or the session resets.
+    fresh_tail_pressure_yield_min_observations: int = 3
 
     # -- Compaction thresholds ---
     # Max source tokens in a leaf chunk before summarization triggers

--- a/config.py
+++ b/config.py
@@ -311,6 +311,7 @@ class _EnvFieldSpec:
 ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("fresh_tail_count", "LCM_FRESH_TAIL_COUNT", int),
     _EnvFieldSpec("fresh_tail_max_tokens", "LCM_FRESH_TAIL_MAX_TOKENS", int),
+    _EnvFieldSpec("fresh_tail_pressure_yield_enabled", "LCM_FRESH_TAIL_PRESSURE_YIELD_ENABLED", bool),
     _EnvFieldSpec("leaf_chunk_tokens", "LCM_LEAF_CHUNK_TOKENS", int),
     _EnvFieldSpec("context_threshold", "LCM_CONTEXT_THRESHOLD", float),
     _EnvFieldSpec("incremental_max_depth", "LCM_INCREMENTAL_MAX_DEPTH", int),
@@ -420,6 +421,11 @@ class LCMConfig:
     fresh_tail_count: int = 32
     # Optional token cap for the protected suffix (0 = disabled)
     fresh_tail_max_tokens: int = 0
+    # Let the count-protected tail yield to a derived token bound when the
+    # host reports sustained over-threshold pressure and the tail is the only
+    # reason compaction cannot make progress. Fires only in a state that
+    # otherwise ends at the provider hard limit (see #441).
+    fresh_tail_pressure_yield_enabled: bool = True
 
     # -- Compaction thresholds ---
     # Max source tokens in a leaf chunk before summarization triggers

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -140,6 +140,8 @@ environment variables:
 | `LCM_CONTEXT_THRESHOLD` | `0.35` | Fraction of the context window that triggers LCM compaction |
 | `LCM_FRESH_TAIL_COUNT` | `32` | Recent messages protected from compaction |
 | `LCM_FRESH_TAIL_MAX_TOKENS` | `0` | Optional token cap for the protected fresh tail (`0` disables it); always retains the newest message and complete assistant/tool-result groups |
+| `LCM_FRESH_TAIL_PRESSURE_YIELD_ENABLED` | `true` | Default-on: when compaction is deadlocked because the count-protected tail covers the whole over-threshold session (#441), the tail yields to a derived token bound so compaction can progress; `false` restores the strict count tail (rollback switch) |
+| `LCM_FRESH_TAIL_PRESSURE_YIELD_MIN_OBSERVATIONS` | `3` | Consecutive tail-blocked compaction attempts under host-observed pressure before the yield engages; any attempt not blocked by the tail resets the count; `1` yields on first observation |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `3` | Max DAG condensation depth (`-1` = unlimited, `0` = leaf only); enables hierarchical summarization |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Raw-backlog floor before leaf compaction; with dynamic chunking enabled, the base chunk target |
 | `LCM_DYNAMIC_LEAF_CHUNK_ENABLED` | `false` | Enable chunk-sized leaf compaction passes instead of compacting the whole non-tail raw backlog per pass |

--- a/engine.py
+++ b/engine.py
@@ -5,6 +5,7 @@ with a DAG-based summarization system that preserves every message.
 """
 
 import asyncio
+import contextlib
 import copy
 import hashlib
 import json
@@ -436,9 +437,21 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         }
 
         # Transient token bound applied to the fresh tail while the current
-        # compress/preflight call runs with the pressure yield engaged
-        # (0 = inactive). Reset at each entry point, never persisted.
+        # compress/preflight invocation runs with the pressure yield engaged
+        # (0 = inactive). Lives strictly inside a
+        # _fresh_tail_pressure_yield_invocation scope: cleared on scope exit
+        # (success or exception), saved/restored across nested invocations,
+        # never persisted.
         self._pressure_yield_tail_token_limit: int = 0
+        # Consecutive entry-point invocations blocked by the fresh tail while
+        # the host observed over-threshold pressure. This is the "sustained"
+        # evidence the yield requires; it survives across invocations by
+        # design and resets on relief (pressure below threshold, a successful
+        # compaction, or session reset).
+        self._pressure_yield_blocked_streak: int = 0
+        # Scope bookkeeping for _fresh_tail_pressure_yield_invocation.
+        self._pressure_yield_scope_depth: int = 0
+        self._pressure_yield_streak_counted: bool = False
 
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
@@ -1857,10 +1870,43 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             fresh_tail_max_tokens=max_tokens,
         )
 
+    @contextlib.contextmanager
+    def _fresh_tail_pressure_yield_invocation(self):
+        """Invocation scope for the transient pressure-yield tail bound.
+
+        Entered by every public compaction entry point (``compress`` and
+        ``should_compress_preflight``). The bound armed inside a scope is
+        cleared on exit through every path — success, exception, and early
+        return — and a nested (reentrant) invocation gets its own clean scope
+        while the outer invocation's bound is restored when the inner one
+        exits. Nothing outside a scope ever observes a bounded tail.
+        """
+        saved_limit = self._pressure_yield_tail_token_limit
+        saved_counted = self._pressure_yield_streak_counted
+        self._pressure_yield_tail_token_limit = 0
+        self._pressure_yield_streak_counted = False
+        self._pressure_yield_scope_depth += 1
+        try:
+            yield
+        finally:
+            self._pressure_yield_scope_depth -= 1
+            self._pressure_yield_tail_token_limit = saved_limit
+            self._pressure_yield_streak_counted = saved_counted
+
+    def _note_fresh_tail_pressure_relieved(self) -> None:
+        """Reset the sustained-pressure evidence.
+
+        Called when an entry point observes the session under threshold or a
+        compaction pass makes real progress: either way the deadlock the yield
+        exists for is not happening, so the streak starts over.
+        """
+        self._pressure_yield_blocked_streak = 0
+
     def _maybe_engage_fresh_tail_pressure_yield(
         self,
         messages: List[Dict[str, Any]],
         observed_tokens: Optional[int] = None,
+        eligible_tokens: Optional[int] = None,
     ) -> bool:
         """Arm a derived token bound for the fresh tail, or return False.
 
@@ -1870,13 +1916,27 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         permanently no-opping while the host reports over-threshold pressure
         every turn — a fatal loop ending at the provider hard limit (#441,
         same class as #414). This helper detects exactly that state: real
-        pressure, and less than one working leaf chunk of raw backlog outside
-        the resolved tail. It then bounds the tail so the backlog can fit the
-        observed overage plus one working leaf chunk, and the caller retries.
+        pressure, and less than one working leaf chunk of eligible raw backlog
+        outside the resolved tail. It then bounds the tail so the backlog can
+        fit the observed overage plus one working leaf chunk, and the caller
+        retries.
 
-        Fires at most once per entry point (the transient bound stays armed
-        for the rest of the call), never when disabled, and never without
-        host-observed pressure, so healthy sessions see no behavior change.
+        Sustained-pressure gate: ``fresh_tail_count`` softens only after
+        ``fresh_tail_pressure_yield_min_observations`` consecutive entry-point
+        invocations were blocked by the tail under host-observed over-threshold
+        pressure (each invocation counts once). A single over-threshold
+        observation therefore does NOT make the tail a soft suffix at the
+        default setting; operators who want first-observation yielding set the
+        knob to 1. The armed bound itself stays invocation-scoped (see
+        ``_fresh_tail_pressure_yield_invocation``); only the blocked-streak
+        evidence persists across invocations, and it resets on relief.
+
+        ``eligible_tokens`` is the caller's already-filtered view of the raw
+        backlog outside the tail (ignored messages and persisted placeholders
+        excluded), so this check agrees with the candidate-status/compress
+        filtering; when omitted it falls back to the unfiltered boundary math.
+        Never arms when disabled, and never without host-observed pressure, so
+        healthy sessions see no behavior change.
         """
         if not self._config.fresh_tail_pressure_yield_enabled:
             return False
@@ -1889,12 +1949,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # numbers would arm the yield outside the deadlock it exists for.
         observed = int(observed_tokens or 0)
         if observed < self.threshold_tokens:
+            self._note_fresh_tail_pressure_relieved()
             return False
         boundary = self._fresh_tail_boundary(messages)
         leading_anchor_count = self._leading_anchor_count(messages)
         raw_messages = messages[leading_anchor_count:]
         raw_tokens = count_messages_tokens(raw_messages)
-        eligible_tokens = max(0, raw_tokens - boundary.tokens)
+        if eligible_tokens is None:
+            eligible_tokens = max(0, raw_tokens - boundary.tokens)
         working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(eligible_tokens)
         if eligible_tokens >= working_leaf_chunk_tokens:
             return False
@@ -1902,11 +1964,36 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         tail_token_limit = max(1, raw_tokens - needed)
         if tail_token_limit >= boundary.tokens:
             return False
+        if (
+            self._pressure_yield_scope_depth == 1
+            and not self._pressure_yield_streak_counted
+        ):
+            self._pressure_yield_blocked_streak += 1
+            self._pressure_yield_streak_counted = True
+        min_observations = max(
+            1, int(self._config.fresh_tail_pressure_yield_min_observations)
+        )
+        if self._pressure_yield_blocked_streak < min_observations:
+            logger.info(
+                "LCM fresh tail blocked under pressure (observation %d/%d): "
+                "observed=%d >= threshold=%d with only %d eligible raw tokens "
+                "outside a %d-message/%d-token tail; yielding once pressure is sustained",
+                self._pressure_yield_blocked_streak,
+                min_observations,
+                observed,
+                self.threshold_tokens,
+                eligible_tokens,
+                boundary.count,
+                boundary.tokens,
+            )
+            return False
         self._pressure_yield_tail_token_limit = tail_token_limit
         logger.warning(
-            "LCM fresh tail yielded under pressure: observed=%d >= threshold=%d "
-            "with only %d eligible raw tokens outside a %d-message/%d-token tail "
-            "(fresh_tail_count=%d); bounding tail to %d tokens so compaction can progress",
+            "LCM fresh tail yielded under sustained pressure (%d blocked observation(s)): "
+            "observed=%d >= threshold=%d with only %d eligible raw tokens outside "
+            "a %d-message/%d-token tail (fresh_tail_count=%d); bounding tail to "
+            "%d tokens so compaction can progress",
+            self._pressure_yield_blocked_streak,
             observed,
             self.threshold_tokens,
             eligible_tokens,
@@ -1917,8 +2004,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         return True
 
-    def _reset_fresh_tail_pressure_yield(self) -> None:
+    def _clear_fresh_tail_pressure_yield_state(self) -> None:
+        """Session-reset clearing: drop the bound and the sustained evidence."""
         self._pressure_yield_tail_token_limit = 0
+        self._pressure_yield_blocked_streak = 0
 
     def _fresh_tail_start(self, messages: List[Dict[str, Any]]) -> int:
         return self._fresh_tail_boundary(messages).start

--- a/engine.py
+++ b/engine.py
@@ -445,13 +445,28 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._pressure_yield_tail_token_limit: int = 0
         # Consecutive entry-point invocations blocked by the fresh tail while
         # the host observed over-threshold pressure. This is the "sustained"
-        # evidence the yield requires; it survives across invocations by
-        # design and resets on relief (pressure below threshold, a successful
-        # compaction, or session reset).
+        # evidence the yield requires. "Consecutive" is literal: any
+        # invocation whose final verdict is not tail-blocked resets it (see
+        # the verdict field below), as do relief (pressure below threshold),
+        # any successful context-reducing pass (compacted or sanitized), and
+        # session reset.
         self._pressure_yield_blocked_streak: int = 0
         # Scope bookkeeping for _fresh_tail_pressure_yield_invocation.
         self._pressure_yield_scope_depth: int = 0
         self._pressure_yield_streak_counted: bool = False
+        # Final verdict of the current outermost invocation, applied at scope
+        # exit: "blocked" keeps the streak (the invocation counted a genuine
+        # tail blockage), "neutral" leaves it untouched (the invocation says
+        # nothing about the pressured session — LCM-bypassed traffic), and
+        # "clear"/None resets it (the invocation was not blocked by fresh-tail
+        # eligibility). Last writer wins within an invocation, so an early
+        # blocked observation is overridden when the same invocation later
+        # finds real work. Exceptions skip the verdict entirely.
+        self._pressure_yield_invocation_verdict: Optional[str] = None
+        # Bumped by _clear_fresh_tail_pressure_yield_state so that a session
+        # reset which happens INSIDE an invocation scope stays authoritative:
+        # scope exits restore their saved state only when no reset intervened.
+        self._pressure_yield_reset_epoch: int = 0
 
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
@@ -936,9 +951,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return self._last_compression_status == "noop"
 
     def _mark_preflight_compression_requested(self) -> bool:
-        """Record that preflight found work and clear any stale no-op reason."""
+        """Record that preflight found work and clear any stale no-op reason.
+
+        A preflight that advertises work is by definition not deadlock-blocked
+        by the fresh tail, so it settles the invocation verdict as clear —
+        UNLESS the work only exists because the pressure yield armed a tail
+        bound this invocation. In that case the blocked verdict (and the
+        streak behind it) must survive so the follow-up ``compress`` call,
+        which runs as its own invocation, can re-engage the yield instead of
+        no-opping against the advertised compaction.
+        """
         self._last_compression_status = "pending"
         self._last_compression_noop_reason = ""
+        if self._pressure_yield_tail_token_limit <= 0:
+            self._pressure_yield_invocation_verdict = "clear"
         return True
 
     @property
@@ -1880,27 +1906,58 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return — and a nested (reentrant) invocation gets its own clean scope
         while the outer invocation's bound is restored when the inner one
         exits. Nothing outside a scope ever observes a bounded tail.
+
+        Two cross-invocation effects happen at exit:
+
+        - Streak verdict (outermost, non-exception exits only): an invocation
+          whose final verdict is not "blocked" resets the sustained-pressure
+          streak, so the streak counts strictly consecutive tail-blocked
+          invocations. "neutral" (LCM-bypassed traffic) leaves the streak
+          untouched, and an exception is not an observation in either
+          direction.
+        - Reset authority: if a session reset ran inside this scope (the reset
+          epoch advanced), the exit does NOT restore its saved pre-reset
+          state; the reset's cleared state wins after every enclosing scope
+          unwinds.
         """
         saved_limit = self._pressure_yield_tail_token_limit
         saved_counted = self._pressure_yield_streak_counted
+        saved_verdict = self._pressure_yield_invocation_verdict
+        entry_epoch = self._pressure_yield_reset_epoch
         self._pressure_yield_tail_token_limit = 0
         self._pressure_yield_streak_counted = False
+        self._pressure_yield_invocation_verdict = None
         self._pressure_yield_scope_depth += 1
+        completed = False
         try:
             yield
+            completed = True
         finally:
             self._pressure_yield_scope_depth -= 1
-            self._pressure_yield_tail_token_limit = saved_limit
-            self._pressure_yield_streak_counted = saved_counted
+            if completed and self._pressure_yield_scope_depth == 0:
+                if self._pressure_yield_invocation_verdict not in ("blocked", "neutral"):
+                    self._pressure_yield_blocked_streak = 0
+            if self._pressure_yield_reset_epoch == entry_epoch:
+                self._pressure_yield_tail_token_limit = saved_limit
+                self._pressure_yield_streak_counted = saved_counted
+                self._pressure_yield_invocation_verdict = saved_verdict
+            else:
+                self._pressure_yield_tail_token_limit = 0
+                self._pressure_yield_streak_counted = False
+                self._pressure_yield_invocation_verdict = None
 
     def _note_fresh_tail_pressure_relieved(self) -> None:
         """Reset the sustained-pressure evidence.
 
         Called when an entry point observes the session under threshold or a
-        compaction pass makes real progress: either way the deadlock the yield
-        exists for is not happening, so the streak starts over.
+        pass makes real progress (leaf compaction, sanitation-only cleanup,
+        overflow recovery): either way the deadlock the yield exists for is
+        not happening, so the streak starts over. Also settles the invocation
+        verdict as clear so a stale earlier blocked mark cannot outlive the
+        relief at scope exit.
         """
         self._pressure_yield_blocked_streak = 0
+        self._pressure_yield_invocation_verdict = "clear"
 
     def _maybe_engage_fresh_tail_pressure_yield(
         self,
@@ -1924,12 +1981,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         Sustained-pressure gate: ``fresh_tail_count`` softens only after
         ``fresh_tail_pressure_yield_min_observations`` consecutive entry-point
         invocations were blocked by the tail under host-observed over-threshold
-        pressure (each invocation counts once). A single over-threshold
+        pressure (each invocation counts once). "Consecutive" is strict: any
+        intervening invocation that is not tail-blocked — an eligible
+        preflight, a sanitation-only pass, forced-overflow recovery, or a
+        blockage attributed to anything other than fresh-tail eligibility —
+        resets the streak at its scope exit. A single over-threshold
         observation therefore does NOT make the tail a soft suffix at the
         default setting; operators who want first-observation yielding set the
         knob to 1. The armed bound itself stays invocation-scoped (see
         ``_fresh_tail_pressure_yield_invocation``); only the blocked-streak
-        evidence persists across invocations, and it resets on relief.
+        evidence persists across invocations.
 
         ``eligible_tokens`` is the caller's already-filtered view of the raw
         backlog outside the tail (ignored messages and persisted placeholders
@@ -1964,12 +2025,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         tail_token_limit = max(1, raw_tokens - needed)
         if tail_token_limit >= boundary.tokens:
             return False
-        if (
-            self._pressure_yield_scope_depth == 1
-            and not self._pressure_yield_streak_counted
-        ):
-            self._pressure_yield_blocked_streak += 1
-            self._pressure_yield_streak_counted = True
+        if self._pressure_yield_scope_depth == 1:
+            self._pressure_yield_invocation_verdict = "blocked"
+            if not self._pressure_yield_streak_counted:
+                self._pressure_yield_blocked_streak += 1
+                self._pressure_yield_streak_counted = True
         min_observations = max(
             1, int(self._config.fresh_tail_pressure_yield_min_observations)
         )
@@ -2005,9 +2065,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return True
 
     def _clear_fresh_tail_pressure_yield_state(self) -> None:
-        """Session-reset clearing: drop the bound and the sustained evidence."""
+        """Session-reset clearing: drop the bound and the sustained evidence.
+
+        Advances the reset epoch so that enclosing invocation scopes (a reset
+        can run inside a nested invocation) do not restore their saved
+        pre-reset state on exit: the reset stays authoritative.
+        """
         self._pressure_yield_tail_token_limit = 0
         self._pressure_yield_blocked_streak = 0
+        self._pressure_yield_streak_counted = False
+        self._pressure_yield_invocation_verdict = None
+        self._pressure_yield_reset_epoch += 1
 
     def _fresh_tail_start(self, messages: List[Dict[str, Any]]) -> int:
         return self._fresh_tail_boundary(messages).start

--- a/engine.py
+++ b/engine.py
@@ -435,6 +435,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             "reason": "not run",
         }
 
+        # Transient token bound applied to the fresh tail while the current
+        # compress/preflight call runs with the pressure yield engaged
+        # (0 = inactive). Reset at each entry point, never persisted.
+        self._pressure_yield_tail_token_limit: int = 0
+
         # State required by ContextEngine ABC and run_agent.py compatibility
         self.model = ""
         self.base_url = ""
@@ -1839,11 +1844,81 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return messages[leading_anchor_count:fresh_tail_start]
 
     def _fresh_tail_boundary(self, messages: List[Dict[str, Any]]) -> FreshTailBoundary:
+        max_tokens = self._config.fresh_tail_max_tokens
+        if self._pressure_yield_tail_token_limit > 0:
+            max_tokens = (
+                min(max_tokens, self._pressure_yield_tail_token_limit)
+                if max_tokens > 0
+                else self._pressure_yield_tail_token_limit
+            )
         return resolve_fresh_tail_boundary(
             messages,
             fresh_tail_count=self._config.fresh_tail_count,
-            fresh_tail_max_tokens=self._config.fresh_tail_max_tokens,
+            fresh_tail_max_tokens=max_tokens,
         )
+
+    def _maybe_engage_fresh_tail_pressure_yield(
+        self,
+        messages: List[Dict[str, Any]],
+        observed_tokens: Optional[int] = None,
+    ) -> bool:
+        """Arm a derived token bound for the fresh tail, or return False.
+
+        The count-protected tail can cover the entire token mass of a
+        tool-heavy session (an operator-tuned ``fresh_tail_count`` protects
+        more tokens than the compaction threshold allows), leaving compaction
+        permanently no-opping while the host reports over-threshold pressure
+        every turn — a fatal loop ending at the provider hard limit (#441,
+        same class as #414). This helper detects exactly that state: real
+        pressure, and less than one working leaf chunk of raw backlog outside
+        the resolved tail. It then bounds the tail so the backlog can fit the
+        observed overage plus one working leaf chunk, and the caller retries.
+
+        Fires at most once per entry point (the transient bound stays armed
+        for the rest of the call), never when disabled, and never without
+        host-observed pressure, so healthy sessions see no behavior change.
+        """
+        if not self._config.fresh_tail_pressure_yield_enabled:
+            return False
+        if self._pressure_yield_tail_token_limit > 0:
+            return False
+        if self.threshold_tokens <= 0 or not messages:
+            return False
+        # Only host-reported pressure counts: the caller must pass the tokens
+        # it actually observed for this attempt. Falling back to stale usage
+        # numbers would arm the yield outside the deadlock it exists for.
+        observed = int(observed_tokens or 0)
+        if observed < self.threshold_tokens:
+            return False
+        boundary = self._fresh_tail_boundary(messages)
+        leading_anchor_count = self._leading_anchor_count(messages)
+        raw_messages = messages[leading_anchor_count:]
+        raw_tokens = count_messages_tokens(raw_messages)
+        eligible_tokens = max(0, raw_tokens - boundary.tokens)
+        working_leaf_chunk_tokens = self._working_leaf_chunk_tokens(eligible_tokens)
+        if eligible_tokens >= working_leaf_chunk_tokens:
+            return False
+        needed = (observed - self.threshold_tokens) + working_leaf_chunk_tokens
+        tail_token_limit = max(1, raw_tokens - needed)
+        if tail_token_limit >= boundary.tokens:
+            return False
+        self._pressure_yield_tail_token_limit = tail_token_limit
+        logger.warning(
+            "LCM fresh tail yielded under pressure: observed=%d >= threshold=%d "
+            "with only %d eligible raw tokens outside a %d-message/%d-token tail "
+            "(fresh_tail_count=%d); bounding tail to %d tokens so compaction can progress",
+            observed,
+            self.threshold_tokens,
+            eligible_tokens,
+            boundary.count,
+            boundary.tokens,
+            self._config.fresh_tail_count,
+            tail_token_limit,
+        )
+        return True
+
+    def _reset_fresh_tail_pressure_yield(self) -> None:
+        self._pressure_yield_tail_token_limit = 0
 
     def _fresh_tail_start(self, messages: List[Dict[str, Any]]) -> int:
         return self._fresh_tail_boundary(messages).start

--- a/reset_state.py
+++ b/reset_state.py
@@ -48,6 +48,7 @@ class ResetStateMixin:
         """
         self._reset_session_counters()
         self._reset_compaction_progress()
+        self._clear_fresh_tail_pressure_yield_state()
         self._generated_ignored_active_replay_placeholder_hashes = set()
         self._generated_ignored_active_replay_placeholder_message_ids = set()
         self._compression_boundary_ingest_pending = False

--- a/tests/test_fresh_tail_pressure_yield.py
+++ b/tests/test_fresh_tail_pressure_yield.py
@@ -360,6 +360,212 @@ def test_session_reset_clears_sustained_evidence_and_bound(tmp_path, monkeypatch
         engine.shutdown()
 
 
+# ── Strict-consecutive streak semantics ──────────────────────────────────────
+
+
+def test_intervening_eligible_invocation_resets_blocked_streak(tmp_path, monkeypatch):
+    # blocked -> eligible -> blocked with min_observations=2: the eligible
+    # turn proves the session is not tail-deadlocked, so the two blocked
+    # turns are separated events, not sustained pressure. Pre-fix the second
+    # blocked turn engaged the yield.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=2,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        assert count_messages_tokens(messages) > engine.threshold_tokens
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+
+        # Shrinking the count tail exposes plenty of raw backlog: an ordinary
+        # eligible preflight, no yield involved.
+        engine._config.fresh_tail_count = 4
+        assert engine.should_compress_preflight(list(messages)) is True
+        assert engine._pressure_yield_blocked_streak == 0
+        engine._config.fresh_tail_count = 128
+
+        # Observation 1/2 again: the classic noop must hold.
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+        assert engine._pressure_yield_tail_token_limit == 0
+    finally:
+        engine.shutdown()
+
+
+def test_non_tail_blockage_resets_blocked_streak(tmp_path, monkeypatch):
+    # An invocation blocked by something other than fresh-tail eligibility
+    # (here: the compression boundary cooldown) is not evidence of the tail
+    # deadlock and must reset the streak.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=2,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                engine, "_compression_boundary_cooldown_active", lambda: True
+            )
+            assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 0
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+        assert engine._pressure_yield_tail_token_limit == 0
+    finally:
+        engine.shutdown()
+
+
+def test_sanitation_only_progress_resets_blocked_streak(tmp_path, monkeypatch):
+    # A compress pass that ends "sanitized" (context cleanup, no leaf node)
+    # is real progress: stale blocked evidence must not survive it.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=5,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 2
+
+        real_sanitize = engine._sanitize_active_context_messages
+
+        def _cleaning_sanitize(msgs, **kwargs):
+            return real_sanitize(msgs, **kwargs) + [
+                {"role": "user", "content": "sanitation marker"}
+            ]
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                engine, "_sanitize_active_context_messages", _cleaning_sanitize
+            )
+            engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "sanitized"
+        assert engine._pressure_yield_blocked_streak == 0
+    finally:
+        engine.shutdown()
+
+
+def test_forced_overflow_preflight_resets_blocked_streak(tmp_path, monkeypatch):
+    # Forced overflow recovery is a context-reducing path in its own right:
+    # a preflight that advertises it is not tail-blocked, so the streak
+    # restarts.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=2,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+
+        # An assembly cap far below the observed tokens makes this turn a
+        # forced-overflow recovery request, which preflight advertises before
+        # it ever consults fresh-tail eligibility.
+        saved_cap = engine._config.max_assembly_tokens
+        engine._config.max_assembly_tokens = 1_000
+        assert engine.should_compress_preflight(list(messages)) is True
+        engine._config.max_assembly_tokens = saved_cap
+        assert engine._pressure_yield_blocked_streak == 0
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 1
+        assert engine._pressure_yield_tail_token_limit == 0
+    finally:
+        engine.shutdown()
+
+
+def test_exception_neither_extends_nor_resets_blocked_streak(tmp_path, monkeypatch):
+    # A summarizer failure mid-invocation is not an observation in either
+    # direction: the accumulated evidence stays exactly as it was.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=3,
+    )
+
+    def _raising_summarizer(chunk, focus_topic=None, **_kwargs):
+        raise RuntimeError("summarizer down")
+
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 2
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                engine, "_summarize_leaf_chunk_with_rescue", _raising_summarizer
+            )
+            with pytest.raises(RuntimeError):
+                engine.compress(list(messages), current_tokens=observed)
+
+        # The failed compress counted its own blocked observation before the
+        # yield engaged and the summarizer died; the exception exit must not
+        # wipe that evidence (the deadlock is still there).
+        assert engine._pressure_yield_blocked_streak == 3
+        assert engine._pressure_yield_tail_token_limit == 0
+    finally:
+        engine.shutdown()
+
+
+# ── Reset authority across nested scopes ─────────────────────────────────────
+
+
+def test_session_reset_inside_nested_invocation_stays_authoritative(
+    tmp_path, monkeypatch
+):
+    # A reset that runs inside a nested invocation scope must win over the
+    # scope-exit restore: pre-fix, leaving the inner scope restored the
+    # outer invocation's pre-reset bound (1234 -> reset to 0 -> exit
+    # restores 1234).
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=3,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 2
+
+        with engine._fresh_tail_pressure_yield_invocation():
+            engine._pressure_yield_tail_token_limit = 1234
+            with engine._fresh_tail_pressure_yield_invocation():
+                engine._reset_session_scoped_runtime_state()
+                assert engine._pressure_yield_tail_token_limit == 0
+            assert engine._pressure_yield_tail_token_limit == 0
+        assert engine._pressure_yield_tail_token_limit == 0
+        assert engine._pressure_yield_blocked_streak == 0
+        assert engine._pressure_yield_scope_depth == 0
+    finally:
+        engine.shutdown()
+
+
 # ── Preflight/compress agreement ─────────────────────────────────────────────
 
 

--- a/tests/test_fresh_tail_pressure_yield.py
+++ b/tests/test_fresh_tail_pressure_yield.py
@@ -1,0 +1,148 @@
+"""Fresh-tail pressure yield: compaction must not deadlock inside the count tail.
+
+Regression tests for #441 (same class as #414): a count-protected fresh tail
+that covers the session's whole token mass made every compaction attempt no-op
+("no eligible raw backlog outside fresh tail" below the count,
+"raw backlog outside fresh tail is below leaf chunk threshold" just above it)
+while the host reported over-threshold pressure every turn, until the session
+died at the provider hard limit.
+"""
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.tokens import count_messages_tokens
+
+
+def _fat_user(index, chars=4000):
+    return {"role": "user", "content": f"turn {index}: " + ("data " * (chars // 5))}
+
+
+def _tiny_user(index):
+    return {"role": "user", "content": f"small turn {index}"}
+
+
+def _stub_summarizer(chunk, focus_topic=None):
+    tokens = count_messages_tokens(chunk)
+    return chunk, tokens, f"[test summary: {len(chunk)} messages]", 1, 1
+
+
+def _make_engine(tmp_path, monkeypatch, **config_overrides):
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_pressure_yield.db")
+    for key, value in config_overrides.items():
+        setattr(config, key, value)
+    engine = LCMEngine(config=config)
+    engine._session_id = "pressure-yield-session"
+    engine.context_length = 200_000
+    engine.threshold_tokens = 5_000
+    monkeypatch.setattr(engine, "_summarize_leaf_chunk_with_rescue", _stub_summarizer)
+    return engine
+
+
+def test_count_tail_covering_everything_yields_under_pressure(tmp_path, monkeypatch):
+    # 40 messages, all inside a 128-count tail: on an unfixed engine this is
+    # a guaranteed "no eligible raw backlog outside fresh tail" no-op forever.
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+        assert observed > engine.threshold_tokens
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert len(compressed) < len(messages)
+        assert count_messages_tokens(compressed) < observed
+    finally:
+        engine.shutdown()
+
+
+def test_backlog_below_leaf_chunk_yields_under_pressure(tmp_path, monkeypatch):
+    # A couple of tiny messages sit outside the count tail; everything heavy is
+    # protected. On an unfixed engine this no-ops with "below leaf chunk
+    # threshold" forever.
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=10)
+    try:
+        messages = [_tiny_user(0), _tiny_user(1)] + [_fat_user(i) for i in range(10)]
+        observed = count_messages_tokens(messages)
+        assert observed > engine.threshold_tokens
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert len(compressed) < len(messages)
+    finally:
+        engine.shutdown()
+
+
+def test_no_pressure_preserves_count_tail_noop(tmp_path, monkeypatch):
+    # Same deadlock topology, but the host reports no over-threshold pressure:
+    # behavior must stay exactly the pre-fix no-op.
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        engine.threshold_tokens = 10_000_000
+        messages = [_fat_user(i) for i in range(40)]
+
+        compressed = engine.compress(list(messages))
+
+        assert engine._last_compression_status == "noop"
+        assert engine._last_compression_noop_reason == (
+            "no eligible raw backlog outside fresh tail"
+        )
+        assert len(compressed) == len(messages)
+    finally:
+        engine.shutdown()
+
+
+def test_kill_switch_preserves_noop_under_pressure(tmp_path, monkeypatch):
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_enabled=False,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "noop"
+        assert engine._last_compression_noop_reason == (
+            "no eligible raw backlog outside fresh tail"
+        )
+        assert len(compressed) == len(messages)
+    finally:
+        engine.shutdown()
+
+
+def test_preflight_advertises_compaction_under_deadlock_pressure(tmp_path, monkeypatch):
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        assert count_messages_tokens(messages) > engine.threshold_tokens
+
+        assert engine.should_compress_preflight(list(messages)) is True
+    finally:
+        engine.shutdown()
+
+
+def test_explicit_token_cap_still_wins_when_smaller(tmp_path, monkeypatch):
+    # An operator-configured fresh_tail_max_tokens below the derived yield cap
+    # keeps bounding the tail; the yield must not loosen it.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_max_tokens=500,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert len(compressed) < len(messages)
+    finally:
+        engine.shutdown()

--- a/tests/test_fresh_tail_pressure_yield.py
+++ b/tests/test_fresh_tail_pressure_yield.py
@@ -6,7 +6,22 @@ that covers the session's whole token mass made every compaction attempt no-op
 "raw backlog outside fresh tail is below leaf chunk threshold" just above it)
 while the host reported over-threshold pressure every turn, until the session
 died at the provider hard limit.
+
+Semantics under test:
+
+- The yield arms only after ``fresh_tail_pressure_yield_min_observations``
+  consecutive blocked entry-point invocations under host-observed pressure
+  ("sustained"); a single over-threshold observation does not soften
+  ``fresh_tail_count``. Setting the knob to 1 restores first-observation
+  yielding.
+- The armed tail bound is invocation-scoped: cleared through success,
+  exception, nested invocation, and session-reset paths.
+- ``should_compress_preflight`` agrees with ``compress`` in the yield states,
+  including persisted ignored-placeholder pressure and threshold full-sweep
+  mode.
 """
+
+import pytest
 
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
@@ -21,7 +36,7 @@ def _tiny_user(index):
     return {"role": "user", "content": f"small turn {index}"}
 
 
-def _stub_summarizer(chunk, focus_topic=None):
+def _stub_summarizer(chunk, focus_topic=None, **_kwargs):
     tokens = count_messages_tokens(chunk)
     return chunk, tokens, f"[test summary: {len(chunk)} messages]", 1, 1
 
@@ -39,10 +54,18 @@ def _make_engine(tmp_path, monkeypatch, **config_overrides):
     return engine
 
 
+# ── First-observation mode (min_observations=1): the original deadlock shapes ──
+
+
 def test_count_tail_covering_everything_yields_under_pressure(tmp_path, monkeypatch):
     # 40 messages, all inside a 128-count tail: on an unfixed engine this is
     # a guaranteed "no eligible raw backlog outside fresh tail" no-op forever.
-    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
     try:
         messages = [_fat_user(i) for i in range(40)]
         observed = count_messages_tokens(messages)
@@ -61,7 +84,12 @@ def test_backlog_below_leaf_chunk_yields_under_pressure(tmp_path, monkeypatch):
     # A couple of tiny messages sit outside the count tail; everything heavy is
     # protected. On an unfixed engine this no-ops with "below leaf chunk
     # threshold" forever.
-    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=10)
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=10,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
     try:
         messages = [_tiny_user(0), _tiny_user(1)] + [_fat_user(i) for i in range(10)]
         observed = count_messages_tokens(messages)
@@ -78,7 +106,12 @@ def test_backlog_below_leaf_chunk_yields_under_pressure(tmp_path, monkeypatch):
 def test_no_pressure_preserves_count_tail_noop(tmp_path, monkeypatch):
     # Same deadlock topology, but the host reports no over-threshold pressure:
     # behavior must stay exactly the pre-fix no-op.
-    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
     try:
         engine.threshold_tokens = 10_000_000
         messages = [_fat_user(i) for i in range(40)]
@@ -100,6 +133,7 @@ def test_kill_switch_preserves_noop_under_pressure(tmp_path, monkeypatch):
         monkeypatch,
         fresh_tail_count=128,
         fresh_tail_pressure_yield_enabled=False,
+        fresh_tail_pressure_yield_min_observations=1,
     )
     try:
         messages = [_fat_user(i) for i in range(40)]
@@ -117,7 +151,12 @@ def test_kill_switch_preserves_noop_under_pressure(tmp_path, monkeypatch):
 
 
 def test_preflight_advertises_compaction_under_deadlock_pressure(tmp_path, monkeypatch):
-    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
     try:
         messages = [_fat_user(i) for i in range(40)]
         assert count_messages_tokens(messages) > engine.threshold_tokens
@@ -135,6 +174,7 @@ def test_explicit_token_cap_still_wins_when_smaller(tmp_path, monkeypatch):
         monkeypatch,
         fresh_tail_count=128,
         fresh_tail_max_tokens=500,
+        fresh_tail_pressure_yield_min_observations=1,
     )
     try:
         messages = [_fat_user(i) for i in range(40)]
@@ -144,5 +184,332 @@ def test_explicit_token_cap_still_wins_when_smaller(tmp_path, monkeypatch):
 
         assert engine._last_compression_status == "compacted"
         assert len(compressed) < len(messages)
+    finally:
+        engine.shutdown()
+
+
+# ── Sustained-pressure semantics (default min_observations) ──────────────────
+
+
+def test_single_blocked_observation_does_not_yield_at_default(tmp_path, monkeypatch):
+    # Default semantics: one over-threshold blocked attempt must NOT soften
+    # fresh_tail_count into a token bound. The classic noop is preserved until
+    # pressure is sustained.
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        assert engine._config.fresh_tail_pressure_yield_min_observations >= 2
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "noop"
+        assert engine._last_compression_noop_reason == (
+            "no eligible raw backlog outside fresh tail"
+        )
+        assert len(compressed) == len(messages)
+        assert engine._pressure_yield_blocked_streak == 1
+    finally:
+        engine.shutdown()
+
+
+def test_sustained_pressure_yields_on_nth_blocked_observation(tmp_path, monkeypatch):
+    # Host loop at default settings: preflight is the per-turn entry point.
+    # It must decline for min_observations-1 blocked turns, then advertise a
+    # compaction that compress actually performs.
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        min_observations = engine._config.fresh_tail_pressure_yield_min_observations
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+        assert observed > engine.threshold_tokens
+
+        verdicts = []
+        for _turn in range(min_observations):
+            verdicts.append(engine.should_compress_preflight(list(messages)))
+
+        assert verdicts == [False] * (min_observations - 1) + [True]
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert len(compressed) < len(messages)
+        # Success resets the sustained evidence.
+        assert engine._pressure_yield_blocked_streak == 0
+    finally:
+        engine.shutdown()
+
+
+def test_pressure_relief_resets_blocked_streak(tmp_path, monkeypatch):
+    # Two blocked turns, one calm turn, two blocked turns: the calm turn resets
+    # the evidence, so blocked turn #4 overall is only observation 2/3 and must
+    # not yield. Only three CONSECUTIVE blocked turns arm the yield.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=3,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        assert count_messages_tokens(messages) > engine.threshold_tokens
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 2
+
+        # A turn observed under threshold relieves the pressure.
+        engine.threshold_tokens = 10_000_000
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 0
+        engine.threshold_tokens = 5_000
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is True
+    finally:
+        engine.shutdown()
+
+
+# ── Invocation scoping and cleanup of the armed bound ────────────────────────
+
+
+def test_yield_bound_cleared_after_successful_compress(tmp_path, monkeypatch):
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert engine._pressure_yield_tail_token_limit == 0
+        # Outside any invocation the tail resolves at its stock geometry:
+        # a 128-count tail still covers this whole 40-message list.
+        assert engine._fresh_tail_start(messages) == 0
+    finally:
+        engine.shutdown()
+
+
+def test_yield_bound_cleared_when_summarizer_raises(tmp_path, monkeypatch):
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
+
+    def _raising_summarizer(chunk, focus_topic=None, **_kwargs):
+        raise RuntimeError("summarizer down")
+
+    monkeypatch.setattr(engine, "_summarize_leaf_chunk_with_rescue", _raising_summarizer)
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        with pytest.raises(RuntimeError):
+            engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "error"
+        assert engine._pressure_yield_tail_token_limit == 0
+        assert engine._pressure_yield_scope_depth == 0
+    finally:
+        engine.shutdown()
+
+
+def test_nested_invocation_gets_clean_scope_and_restores_outer(tmp_path, monkeypatch):
+    engine = _make_engine(tmp_path, monkeypatch, fresh_tail_count=128)
+    try:
+        with engine._fresh_tail_pressure_yield_invocation():
+            engine._pressure_yield_tail_token_limit = 1234
+            with engine._fresh_tail_pressure_yield_invocation():
+                # The inner (reentrant) invocation must not observe or clear
+                # the outer invocation's bound.
+                assert engine._pressure_yield_tail_token_limit == 0
+                engine._pressure_yield_tail_token_limit = 77
+            assert engine._pressure_yield_tail_token_limit == 1234
+        assert engine._pressure_yield_tail_token_limit == 0
+        assert engine._pressure_yield_scope_depth == 0
+    finally:
+        engine.shutdown()
+
+
+def test_session_reset_clears_sustained_evidence_and_bound(tmp_path, monkeypatch):
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=3,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine.should_compress_preflight(list(messages)) is False
+        assert engine._pressure_yield_blocked_streak == 2
+
+        engine._reset_session_scoped_runtime_state()
+
+        assert engine._pressure_yield_blocked_streak == 0
+        assert engine._pressure_yield_tail_token_limit == 0
+    finally:
+        engine.shutdown()
+
+
+# ── Preflight/compress agreement ─────────────────────────────────────────────
+
+
+def test_preflight_agrees_with_compress_under_persisted_placeholder_pressure(
+    tmp_path, monkeypatch
+):
+    # A session carrying a persisted ignored-message placeholder used to park in
+    # the pre-ingest ambiguous-noop state: preflight declined forever while
+    # compress would have engaged the yield. Both sides must now agree.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
+    try:
+        placeholder_text = LCMEngine._ignored_active_replay_placeholder("ignored content")
+        digest = LCMEngine._active_replay_placeholder_digest(placeholder_text)
+        assert digest is not None
+        engine._generated_ignored_active_replay_placeholder_hashes = {digest}
+        messages = [{"role": "assistant", "content": placeholder_text}] + [
+            _fat_user(i) for i in range(40)
+        ]
+        observed = count_messages_tokens(messages)
+        assert observed > engine.threshold_tokens
+
+        assert engine.should_compress_preflight(list(messages)) is True
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status in {"compacted", "sanitized"}
+        assert len(compressed) < len(messages)
+    finally:
+        engine.shutdown()
+
+
+def test_preflight_and_compress_agree_while_disabled_under_placeholder_pressure(
+    tmp_path, monkeypatch
+):
+    # Kill switch on the same topology: both sides must land on the same noop.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_enabled=False,
+    )
+    try:
+        placeholder_text = LCMEngine._ignored_active_replay_placeholder("ignored content")
+        digest = LCMEngine._active_replay_placeholder_digest(placeholder_text)
+        engine._generated_ignored_active_replay_placeholder_hashes = {digest}
+        messages = [{"role": "assistant", "content": placeholder_text}] + [
+            _fat_user(i) for i in range(40)
+        ]
+        observed = count_messages_tokens(messages)
+
+        assert engine.should_compress_preflight(list(messages)) is False
+        preflight_status = engine._last_compression_status
+
+        engine.compress(list(messages), current_tokens=observed)
+
+        assert preflight_status == "noop"
+        assert engine._last_compression_status in {"noop", "sanitized"}
+    finally:
+        engine.shutdown()
+
+
+def test_full_sweep_deadlock_yields_and_compacts(tmp_path, monkeypatch):
+    # threshold_full_sweep_enabled must not resurrect the deadlock: a sweep
+    # whose "drained" raw prefix is really a tail covering the whole session
+    # yields like any other blocked pass. Before this revision, preflight
+    # advertised the sweep but compress no-opped forever.
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        threshold_full_sweep_enabled=True,
+        fresh_tail_pressure_yield_min_observations=1,
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+        assert observed > engine.threshold_tokens
+
+        assert engine.should_compress_preflight(list(messages)) is True
+
+        compressed = engine.compress(list(messages), current_tokens=observed)
+
+        assert engine._last_compression_status == "compacted"
+        assert len(compressed) < len(messages)
+        assert engine._last_threshold_full_sweep["status"] in {"completed", "partial"}
+        assert engine._last_threshold_full_sweep["leaf_passes"] >= 1
+    finally:
+        engine.shutdown()
+
+
+# ── Rollup/compaction interplay (deterministic, no scheduler timing) ─────────
+
+
+def test_yielded_compaction_stales_and_rebuilds_rollups_deterministically(
+    tmp_path, monkeypatch
+):
+    # A yield-driven compaction publishes summary nodes like any other pass, so
+    # it must feed temporal-rollup staleness the same way: the covered day goes
+    # stale on publication and a synchronous maintenance pass rebuilds it. All
+    # driven inline — no background scheduler, no wall-clock dependence — so the
+    # validation composes with rollup-maintenance scheduling changes (#440).
+    from datetime import datetime, timezone
+
+    import hermes_lcm.rollup_builder as builder_module
+    from hermes_lcm.rollup_builder import run_rollup_maintenance
+    from hermes_lcm.rollup_store import RollupStore
+
+    engine = _make_engine(
+        tmp_path,
+        monkeypatch,
+        fresh_tail_count=128,
+        fresh_tail_pressure_yield_min_observations=1,
+        temporal_rollups_enabled=True,
+    )
+    monkeypatch.setattr(
+        builder_module,
+        "summarize_with_escalation",
+        lambda _text, **_kwargs: ("rebuilt rollup", 1),
+    )
+    try:
+        messages = [_fat_user(i) for i in range(40)]
+        observed = count_messages_tokens(messages)
+
+        engine.compress(list(messages), current_tokens=observed)
+        assert engine._last_compression_status == "compacted"
+
+        nodes = engine._dag.get_session_nodes(engine._session_id)
+        assert nodes
+        latest = max(node.latest_at or node.created_at for node in nodes)
+        day = datetime.fromtimestamp(latest, tz=timezone.utc).date().isoformat()
+
+        store = RollupStore(engine._dag.db_path)
+        try:
+            row = store.get_rollup("day", day, engine._session_id)
+            assert row is not None
+            assert row["status"] == "stale"
+
+            built = run_rollup_maintenance(
+                engine._dag, engine._config, engine._session_id
+            )
+            assert built >= 1
+
+            row = store.get_rollup("day", day, engine._session_id)
+            assert row["status"] == "ready"
+        finally:
+            store.close()
     finally:
         engine.shutdown()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1591,10 +1591,15 @@ class TestEngineABC:
         assert instance.should_compress(90)
 
     def test_preflight_does_not_request_compaction_when_only_fresh_tail_is_over_threshold(self, tmp_path):
+        # Yield disabled: this test pins the classic contract that preflight
+        # never advertises a pass that would no-op. With the pressure yield
+        # enabled the same state legitimately compacts instead (see
+        # test_fresh_tail_pressure_yield.py).
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_preflight_fresh_tail.db"),
             fresh_tail_count=4,
             leaf_chunk_tokens=100,
+            fresh_tail_pressure_yield_enabled=False,
         )
         instance = LCMEngine(config=config)
         instance._session_id = "test-session"
@@ -1618,10 +1623,14 @@ class TestEngineABC:
             instance.shutdown()
 
     def test_positive_preflight_clears_prior_noop_status(self, tmp_path):
+        # Yield disabled so the first preflight still lands in the classic
+        # noop state this test transitions out of (see
+        # test_fresh_tail_pressure_yield.py for yield-on coverage).
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_preflight_clears_noop.db"),
             fresh_tail_count=4,
             leaf_chunk_tokens=100,
+            fresh_tail_pressure_yield_enabled=False,
         )
         instance = LCMEngine(config=config)
         instance._session_id = "test-session"


### PR DESCRIPTION
## Why

A count-protected fresh tail that covers the session's whole token mass makes every compaction attempt no-op while the host reports over-threshold pressure on every turn, until the session dies at the provider hard limit. This is the fatal deadlock in #441 (same class as #414), reproduced by replaying the reporter's durable transcript against both v0.19.0 and current main: at or below `fresh_tail_count` messages every attempt logs `no eligible raw backlog outside fresh tail`; just above it, the 1-2 messages outside the tail sit below `leaf_chunk_tokens` and attempts log `raw backlog outside fresh tail is below leaf chunk threshold`. Forced overflow recovery could not engage because `max_assembly_tokens` and `reserve_tokens_floor` both default to 0 (tracked separately in #441).

The fix is a fresh-tail pressure yield. In exactly that state, and only that state, the engine re-resolves the tail with a token bound derived from the observed overage so compaction can progress. `fresh_tail_max_tokens` (#381) already guards this failure mode but is opt-in; the deadlock is silent, permanent, and fatal when the operator does not know to set it, which is why the yield defaults on.

The yield engages only when all of the following hold:

- `fresh_tail_pressure_yield_enabled` is on (default) and the caller passed host-observed tokens at or above `threshold_tokens` for this attempt,
- less than one working leaf chunk of eligible raw backlog sits outside the resolved tail (the tail is the only blocker),
- the blockage is sustained: `fresh_tail_pressure_yield_min_observations` (default 3) strictly consecutive entry-point invocations ended tail-blocked under pressure. Any invocation that is not tail-blocked (an eligible preflight, a sanitation-only pass, forced-overflow recovery, a non-tail blockage) resets the streak at its scope exit; LCM-bypassed traffic and exceptions are not observations in either direction. A session reset clears everything and advances an epoch so that a reset inside a nested invocation scope stays authoritative after the scope unwinds.

The armed bound itself is invocation-scoped: cleared on every exit path, saved and restored across nested invocations, never persisted. While armed, the leaf-chunk minimum is waived (the freed backlog can legitimately be smaller than one chunk). An explicit smaller `fresh_tail_max_tokens` still wins, and `resolve_fresh_tail_boundary` still enforces newest-message retention and tool-group integrity.

## Validation

- `tests/test_fresh_tail_pressure_yield.py` (23 tests): both deadlock shapes compact under pressure (red on unfixed main); no-pressure and kill-switch cases preserve the exact pre-fix no-op; the sustained gate (single observation preserves the classic no-op, the Nth consecutive blocked turn yields, relief resets); strict-consecutive regressions (blocked -> eligible -> blocked, non-tail blockage, sanitation-only progress, forced-overflow preflight, exception neutrality); invocation scoping (success, summarizer exception, nested isolation, session reset, and the composed nested-reset shape where the reset must win over the scope-exit restore); preflight/compress agreement under persisted-placeholder and threshold full-sweep pressure; deterministic rollup/compaction interplay against the merged #440.
- Full suite: 2331 passed, 12 xfailed, plus the two macOS-only path-test failures that reproduce identically on stock main. Same result under `ulimit -n 1024`.
- `ruff check`, `compileall`, script `bash -n`, and `git diff --check` pass.

## Risk / impact

Default-on, but the yield cannot fire outside the deadlock it exists for: it requires host-observed over-threshold pressure on the current attempt, a tail that is the only blocker, and the sustained streak. Healthy sessions never accumulate a streak because any non-blocked invocation resets it. The failure direction is bounded in both senses: if the gate is too strict the session simply stays in the pre-fix no-op for more turns; if it engages, the bound frees only the observed overage plus one working leaf chunk and evaporates at invocation exit. Engagement logs a WARNING with the observed/threshold/tail numbers.

## Scope boundaries

- No persistence: neither the streak nor the bound is written to the store; a process restart starts the evidence over.
- `fresh_tail_max_tokens` semantics are untouched; the yield composes with it and the smaller bound wins.
- The `max_assembly_tokens` / `reserve_tokens_floor` zero-default question stays in #441.
- No store schema, rollup, or condensation changes; the #440 interplay test exercises published rollups but changes nothing about them.

## Rollout / operator notes

- `LCM_FRESH_TAIL_PRESSURE_YIELD_ENABLED` (default `true`): rollback switch. Setting `false` restores the strict count tail immediately; no state to migrate.
- `LCM_FRESH_TAIL_PRESSURE_YIELD_MIN_OBSERVATIONS` (default `3`): consecutive blocked invocations before the yield engages; `1` restores first-observation yielding.
- Both are documented in the README and operator guide configuration tables.
- The engagement WARNING is the signal to tune `fresh_tail_count` or set `fresh_tail_max_tokens` deliberately.

## Reviewer focus

- The verdict-at-exit logic in `_fresh_tail_pressure_yield_invocation` (engine.py): "blocked" keeps the streak, "neutral" (bypassed traffic) leaves it, anything else resets it, and exceptions skip the verdict. This is the strict-consecutive contract.
- The guard in `_mark_preflight_compression_requested`: a preflight that advertises work settles the verdict as clear unless the work exists only because the yield armed this invocation. Without that exception, the yield-engaging preflight would reset the streak and the follow-up `compress` (its own invocation) would no-op against the advertised compaction.
- The epoch-guarded restore: `_clear_fresh_tail_pressure_yield_state` advances `_pressure_yield_reset_epoch`, and a scope exit restores its saved state only when no reset intervened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jYv3WkS7NKMqfZtU4zSSU
