### PR TITLE
fix(codex): honor GPT-5.4 1M context override

### DIFF
--- a/codex_routing.py
+++ b/codex_routing.py
@@ -9,13 +9,11 @@ policy constants (for example the gpt-5.5 compaction threshold).
 
 from __future__ import annotations
 
-# ChatGPT Codex OAuth exposes provider-enforced context windows that can be
-# materially lower than the same model slug on direct OpenAI/OpenRouter routes.
-# Hermes Agent resolves these from chatgpt.com/backend-api/codex/models, with
-# this table as its fallback. LCM sees only the host-advertised context_length;
-# when that value was explicitly overridden above the real Codex OAuth window,
-# we still have to budget against the effective provider window or compaction
-# fires too late and provider requests can overflow.
+# ChatGPT Codex OAuth exposes provider-enforced maximum context windows that can
+# be materially lower than the same model slug on direct OpenAI/OpenRouter
+# routes. The catalogue's default ``context_window`` may be lower than its
+# ``max_context_window``; LCM must preserve a host-selected value up to that
+# maximum while rejecting overrides beyond it.
 _CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
@@ -24,7 +22,7 @@ _CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
     "gpt-5.5": 272_000,
-    "gpt-5.4": 272_000,
+    "gpt-5.4": 1_000_000,
     "gpt-5.2": 272_000,
     "gpt-5.6": 372_000,
     "gpt-5": 272_000,
@@ -40,12 +38,10 @@ def _is_openai_codex_route(provider: str | None) -> bool:
 
 
 def _codex_oauth_context_cap(model: str | None, provider: str | None) -> int | None:
-    """Return LCM's best-known Codex OAuth effective context cap.
+    """Return LCM's best-known Codex OAuth maximum context cap.
 
-    This intentionally mirrors Hermes Agent's hardcoded fallback policy, not the
-    direct OpenAI model catalog. A host-provided context_length may be a user
-    override or stale cache entry; Codex OAuth still enforces these lower route
-    windows.
+    A host-provided context_length may be the catalogue default or an explicit
+    override. Codex OAuth accepts either up to the route's advertised maximum.
     """
     if not _is_openai_codex_route(provider):
         return None

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -351,6 +351,16 @@ def test_update_model_updates_runtime_metadata_and_context_window(engine):
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
 
 
+def test_codex_gpt54_honors_one_million_context_override(engine):
+    engine.update_model(
+        model="gpt-5.4",
+        provider="openai-codex",
+        context_length=1_000_000,
+    )
+
+    assert engine.context_length == 1_000_000
+
+
 def test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold(tmp_path):
     config = LCMConfig(
         context_threshold=0.68,


### PR DESCRIPTION
## Summary
- Treat Codex OAuth caps as `max_context_window`, not the lower default `context_window`.
- Preserve an explicit 1M Hermes context for GPT-5.4 while retaining the 1M safety ceiling.

## Why
Codex reports GPT-5.4 with a 272K default and a 1M maximum. LCM hardcoded 272K as the maximum, so this valid Hermes configuration was silently reduced:

```yaml
model:
  default: gpt-5.4
  provider: openai-codex
  base_url: https://chatgpt.com/backend-api/codex
  context_length: 1000000
```

OpenAI's catalog and override implementation:
- https://github.com/openai/codex/blob/f2bee854a73666e1c3e922a853dda591b1a25fcf/codex-rs/models-manager/models.json#L444-L466
- https://github.com/openai/codex/blob/f2bee854a73666e1c3e922a853dda591b1a25fcf/codex-rs/models-manager/src/model_info.rs#L25-L33

## Validation
- [x] Regression test failed at 272K before the fix and passes at 1M after it.
- [x] `python -m pytest tests/test_lcm_engine.py -k codex -q` — 10 passed.
- [x] Full suite excluding two inherited import/externalization failures — 2,296 passed, 12 xfailed.
- [x] The two exclusions reproduce unchanged on `origin/main`.
- [x] Ruff, compile, shell syntax, and `git diff --check` pass.

## Notes
The normal 272K default is unchanged when Hermes passes 272K; only explicit values above the default and at or below the advertised 1M maximum are preserved.
