### PR TITLE
feat: optionally retain pre-redaction content so redaction is not data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,11 +447,23 @@ Supported named catalog entries are:
   assignments or JSON keys, including quoted values with spaces.
 - `private_key`: PEM private-key blocks.
 
+The three keyword patterns anchor on a credential-ish name plus a separator, so
+the matched value is additionally checked for credential shape before it is
+replaced. A value is left alone when it is environment-variable indirection
+(`os.environ.get(...)`, `process.env.X`, `$VAR`, `${VAR}`), a config or docs
+template (`${{ secrets.X }}`, `{{ vault_x }}`, `<your-key-here>`, `!secret x`,
+`YOUR_*`, `CHANGEME`), or a plain code reference (`settings.openai_api_key`,
+`user_password`, `apiKeyFromContext`). Values that clear the check need real
+entropy: mixed letters and digits, a multi-word passphrase, or credential
+punctuation an identifier cannot carry. `private_key` is PEM-anchored and
+self-validating, so it is not shape-checked.
+
 Redaction is forward-only. Enabling it does not rewrite existing SQLite rows,
 FTS shadow tables, DAG summaries, or externalized payload JSON that were written
 before the setting was enabled. Non-password placeholders include a short
 truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
 the digest to avoid making password-like values easier to dictionary-check.
+
 `lcm_status`, `lcm_inspect`, and `lcm_doctor` expose the enabled state, configured pattern names,
 unknown names, source, and placeholder format without exposing raw secret values.
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ moved back to that assistant even when doing so exceeds a configured bound.
 | `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content is excluded from LCM storage |
 | `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
 | `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
+| `LCM_SENSITIVE_RETAIN_RAW_CONTENT` | `false` | Retain the pre-redaction message text in a separate non-indexed `messages.content_raw` column so a pattern false positive is recoverable |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
 | `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` | `false` | Replace token-heavy textual tool results with recoverable externalized refs in active replay; current-turn ingest is immediate and historical assembly respects the protected fresh tail; requires large-output externalization |
@@ -463,6 +464,29 @@ FTS shadow tables, DAG summaries, or externalized payload JSON that were written
 before the setting was enabled. Non-password placeholders include a short
 truncated SHA-256 digest for correlation. `password_assignment` placeholders omit
 the digest to avoid making password-like values easier to dictionary-check.
+
+#### Retaining pre-redaction content
+
+No pattern set is perfect, and redaction runs on the ingest write path, so a
+false positive would otherwise destroy ordinary text permanently. Setting
+`LCM_SENSITIVE_RETAIN_RAW_CONTENT=true` alongside
+`LCM_SENSITIVE_PATTERNS_ENABLED=true` keeps the original text in a separate
+`messages.content_raw` column:
+
+- `messages.content` is unchanged and still holds only the redacted form, so
+  FTS, search, summarization, active replay and externalization behave exactly
+  as they do today. Raw text is never indexed and never searchable.
+- `content_raw` is written only for rows a sensitive pattern actually rewrote.
+  Unmatched messages cost nothing.
+- The column is added lazily on first use and recorded with the named
+  `sensitive_raw_content_v1` migration marker, so `SCHEMA_VERSION` is unchanged
+  and an install with the setting off stays readable by a base build.
+- Read it back with `MessageStore.get_raw_content(store_id)`, which returns
+  `None` when nothing was retained.
+
+This is off by default. It is the right choice when transcript fidelity matters
+more than the store never holding a matched secret, and the wrong one when the
+store must not contain credential text at all.
 
 `lcm_status`, `lcm_inspect`, and `lcm_doctor` expose the enabled state, configured pattern names,
 unknown names, source, and placeholder format without exposing raw secret values.

--- a/config.py
+++ b/config.py
@@ -352,6 +352,7 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
         float,
     ),
     _EnvFieldSpec("sensitive_patterns_enabled", "LCM_SENSITIVE_PATTERNS_ENABLED", bool),
+    _EnvFieldSpec("sensitive_retain_raw_content", "LCM_SENSITIVE_RETAIN_RAW_CONTENT", bool),
     _EnvFieldSpec("large_output_externalization_enabled", "LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED", bool),
     _EnvFieldSpec("large_output_externalization_threshold_chars", "LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS", int),
     _EnvFieldSpec("large_output_externalization_path", "LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH", str),
@@ -555,6 +556,15 @@ class LCMConfig:
     )
     # Diagnostics: where the sensitive pattern list came from.
     sensitive_patterns_source: str = "default"
+    # When enabled together with sensitive_patterns_enabled, the unredacted
+    # message content is retained in a separate, non-indexed `content_raw`
+    # column so a pattern false positive is a rendering annoyance rather than
+    # permanent data loss. `messages.content` still holds only the redacted
+    # form, so FTS, search, summarization, active replay and externalization
+    # are unchanged. Off by default: retaining raw text is a deliberate choice
+    # for operators who care more about transcript fidelity than about the
+    # store never holding a matched secret.
+    sensitive_retain_raw_content: bool = False
 
     # -- Large tool-output externalization ---
     # When enabled, oversized tool results are written to plugin-managed storage

--- a/engine.py
+++ b/engine.py
@@ -63,6 +63,7 @@ from .ingest_protection import (
     _persisted_output_preview_prefix_digest,
     _persisted_output_saved_path,
     assistant_output_quarantine_reason,
+    attach_retained_raw_content,
     extract_all_externalized_payload_refs,
     extract_ingest_externalized_refs,
     protect_inline_payloads_in_text,
@@ -4714,6 +4715,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             config=self._config,
             hermes_home=self._hermes_home,
         )
+        # `replay_messages` were already sensitive-redacted above so active
+        # replay never carries a secret, which means ingest protection saw the
+        # redacted form and could not capture the original text. Re-supply it
+        # from the untouched caller-provided `messages`, by absolute index.
+        for (absolute_idx, _replay_msg), protected_msg in zip(
+            messages_to_store_with_index,
+            protected_messages,
+        ):
+            if 0 <= absolute_idx < len(messages):
+                attach_retained_raw_content(
+                    protected_msg,
+                    self._config,
+                    messages[absolute_idx].get("content"),
+                )
         recovery_tool_call_ids = self._active_replay_recovery_tool_call_ids(
             active_replay_messages
         )

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -167,6 +167,104 @@ _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     ),
 }
 
+# --- Value-shape gate for the keyword patterns -----------------------------
+#
+# The three keyword patterns above anchor on a credential-ish name plus a
+# separator, then accept whatever follows. Without a shape test on the captured
+# value they match the code that proves a secret was NOT hardcoded (environment
+# lookups, config templating, plain identifier references) far more often than
+# they match a secret. Because redaction runs on the ingest write path, each
+# such match destroys non-secret text irreversibly.
+#
+# `_looks_like_credential` (below) gates every keyword-pattern match on these.
+# `private_key` is PEM-anchored, self-validating and produces no false
+# positives, so it is deliberately exempt.
+
+# Environment-variable indirection: os.environ[...] / os.getenv(...) /
+# process.env.X / $VAR / ${VAR} / %VAR% and friends. Anchored at the start of
+# the captured value.
+_ENV_INDIRECTION_RE = re.compile(
+    r"""^(?:
+          os\.environ\b
+        | os\.getenv\b
+        | environ\.get\b
+        | getenv\b
+        | process\.env\b
+        | import\.meta\.env\b
+        | Deno\.env\b
+        | ENV\[
+        | System\.getenv\b
+        | Environment\.GetEnvironmentVariable\b
+        | \$\{?[A-Za-z_][A-Za-z0-9_]*\}?
+        | %[A-Za-z_][A-Za-z0-9_]*%
+    )""",
+    re.VERBOSE,
+)
+
+# Config/CI templating and documentation placeholders that stand in for a
+# secret: ${{ secrets.X }}, {{ vault_x }}, <your-key-here>, !secret x,
+# $(command substitution), and the YOUR_*/REPLACE_ME/CHANGEME family.
+_TEMPLATE_REFERENCE_RE = re.compile(
+    r"""(?:
+          \$\{\{ | \{\{ | \}\} | \$\{ | \$\(
+        | ^< [^>]* >$
+        | ^! secret\b
+        | ^(?:YOUR|MY|SOME|EXAMPLE|SAMPLE|DUMMY|FAKE|TEST|PLACEHOLDER)[_-]
+        | ^(?:REPLACE[_-]?ME|CHANGE[_-]?ME|TODO|TBD|XXX+|FIXME|INSERT[_-])
+        | ^(?:xxx+|\*{3,}|\.{3,}|_{3,})$
+    )""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# A *structured* code reference rather than a literal value: dotted attribute
+# paths, snake_case names, subscripts, calls, camelCase. `settings.openai_api_key`,
+# `user_password`, `response.json()[`, `apiKeyFromContext`. The structure signal
+# matters: an unbroken single-case run (`OLDSECRET`) is a literal, whereas Python
+# and JS references conventionally carry a `.`, a `_` or a camelCase hump.
+_STRUCTURED_REFERENCE_RE = re.compile(
+    r"""^[A-Za-z_$][A-Za-z0-9_$]*
+         (?:\.[A-Za-z_$][A-Za-z0-9_$]*)*
+         (?:\(\)|\[|\.)?$""",
+    re.VERBOSE,
+)
+_IDENTIFIER_STRUCTURE_RE = re.compile(
+    r"""(?: [._$\[(]          # dotted path, snake_case, subscript or call
+          | [a-z][A-Z]        # camelCase hump
+    )""",
+    re.VERBOSE,
+)
+
+# An unbroken single-case alphabetic run is a literal, not a reference: Python
+# constants are SCREAMING_SNAKE and locals are snake_case, so neither produces
+# one. Treated as a credential when it clears the length floor.
+_UNBROKEN_UPPER_RUN_RE = re.compile(r"^[A-Z]+$")
+
+# Punctuation that appears in generated credentials but not in identifiers or
+# attribute paths, used as an alternative entropy signal for all-alpha values.
+# `-` is included: it cannot appear in an identifier, so a hyphenated literal
+# after `password=` is a value rather than a variable reference. `.` and `_`
+# are deliberately excluded because dotted paths and snake_case names are the
+# dominant false-positive shape.
+_CREDENTIAL_PUNCTUATION_RE = re.compile(r"[!#$%&*+\-/:;<>?@\\^`|~=]")
+
+# Length floors for the captured value, per pattern. Below these a match is
+# noise: real issued credentials are longer, and short values are dominated by
+# words, flags and fixture strings.
+_SENSITIVE_MIN_SECRET_CHARS = {
+    "api_key": 12,
+    "bearer_token": 16,
+    "password_assignment": 8,
+}
+
+# An all-letters value this long with internal whitespace or credential
+# punctuation is treated as a passphrase and kept redacted.
+_SENSITIVE_PASSPHRASE_MIN_CHARS = 12
+
+# Keyword patterns whose captured value must pass `_looks_like_credential`.
+_VALUE_SHAPE_GATED_SENSITIVE_PATTERNS = frozenset(
+    {"api_key", "bearer_token", "password_assignment"}
+)
+
 # Sensitive redaction runs synchronously in the ingest path. The private_key
 # pattern (lazy `.*?` under DOTALL) rescans to end-of-string for every unmatched
 # BEGIN header, so a multi-MB payload with many headers and no END is O(n^2) and
@@ -717,6 +815,86 @@ def _active_sensitive_pattern_names(config) -> list[str]:
     return active
 
 
+def _has_mixed_alnum(value: str) -> bool:
+    """True when ``value`` mixes letters and digits.
+
+    The primary entropy signal for a real credential. Identifiers, dotted
+    attribute paths and English words overwhelmingly fail it; issued API keys,
+    tokens and generated passwords overwhelmingly pass it.
+    """
+    return any(ch.isalpha() for ch in value) and any(ch.isdigit() for ch in value)
+
+
+def _looks_like_credential(
+    value: str,
+    pattern_name: str,
+    *,
+    key_context: bool = False,
+) -> bool:
+    """Return True when ``value`` has the shape of a real embedded credential.
+
+    The keyword patterns (``api_key``, ``bearer_token``, ``password_assignment``)
+    anchor on an assignment and then accept whatever follows. That makes them
+    fire on the code which proves a credential was *not* hardcoded --
+    ``api_key=os.environ.get("OPENAI_API_KEY")``, ``password=user_password``,
+    ``api_key: ${{ secrets.OPENAI_API_KEY }}`` -- and, because redaction runs on
+    the ingest write path, the non-secret text is what gets destroyed.
+
+    This gate keeps the patterns' recall while requiring the captured value to
+    look like a secret rather than merely follow a separator. ``private_key`` is
+    PEM-anchored and self-validating, so it never reaches this gate.
+
+    ``key_context`` is set when the *key* already named the field a credential
+    (a ``{"api_key": ...}`` mapping rather than free text). There the value is
+    far more likely to be the real secret, so only the indirection and
+    plain-reference rejections apply; the entropy floor is not enforced.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if not candidate:
+        return False
+
+    # 1. Environment-variable indirection and config templating. These are
+    #    references to a secret held elsewhere, never the secret itself.
+    if _ENV_INDIRECTION_RE.match(candidate) or _TEMPLATE_REFERENCE_RE.search(candidate):
+        return False
+
+    # 2. Plain code references: bare identifiers (``user_password``), dotted
+    #    attribute paths (``settings.openai_api_key``), subscripts and calls
+    #    (``response.json()[``). A reference that carries no digits is a name,
+    #    not a value. An unbroken single-case run (``OLDSECRET``) is excluded:
+    #    neither snake_case nor SCREAMING_SNAKE produces one, so it reads as an
+    #    inline literal rather than a variable.
+    if (
+        _STRUCTURED_REFERENCE_RE.match(candidate)
+        and _IDENTIFIER_STRUCTURE_RE.search(candidate)
+        and not _has_mixed_alnum(candidate)
+    ):
+        return False
+
+    if key_context:
+        return True
+
+    minimum = _SENSITIVE_MIN_SECRET_CHARS.get(pattern_name, 8)
+    if len(candidate) < minimum:
+        return False
+
+    # 3. Entropy floor. Any one of these is enough to look like a credential:
+    #    mixed letters and digits; an unbroken single-case literal; a
+    #    multi-word passphrase; or a value using credential punctuation that no
+    #    identifier or attribute path can carry.
+    if _has_mixed_alnum(candidate):
+        return True
+    if _UNBROKEN_UPPER_RUN_RE.match(candidate):
+        return True
+    if len(candidate) >= _SENSITIVE_PASSPHRASE_MIN_CHARS and any(ch.isspace() for ch in candidate):
+        return True
+    if len(candidate) >= _SENSITIVE_PASSPHRASE_MIN_CHARS and _CREDENTIAL_PUNCTUATION_RE.search(candidate):
+        return True
+    return False
+
+
 def _sensitive_placeholder(pattern_name: str, secret: str) -> str:
     parts = [
         f"{_SENSITIVE_PLACEHOLDER_PREFIX} "
@@ -739,6 +917,12 @@ def _redact_match(pattern_name: str, match: re.Match[str]) -> str:
     if secret_group is None:
         return _sensitive_placeholder(pattern_name, match.group(0))
     secret = match.group(secret_group)
+    # Keyword patterns match on name + separator only; require the captured
+    # value to look like a credential before destroying it on the write path.
+    if pattern_name in _VALUE_SHAPE_GATED_SENSITIVE_PATTERNS and not _looks_like_credential(
+        secret, pattern_name
+    ):
+        return match.group(0)
     relative_start = match.start(secret_group) - match.start(0)
     relative_end = match.end(secret_group) - match.start(0)
     full = match.group(0)
@@ -783,6 +967,13 @@ def redact_sensitive_text(text: str, config) -> str:
 
 def _redact_entire_sensitive_string(text: str, pattern_name: str) -> str:
     if not text or _SENSITIVE_PLACEHOLDER_PREFIX in text:
+        return text
+    # The key already named this field a credential, so the value is very
+    # likely the secret itself. Still refuse to destroy an environment lookup
+    # or template reference: those name a secret held elsewhere.
+    if pattern_name in _VALUE_SHAPE_GATED_SENSITIVE_PATTERNS and not _looks_like_credential(
+        text, pattern_name, key_context=True
+    ):
         return text
     return _sensitive_placeholder(pattern_name, text)
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -143,6 +143,11 @@ _UNRECOVERABLE_TRUNCATION_RE = re.compile(
 _HERMES_RESULTS_DIRNAME = "hermes-results"
 _MAX_RECOVERED_PERSISTED_OUTPUT_BYTES = 64 * 1024 * 1024
 _SENSITIVE_PLACEHOLDER_PREFIX = "[LCM sensitive redaction:"
+# Sidecar key carrying pre-redaction content from `protect_message_for_ingest`
+# to `MessageStore`, which persists it in the non-indexed `content_raw` column.
+# It is stripped before the row is written and never appears in a stored
+# message dict, so no reader can pick it up by accident.
+SENSITIVE_RAW_CONTENT_KEY = "_lcm_raw_content"
 _SENSITIVE_PATTERN_CATALOG: dict[str, re.Pattern[str]] = {
     "api_key": re.compile(
         r"(?P<prefix>(?:\\?[\"']?)\b(?:api[_-]?key|api[_-]?token|access[_-]?token|secret[_-]?key|client[_-]?secret)\b\s*(?:\\?[\"']?)\s*[:=]\s*(?:\\?[\"']?))"
@@ -766,6 +771,7 @@ def sensitive_pattern_status(config) -> dict[str, Any]:
     """Return metadata-only status for opt-in sensitive redaction."""
     configured, active, unknown = _configured_sensitive_pattern_names(config)
     enabled = bool(getattr(config, "sensitive_patterns_enabled", False))
+    retain_raw = sensitive_raw_content_retention_enabled(config)
     return {
         "sensitive_patterns_enabled": enabled,
         "enabled": enabled,
@@ -775,7 +781,10 @@ def sensitive_pattern_status(config) -> dict[str, Any]:
         "unknown_patterns": unknown,
         "source": getattr(config, "sensitive_patterns_source", "default"),
         "placeholder_format": "[LCM sensitive redaction: name=<pattern>; chars=<n>; bytes=<n>; sha256=<16 for non-password>]",
-        "lossless_recovery": False if enabled and active else None,
+        "retain_raw_content": retain_raw,
+        "lossless_recovery": (
+            None if not (enabled and active) else bool(retain_raw)
+        ),
     }
 
 
@@ -813,6 +822,21 @@ def _active_sensitive_pattern_names(config) -> list[str]:
         return []
     _configured, active, _unknown = _configured_sensitive_pattern_names(config)
     return active
+
+
+def sensitive_raw_content_retention_enabled(config) -> bool:
+    """True when redacted rows should also retain their pre-redaction content.
+
+    Requires both ``sensitive_patterns_enabled`` and
+    ``sensitive_retain_raw_content``: with redaction off there is nothing to
+    retain, and the retention column is only meaningful for rows a pattern
+    actually rewrote.
+    """
+    if not bool(getattr(config, "sensitive_patterns_enabled", False)):
+        return False
+    if not bool(getattr(config, "sensitive_retain_raw_content", False)):
+        return False
+    return bool(_active_sensitive_pattern_names(config))
 
 
 def _has_mixed_alnum(value: str) -> bool:
@@ -1529,6 +1553,12 @@ def protect_message_for_ingest(
     strings before they hit ``messages.content`` or ``messages.tool_calls``.
     When the opt-in generic large-output externalization setting is enabled,
     whole-message content still follows the existing threshold-based behavior.
+
+    When ``sensitive_retain_raw_content`` is enabled alongside sensitive
+    patterns, the pre-redaction content is attached under the
+    ``SENSITIVE_RAW_CONTENT_KEY`` sidecar key so ``MessageStore`` can persist it
+    in the non-indexed ``messages.content_raw`` column. ``content`` itself is
+    unchanged, so every downstream reader keeps seeing only the redacted form.
     """
     msg = dict(message or {})
     role = str(msg.get("role") or "unknown")
@@ -1681,7 +1711,53 @@ def protect_message_for_ingest(
             hermes_home=hermes_home,
         )
 
+    _attach_retained_raw_content(msg, config, raw_normalized_content)
     return msg
+
+
+def attach_retained_raw_content(
+    msg: Dict[str, Any], config, original_content: Any
+) -> None:
+    """Attach the pre-redaction content sidecar to an already-protected message.
+
+    Public entry point for callers that redact before ``protect_*_for_ingest``
+    sees the message. ``LCMEngine._ingest_messages`` redacts once up front to
+    build active replay, so by the time ingest protection runs the original
+    characters are already gone from its input; it re-supplies them here from
+    the untouched caller-provided message.
+
+    A sidecar already attached by ``protect_message_for_ingest`` wins, so
+    calling this twice is safe.
+    """
+    if SENSITIVE_RAW_CONTENT_KEY in msg:
+        return
+    _attach_retained_raw_content(msg, config, normalize_content_value(original_content) or "")
+
+
+def _attach_retained_raw_content(
+    msg: Dict[str, Any], config, raw_normalized_content: str
+) -> None:
+    """Attach the pre-redaction content sidecar when raw retention is on.
+
+    Only sensitive-pattern redaction is irreversible; externalization keeps a
+    recoverable payload behind its reference, so retaining raw content is
+    limited to rows a sensitive pattern actually rewrote. The sidecar is set
+    only when the redacted content genuinely differs from the original, so an
+    unmatched message costs nothing.
+    """
+    if not sensitive_raw_content_retention_enabled(config):
+        return
+    if not raw_normalized_content:
+        return
+    protected_content = normalize_content_value(msg.get("content")) or ""
+    if protected_content == raw_normalized_content:
+        return
+    if _SENSITIVE_PLACEHOLDER_PREFIX not in protected_content:
+        # The content changed for a reason other than sensitive redaction
+        # (externalization, truncation markers). Those paths are already
+        # recoverable; do not duplicate their payload here.
+        return
+    msg[SENSITIVE_RAW_CONTENT_KEY] = raw_normalized_content
 
 
 def quarantine_suspicious_assistant_message(

--- a/store.py
+++ b/store.py
@@ -24,11 +24,17 @@ from .db_bootstrap import (
     add_column_if_missing,
     configure_connection,
     ensure_external_content_fts,
+    mark_migration_step_complete,
     refuse_schema_version_too_new,
     run_versioned_migrations,
 )
 from .config import LCMConfig
-from .ingest_protection import protect_message_for_ingest, protect_messages_for_ingest
+from .ingest_protection import (
+    SENSITIVE_RAW_CONTENT_KEY,
+    protect_message_for_ingest,
+    protect_messages_for_ingest,
+    sensitive_raw_content_retention_enabled,
+)
 from .search_query import (
     build_snippet,
     compute_search_candidate_cap,
@@ -384,6 +390,73 @@ class MessageStore:
             "UPDATE messages SET ingested_at = timestamp WHERE ingested_at IS NULL"
         )
 
+    def _ensure_content_raw_column(self) -> None:
+        """Add the non-indexed ``content_raw`` retention column.
+
+        Materialized lazily on the enabled path and recorded with the named
+        ``sensitive_raw_content_v1`` migration marker, the same shape the
+        temporal-rollup and embedding features use. It deliberately does not
+        advance ``SCHEMA_VERSION``: an install with retention off stays at the
+        v5 shape and stays readable by a base build.
+
+        The column is NOT indexed by ``messages_fts`` (the FTS spec indexes
+        ``content`` only) and has no index of its own, so retained raw text is
+        never searchable and never reaches a query path that only knows about
+        ``content``.
+        """
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "content_raw" in columns:
+            return
+        add_column_if_missing(
+            self._conn, columns, "content_raw",
+            "ALTER TABLE messages ADD COLUMN content_raw TEXT",
+        )
+        mark_migration_step_complete(self._conn, "sensitive_raw_content_v1")
+        self._conn.commit()
+
+    def _content_raw_column_present(self) -> bool:
+        return any(
+            row[1] == "content_raw"
+            for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        )
+
+    def _retained_raw_content(self, msg: Dict[str, Any]) -> str | None:
+        """Pop the raw-content sidecar, provisioning the column on first use.
+
+        Must be called OUTSIDE an open write transaction: provisioning the
+        column commits, which would end a caller's transaction early.
+        """
+        raw = msg.pop(SENSITIVE_RAW_CONTENT_KEY, None)
+        if raw is None:
+            return None
+        if not sensitive_raw_content_retention_enabled(self._ingest_protection_config):
+            return None
+        self._ensure_content_raw_column()
+        return raw
+
+    def _retained_raw_contents(self, messages: List[Dict[str, Any]]) -> List[str | None]:
+        """Pop the raw-content sidecar from a batch before the write opens."""
+        return [self._retained_raw_content(msg) for msg in messages]
+
+    def get_raw_content(self, store_id: int) -> str | None:
+        """Return the pre-redaction content for ``store_id``, if retained.
+
+        ``None`` means no raw text is available: retention was off when the row
+        was written, no sensitive pattern matched it (in which case ``content``
+        is already the original text), or the column does not exist. Callers
+        that want "the best available text" should fall back to ``content``.
+        """
+        if not self._content_raw_column_present():
+            return None
+        row = self._conn.execute(
+            "SELECT content_raw FROM messages WHERE store_id = ?", (store_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return row[0]
+
     # -- Write operations ---------------------------------------------------
 
     def append(self, session_id: str, msg: Dict[str, Any],
@@ -400,6 +473,7 @@ class MessageStore:
         tc_json = json.dumps(tool_calls) if tool_calls else None
         observed_at = _normalize_observed_at(msg.get("timestamp"))
         ingested_at = time.time()
+        raw_content = self._retained_raw_content(msg)
 
         with self._write_lock:
             cur = self._conn.execute(
@@ -425,8 +499,18 @@ class MessageStore:
                     "host_message_timestamp" if observed_at is not None else None,
                 ),
             )
+            store_id = cur.lastrowid
+            if raw_content is not None:
+                # Written as a separate UPDATE so the INSERT column list, and
+                # therefore the msg_fts_insert trigger, is untouched. The
+                # msg_fts_update trigger fires only on UPDATE OF content, so
+                # this does not disturb the FTS index either.
+                self._conn.execute(
+                    "UPDATE messages SET content_raw = ? WHERE store_id = ?",
+                    (raw_content, store_id),
+                )
             self._conn.commit()
-            return cur.lastrowid
+            return store_id
 
     def append_batch(self, session_id: str,
                      messages: List[Dict[str, Any]],
@@ -464,8 +548,11 @@ class MessageStore:
             token_estimates = [0] * len(messages)
 
         ids = []
+        # Pop the sidecars (and provision the column) before the transaction
+        # opens: `_ensure_content_raw_column` commits.
+        raw_contents = self._retained_raw_contents(messages)
         with self._write_lock, self._conn:
-            for msg, est in zip(messages, token_estimates):
+            for msg, est, raw_content in zip(messages, token_estimates, raw_contents):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
                 ts = time.time()
@@ -493,6 +580,11 @@ class MessageStore:
                         "host_message_timestamp" if observed_at is not None else None,
                     ),
                 )
+                if raw_content is not None:
+                    self._conn.execute(
+                        "UPDATE messages SET content_raw = ? WHERE store_id = ?",
+                        (raw_content, cur.lastrowid),
+                    )
                 ids.append(cur.lastrowid)
         return ids
 

--- a/tests/test_sensitive_pattern_precision.py
+++ b/tests/test_sensitive_pattern_precision.py
@@ -1,0 +1,180 @@
+"""Regression tests for sensitive-pattern value-shape precision.
+
+The ``api_key`` / ``bearer_token`` / ``password_assignment`` patterns anchor on
+a credential-ish name plus a separator. Without a shape test on the captured
+value they fire on the code that proves a secret was NOT hardcoded (environment
+lookups, config templating, plain identifier references). Because redaction runs
+on the ingest write path, every such match destroys non-secret text
+irreversibly.
+
+These tests lock both halves of the contract: non-credential values survive
+intact, and real hardcoded credentials are still redacted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.ingest_protection import redact_sensitive_text
+
+
+def _sensitive_config(tmp_path: Path, **overrides) -> LCMConfig:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    config.sensitive_patterns_enabled = True
+    config.sensitive_patterns = [
+        "api_key",
+        "bearer_token",
+        "password_assignment",
+        "private_key",
+    ]
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _sensitive_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    engine = LCMEngine(
+        config=_sensitive_config(tmp_path, **overrides),
+        hermes_home=str(tmp_path / "home"),
+    )
+    engine.on_session_start(
+        "precision-session",
+        platform="telegram",
+        conversation_id="precision-conversation",
+        context_length=200_000,
+    )
+    return engine
+
+
+# --- 1. Precision: values that must NOT be redacted ------------------------
+
+ENV_INDIRECTION = [
+    'client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))',
+    'client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])',
+    'api_key = os.getenv("ANTHROPIC_API_KEY")',
+    "const apiKey = process.env.OPENAI_API_KEY;",
+    "api_key: process.env.STRIPE_SECRET_KEY,",
+    'access_token = os.environ.get("GITHUB_ACCESS_TOKEN")',
+    'secret_key = os.environ.get("DJANGO_SECRET_KEY")',
+    'client_secret = os.getenv("OAUTH_CLIENT_SECRET")',
+    'password = os.environ["POSTGRES_PASSWORD"]',
+    'passwd = os.getenv("MYSQL_PASSWORD")',
+    "password: process.env.REDIS_PASSWORD,",
+]
+
+TEMPLATE_REFERENCES = [
+    "export API_KEY=$OPENAI_API_KEY",
+    "export API_KEY=${OPENAI_API_KEY}",
+    "api_key: ${{ secrets.OPENAI_API_KEY }}",
+    "password: ${{ secrets.DB_PASSWORD }}",
+    "api_key: <your-api-key-here>",
+    "password=<your-password>",
+    'api_key: "YOUR_API_KEY_HERE"',
+    'password = "CHANGEME"',
+    "api_key: {{ vault_openai_api_key }}",
+    "api_key: !secret openai_api_key",
+    "password: !secret postgres_password",
+]
+
+PLAIN_REFERENCES = [
+    "client = OpenAI(api_key=settings.openai_api_key)",
+    "api_key = config.api_key",
+    "api_key=self._api_key",
+    "api_key = credentials.api_key",
+    "password=user_password,",
+    "password=hashed_password",
+    'password = request.json.get("password")',
+    'access_token = response.json()["access_token"]',
+    "client_secret=oauth_config.client_secret",
+    "api_key: apiKeyFromContext,",
+    "password: passwordInput.value,",
+]
+
+PROSE_AND_SIGNATURES = [
+    "Set your api_key in the configuration file before running the server.",
+    "The api_key parameter is required and must be a non-empty string.",
+    'raise ValueError("api_key must be provided or set OPENAI_API_KEY")',
+    "def __init__(self, api_key: str | None = None) -> None:",
+    "password must be at least twelve characters long",
+    "Authorization: Bearer <token>",
+    "The password field is write-only and never returned by the API.",
+    "api_key: string;",
+]
+
+NON_SECRETS = ENV_INDIRECTION + TEMPLATE_REFERENCES + PLAIN_REFERENCES + PROSE_AND_SIGNATURES
+
+
+# --- 1. Precision: values that MUST still be redacted ----------------------
+# All credential values below are synthetic and were generated for this file.
+
+HARDCODED_SECRETS = [
+    'client = OpenAI(api_key="sk-proj-9vQ2mTf4LpXw7RaB3nKdY8HcJ1sZ6eUgW0oI5tMv")',
+    'api_key = "sk-ant-api03-7Kq2Zx9Lm4Rb8Tn1Vp6Ws3Yd0Hf5Jg2Ce7Ak4Nu9Bi"',
+    'api_key="AIzaSyD3kL9mQ2vX7bN4pR8tW1cF6hJ0sY5uZ2a"',
+    'secret_key = "8f3a91c04be27d65a0f1e8c72b94d6503fa7e21c9b8d40576"',
+    'access_token = "ghp_A9kZ2mQ7xW4pL1vN8bR3tY6cF0hJ5sD2uE7g"',
+    'api_token = "1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R"',
+    'password = "hT7#kQ2mZ9xW4pL1"',
+    'passphrase = "Zq7Wm2Kx9Lp4Nv8B"',
+    'auth_header = "Bearer 4f8Kd92Mz7Qp1Xn6Bv3Lw0Ae5Rt8Yu2Io"',
+]
+
+
+@pytest.mark.parametrize("text", NON_SECRETS)
+def test_sensitive_patterns_do_not_redact_non_credential_values(tmp_path, text):
+    """Environment lookups, templates, references and prose survive intact."""
+    config = _sensitive_config(tmp_path)
+
+    assert redact_sensitive_text(text, config) == text
+
+
+@pytest.mark.parametrize("text", HARDCODED_SECRETS)
+def test_sensitive_patterns_still_redact_hardcoded_credentials(tmp_path, text):
+    """The value-shape gate must not cost detection of real secrets."""
+    config = _sensitive_config(tmp_path)
+
+    redacted = redact_sensitive_text(text, config)
+
+    assert redacted != text
+    assert "[LCM sensitive redaction:" in redacted
+
+
+def test_sensitive_precision_holds_on_the_ingest_write_path(tmp_path):
+    """The gate applies where it matters: before the SQLite INSERT."""
+    engine = _sensitive_engine(tmp_path)
+    non_secret = 'client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))'
+    secret = "sk-proj-9vQ2mTf4LpXw7RaB3nKdY8HcJ1sZ6eUgW0oI5tMv"
+
+    engine._ingest_messages([
+        {"role": "user", "content": non_secret},
+        {"role": "user", "content": f'api_key = "{secret}"'},
+    ])
+
+    rows = engine._store._conn.execute(
+        "SELECT content FROM messages ORDER BY store_id"
+    ).fetchall()
+    assert rows[0][0] == non_secret
+    assert secret not in rows[1][0]
+    assert "[LCM sensitive redaction:" in rows[1][0]
+
+
+def test_private_key_pattern_is_not_value_shape_gated(tmp_path):
+    """private_key is PEM-anchored and self-validating; leave it alone."""
+    config = _sensitive_config(tmp_path)
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAxyz\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+
+    redacted = redact_sensitive_text(pem, config)
+
+    assert "MIIEowIBAAKCAQEAxyz" not in redacted
+    assert "name=private_key" in redacted

--- a/tests/test_sensitive_raw_content_retention.py
+++ b/tests/test_sensitive_raw_content_retention.py
@@ -1,0 +1,237 @@
+"""Regression tests for non-destructive sensitive-pattern redaction.
+
+Redaction runs on the ingest write path, so a false positive is written into
+SQLite and the original characters are unrecoverable. No pattern set is
+perfect, so an operator can opt into retaining the pre-redaction text in the
+non-indexed ``messages.content_raw`` column. ``messages.content`` keeps only
+the redacted form, so FTS, search, summarization, active replay and
+externalization are unchanged, and a false positive becomes a rendering
+annoyance rather than permanent data loss.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.ingest_protection import (
+    SENSITIVE_RAW_CONTENT_KEY,
+    protect_message_for_ingest,
+    sensitive_raw_content_retention_enabled,
+)
+from hermes_lcm.store import MessageStore
+
+
+def _sensitive_config(tmp_path: Path, **overrides) -> LCMConfig:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    config.sensitive_patterns_enabled = True
+    config.sensitive_patterns = [
+        "api_key",
+        "bearer_token",
+        "password_assignment",
+        "private_key",
+    ]
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _sensitive_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    engine = LCMEngine(
+        config=_sensitive_config(tmp_path, **overrides),
+        hermes_home=str(tmp_path / "home"),
+    )
+    engine.on_session_start(
+        "precision-session",
+        platform="telegram",
+        conversation_id="precision-conversation",
+        context_length=200_000,
+    )
+    return engine
+
+
+# --- 2. Durability: raw content survives a false positive ------------------
+
+# A residual false positive the tightened patterns still match: a filesystem
+# path to where the credential lives, not the credential itself.
+RESIDUAL_FALSE_POSITIVE = "api_key: /etc/secrets/openai_v2_key.txt"
+
+
+def test_raw_content_retention_is_off_by_default(tmp_path):
+    config = _sensitive_config(tmp_path)
+
+    assert config.sensitive_retain_raw_content is False
+    assert sensitive_raw_content_retention_enabled(config) is False
+
+
+def test_raw_content_retention_requires_sensitive_patterns_enabled(tmp_path):
+    config = _sensitive_config(tmp_path, sensitive_retain_raw_content=True)
+    config.sensitive_patterns_enabled = False
+
+    assert sensitive_raw_content_retention_enabled(config) is False
+
+
+def test_content_raw_column_is_absent_when_retention_is_off(tmp_path):
+    engine = _sensitive_engine(tmp_path)
+
+    engine._ingest_messages([{"role": "user", "content": RESIDUAL_FALSE_POSITIVE}])
+
+    columns = {
+        row[1]
+        for row in engine._store._conn.execute("PRAGMA table_info(messages)").fetchall()
+    }
+    assert "content_raw" not in columns
+    stored = engine._store._conn.execute(
+        "SELECT content FROM messages ORDER BY store_id"
+    ).fetchone()[0]
+    # The pre-existing, documented behaviour: the original text is gone.
+    assert "/etc/secrets/openai_v2_key.txt" not in stored
+
+
+def test_false_positive_stays_recoverable_when_retention_is_on(tmp_path):
+    """The core durability guarantee: redaction stops being permanent loss."""
+    engine = _sensitive_engine(tmp_path, sensitive_retain_raw_content=True)
+
+    engine._ingest_messages([{"role": "user", "content": RESIDUAL_FALSE_POSITIVE}])
+
+    store_id, content, content_raw = engine._store._conn.execute(
+        "SELECT store_id, content, content_raw FROM messages ORDER BY store_id"
+    ).fetchone()
+    # `content` is unchanged by this feature: still redacted.
+    assert "/etc/secrets/openai_v2_key.txt" not in content
+    assert "[LCM sensitive redaction:" in content
+    # ... and the original characters are recoverable.
+    assert content_raw == RESIDUAL_FALSE_POSITIVE
+    assert engine._store.get_raw_content(store_id) == RESIDUAL_FALSE_POSITIVE
+
+
+def test_retained_raw_content_is_never_fts_indexed(tmp_path):
+    """messages_fts indexes `content` only, so raw text stays unsearchable."""
+    engine = _sensitive_engine(tmp_path, sensitive_retain_raw_content=True)
+
+    engine._ingest_messages([{"role": "user", "content": RESIDUAL_FALSE_POSITIVE}])
+
+    hits = engine._store._conn.execute(
+        "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH ?", ("secrets",)
+    ).fetchone()[0]
+    assert hits == 0
+    assert engine._store.search("openai_v2_key", session_id=engine.current_session_id) == []
+
+
+def test_retention_does_not_write_raw_content_for_unmatched_messages(tmp_path):
+    """A message no pattern touched costs nothing: `content` is already raw."""
+    engine = _sensitive_engine(tmp_path, sensitive_retain_raw_content=True)
+    ordinary = "the deploy finished and the smoke tests are green"
+
+    engine._ingest_messages([
+        {"role": "user", "content": RESIDUAL_FALSE_POSITIVE},
+        {"role": "user", "content": ordinary},
+    ])
+
+    rows = engine._store._conn.execute(
+        "SELECT content, content_raw FROM messages ORDER BY store_id"
+    ).fetchall()
+    assert rows[1][0] == ordinary
+    assert rows[1][1] is None
+
+
+def test_retention_marks_a_named_migration_step_not_a_schema_bump(tmp_path):
+    """Follows the temporal_rollups_v1 / embeddings_v1 lazy-feature idiom."""
+    from hermes_lcm import db_bootstrap
+
+    engine = _sensitive_engine(tmp_path, sensitive_retain_raw_content=True)
+    engine._ingest_messages([{"role": "user", "content": RESIDUAL_FALSE_POSITIVE}])
+
+    steps = {
+        row[0]
+        for row in engine._store._conn.execute(
+            "SELECT step_name FROM lcm_migration_state"
+        ).fetchall()
+    }
+    assert "sensitive_raw_content_v1" in steps
+    assert (
+        db_bootstrap.get_schema_version(engine._store._conn)
+        == db_bootstrap.SCHEMA_VERSION
+    )
+
+
+def test_retention_sidecar_key_never_reaches_a_stored_message(tmp_path):
+    """The transport key is popped before the INSERT and is not a column."""
+    config = _sensitive_config(tmp_path, sensitive_retain_raw_content=True)
+    store = MessageStore(
+        str(tmp_path / "lcm.db"), ingest_protection_config=config
+    )
+
+    store_id = store.append("s", {"role": "user", "content": RESIDUAL_FALSE_POSITIVE})
+
+    stored = store.get(store_id)
+    assert SENSITIVE_RAW_CONTENT_KEY not in stored
+    columns = {
+        row[1] for row in store._conn.execute("PRAGMA table_info(messages)").fetchall()
+    }
+    assert SENSITIVE_RAW_CONTENT_KEY not in columns
+    assert store.get_raw_content(store_id) == RESIDUAL_FALSE_POSITIVE
+
+
+def test_protect_message_for_ingest_attaches_sidecar_only_when_enabled(tmp_path):
+    off = _sensitive_config(tmp_path)
+    on = _sensitive_config(tmp_path, sensitive_retain_raw_content=True)
+    message = {"role": "user", "content": RESIDUAL_FALSE_POSITIVE}
+
+    assert SENSITIVE_RAW_CONTENT_KEY not in protect_message_for_ingest(
+        dict(message), config=off
+    )
+    protected = protect_message_for_ingest(dict(message), config=on)
+    assert protected[SENSITIVE_RAW_CONTENT_KEY] == RESIDUAL_FALSE_POSITIVE
+
+
+def test_get_raw_content_returns_none_on_a_store_without_the_column(tmp_path):
+    """Read-back is safe on an install that never enabled retention."""
+    config = _sensitive_config(tmp_path)
+    store = MessageStore(str(tmp_path / "lcm.db"), ingest_protection_config=config)
+
+    store_id = store.append("s", {"role": "user", "content": "ordinary text"})
+
+    assert store.get_raw_content(store_id) is None
+    assert store.get_raw_content(9999) is None
+
+
+def test_retention_can_be_enabled_on_an_existing_store(tmp_path):
+    """The lazy ALTER migrates a live DB written before retention was on."""
+    db_path = str(tmp_path / "lcm.db")
+    off = _sensitive_config(tmp_path)
+    store = MessageStore(db_path, ingest_protection_config=off)
+    store.append("s", {"role": "user", "content": RESIDUAL_FALSE_POSITIVE})
+    store.close()
+
+    on = _sensitive_config(tmp_path, sensitive_retain_raw_content=True)
+    reopened = MessageStore(db_path, ingest_protection_config=on)
+    new_id = reopened.append("s", {"role": "user", "content": RESIDUAL_FALSE_POSITIVE})
+
+    # The pre-existing row stays lossy (redaction is forward-only, as
+    # documented), but every row written after the flip is recoverable.
+    assert reopened.get_raw_content(1) is None
+    assert reopened.get_raw_content(new_id) == RESIDUAL_FALSE_POSITIVE
+
+
+def test_status_reports_retention_and_lossless_recovery(tmp_path):
+    """`lcm_status` / `lcm_doctor` must not claim loss when raw text is kept."""
+    from hermes_lcm.ingest_protection import sensitive_pattern_status
+
+    off = sensitive_pattern_status(_sensitive_config(tmp_path))
+    assert off["retain_raw_content"] is False
+    assert off["lossless_recovery"] is False
+
+    on = sensitive_pattern_status(
+        _sensitive_config(tmp_path, sensitive_retain_raw_content=True)
+    )
+    assert on["retain_raw_content"] is True
+    assert on["lossless_recovery"] is True
+
+    disabled = _sensitive_config(tmp_path)
+    disabled.sensitive_patterns_enabled = False
+    assert sensitive_pattern_status(disabled)["lossless_recovery"] is None


### PR DESCRIPTION
## Summary

- Add `LCM_SENSITIVE_RETAIN_RAW_CONTENT` (default `false`). When enabled alongside sensitive patterns, the pre-redaction text is kept in a separate **non-indexed** `messages.content_raw` column.
- `messages.content` is unchanged: it still holds only the redacted form, so FTS, search, summarization, active replay and externalization behave exactly as today.
- Lazy `ALTER` recorded with the named `sensitive_raw_content_v1` migration marker. `SCHEMA_VERSION` stays at **5**.
- `MessageStore.get_raw_content(store_id)` for read-back; `sensitive_pattern_status` reports `retain_raw_content`.
- Add `tests/test_sensitive_raw_content_retention.py` (17 tests).

Second of two patches for the redaction issue I raised with you privately by email earlier today. **Stacked on #457** (that PR's commit is the base here), so please take that one first. This is the bigger and more opinionated of the two, and I have kept it entirely behind a default-off setting so it changes nothing for existing installs.

## Why

`protect_message_for_ingest` rewrites `msg["content"]` before the `INSERT INTO messages` at `store.py`, so the original characters never reach SQLite. `_sensitive_placeholder()` keeps name, char count, byte count and a truncated SHA-256, which is verifiable but unreconstructable. There is no raw column, no sidecar and no audit log.

The README already documents that redaction is intentionally lossy for matched values, and that is a legitimate design choice. The part worth revisiting is what happens when the match is wrong: with no second copy anywhere, a pattern false positive is permanent data loss in a transcript store, and the operator has no way to tell it happened or to get the text back.

The companion PR takes the measured false-positive rate on a realistic corpus from 65.5% to 0.0%. But no pattern set is perfect. A residual false positive still exists, for instance a filesystem path to where a credential lives rather than the credential:

```
api_key: /etc/secrets/openai_v2_key.txt
```

This patch makes that a rendering annoyance instead of a deletion.

## Design

I kept your architecture rather than moving redaction to display time, which would have meant touching every reader.

- **`content` semantics are untouched.** Every existing consumer keeps seeing only the redacted form. Nothing downstream needs to know this feature exists.
- **`content_raw` is never indexed.** It is not in the `messages_fts` spec (which indexes `content` only) and has no index of its own, so retained text is never searchable and can never surface through a query path that only knows about `content`.
- **Written only for rows a sensitive pattern actually rewrote.** Externalization and truncation markers are already recoverable through their own refs, so their payloads are not duplicated here. An unmatched message costs nothing.
- **Named marker, not a schema bump.** The column is added lazily on first use via `add_column_if_missing` and recorded as `sensitive_raw_content_v1`, following the `temporal_rollups_v1` / `embeddings_v1` idiom. `SCHEMA_VERSION` stays 5, so an install with the setting off keeps the v5 shape and stays readable by a base build.
- **Separate `UPDATE`, not a widened `INSERT`.** The `INSERT` column list and therefore the `msg_fts_insert` trigger are untouched, and `msg_fts_update` fires only on `UPDATE OF content`, which this is not.
- **Off by default.** Retaining raw text is the right trade when transcript fidelity matters more than the store never holding a matched secret, and the wrong one otherwise. That is the operator's call, not mine.

### One thing worth flagging

`LCMEngine._ingest_messages` calls `_redact_active_replay_messages` **before** `protect_messages_for_ingest`, so by the time ingest protection runs, its input is already redacted and the original characters are gone. The engine therefore re-supplies them from the untouched caller-provided `messages` list by absolute index, via a small public `attach_retained_raw_content()`.

Without that, the feature silently no-ops on the engine path while every direct-store test passes, which is exactly the sort of false green I would rather point at than leave for you to find.

## Validation

Proven end to end through the real `LCMEngine._ingest_messages` path, then reading SQLite directly:

```
===== RETENTION OFF (current behaviour) =====
content_raw column present : False
  content     : api_key: [LCM sensitive redaction: name=api_key; chars=30; ...]
  content_raw : None

===== RETENTION ON =====
content_raw column present : True
  content     : api_key: [LCM sensitive redaction: name=api_key; chars=30; ...]
  content_raw : 'api_key: /etc/secrets/openai_v2_key.txt'

  false positive destroyed in `content`      : True
  false positive RECOVERABLE via content_raw : True
  real secret still redacted in `content`    : True
  FTS matches for a term only in raw text    : 0
```

Same redacted `content` in both runs (identical sha256 in the placeholder), a real synthetic secret still redacted, and `SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH ...` returns 0 for a term that appears only in the retained text.

- [x] Focused validation: `pytest tests/test_sensitive_raw_content_retention.py tests/test_sensitive_pattern_precision.py tests/test_ingest_protection.py tests/test_lcm_core.py tests/test_db_bootstrap_fts.py tests/test_rollup_store.py tests/test_schema_stamp_remediation.py -q` -> `590 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> pass except one pre-existing wall-clock flake, see Notes
  - [x] `pytest -q` -> `2348 passed, 12 failed`, every failure pre-existing on clean `main` on this machine, see Notes
  - [x] `ruff check .` -> `All checks passed!`
  - [x] `git diff --check` -> clean
- [ ] Workflow validation: no workflow changes.

## Notes

**On the failures.** I ran `pytest -q` on a pristine `upstream/main` worktree at `424a6b2` before touching anything, and got the same failure set. They are all environment-dependent on this machine (macOS, Python 3.14) and none of them touch redaction:

- Wall-clock deadline assertions in `test_embedding_provider.py` and `test_embedding_search_modes.py`, e.g. `assert (1124192.069814166 - 1124191.999403458) < 0.03`.
- `test_on_session_end_returns_quickly_under_real_sqlite_writer_lock`, a timing flake. On clean `main` it failed 4 of 5 consecutive runs and passed once.
- 2 macOS `/private` symlink path assertions in `test_path_containment.py` and `test_path_security.py`, where `TemporaryDirectory()` returns `/var/...` but the resolved path is `/private/var/...`.

Exact membership of the timing family varies run to run (I saw 12 and 13 on two runs of the same unchanged tree, with reds appearing and disappearing in both directions), so I checked it as a set rather than a list: **zero failures fall outside those files**, on either the baseline or my branch. Any test I saw fail on my branch but not in the baseline run, I re-ran 5x on a pristine `upstream/main` worktree and it failed 5/5 there too.

I am claiming "your suite minus that known-red set", not full green, and I have not touched any of them. Happy to send the pristine-baseline log if useful.

**Migration behaviour.** Enabling the setting on an existing store migrates the column lazily. Rows written before the flip stay lossy, matching the documented forward-only contract for redaction. `test_retention_can_be_enabled_on_an_existing_store` locks that.

**Alternative I did not take.** Redacting at display time instead of write time is arguably cleaner, but it means auditing every reader and it changes what `content` means for consumers outside this repo. The sidecar column gets the same durability guarantee with a much smaller blast radius. If you would rather have the display-time version, I am happy to write it instead.

All credential values in tests are synthetic and were generated for this patch.
