### PR TITLE
fix: require credential shape before sensitive-pattern redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,11 +447,23 @@ Supported named catalog entries are:
   assignments or JSON keys, including quoted values with spaces.
 - `private_key`: PEM private-key blocks.
 
+The three keyword patterns anchor on a credential-ish name plus a separator, so
+the matched value is additionally checked for credential shape before it is
+replaced. A value is left alone when it is environment-variable indirection
+(`os.environ.get(...)`, `process.env.X`, `$VAR`, `${VAR}`), a config or docs
+template (`${{ secrets.X }}`, `{{ vault_x }}`, `<your-key-here>`, `!secret x`,
+`YOUR_*`, `CHANGEME`), or a plain code reference (`settings.openai_api_key`,
+`user_password`, `apiKeyFromContext`). Values that clear the check need real
+entropy: mixed letters and digits, a multi-word passphrase, or credential
+punctuation an identifier cannot carry. `private_key` is PEM-anchored and
+self-validating, so it is not shape-checked.
+
 Redaction is forward-only. Enabling it does not rewrite existing SQLite rows,
 FTS shadow tables, DAG summaries, or externalized payload JSON that were written
 before the setting was enabled. Non-password placeholders include a short
 truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
 the digest to avoid making password-like values easier to dictionary-check.
+
 `lcm_status`, `lcm_inspect`, and `lcm_doctor` expose the enabled state, configured pattern names,
 unknown names, source, and placeholder format without exposing raw secret values.
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -167,6 +167,104 @@ _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     ),
 }
 
+# --- Value-shape gate for the keyword patterns -----------------------------
+#
+# The three keyword patterns above anchor on a credential-ish name plus a
+# separator, then accept whatever follows. Without a shape test on the captured
+# value they match the code that proves a secret was NOT hardcoded (environment
+# lookups, config templating, plain identifier references) far more often than
+# they match a secret. Because redaction runs on the ingest write path, each
+# such match destroys non-secret text irreversibly.
+#
+# `_looks_like_credential` (below) gates every keyword-pattern match on these.
+# `private_key` is PEM-anchored, self-validating and produces no false
+# positives, so it is deliberately exempt.
+
+# Environment-variable indirection: os.environ[...] / os.getenv(...) /
+# process.env.X / $VAR / ${VAR} / %VAR% and friends. Anchored at the start of
+# the captured value.
+_ENV_INDIRECTION_RE = re.compile(
+    r"""^(?:
+          os\.environ\b
+        | os\.getenv\b
+        | environ\.get\b
+        | getenv\b
+        | process\.env\b
+        | import\.meta\.env\b
+        | Deno\.env\b
+        | ENV\[
+        | System\.getenv\b
+        | Environment\.GetEnvironmentVariable\b
+        | \$\{?[A-Za-z_][A-Za-z0-9_]*\}?
+        | %[A-Za-z_][A-Za-z0-9_]*%
+    )""",
+    re.VERBOSE,
+)
+
+# Config/CI templating and documentation placeholders that stand in for a
+# secret: ${{ secrets.X }}, {{ vault_x }}, <your-key-here>, !secret x,
+# $(command substitution), and the YOUR_*/REPLACE_ME/CHANGEME family.
+_TEMPLATE_REFERENCE_RE = re.compile(
+    r"""(?:
+          \$\{\{ | \{\{ | \}\} | \$\{ | \$\(
+        | ^< [^>]* >$
+        | ^! secret\b
+        | ^(?:YOUR|MY|SOME|EXAMPLE|SAMPLE|DUMMY|FAKE|TEST|PLACEHOLDER)[_-]
+        | ^(?:REPLACE[_-]?ME|CHANGE[_-]?ME|TODO|TBD|XXX+|FIXME|INSERT[_-])
+        | ^(?:xxx+|\*{3,}|\.{3,}|_{3,})$
+    )""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# A *structured* code reference rather than a literal value: dotted attribute
+# paths, snake_case names, subscripts, calls, camelCase. `settings.openai_api_key`,
+# `user_password`, `response.json()[`, `apiKeyFromContext`. The structure signal
+# matters: an unbroken single-case run (`OLDSECRET`) is a literal, whereas Python
+# and JS references conventionally carry a `.`, a `_` or a camelCase hump.
+_STRUCTURED_REFERENCE_RE = re.compile(
+    r"""^[A-Za-z_$][A-Za-z0-9_$]*
+         (?:\.[A-Za-z_$][A-Za-z0-9_$]*)*
+         (?:\(\)|\[|\.)?$""",
+    re.VERBOSE,
+)
+_IDENTIFIER_STRUCTURE_RE = re.compile(
+    r"""(?: [._$\[(]          # dotted path, snake_case, subscript or call
+          | [a-z][A-Z]        # camelCase hump
+    )""",
+    re.VERBOSE,
+)
+
+# An unbroken single-case alphabetic run is a literal, not a reference: Python
+# constants are SCREAMING_SNAKE and locals are snake_case, so neither produces
+# one. Treated as a credential when it clears the length floor.
+_UNBROKEN_UPPER_RUN_RE = re.compile(r"^[A-Z]+$")
+
+# Punctuation that appears in generated credentials but not in identifiers or
+# attribute paths, used as an alternative entropy signal for all-alpha values.
+# `-` is included: it cannot appear in an identifier, so a hyphenated literal
+# after `password=` is a value rather than a variable reference. `.` and `_`
+# are deliberately excluded because dotted paths and snake_case names are the
+# dominant false-positive shape.
+_CREDENTIAL_PUNCTUATION_RE = re.compile(r"[!#$%&*+\-/:;<>?@\\^`|~=]")
+
+# Length floors for the captured value, per pattern. Below these a match is
+# noise: real issued credentials are longer, and short values are dominated by
+# words, flags and fixture strings.
+_SENSITIVE_MIN_SECRET_CHARS = {
+    "api_key": 12,
+    "bearer_token": 16,
+    "password_assignment": 8,
+}
+
+# An all-letters value this long with internal whitespace or credential
+# punctuation is treated as a passphrase and kept redacted.
+_SENSITIVE_PASSPHRASE_MIN_CHARS = 12
+
+# Keyword patterns whose captured value must pass `_looks_like_credential`.
+_VALUE_SHAPE_GATED_SENSITIVE_PATTERNS = frozenset(
+    {"api_key", "bearer_token", "password_assignment"}
+)
+
 # Sensitive redaction runs synchronously in the ingest path. The private_key
 # pattern (lazy `.*?` under DOTALL) rescans to end-of-string for every unmatched
 # BEGIN header, so a multi-MB payload with many headers and no END is O(n^2) and
@@ -717,6 +815,86 @@ def _active_sensitive_pattern_names(config) -> list[str]:
     return active
 
 
+def _has_mixed_alnum(value: str) -> bool:
+    """True when ``value`` mixes letters and digits.
+
+    The primary entropy signal for a real credential. Identifiers, dotted
+    attribute paths and English words overwhelmingly fail it; issued API keys,
+    tokens and generated passwords overwhelmingly pass it.
+    """
+    return any(ch.isalpha() for ch in value) and any(ch.isdigit() for ch in value)
+
+
+def _looks_like_credential(
+    value: str,
+    pattern_name: str,
+    *,
+    key_context: bool = False,
+) -> bool:
+    """Return True when ``value`` has the shape of a real embedded credential.
+
+    The keyword patterns (``api_key``, ``bearer_token``, ``password_assignment``)
+    anchor on an assignment and then accept whatever follows. That makes them
+    fire on the code which proves a credential was *not* hardcoded --
+    ``api_key=os.environ.get("OPENAI_API_KEY")``, ``password=user_password``,
+    ``api_key: ${{ secrets.OPENAI_API_KEY }}`` -- and, because redaction runs on
+    the ingest write path, the non-secret text is what gets destroyed.
+
+    This gate keeps the patterns' recall while requiring the captured value to
+    look like a secret rather than merely follow a separator. ``private_key`` is
+    PEM-anchored and self-validating, so it never reaches this gate.
+
+    ``key_context`` is set when the *key* already named the field a credential
+    (a ``{"api_key": ...}`` mapping rather than free text). There the value is
+    far more likely to be the real secret, so only the indirection and
+    plain-reference rejections apply; the entropy floor is not enforced.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if not candidate:
+        return False
+
+    # 1. Environment-variable indirection and config templating. These are
+    #    references to a secret held elsewhere, never the secret itself.
+    if _ENV_INDIRECTION_RE.match(candidate) or _TEMPLATE_REFERENCE_RE.search(candidate):
+        return False
+
+    # 2. Plain code references: bare identifiers (``user_password``), dotted
+    #    attribute paths (``settings.openai_api_key``), subscripts and calls
+    #    (``response.json()[``). A reference that carries no digits is a name,
+    #    not a value. An unbroken single-case run (``OLDSECRET``) is excluded:
+    #    neither snake_case nor SCREAMING_SNAKE produces one, so it reads as an
+    #    inline literal rather than a variable.
+    if (
+        _STRUCTURED_REFERENCE_RE.match(candidate)
+        and _IDENTIFIER_STRUCTURE_RE.search(candidate)
+        and not _has_mixed_alnum(candidate)
+    ):
+        return False
+
+    if key_context:
+        return True
+
+    minimum = _SENSITIVE_MIN_SECRET_CHARS.get(pattern_name, 8)
+    if len(candidate) < minimum:
+        return False
+
+    # 3. Entropy floor. Any one of these is enough to look like a credential:
+    #    mixed letters and digits; an unbroken single-case literal; a
+    #    multi-word passphrase; or a value using credential punctuation that no
+    #    identifier or attribute path can carry.
+    if _has_mixed_alnum(candidate):
+        return True
+    if _UNBROKEN_UPPER_RUN_RE.match(candidate):
+        return True
+    if len(candidate) >= _SENSITIVE_PASSPHRASE_MIN_CHARS and any(ch.isspace() for ch in candidate):
+        return True
+    if len(candidate) >= _SENSITIVE_PASSPHRASE_MIN_CHARS and _CREDENTIAL_PUNCTUATION_RE.search(candidate):
+        return True
+    return False
+
+
 def _sensitive_placeholder(pattern_name: str, secret: str) -> str:
     parts = [
         f"{_SENSITIVE_PLACEHOLDER_PREFIX} "
@@ -739,6 +917,12 @@ def _redact_match(pattern_name: str, match: re.Match[str]) -> str:
     if secret_group is None:
         return _sensitive_placeholder(pattern_name, match.group(0))
     secret = match.group(secret_group)
+    # Keyword patterns match on name + separator only; require the captured
+    # value to look like a credential before destroying it on the write path.
+    if pattern_name in _VALUE_SHAPE_GATED_SENSITIVE_PATTERNS and not _looks_like_credential(
+        secret, pattern_name
+    ):
+        return match.group(0)
     relative_start = match.start(secret_group) - match.start(0)
     relative_end = match.end(secret_group) - match.start(0)
     full = match.group(0)
@@ -783,6 +967,13 @@ def redact_sensitive_text(text: str, config) -> str:
 
 def _redact_entire_sensitive_string(text: str, pattern_name: str) -> str:
     if not text or _SENSITIVE_PLACEHOLDER_PREFIX in text:
+        return text
+    # The key already named this field a credential, so the value is very
+    # likely the secret itself. Still refuse to destroy an environment lookup
+    # or template reference: those name a secret held elsewhere.
+    if pattern_name in _VALUE_SHAPE_GATED_SENSITIVE_PATTERNS and not _looks_like_credential(
+        text, pattern_name, key_context=True
+    ):
         return text
     return _sensitive_placeholder(pattern_name, text)
 

--- a/tests/test_sensitive_pattern_precision.py
+++ b/tests/test_sensitive_pattern_precision.py
@@ -1,0 +1,180 @@
+"""Regression tests for sensitive-pattern value-shape precision.
+
+The ``api_key`` / ``bearer_token`` / ``password_assignment`` patterns anchor on
+a credential-ish name plus a separator. Without a shape test on the captured
+value they fire on the code that proves a secret was NOT hardcoded (environment
+lookups, config templating, plain identifier references). Because redaction runs
+on the ingest write path, every such match destroys non-secret text
+irreversibly.
+
+These tests lock both halves of the contract: non-credential values survive
+intact, and real hardcoded credentials are still redacted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.ingest_protection import redact_sensitive_text
+
+
+def _sensitive_config(tmp_path: Path, **overrides) -> LCMConfig:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    config.sensitive_patterns_enabled = True
+    config.sensitive_patterns = [
+        "api_key",
+        "bearer_token",
+        "password_assignment",
+        "private_key",
+    ]
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _sensitive_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    engine = LCMEngine(
+        config=_sensitive_config(tmp_path, **overrides),
+        hermes_home=str(tmp_path / "home"),
+    )
+    engine.on_session_start(
+        "precision-session",
+        platform="telegram",
+        conversation_id="precision-conversation",
+        context_length=200_000,
+    )
+    return engine
+
+
+# --- 1. Precision: values that must NOT be redacted ------------------------
+
+ENV_INDIRECTION = [
+    'client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))',
+    'client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])',
+    'api_key = os.getenv("ANTHROPIC_API_KEY")',
+    "const apiKey = process.env.OPENAI_API_KEY;",
+    "api_key: process.env.STRIPE_SECRET_KEY,",
+    'access_token = os.environ.get("GITHUB_ACCESS_TOKEN")',
+    'secret_key = os.environ.get("DJANGO_SECRET_KEY")',
+    'client_secret = os.getenv("OAUTH_CLIENT_SECRET")',
+    'password = os.environ["POSTGRES_PASSWORD"]',
+    'passwd = os.getenv("MYSQL_PASSWORD")',
+    "password: process.env.REDIS_PASSWORD,",
+]
+
+TEMPLATE_REFERENCES = [
+    "export API_KEY=$OPENAI_API_KEY",
+    "export API_KEY=${OPENAI_API_KEY}",
+    "api_key: ${{ secrets.OPENAI_API_KEY }}",
+    "password: ${{ secrets.DB_PASSWORD }}",
+    "api_key: <your-api-key-here>",
+    "password=<your-password>",
+    'api_key: "YOUR_API_KEY_HERE"',
+    'password = "CHANGEME"',
+    "api_key: {{ vault_openai_api_key }}",
+    "api_key: !secret openai_api_key",
+    "password: !secret postgres_password",
+]
+
+PLAIN_REFERENCES = [
+    "client = OpenAI(api_key=settings.openai_api_key)",
+    "api_key = config.api_key",
+    "api_key=self._api_key",
+    "api_key = credentials.api_key",
+    "password=user_password,",
+    "password=hashed_password",
+    'password = request.json.get("password")',
+    'access_token = response.json()["access_token"]',
+    "client_secret=oauth_config.client_secret",
+    "api_key: apiKeyFromContext,",
+    "password: passwordInput.value,",
+]
+
+PROSE_AND_SIGNATURES = [
+    "Set your api_key in the configuration file before running the server.",
+    "The api_key parameter is required and must be a non-empty string.",
+    'raise ValueError("api_key must be provided or set OPENAI_API_KEY")',
+    "def __init__(self, api_key: str | None = None) -> None:",
+    "password must be at least twelve characters long",
+    "Authorization: Bearer <token>",
+    "The password field is write-only and never returned by the API.",
+    "api_key: string;",
+]
+
+NON_SECRETS = ENV_INDIRECTION + TEMPLATE_REFERENCES + PLAIN_REFERENCES + PROSE_AND_SIGNATURES
+
+
+# --- 1. Precision: values that MUST still be redacted ----------------------
+# All credential values below are synthetic and were generated for this file.
+
+HARDCODED_SECRETS = [
+    'client = OpenAI(api_key="sk-proj-9vQ2mTf4LpXw7RaB3nKdY8HcJ1sZ6eUgW0oI5tMv")',
+    'api_key = "sk-ant-api03-7Kq2Zx9Lm4Rb8Tn1Vp6Ws3Yd0Hf5Jg2Ce7Ak4Nu9Bi"',
+    'api_key="AIzaSyD3kL9mQ2vX7bN4pR8tW1cF6hJ0sY5uZ2a"',
+    'secret_key = "8f3a91c04be27d65a0f1e8c72b94d6503fa7e21c9b8d40576"',
+    'access_token = "ghp_A9kZ2mQ7xW4pL1vN8bR3tY6cF0hJ5sD2uE7g"',
+    'api_token = "1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R"',
+    'password = "hT7#kQ2mZ9xW4pL1"',
+    'passphrase = "Zq7Wm2Kx9Lp4Nv8B"',
+    'auth_header = "Bearer 4f8Kd92Mz7Qp1Xn6Bv3Lw0Ae5Rt8Yu2Io"',
+]
+
+
+@pytest.mark.parametrize("text", NON_SECRETS)
+def test_sensitive_patterns_do_not_redact_non_credential_values(tmp_path, text):
+    """Environment lookups, templates, references and prose survive intact."""
+    config = _sensitive_config(tmp_path)
+
+    assert redact_sensitive_text(text, config) == text
+
+
+@pytest.mark.parametrize("text", HARDCODED_SECRETS)
+def test_sensitive_patterns_still_redact_hardcoded_credentials(tmp_path, text):
+    """The value-shape gate must not cost detection of real secrets."""
+    config = _sensitive_config(tmp_path)
+
+    redacted = redact_sensitive_text(text, config)
+
+    assert redacted != text
+    assert "[LCM sensitive redaction:" in redacted
+
+
+def test_sensitive_precision_holds_on_the_ingest_write_path(tmp_path):
+    """The gate applies where it matters: before the SQLite INSERT."""
+    engine = _sensitive_engine(tmp_path)
+    non_secret = 'client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))'
+    secret = "sk-proj-9vQ2mTf4LpXw7RaB3nKdY8HcJ1sZ6eUgW0oI5tMv"
+
+    engine._ingest_messages([
+        {"role": "user", "content": non_secret},
+        {"role": "user", "content": f'api_key = "{secret}"'},
+    ])
+
+    rows = engine._store._conn.execute(
+        "SELECT content FROM messages ORDER BY store_id"
+    ).fetchall()
+    assert rows[0][0] == non_secret
+    assert secret not in rows[1][0]
+    assert "[LCM sensitive redaction:" in rows[1][0]
+
+
+def test_private_key_pattern_is_not_value_shape_gated(tmp_path):
+    """private_key is PEM-anchored and self-validating; leave it alone."""
+    config = _sensitive_config(tmp_path)
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAxyz\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+
+    redacted = redact_sensitive_text(pem, config)
+
+    assert "MIIEowIBAAKCAQEAxyz" not in redacted
+    assert "name=private_key" in redacted


### PR DESCRIPTION
## Summary

- Require the captured value to look like a credential before `api_key`, `bearer_token` or `password_assignment` redaction fires.
- Reject environment-variable indirection, config/docs templating, and structured code references; then require a per-pattern length floor and an entropy floor.
- Leave `private_key` untouched: it is PEM-anchored, self-validating and already precise.
- Add `tests/test_sensitive_pattern_precision.py` (46 tests) covering both directions.

This is the first of two patches for the redaction precision and durability issue I raised with you privately by email earlier today. It stands alone and does not depend on the second one. Happy to close it if you would rather take a different approach; it is your architecture and your call.

## Why

The three keyword patterns anchor on a credential-ish name plus a separator, then accept whatever follows with no test on the captured value:

```python
"api_key": re.compile(
    r"(?P<prefix>...(?:api[_-]?key|...)\b\s*...[:=]\s*...)"
    r"(?P<secret>[A-Za-z0-9._~+/=-]{12,})"   # <- no shape test
    ...
```

So they match the code that proves a secret was *not* hardcoded:

```
client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
  -> client = OpenAI(api_key=[LCM sensitive redaction: name=api_key; chars=14; ...]("OPENAI_API_KEY"))

password = os.environ["POSTGRES_PASSWORD"]
  -> password = [LCM sensitive redaction: name=password_assignment; chars=11; ...]"POSTGRES_PASSWORD"]

client = OpenAI(api_key=settings.openai_api_key)
  -> client = OpenAI(api_key=[LCM sensitive redaction: name=api_key; chars=23; ...])

access_token = response.json()["access_token"]
  -> access_token = [LCM sensitive redaction: name=api_key; chars=13; ...]()["access_token"]
```

The destroyed span is `os.environ.get`, `settings.openai_api_key`, `response.json()`. The secret name in the string literal survives; the surrounding source is what gets eaten. Since redaction runs on the ingest write path, that lands in SQLite and the original characters are unrecoverable.

### What the gate does

`_looks_like_credential(value, pattern_name)` is applied to the captured `secret` group before substitution, on both the regex-span path (`_redact_match`) and the JSON-key-context path (`_redact_entire_sensitive_string`). It rejects, in order:

1. **Environment-variable indirection**: `os.environ`, `os.getenv`, `environ.get`, `process.env`, `import.meta.env`, `Deno.env`, `ENV[`, `System.getenv`, `Environment.GetEnvironmentVariable`, `$VAR`, `${VAR}`, `%VAR%`.
2. **Config/CI templating and doc placeholders**: `${{ secrets.X }}`, `{{ vault_x }}`, `${...}`, `$(...)`, `<anything>`, `!secret x`, `YOUR_*`/`DUMMY_*`/`TEST_*`, `REPLACE_ME`, `CHANGEME`, `TODO`, `xxx`, `...`.
3. **Structured code references** carrying no digits: dotted paths, snake_case names, subscripts, calls, camelCase. The structure requirement matters, because an unbroken single-case run like `OLDSECRET` is a literal rather than a reference and is still redacted (your `test_replay_*_lossy_redaction` tests depend on exactly that, and they stay green).

Values that clear those must then meet a length floor (`api_key` 12, `bearer_token` 16, `password_assignment` 8) and an entropy floor: mixed letters and digits, an unbroken single-case literal, a multi-word passphrase, or credential punctuation an identifier cannot carry.

`private_key` is exempt via `_VALUE_SHAPE_GATED_SENSITIVE_PATTERNS`. It produced no false positives in anything I measured, so there is nothing to fix there.

### Measured effect

110-line corpus of realistic code-review traffic: 90 non-secret lines (environment indirection, shell/YAML templating, identifier references, prose and type signatures, test fixtures) and 20 synthetic hardcoded credentials shaped like real provider keys.

| | before | after |
|---|---|---|
| spans redacted | 55 | 19 |
| false positives | **36** / 90 non-secret lines | **0** / 90 |
| FP rate (FP / redactions) | **65.5%** | **0.0%** |
| detection of real secrets | 19 / 20 (95.0%) | 19 / 20 (95.0%) |

Detection is unchanged. The one miss (`DB_PASSWORD = "..."`) fails on both versions because `\b(?:password|passwd|pwd|passphrase)\b` does not match the `DB_PASSWORD` prefix. That is a pre-existing recall gap in the shipped pattern and I have deliberately left it alone rather than widen scope here.

Per family, false positives before -> after: environment indirection 14 -> 0, templating 4 -> 0, identifier references 15 -> 0, prose 1 -> 0, test fixtures 2 -> 0, real secrets correctly redacted 19 -> 19.

## Validation

- [x] Focused validation: `pytest tests/test_sensitive_pattern_precision.py tests/test_ingest_protection.py tests/test_lcm_core.py -q` -> `481 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> pass except one pre-existing wall-clock flake, see Notes
  - [x] `pytest -q` -> `2348 passed, 12 failed`, every failure pre-existing on clean `main` on this machine, see Notes
  - [x] `ruff check .` -> `All checks passed!`
  - [x] `git diff --check` -> clean
- [ ] Workflow validation: no workflow changes.

## Notes

**On the failures.** I ran `pytest -q` on a pristine `upstream/main` worktree at `424a6b2` before touching anything, and got the same failure set. They are all environment-dependent on this machine (macOS, Python 3.14) and none of them touch redaction:

- Wall-clock deadline assertions in `test_embedding_provider.py` and `test_embedding_search_modes.py`, e.g. `assert (1124192.069814166 - 1124191.999403458) < 0.03`.
- `test_on_session_end_returns_quickly_under_real_sqlite_writer_lock`, a timing flake. On clean `main` it failed 4 of 5 consecutive runs and passed once.
- 2 macOS `/private` symlink path assertions in `test_path_containment.py` and `test_path_security.py`, where `TemporaryDirectory()` returns `/var/...` but the resolved path is `/private/var/...`.

Exact membership of the timing family varies run to run (I saw 12 and 13 on two runs of the same unchanged tree, with reds appearing and disappearing in both directions), so I checked it as a set rather than a list: **zero failures fall outside those files**, on either the baseline or my branch. Any test I saw fail on my branch but not in the baseline run, I re-ran 5x on a pristine `upstream/main` worktree and it failed 5/5 there too.

I am claiming "your suite minus that known-red set", not full green, and I have not touched any of them. Happy to send the pristine-baseline log if useful.

**Scope.** This does not change the write-path architecture. A false positive that still slips through is still permanent, because redaction rewrites `content` before the `INSERT`. That is the second patch, and it is deliberately separate so this one can land or not on its own merits.

**Testing style.** I followed the shape of `tests/test_ingest_protection.py` (real `LCMEngine`, real store, assert on the actual SQLite row). All credential values in the tests and the corpus are synthetic and were generated for this patch; no real key, token or transcript is included anywhere.
