### PR TITLE
retrieval: add exhaustive citable recall mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -353,6 +353,12 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("embeddings_enabled", "LCM_EMBEDDINGS_ENABLED", bool),
     _EnvFieldSpec("rerank_enabled", "LCM_RERANK_ENABLED", bool),
     _EnvFieldSpec("recall_scan_rows", "LCM_RECALL_SCAN_ROWS", int),
+    _EnvFieldSpec(
+        "recall_full_corpus_scan_enabled",
+        "LCM_RECALL_FULL_CORPUS_SCAN_ENABLED",
+        bool,
+    ),
+    _EnvFieldSpec("recall_reference_strict", "LCM_RECALL_REFERENCE_STRICT", bool),
     _EnvFieldSpec("proactive_recall_enabled", "LCM_PROACTIVE_RECALL_ENABLED", bool),
     _EnvFieldSpec("proactive_recall_min_score", "LCM_PROACTIVE_RECALL_MIN_SCORE", float),
     _EnvFieldSpec("proactive_recall_budget_tokens", "LCM_PROACTIVE_RECALL_BUDGET_TOKENS", int),
@@ -589,6 +595,12 @@ class LCMConfig:
     # (still deadline-guarded) lets recall cover a realistic forever-memory
     # corpus while capping worst-case cost on a very large one.
     recall_scan_rows: int = 25_000
+    # Exact, keyset-paginated whole-corpus scoring for lcm_recall vector arms.
+    # Disable to restore the previous recency-bounded scan immediately.
+    recall_full_corpus_scan_enabled: bool = True
+    # answer_ready delivery rehydrates every result to an existing raw store row
+    # and omits unresolved references. Disable to restore legacy snippet shaping.
+    recall_reference_strict: bool = True
     # Per-arm RRF fusion weights for lcm_recall's 3-arm hybrid (fts/summary/chunk).
     # Down-weighting the weak FTS arm keeps naive equal-weight fusion from dragging
     # fused recall below its best (vector) arm — measured −21 R@5 on LongMemEval.

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -20,6 +20,32 @@ for earlier separate sessions or broad cross-session history.
 | `lcm_inspect` | Read-only operator inventory for current-session lineage, message/frontier metadata, fresh tail, externalized refs/readability, compaction skip/no-op reasons, and matched ignore/stateless patterns. It returns metadata only; use `lcm_load_session`/`lcm_expand` when you need content. |
 | `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
 
+`lcm_recall` now scores each live summary/chunk vector exactly through a
+keyset-paginated, deadline-guarded scan. Its working set is capped at 1,024
+vectors per batch even when `LCM_RECALL_SCAN_ROWS` is larger; that setting still
+controls the legacy recency window and can reduce the exact-scan batch size.
+The FTS arm already searches the complete FTS index and reports `coverage='full'`.
+
+Set `detail='answer_ready'` when results will be used as evidence. Every delivered
+hit is then rehydrated from an existing raw `messages.store_id`; summary hits are
+resolved through at most 64 DAG nodes / 64 raw references and are represented by
+the exact raw excerpt rather than uncited summary prose. Missing rows, malformed
+ids/spans, corrupt lineage, and empty sources are omitted without crashing, and
+lower-ranked citable hits backfill the requested limit. Each delivered hit carries
+a structured `citation` for `lcm_expand(store_id=..., content_offset=...)`.
+
+The rollback boundary is explicit and process-local:
+
+```bash
+LCM_RECALL_FULL_CORPUS_SCAN_ENABLED=false
+LCM_RECALL_REFERENCE_STRICT=false
+```
+
+The first flag restores the prior recency-bounded vector scan. The second makes an
+`answer_ready` request fall back to legacy snippet shaping. Neither rollback writes
+the database or migrates stored data, so both changes are reversible by removing
+the variables and restarting the Hermes process.
+
 ### Retrieval contract
 
 LCM retrieval tools default to current-session scope. `lcm_grep` accepts
@@ -150,8 +176,9 @@ erroring the tool. `lcm_grep`'s hybrid RRF is unaffected: it keeps implicit
 actually applied to the arms that ran are echoed back under
 `provenance.arm_weights`.
 
-If the summary or chunk arm ran under `coverage='bounded'` (recency-truncated
-candidate scan) or `coverage='full_approx'` (two-stage binary-prescreen KNN,
+If the rollback configuration makes a summary or chunk arm run under
+`coverage='bounded'` (recency-truncated candidate scan) or `coverage='full_approx'`
+(two-stage binary-prescreen KNN,
 see [vector storage scale options](operator-guide.md#vector-storage-scale-options-v3)),
 `lcm_recall` surfaces that in its response `degraded_reason`, naming the arm and
 the caveat — the same disclosure mechanism as `lcm_grep`'s `degraded_reason` —

--- a/retrieval_core.py
+++ b/retrieval_core.py
@@ -118,7 +118,14 @@ def _run_pooled_knn(
             try:
                 if time.monotonic() >= deadline:
                     raise TimeoutError("semantic vector search deadline exhausted")
-                return query(store)
+                try:
+                    return query(store)
+                except sqlite3.OperationalError as exc:
+                    if "interrupt" in str(exc).lower() or time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            "semantic vector search deadline exhausted"
+                        ) from exc
+                    raise
             finally:
                 if vector_conn is not None:
                     vector_conn.set_progress_handler(None, 1000)
@@ -232,6 +239,7 @@ def run_knn(
     source: str | None,
     vector_store_cls: Any,
     scan_rows: int | None = None,
+    full_scan: bool = False,
 ) -> Any:
     """Run the vector KNN query inside the operation's absolute deadline.
 
@@ -257,6 +265,8 @@ def run_knn(
             until=until,
             conversation_ids=conversation_ids,
             source=source,
+            full_scan=full_scan,
+            deadline=deadline,
         ),
     )
 
@@ -274,6 +284,7 @@ def run_chunk_knn(
     source: str | None,
     vector_store_cls: Any,
     scan_rows: int | None = None,
+    full_scan: bool = False,
 ) -> Any:
     """Run the chunk-corpus KNN query inside the operation's absolute deadline.
 
@@ -299,6 +310,8 @@ def run_chunk_knn(
             until=until,
             conversation_ids=conversation_ids,
             source=source,
+            full_scan=full_scan,
+            deadline=deadline,
         ),
     )
 

--- a/schemas.py
+++ b/schemas.py
@@ -176,6 +176,18 @@ LCM_RECALL = {
                 ),
                 "default": "all",
             },
+            "detail": {
+                "type": "string",
+                "enum": ["snippets", "answer_ready"],
+                "description": (
+                    "Delivery mode. 'snippets' (default) preserves ranked previews. "
+                    "'answer_ready' returns only excerpts rehydrated from existing raw "
+                    "message rows, with exact lcm_expand citations; malformed, stale, "
+                    "or otherwise uncitable candidates are omitted and lower-ranked "
+                    "citable candidates backfill the requested limit."
+                ),
+                "default": "snippets",
+            },
         },
         "required": ["query"],
     },

--- a/store.py
+++ b/store.py
@@ -59,6 +59,14 @@ _MESSAGE_SELECT_COLUMNS = (
 _UNKNOWN_SOURCE = "unknown"
 
 
+class _SearchHits(list[Dict[str, Any]]):
+    """List-compatible search results carrying corpus-coverage metadata."""
+
+    def __init__(self, rows=(), *, coverage: str = "full"):
+        super().__init__(rows)
+        self.coverage = coverage
+
+
 def _legacy_blank_source_clause(column: str) -> str:
     # SQLite TRIM() only strips spaces unless given an explicit character set.
     # Match Python's write-time `str.strip()` behavior for common ASCII whitespace
@@ -1071,7 +1079,7 @@ class MessageStore:
         terms = extract_search_terms(safe_query)
         phrases = extract_quoted_phrases(safe_query)
         if not terms:
-            return []
+            return _SearchHits(coverage="bounded")
         fetch_limit = compute_search_fetch_limit(limit, terms, phrases)
 
         where: list[str] = ["content IS NOT NULL"]
@@ -1296,7 +1304,7 @@ class MessageStore:
         results.sort(key=lambda result: _fallback_result_sort_key(result, sort))
         for result in results:
             result.pop("_fallback_score", None)
-        return results[:limit]
+        return _SearchHits(results[:limit], coverage="bounded")
 
     # -- Helpers ------------------------------------------------------------
 

--- a/tests/test_chunk_vector_store.py
+++ b/tests/test_chunk_vector_store.py
@@ -129,6 +129,40 @@ class TestChunkWriteAndKnn:
         finally:
             vs.close()
 
+    def test_full_scan_reaches_best_chunk_outside_recency_bound(self, tmp_path):
+        db_path = tmp_path / "lcm.db"
+        _seed_messages(
+            db_path,
+            [
+                (1, "s", "history", "user", "old exact match", 1.0),
+                (2, "s", "history", "user", "new distractor", 2.0),
+            ],
+        )
+        vs = VectorStore(db_path, bounded_scan_rows=1)
+        vs.register_profile(MODEL, PROVIDER, DIM, task="chunk")
+        try:
+            _write(vs, "1:0", 1, 0, [1.0, 0.0, 0.0, 0.0])
+            _write(vs, "2:0", 2, 0, [0.0, 1.0, 0.0, 0.0])
+
+            bounded = vs.knn_chunks(
+                [1.0, 0.0, 0.0, 0.0], k=1, model=MODEL, provider=PROVIDER
+            )
+            exhaustive = vs.knn_chunks(
+                [1.0, 0.0, 0.0, 0.0],
+                k=1,
+                model=MODEL,
+                provider=PROVIDER,
+                full_scan=True,
+            )
+
+            assert bounded.coverage == "bounded"
+            assert [row[0] for row in bounded] == ["2:0"]
+            assert exhaustive.coverage == "full"
+            assert exhaustive.scanned == exhaustive.total == 2
+            assert [row[0] for row in exhaustive] == ["1:0"]
+        finally:
+            vs.close()
+
     def test_numpy_absent_reports_full_when_scan_covers_corpus(
         self, store, monkeypatch
     ):

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -499,6 +499,64 @@ def test_answer_ready_fts_citation_preserves_late_query_match_offset(
     )
 
 
+def test_answer_ready_implicit_and_backfills_when_terms_do_not_fit_one_window(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    fallback_id = recall_engine._store.append(
+        "session-fallback",
+        {"role": "assistant", "content": "alpha omega verified fallback"},
+    )
+    incomplete_id = recall_engine._store.append(
+        "session-incomplete",
+        {"role": "assistant", "content": "alpha" + (" " * 400) + "omega"},
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="alpha omega",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == fallback_id
+    assert payload["hits"][0]["store_id"] != incomplete_id
+    assert "alpha" in payload["hits"][0]["snippet"]
+    assert "omega" in payload["hits"][0]["snippet"]
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
+
+
+def test_answer_ready_quoted_phrase_and_term_must_fit_one_window(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    fallback_id = recall_engine._store.append(
+        "session-fallback",
+        {"role": "assistant", "content": "alpha beta omega verified fallback"},
+    )
+    incomplete_id = recall_engine._store.append(
+        "session-incomplete",
+        {"role": "assistant", "content": "alpha beta" + (" " * 400) + "omega"},
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query='"alpha beta" omega',
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == fallback_id
+    assert payload["hits"][0]["store_id"] != incomplete_id
+    assert "alpha beta" in payload["hits"][0]["snippet"]
+    assert "omega" in payload["hits"][0]["snippet"]
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
+
+
 @pytest.mark.parametrize("match_start", [299, 294])
 def test_answer_ready_boundary_match_is_complete_and_offsets_are_truthful(
     recall_engine, monkeypatch, match_start

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -402,6 +402,52 @@ def test_answer_ready_summary_selects_source_relevant_to_matched_fact(
     assert payload["hits"][0]["store_id"] == relevant_id
 
 
+def test_answer_ready_summary_uses_matched_fact_beyond_display_preview(
+    recall_engine, monkeypatch
+):
+    preview_source_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "archive"},
+    )
+    supporting_id = recall_engine._store.append(
+        "session-source",
+        {
+            "role": "assistant",
+            "content": "the launch vehicle uses a methane engine",
+        },
+    )
+    prefix = "archive " * 40
+    fact = "the launch vehicle uses a methane engine"
+    summary = prefix + fact
+    assert len(prefix) > 300
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary=summary,
+            token_count=50,
+            source_token_count=100,
+            source_ids=[preview_source_id, supporting_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    _seed_summary_vectors(recall_engine, [(node_id, [1.0, 0.0])])
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="rocket propulsion",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == supporting_id
+    assert payload["hits"][0]["snippet"] == fact
+    assert payload["hits"][0]["source_node_id"] == node_id
+
+
 def test_answer_ready_summary_support_outranks_incidental_query_overlap(
     recall_engine, monkeypatch
 ):

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -402,6 +402,62 @@ def test_answer_ready_summary_selects_source_relevant_to_matched_fact(
     assert payload["hits"][0]["store_id"] == relevant_id
 
 
+def test_answer_ready_summary_support_outranks_incidental_query_overlap(
+    recall_engine, monkeypatch
+):
+    incidental_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "What"},
+    )
+    supporting_id = recall_engine._store.append(
+        "session-source",
+        {
+            "role": "assistant",
+            "content": "The launch vehicle uses a methane engine.",
+        },
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="The launch vehicle uses a methane engine.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[incidental_id, supporting_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: ([{
+            "kind": "summary",
+            "node_id": node_id,
+            "session_id": "session-summary",
+            "snippet": "The launch vehicle uses a methane engine.",
+            "timestamp": 1.0,
+            "from_current_session": False,
+        }], "full", 1, 1),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="What powers rocket",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == supporting_id
+    assert payload["hits"][0]["snippet"].startswith(
+        "The launch vehicle uses a methane engine."
+    )
+    assert payload["hits"][0]["source_node_id"] == node_id
+
+
 def test_answer_ready_fts_citation_preserves_late_query_match_offset(
     recall_engine, monkeypatch
 ):
@@ -520,6 +576,91 @@ def test_answer_ready_casefold_match_uses_original_character_offset(
     assert hit["citation"]["content_offset"] == expected_offset
     assert hit["snippet"].startswith(fact)
     assert content[expected_offset:expected_offset + len(hit["snippet"])] == hit["snippet"]
+
+
+def test_answer_ready_preserves_exact_emoji_like_match(recall_engine, monkeypatch):
+    recall_engine._config.embeddings_enabled = False
+    content = "durable 🧠 note"
+    store_id = recall_engine._store.append(
+        "session-emoji",
+        {"role": "user", "content": content},
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="🧠",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == store_id
+    assert payload["hits"][0]["snippet"] == content
+    assert payload["hits"][0]["citation"]["content_offset"] == 0
+
+
+def test_answer_ready_emoji_sequence_uses_original_late_character_offset(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    prefix = "Straße " + ("🙂" * 320)
+    query = "👩‍💻"
+    content = prefix + query + " durable note"
+    store_id = recall_engine._store.append(
+        "session-emoji",
+        {"role": "user", "content": content},
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query=query,
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    hit = payload["hits"][0]
+    expected_offset = content.index(query)
+    assert expected_offset > 300
+    assert hit["store_id"] == store_id
+    assert hit["citation"]["content_offset"] == expected_offset
+    assert hit["snippet"].startswith(query)
+    assert content[expected_offset:expected_offset + len(hit["snippet"])] == hit["snippet"]
+
+
+def test_answer_ready_emoji_sequence_requires_verified_exact_match(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    store_id = recall_engine._store.append(
+        "session-emoji",
+        {"role": "user", "content": "durable 👩 note without the joined sequence"},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([{
+            "kind": "message_excerpt",
+            "store_id": store_id,
+            "session_id": "session-emoji",
+            "snippet": "forged 👩‍💻 preview",
+            "timestamp": 1.0,
+        }], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="👩‍💻",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"] == []
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
 
 
 def test_answer_ready_long_unrelated_chunk_span_is_omitted_and_backfilled(

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -123,6 +123,198 @@ def _recall(engine, monkeypatch, provider=None, **args):
     return payload
 
 
+def test_recall_fts_finds_oldest_matching_message_beyond_candidate_window(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    oldest = recall_engine._store.append(
+        "session-old",
+        {"role": "user", "content": "cobalt-orchid immutable recovery note"},
+    )
+    for index in range(75):
+        recall_engine._store.append(
+            f"session-new-{index}",
+            {"role": "user", "content": f"ordinary recent note {index}"},
+        )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        provider=MockProvider(),
+        query="cobalt orchid",
+        include="verbatim",
+        limit=1,
+    )
+
+    assert payload["provenance"]["coverage"]["fts"] == "full"
+    assert payload["hits"][0]["store_id"] == oldest
+
+
+def test_answer_ready_backfills_past_malformed_and_missing_references(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    valid_id = recall_engine._store.append(
+        "session-valid",
+        {"role": "user", "content": "exact citable evidence from durable storage"},
+    )
+    malformed_hits = [
+        {
+            "kind": "message_excerpt",
+            "store_id": "not-an-integer",
+            "session_id": "session-bad",
+            "snippet": "must not escape",
+            "timestamp": 3.0,
+        },
+        {
+            "kind": "message_excerpt",
+            "store_id": 999_999,
+            "session_id": "session-missing",
+            "snippet": "must not cite a missing row",
+            "timestamp": 2.0,
+        },
+        {
+            "kind": "message_excerpt",
+            "store_id": valid_id,
+            "session_id": "forged-session-id",
+            "snippet": "untrusted preview",
+            "timestamp": 1.0,
+            "chunk_span": {"char_start": "broken", "char_end": -1},
+        },
+    ]
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_args, **_kwargs: (malformed_hits, None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["detail"] == "answer_ready"
+    assert payload["total_results"] == 1
+    assert payload["hits"] == [
+        {
+            "kind": "message_excerpt",
+            "store_id": valid_id,
+            "session_id": "session-valid",
+            "timestamp": payload["hits"][0]["timestamp"],
+            "snippet": "exact citable evidence from durable storage",
+            "score": payload["hits"][0]["score"],
+            "expand_hint": f"lcm_expand(store_id={valid_id}, content_offset=0)",
+            "from_current_session": False,
+            "arms": ["fts"],
+            "citation": {
+                "tool": "lcm_expand",
+                "store_id": valid_id,
+                "content_offset": 0,
+            },
+        }
+    ]
+    assert payload["provenance"]["reference_strict"] == {
+        "enabled": True,
+        "omitted_uncitable": 2,
+    }
+
+
+def test_answer_ready_hydrates_summary_to_exact_raw_source(recall_engine, monkeypatch):
+    source_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "raw source that supports the memory"},
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="summary prose must not be presented as a verbatim citation",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[source_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: (
+            [
+                {
+                    "kind": "summary",
+                    "node_id": node_id,
+                    "session_id": "session-summary",
+                    "snippet": "summary prose must not be cited directly",
+                    "timestamp": 1.0,
+                    "from_current_session": False,
+                }
+            ],
+            "full",
+            1,
+            1,
+        ),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["kind"] == "message_excerpt"
+    assert payload["hits"][0]["store_id"] == source_id
+    assert payload["hits"][0]["snippet"] == "raw source that supports the memory"
+    assert payload["hits"][0]["source_node_id"] == node_id
+
+
+def test_retrieval_flags_restore_bounded_and_snippet_behavior(
+    recall_engine, monkeypatch
+):
+    monkeypatch.setenv("LCM_RECALL_FULL_CORPUS_SCAN_ENABLED", "false")
+    monkeypatch.setenv("LCM_RECALL_REFERENCE_STRICT", "false")
+    config = LCMConfig.from_env()
+    assert config.recall_full_corpus_scan_enabled is False
+    assert config.recall_reference_strict is False
+
+    recall_engine._config.recall_reference_strict = False
+    recall_engine._config.embeddings_enabled = False
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: (
+            [
+                {
+                    "kind": "message_excerpt",
+                    "store_id": "legacy-unchecked",
+                    "session_id": "legacy-session",
+                    "snippet": "legacy snippet",
+                    "timestamp": 1.0,
+                }
+            ],
+            None,
+        ),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["detail"] == "snippets"
+    assert payload["hits"][0]["store_id"] == "legacy-unchecked"
+    assert payload["provenance"]["reference_strict"]["enabled"] is False
+
+
 def test_voyage_chunk_recall_uses_context_model(recall_engine, monkeypatch):
     summary = MockProvider()
     summary.provider_id = "voyage"
@@ -502,6 +694,7 @@ def test_bounded_chunk_coverage_surfaces_as_degraded(recall_engine, monkeypatch)
     """SCAN-1: a recency-bounded chunk arm reports a degraded_reasons entry naming
     the arm + scanned/total, instead of silently truncating."""
     recall_engine._config.recall_scan_rows = 1
+    recall_engine._config.recall_full_corpus_scan_enabled = False
     ids = []
     for i in range(3):
         sid = recall_engine._store.append(
@@ -527,6 +720,7 @@ def test_two_stage_full_approx_coverage_surfaces_as_approximate(recall_engine, m
     the approximate prescreen in degraded_reason (like 'bounded' is disclosed),
     rather than passing as an exact 'full'."""
     recall_engine._config.embedding_binary_prescreen = True
+    recall_engine._config.recall_full_corpus_scan_enabled = False
     node = _add_summary(
         recall_engine, "kanban board dashboard sprint plan",
         session_id="session-a", created_at=10.0,
@@ -551,6 +745,7 @@ def test_pooled_vector_store_survives_across_recall_calls(recall_engine, monkeyp
 
     rc._reset_vector_store_pool()
     try:
+        recall_engine._config.recall_full_corpus_scan_enabled = False
         node = _add_summary(recall_engine, "kanban pooled cache", session_id="session-a", created_at=5.0)
         _seed_summary_vectors(recall_engine, [(node, [1.0, 0.0])])
 

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -160,7 +160,10 @@ def test_answer_ready_backfills_past_malformed_and_missing_references(
     )
     fallback_id = recall_engine._store.append(
         "session-fallback",
-        {"role": "user", "content": "exact citable fallback from durable storage"},
+        {
+            "role": "user",
+            "content": "kanban dashboard sprint exact citable fallback from durable storage",
+        },
     )
     malformed_hits = [
         {
@@ -215,7 +218,7 @@ def test_answer_ready_backfills_past_malformed_and_missing_references(
             "store_id": fallback_id,
             "session_id": "session-fallback",
             "timestamp": payload["hits"][0]["timestamp"],
-            "snippet": "exact citable fallback from durable storage",
+            "snippet": "kanban dashboard sprint exact citable fallback from durable storage",
             "score": payload["hits"][0]["score"],
             "expand_hint": f"lcm_expand(store_id={fallback_id}, content_offset=0)",
             "from_current_session": False,
@@ -396,6 +399,145 @@ def test_answer_ready_summary_selects_source_relevant_to_matched_fact(
     )
 
     assert payload["hits"][0]["store_id"] == relevant_id
+
+
+def test_answer_ready_fts_citation_preserves_late_query_match_offset(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    prefix = "unrelated archive padding " * 16
+    fact = "cobalt orchid launch code is seven"
+    content = prefix + fact + " afterword"
+    store_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": content},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([{
+            "kind": "message_excerpt",
+            "store_id": store_id,
+            "session_id": "session-source",
+            "snippet": fact,
+            "timestamp": 1.0,
+        }], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid launch code",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    expected_offset = content.index("cobalt orchid launch code")
+    assert expected_offset > 300
+    assert payload["hits"][0]["snippet"].startswith(fact)
+    assert payload["hits"][0]["citation"]["content_offset"] == expected_offset
+    assert payload["hits"][0]["expand_hint"] == (
+        f"lcm_expand(store_id={store_id}, content_offset={expected_offset})"
+    )
+
+
+def test_answer_ready_summary_citation_preserves_late_matched_fact_offset(
+    recall_engine, monkeypatch
+):
+    prefix = "unrelated archive padding " * 16
+    fact = "the launch vehicle uses a methane engine"
+    content = prefix + fact + " afterword"
+    source_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": content},
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="The launch vehicle uses a methane engine.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[source_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: ([{
+            "kind": "summary",
+            "node_id": node_id,
+            "session_id": "session-summary",
+            "snippet": "The launch vehicle uses a methane engine.",
+            "timestamp": 1.0,
+            "from_current_session": False,
+        }], "full", 1, 1),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="rocket propulsion",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    expected_offset = content.index(fact)
+    assert expected_offset > 300
+    assert payload["hits"][0]["snippet"].startswith(fact)
+    assert payload["hits"][0]["citation"]["content_offset"] == expected_offset
+    assert payload["hits"][0]["source_node_id"] == node_id
+
+
+def test_answer_ready_omits_unverified_fts_match_and_backfills(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    unrelated_id = recall_engine._store.append(
+        "session-unrelated",
+        {"role": "assistant", "content": "weather forecast only"},
+    )
+    fallback_id = recall_engine._store.append(
+        "session-fallback",
+        {"role": "assistant", "content": "cobalt orchid verified fallback"},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([
+            {
+                "kind": "message_excerpt",
+                "store_id": unrelated_id,
+                "session_id": "session-unrelated",
+                "snippet": "forged cobalt orchid preview",
+                "timestamp": 2.0,
+            },
+            {
+                "kind": "message_excerpt",
+                "store_id": fallback_id,
+                "session_id": "session-fallback",
+                "snippet": "cobalt orchid verified fallback",
+                "timestamp": 1.0,
+            },
+        ], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == fallback_id
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
 
 
 def test_answer_ready_summary_without_relevant_source_backfills(
@@ -1011,6 +1153,41 @@ def test_answer_ready_hydration_stops_at_deadline_and_reports_timeout(
     assert payload["timeout"] is True
     assert payload["degraded"] is True
     assert "citation hydration timed out" in payload["degraded_reason"]
+
+
+@pytest.mark.parametrize(
+    ("arm", "include", "scan_name"),
+    [
+        ("summary", "summaries", "run_knn"),
+        ("chunk", "verbatim", "run_chunk_knn"),
+    ],
+)
+def test_full_corpus_scan_timeout_is_degraded(
+    recall_engine, monkeypatch, arm, include, scan_name
+):
+    recall_engine._config.recall_full_corpus_scan_enabled = True
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    calls = []
+
+    def timeout_scan(*_args, **kwargs):
+        calls.append(kwargs)
+        raise TimeoutError(f"simulated {arm} full-corpus scan timeout")
+
+    monkeypatch.setattr(lcm_tools, scan_name, timeout_scan)
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        include=include,
+        limit=1,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["full_scan"] is True
+    assert payload["timeout"] is True
+    assert payload["degraded"] is True
+    assert payload["provenance"]["coverage"][arm] == "none"
+    assert f"{arm} arm timed out" in payload["degraded_reason"]
 
 
 @pytest.mark.parametrize("failure_path", ["search", "like_fallback"])

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_lcm.tools as lcm_tools
+from hermes_lcm import store as store_module
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.dag import SummaryDAG, SummaryNode
 from hermes_lcm.store import MessageStore
@@ -440,6 +441,131 @@ def test_answer_ready_fts_citation_preserves_late_query_match_offset(
     assert payload["hits"][0]["expand_hint"] == (
         f"lcm_expand(store_id={store_id}, content_offset={expected_offset})"
     )
+
+
+@pytest.mark.parametrize("match_start", [299, 294])
+def test_answer_ready_boundary_match_is_complete_and_offsets_are_truthful(
+    recall_engine, monkeypatch, match_start
+):
+    recall_engine._config.embeddings_enabled = False
+    fact = "cobalt orchid launch code is seven"
+    content = ("x" * match_start) + fact + " afterword"
+    store_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": content},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([{
+            "kind": "message_excerpt",
+            "store_id": store_id,
+            "session_id": "session-source",
+            "snippet": fact,
+            "timestamp": 1.0,
+        }], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid launch code",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    hit = payload["hits"][0]
+    offset = hit["citation"]["content_offset"]
+    assert fact in hit["snippet"]
+    assert content[offset:offset + len(hit["snippet"])] == hit["snippet"]
+    assert offset <= match_start
+    assert match_start + len("cobalt orchid launch code") <= offset + len(hit["snippet"])
+
+
+def test_answer_ready_casefold_match_uses_original_character_offset(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    prefix = "Straße " + ("🙂" * 320)
+    fact = "cobalt orchid launch code"
+    content = prefix + fact
+    store_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": content},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([{
+            "kind": "message_excerpt",
+            "store_id": store_id,
+            "session_id": "session-source",
+            "snippet": fact,
+            "timestamp": 1.0,
+        }], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="COBALT ORCHID LAUNCH CODE",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    hit = payload["hits"][0]
+    expected_offset = content.index(fact)
+    assert hit["citation"]["content_offset"] == expected_offset
+    assert hit["snippet"].startswith(fact)
+    assert content[expected_offset:expected_offset + len(hit["snippet"])] == hit["snippet"]
+
+
+def test_answer_ready_long_unrelated_chunk_span_is_omitted_and_backfilled(
+    recall_engine, monkeypatch
+):
+    unrelated_id = recall_engine._store.append(
+        "session-unrelated",
+        {"role": "assistant", "content": "x" * 600},
+    )
+    fallback_id = recall_engine._store.append(
+        "session-fallback",
+        {"role": "assistant", "content": "cobalt orchid verified fallback"},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([
+            {
+                "kind": "message_excerpt",
+                "store_id": unrelated_id,
+                "session_id": "session-unrelated",
+                "snippet": "forged cobalt orchid preview",
+                "timestamp": 2.0,
+                "chunk_span": {"char_start": 0, "char_end": 600},
+            },
+            {
+                "kind": "message_excerpt",
+                "store_id": fallback_id,
+                "session_id": "session-fallback",
+                "snippet": "cobalt orchid verified fallback",
+                "timestamp": 1.0,
+            },
+        ], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid",
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == fallback_id
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
 
 
 def test_answer_ready_summary_citation_preserves_late_matched_fact_offset(
@@ -1218,6 +1344,94 @@ def test_recall_reports_full_text_failures_instead_of_full_empty_coverage(
     assert payload["provenance"]["coverage"]["fts"] == "none"
     assert payload["degraded"] is True
     assert "full-text arm unavailable" in payload["degraded_reason"]
+
+
+def test_recall_like_fallback_reports_bounded_coverage_when_older_match_is_omitted(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    old_exact = recall_engine._store.append(
+        "session-old",
+        {"role": "assistant", "content": "cobalt orchid exact durable fact"},
+    )
+    recent_partial = recall_engine._store.append(
+        "session-new",
+        {"role": "assistant", "content": "cobalt only recent partial"},
+    )
+    monkeypatch.setattr(store_module, "compute_search_candidate_cap", lambda _limit: 1)
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt/orchid",
+        include="verbatim",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == recent_partial
+    assert old_exact not in {hit["store_id"] for hit in payload["hits"]}
+    assert payload["provenance"]["coverage"]["fts"] == "bounded"
+    assert payload["degraded"] is True
+    assert "LIKE fallback" in payload["degraded_reason"]
+
+
+@pytest.mark.parametrize(
+    ("query", "content"),
+    [
+        ("alpha/beta", "alpha beta punctuation route"),
+        ("記憶", "古い記憶の記録"),
+        ("🧠", "durable 🧠 note"),
+    ],
+)
+def test_recall_like_routes_disclose_bounded_coverage(
+    recall_engine, monkeypatch, query, content
+):
+    recall_engine._config.embeddings_enabled = False
+    recall_engine._store.append(
+        "session-old",
+        {"role": "assistant", "content": content},
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query=query,
+        include="verbatim",
+        limit=1,
+    )
+
+    assert payload["hits"]
+    assert payload["provenance"]["coverage"]["fts"] == "bounded"
+    assert payload["degraded"] is True
+    assert "LIKE fallback" in payload["degraded_reason"]
+
+
+def test_recall_like_fallback_timeout_is_never_reported_as_full(
+    recall_engine, monkeypatch
+):
+    recall_engine._config.embeddings_enabled = False
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_grep_full_text_with_deadline",
+        lambda *_a, **_k: {
+            "error": "lcm_grep request deadline exceeded",
+            "mode": "recall",
+            "timeout": True,
+        },
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt/orchid",
+        include="verbatim",
+        limit=1,
+    )
+
+    assert payload["hits"] == []
+    assert payload["provenance"]["coverage"]["fts"] == "none"
+    assert payload["degraded"] is True
+    assert payload["timeout"] is True
 
 
 def test_bounded_chunk_coverage_surfaces_as_degraded(recall_engine, monkeypatch):

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -154,9 +154,13 @@ def test_answer_ready_backfills_past_malformed_and_missing_references(
     recall_engine, monkeypatch
 ):
     recall_engine._config.embeddings_enabled = False
-    valid_id = recall_engine._store.append(
-        "session-valid",
-        {"role": "user", "content": "exact citable evidence from durable storage"},
+    stale_span_id = recall_engine._store.append(
+        "session-stale",
+        {"role": "user", "content": "stale span must not cite this offset-zero text"},
+    )
+    fallback_id = recall_engine._store.append(
+        "session-fallback",
+        {"role": "user", "content": "exact citable fallback from durable storage"},
     )
     malformed_hits = [
         {
@@ -175,11 +179,18 @@ def test_answer_ready_backfills_past_malformed_and_missing_references(
         },
         {
             "kind": "message_excerpt",
-            "store_id": valid_id,
+            "store_id": stale_span_id,
             "session_id": "forged-session-id",
             "snippet": "untrusted preview",
             "timestamp": 1.0,
             "chunk_span": {"char_start": "broken", "char_end": -1},
+        },
+        {
+            "kind": "message_excerpt",
+            "store_id": fallback_id,
+            "session_id": "forged-session-id",
+            "snippet": "untrusted preview",
+            "timestamp": 0.5,
         },
     ]
     monkeypatch.setattr(
@@ -201,31 +212,34 @@ def test_answer_ready_backfills_past_malformed_and_missing_references(
     assert payload["hits"] == [
         {
             "kind": "message_excerpt",
-            "store_id": valid_id,
-            "session_id": "session-valid",
+            "store_id": fallback_id,
+            "session_id": "session-fallback",
             "timestamp": payload["hits"][0]["timestamp"],
-            "snippet": "exact citable evidence from durable storage",
+            "snippet": "exact citable fallback from durable storage",
             "score": payload["hits"][0]["score"],
-            "expand_hint": f"lcm_expand(store_id={valid_id}, content_offset=0)",
+            "expand_hint": f"lcm_expand(store_id={fallback_id}, content_offset=0)",
             "from_current_session": False,
             "arms": ["fts"],
             "citation": {
                 "tool": "lcm_expand",
-                "store_id": valid_id,
+                "store_id": fallback_id,
                 "content_offset": 0,
             },
         }
     ]
     assert payload["provenance"]["reference_strict"] == {
         "enabled": True,
-        "omitted_uncitable": 2,
+        "omitted_uncitable": 3,
     }
 
 
 def test_answer_ready_hydrates_summary_to_exact_raw_source(recall_engine, monkeypatch):
     source_id = recall_engine._store.append(
         "session-source",
-        {"role": "assistant", "content": "raw source that supports the memory"},
+        {
+            "role": "assistant",
+            "content": "raw kanban dashboard sprint source that supports the memory",
+        },
     )
     node_id = recall_engine._dag.add_node(
         SummaryNode(
@@ -270,8 +284,239 @@ def test_answer_ready_hydrates_summary_to_exact_raw_source(recall_engine, monkey
 
     assert payload["hits"][0]["kind"] == "message_excerpt"
     assert payload["hits"][0]["store_id"] == source_id
-    assert payload["hits"][0]["snippet"] == "raw source that supports the memory"
+    assert payload["hits"][0]["snippet"] == (
+        "raw kanban dashboard sprint source that supports the memory"
+    )
     assert payload["hits"][0]["source_node_id"] == node_id
+
+
+def test_answer_ready_summary_selects_query_relevant_source(recall_engine, monkeypatch):
+    unrelated_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "the weather forecast is clear tomorrow"},
+    )
+    relevant_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "the cobalt orchid launch code is seven"},
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="The cobalt orchid launch code is seven.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[unrelated_id, relevant_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: (
+            [{
+                "kind": "summary",
+                "node_id": node_id,
+                "session_id": "session-summary",
+                "snippet": "The cobalt orchid launch code is seven.",
+                "timestamp": 1.0,
+                "from_current_session": False,
+            }],
+            "full",
+            1,
+            1,
+        ),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid launch code",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == relevant_id
+    assert payload["hits"][0]["snippet"] == "the cobalt orchid launch code is seven"
+    assert payload["hits"][0]["source_node_id"] == node_id
+
+
+def test_answer_ready_summary_selects_source_relevant_to_matched_fact(
+    recall_engine, monkeypatch
+):
+    unrelated_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "weather forecast clear tomorrow"},
+    )
+    relevant_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "the launch vehicle uses a methane engine"},
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="The launch vehicle uses a methane engine.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[unrelated_id, relevant_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: (
+            [{
+                "kind": "summary",
+                "node_id": node_id,
+                "session_id": "session-summary",
+                "snippet": "The launch vehicle uses a methane engine.",
+                "timestamp": 1.0,
+                "from_current_session": False,
+            }],
+            "full",
+            1,
+            1,
+        ),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="rocket propulsion",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == relevant_id
+
+
+def test_answer_ready_summary_without_relevant_source_backfills(
+    recall_engine, monkeypatch
+):
+    unrelated_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "the weather forecast is clear tomorrow"},
+    )
+    relevant_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "cobalt orchid evidence from the later summary"},
+    )
+    unrelated_node = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="Cobalt orchid launch code.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[unrelated_id],
+            source_type="messages",
+            created_at=2.0,
+        )
+    )
+    relevant_node = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="Cobalt orchid evidence.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[relevant_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: (
+            [
+                {
+                    "kind": "summary",
+                    "node_id": unrelated_node,
+                    "session_id": "session-summary",
+                    "snippet": "Cobalt orchid launch code.",
+                    "timestamp": 2.0,
+                    "from_current_session": False,
+                },
+                {
+                    "kind": "summary",
+                    "node_id": relevant_node,
+                    "session_id": "session-summary",
+                    "snippet": "Cobalt orchid evidence.",
+                    "timestamp": 1.0,
+                    "from_current_session": False,
+                },
+            ],
+            "full",
+            2,
+            2,
+        ),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"][0]["store_id"] == relevant_id
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
+
+
+@pytest.mark.parametrize(
+    "span",
+    [
+        None,
+        [],
+        {"char_start": "0", "char_end": 8},
+        {"char_start": True, "char_end": 8},
+        {"char_start": 8, "char_end": 8},
+        {"char_start": 0, "char_end": 999},
+    ],
+)
+def test_answer_ready_rejects_malformed_or_stale_chunk_span(
+    recall_engine, monkeypatch, span
+):
+    recall_engine._config.embeddings_enabled = False
+    store_id = recall_engine._store.append(
+        "session-source",
+        {"role": "user", "content": "unrelated offset-zero text then actual evidence"},
+    )
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_fts_arm",
+        lambda *_a, **_k: ([{
+            "kind": "message_excerpt",
+            "store_id": store_id,
+            "session_id": "session-source",
+            "snippet": "forged preview",
+            "timestamp": 1.0,
+            "chunk_span": span,
+        }], None),
+    )
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        include="verbatim",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert payload["hits"] == []
+    assert payload["provenance"]["reference_strict"]["omitted_uncitable"] == 1
 
 
 def test_retrieval_flags_restore_bounded_and_snippet_behavior(
@@ -688,6 +933,114 @@ def test_recall_uses_recall_timeout_budget(recall_engine, monkeypatch):
     payload = _recall(recall_engine, monkeypatch, include="verbatim", limit=5)
     assert payload.get("timeout") is not True
     assert payload["hits"]
+
+
+@pytest.mark.parametrize("slow_stage", ["dag", "message"])
+def test_answer_ready_hydration_stops_at_deadline_and_reports_timeout(
+    recall_engine, monkeypatch, slow_stage
+):
+    source_id = recall_engine._store.append(
+        "session-source",
+        {"role": "assistant", "content": "cobalt orchid deadline evidence"},
+    )
+    node_id = recall_engine._dag.add_node(
+        SummaryNode(
+            session_id="session-summary",
+            depth=0,
+            summary="Cobalt orchid deadline evidence.",
+            token_count=10,
+            source_token_count=20,
+            source_ids=[source_id],
+            source_type="messages",
+            created_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lcm_tools, "_lcm_recall_fts_arm", lambda *_a, **_k: ([], None))
+    monkeypatch.setattr(
+        lcm_tools,
+        "_lcm_recall_summary_arm",
+        lambda *_a, **_k: (
+            [
+                {
+                    "kind": "summary",
+                    "node_id": node_id,
+                    "session_id": "session-summary",
+                    "snippet": "Cobalt orchid deadline evidence.",
+                    "timestamp": 1.0,
+                    "from_current_session": False,
+                }
+            ],
+            "full",
+            1,
+            1,
+        ),
+    )
+    real_get_node = recall_engine._dag.get_node
+    real_get_batch = recall_engine._store.get_batch
+    calls = {"dag": 0, "message": 0}
+
+    def slow_get_node(requested_node_id):
+        calls["dag"] += 1
+        if slow_stage == "dag":
+            time.sleep(0.55)
+        return real_get_node(requested_node_id)
+
+    def slow_get_batch(store_ids):
+        calls["message"] += 1
+        if slow_stage == "message":
+            time.sleep(0.55)
+        return real_get_batch(store_ids)
+
+    monkeypatch.setattr(recall_engine._dag, "get_node", slow_get_node)
+    monkeypatch.setattr(recall_engine._store, "get_batch", slow_get_batch)
+    recall_engine._config.recall_query_timeout_s = 0.5
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query="cobalt orchid",
+        include="summaries",
+        detail="answer_ready",
+        limit=1,
+    )
+
+    assert calls[slow_stage] == 1
+    if slow_stage == "dag":
+        assert calls["message"] == 0
+    assert payload["hits"] == []
+    assert payload["timeout"] is True
+    assert payload["degraded"] is True
+    assert "citation hydration timed out" in payload["degraded_reason"]
+
+
+@pytest.mark.parametrize("failure_path", ["search", "like_fallback"])
+def test_recall_reports_full_text_failures_instead_of_full_empty_coverage(
+    recall_engine, monkeypatch, failure_path
+):
+    recall_engine._config.embeddings_enabled = False
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError(f"simulated {failure_path} database failure")
+
+    if failure_path == "search":
+        monkeypatch.setattr(recall_engine._store, "search", fail)
+        query = "cobalt orchid"
+    else:
+        monkeypatch.setattr(type(recall_engine._store), "_search_like", fail)
+        query = "cobalt/orchid"
+
+    payload = _recall(
+        recall_engine,
+        monkeypatch,
+        query=query,
+        include="verbatim",
+        limit=1,
+    )
+
+    assert payload["hits"] == []
+    assert payload["provenance"]["coverage"]["fts"] == "none"
+    assert payload["degraded"] is True
+    assert "full-text arm unavailable" in payload["degraded_reason"]
 
 
 def test_bounded_chunk_coverage_surfaces_as_degraded(recall_engine, monkeypatch):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -391,6 +391,73 @@ def test_bounded_scan_uses_source_recency_after_newest_first_backfill(
         dag.close()
 
 
+def test_full_scan_reaches_best_vector_outside_recency_bound(tmp_path):
+    db_path = tmp_path / "full-scan.db"
+    dag = SummaryDAG(db_path)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        oldest = _add_summary(dag, created_at=1.0)
+        newest = _add_summary(dag, created_at=2.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, oldest, "summary", "full-scan", [1.0, 0.0])
+        _record_embedding(store, newest, "summary", "full-scan", [0.0, 1.0])
+
+        bounded = store.knn([1.0, 0.0], k=1, model="full-scan")
+        exhaustive = store.knn(
+            [1.0, 0.0],
+            k=1,
+            model="full-scan",
+            full_scan=True,
+        )
+
+        assert bounded.coverage == "bounded"
+        assert [row[0] for row in bounded] == [str(newest)]
+        assert exhaustive.coverage == "full"
+        assert exhaustive.scanned == exhaustive.total == 2
+        assert [row[0] for row in exhaustive] == [str(oldest)]
+    finally:
+        store.close()
+        dag.close()
+
+
+def test_full_scan_timeout_releases_read_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "full-scan-timeout.db"
+    dag = SummaryDAG(db_path)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        node_id = _add_summary(dag, created_at=1.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, node_id, "summary", "full-scan", [1.0, 0.0])
+        ticks = iter([0.0, 1.0])
+        monkeypatch.setattr(
+            vector_store_module.time, "monotonic", lambda: next(ticks, 1.0)
+        )
+
+        with pytest.raises(TimeoutError, match="deadline exhausted"):
+            store.knn(
+                [1.0, 0.0],
+                k=1,
+                model="full-scan",
+                full_scan=True,
+                deadline=0.5,
+            )
+        assert store.connection.in_transaction is False
+
+        monkeypatch.setattr(vector_store_module.time, "monotonic", lambda: 0.0)
+        recovered = store.knn(
+            [1.0, 0.0],
+            k=1,
+            model="full-scan",
+            full_scan=True,
+            deadline=1.0,
+        )
+        assert recovered.coverage == "full"
+        assert [row[0] for row in recovered] == [str(node_id)]
+    finally:
+        store.close()
+        dag.close()
+
+
 
 def test_bounded_scan_keeps_null_latest_at_legacy_rows_by_created_at(
     tmp_path, monkeypatch

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -413,8 +413,41 @@ def test_full_scan_reaches_best_vector_outside_recency_bound(tmp_path):
         assert bounded.coverage == "bounded"
         assert [row[0] for row in bounded] == [str(newest)]
         assert exhaustive.coverage == "full"
+        assert exhaustive.reason is None
         assert exhaustive.scanned == exhaustive.total == 2
         assert [row[0] for row in exhaustive] == [str(oldest)]
+    finally:
+        store.close()
+        dag.close()
+
+
+def test_full_scan_reports_incomplete_coverage_when_vector_decode_fails(tmp_path):
+    db_path = tmp_path / "full-scan-malformed.db"
+    dag = SummaryDAG(db_path)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        valid = _add_summary(dag, created_at=1.0)
+        malformed = _add_summary(dag, created_at=2.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, valid, "summary", "full-scan", [1.0, 0.0])
+        _record_embedding(store, malformed, "summary", "full-scan", [0.0, 1.0])
+        store.connection.execute(
+            "UPDATE lcm_embedding_vectors SET vec = ? WHERE embedded_id = ?",
+            (sqlite3.Binary(b"\x00"), str(malformed)),
+        )
+
+        result = store.knn(
+            [1.0, 0.0],
+            k=2,
+            model="full-scan",
+            full_scan=True,
+        )
+
+        assert result.coverage == "bounded"
+        assert result.reason == "malformed_vectors_skipped"
+        assert result.scanned == 1
+        assert result.total == 2
+        assert [row[0] for row in result] == [str(valid)]
     finally:
         store.close()
         dag.close()

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -458,6 +458,126 @@ def test_full_scan_timeout_releases_read_snapshot(tmp_path, monkeypatch):
         dag.close()
 
 
+def test_full_scan_timeout_clears_progress_handler_before_rollback_and_refreshes(
+    tmp_path, monkeypatch
+):
+    """An expired progress handler must not interrupt read-snapshot cleanup."""
+    db_path = tmp_path / "full-scan-progress-timeout.db"
+    dag = SummaryDAG(db_path)
+    real_connect = sqlite3.connect
+
+    class InterruptingRollbackConnection(sqlite3.Connection):
+        progress_handler_active = False
+
+        def set_progress_handler(self, progress_handler, n):
+            self.progress_handler_active = progress_handler is not None
+            return super().set_progress_handler(progress_handler, n)
+
+        def rollback(self):
+            if self.progress_handler_active:
+                raise sqlite3.OperationalError("interrupted")
+            return super().rollback()
+
+    def tracked_connect(*args, **kwargs):
+        kwargs["factory"] = InterruptingRollbackConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(vector_store_module.sqlite3, "connect", tracked_connect)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        first = _add_summary(dag, created_at=1.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, first, "summary", "full-scan", [1.0, 0.0])
+        store.connection.set_progress_handler(lambda: 0, 1000)
+        ticks = iter([0.0, 1.0])
+        monkeypatch.setattr(
+            vector_store_module.time, "monotonic", lambda: next(ticks, 1.0)
+        )
+
+        with pytest.raises(TimeoutError, match="deadline exhausted"):
+            store.knn(
+                [0.0, 1.0],
+                k=1,
+                model="full-scan",
+                full_scan=True,
+                deadline=0.5,
+            )
+        assert store.connection.in_transaction is False
+        assert store.connection.progress_handler_active is False
+
+        second = _add_summary(dag, created_at=2.0)
+        writer = VectorStore(db_path)
+        try:
+            _record_embedding(writer, second, "summary", "full-scan", [0.0, 1.0])
+        finally:
+            writer.close()
+
+        monkeypatch.setattr(vector_store_module.time, "monotonic", lambda: 0.0)
+        refreshed = store.knn(
+            [0.0, 1.0],
+            k=1,
+            model="full-scan",
+            full_scan=True,
+            deadline=1.0,
+        )
+        assert refreshed.coverage == "full"
+        assert [row[0] for row in refreshed] == [str(second)]
+        assert store.connection.in_transaction is False
+    finally:
+        store.close()
+        dag.close()
+
+
+def test_full_scan_exception_releases_owned_read_transaction(tmp_path, monkeypatch):
+    db_path = tmp_path / "full-scan-exception.db"
+    dag = SummaryDAG(db_path)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        node_id = _add_summary(dag, created_at=1.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, node_id, "summary", "full-scan", [1.0, 0.0])
+
+        def fail_decode(*_args, **_kwargs):
+            raise RuntimeError("simulated decode failure")
+
+        monkeypatch.setattr(store, "_decode_stored_vec", fail_decode)
+        with pytest.raises(RuntimeError, match="simulated decode failure"):
+            store.knn(
+                [1.0, 0.0],
+                k=1,
+                model="full-scan",
+                full_scan=True,
+            )
+        assert store.connection.in_transaction is False
+    finally:
+        store.close()
+        dag.close()
+
+
+def test_full_scan_releases_preexisting_stale_read_transaction(tmp_path):
+    db_path = tmp_path / "full-scan-stale-transaction.db"
+    dag = SummaryDAG(db_path)
+    store = VectorStore(db_path, bounded_scan_rows=1)
+    try:
+        node_id = _add_summary(dag, created_at=1.0)
+        store.register_profile("full-scan", "local", 2)
+        _record_embedding(store, node_id, "summary", "full-scan", [1.0, 0.0])
+        store.connection.execute("BEGIN")
+        store.connection.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()
+
+        result = store.knn(
+            [1.0, 0.0],
+            k=1,
+            model="full-scan",
+            full_scan=True,
+        )
+
+        assert result.coverage == "full"
+        assert store.connection.in_transaction is False
+    finally:
+        store.close()
+        dag.close()
+
 
 def test_bounded_scan_keeps_null_latest_at_legacy_rows_by_created_at(
     tmp_path, monkeypatch

--- a/tools.py
+++ b/tools.py
@@ -73,6 +73,7 @@ from .search_query import (
     extract_quoted_phrases,
     extract_search_terms,
     normalize_search_sort,
+    requires_like_fallback,
 )
 from .session_patterns import build_session_match_keys, compile_session_pattern
 from .sqlite_util import _sqlite_savepoint
@@ -444,6 +445,11 @@ def _query_terms_for_match_window(query: str | None) -> list[str]:
             token = token.rsplit(":", 1)[-1]
         if len(token) >= 2:
             add_term(token)
+    if not terms and requires_like_fallback(query):
+        # LIKE supports exact raw terms that FTS/window tokenization cannot
+        # represent, notably emoji-only queries. Keep that literal intact so
+        # hydration can verify the same match and retain truthful offsets.
+        add_term(query)
     seen: set[str] = set()
     unique: list[str] = []
     for term in sorted(terms, key=len, reverse=True):
@@ -2996,10 +3002,10 @@ def _lcm_recall_relevant_summary_row(
         summary_score = compute_directness_score(
             content, summary_terms, summary_phrases
         )
-        if query_score > 0:
-            rank = (2.0, query_score, summary_score, -index)
-        elif summary_score > 0:
-            rank = (1.0, summary_score, 0.0, -index)
+        if summary_score > 0:
+            rank = (2.0, summary_score, query_score, -index)
+        elif query_score > 0:
+            rank = (1.0, query_score, 0.0, -index)
         else:
             continue
         if best is None or rank > best[0]:

--- a/tools.py
+++ b/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import heapq
 import json
 import logging
 import re
@@ -460,6 +461,47 @@ def _query_terms_for_match_window(query: str | None) -> list[str]:
     return unique
 
 
+def _query_conjuncts_for_match_window(query: str | None) -> list[str]:
+    """Return lexical requirements for a simple implicit/explicit AND query."""
+    if not query or requires_like_fallback(query):
+        return []
+    quoted_phrases = [
+        phrase.strip() for phrase in re.findall(r'"([^"]+)"', query) if phrase.strip()
+    ]
+    unquoted = re.sub(r'"[^"]+"', " ", query)
+    tokens = re.findall(r"[\w][\w:-]*\*?", unquoted)
+    if any(token.upper() == "OR" for token in tokens):
+        # OR branches are alternatives, not a set of jointly required evidence.
+        return []
+
+    conjuncts = list(quoted_phrases)
+    skip_negated = False
+    for token in tokens:
+        operator = token.upper()
+        if operator == "NOT":
+            skip_negated = True
+            continue
+        if operator in {"AND", "NEAR"}:
+            continue
+        if skip_negated:
+            skip_negated = False
+            continue
+        token = token.rstrip("*").strip()
+        if ":" in token:
+            token = token.rsplit(":", 1)[-1]
+        if len(token) >= 2:
+            conjuncts.append(token)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for conjunct in conjuncts:
+        key = conjunct.casefold()
+        if key not in seen:
+            seen.add(key)
+            unique.append(conjunct)
+    return unique
+
+
 def _content_offset_for_query_match_or_none(
     content: str, query: str | None
 ) -> int | None:
@@ -487,6 +529,43 @@ def _query_match_span_or_none(
     folded, original_offsets = _casefold_with_original_offsets(content)
     if not folded or not original_offsets:
         return None
+    conjuncts = _query_conjuncts_for_match_window(query)
+    if conjuncts:
+        needles = [conjunct.casefold() for conjunct in conjuncts]
+        heap: list[tuple[int, int, int, int]] = []
+        max_end = 0
+        for needle_index, needle in enumerate(needles):
+            if not needle:
+                return None
+            folded_start = folded.find(needle)
+            if folded_start < 0:
+                return None
+            folded_end = folded_start + len(needle)
+            start = original_offsets[folded_start]
+            end = original_offsets[folded_end - 1] + 1
+            heapq.heappush(heap, (start, end, needle_index, folded_start))
+            max_end = max(max_end, end)
+
+        best: tuple[int, int] | None = None
+        while heap:
+            min_start, _end, needle_index, folded_start = heapq.heappop(heap)
+            candidate = (min_start, max_end)
+            if best is None or candidate[1] - candidate[0] < best[1] - best[0]:
+                best = candidate
+            needle = needles[needle_index]
+            next_folded_start = folded.find(needle, folded_start + 1)
+            if next_folded_start < 0:
+                break
+            next_folded_end = next_folded_start + len(needle)
+            next_start = original_offsets[next_folded_start]
+            next_end = original_offsets[next_folded_end - 1] + 1
+            heapq.heappush(
+                heap,
+                (next_start, next_end, needle_index, next_folded_start),
+            )
+            max_end = max(max_end, next_end)
+        return best
+
     for term in _query_terms_for_match_window(query):
         needle = term.casefold()
         if not needle:

--- a/tools.py
+++ b/tools.py
@@ -454,13 +454,19 @@ def _query_terms_for_match_window(query: str | None) -> list[str]:
     return unique
 
 
-def _content_offset_for_query_match(content: str, query: str | None) -> int:
+def _content_offset_for_query_match_or_none(
+    content: str, query: str | None
+) -> int | None:
     folded = content.casefold()
     for term in _query_terms_for_match_window(query):
         index = folded.find(term.casefold())
         if index >= 0:
             return index
-    return 0
+    return None
+
+
+def _content_offset_for_query_match(content: str, query: str | None) -> int:
+    return _content_offset_for_query_match_or_none(content, query) or 0
 
 
 def _full_content_slice(content: str, content_offset: int = 0) -> dict[str, Any]:
@@ -2995,8 +3001,6 @@ def _lcm_recall_citable_hit(
     if store_id is None:
         return None
     content = str(row.get("content") or "")
-    content_offset = 0
-    excerpt = content[:_LCM_RECALL_SNIPPET_CHARS]
     if "chunk_span" in hit:
         span = hit.get("chunk_span")
         if not isinstance(span, dict):
@@ -3013,8 +3017,22 @@ def _lcm_recall_citable_hit(
             return None
         content_offset = start
         excerpt = content[start:end][:_LCM_RECALL_SNIPPET_CHARS]
-        if not excerpt:
+    else:
+        match_offset = _content_offset_for_query_match_or_none(content, query)
+        if match_offset is None and source_node_id is not None:
+            match_offset = _content_offset_for_query_match_or_none(
+                content, str(hit.get("snippet") or "")
+            )
+        if match_offset is None:
             return None
+        content_offset = (
+            match_offset if match_offset >= _LCM_RECALL_SNIPPET_CHARS else 0
+        )
+        excerpt = content[
+            content_offset:content_offset + _LCM_RECALL_SNIPPET_CHARS
+        ]
+    if not excerpt:
+        return None
     _lcm_recall_require_deadline(deadline, "candidate hydration")
     citable = {
         "kind": "message_excerpt",
@@ -3476,6 +3494,7 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
                     except TimeoutError:
                         timed_out = True
                         coverage["summary"] = "none"
+                        degraded_reasons.append("summary arm timed out")
                     except Exception as exc:  # noqa: BLE001
                         coverage["summary"] = "none"
                         degraded_reasons.append(f"summary arm failed: {exc}")
@@ -3504,6 +3523,7 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
                     except TimeoutError:
                         timed_out = True
                         coverage["chunk"] = "none"
+                        degraded_reasons.append("chunk arm timed out")
                     except Exception as exc:  # noqa: BLE001
                         coverage["chunk"] = "none"
                         degraded_reasons.append(f"chunk arm failed: {exc}")

--- a/tools.py
+++ b/tools.py
@@ -67,7 +67,13 @@ from .retrieval_core import (
     run_knn,
 )
 from .rollup_store import RollupStore
-from .search_query import AGE_DECAY_RATE, normalize_search_sort
+from .search_query import (
+    AGE_DECAY_RATE,
+    compute_directness_score,
+    extract_quoted_phrases,
+    extract_search_terms,
+    normalize_search_sort,
+)
 from .session_patterns import build_session_match_keys, compile_session_pattern
 from .sqlite_util import _sqlite_savepoint
 from .store import build_message_fts_spec
@@ -1820,6 +1826,7 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
     current_session_id = engine.current_session_id
     has_current_session = bool(current_session_id)
     results: list[Dict[str, Any]] = []
+    search_failures: list[str] = []
 
     if content_scope in {"history", "both"}:
         try:
@@ -1844,6 +1851,7 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
                 )
         except Exception as exc:
             logger.warning("Message search failed: %s", exc)
+            search_failures.append(f"message search failed: {exc}")
 
     # Summary-node search is intentionally current-session only. Cross-session
     # DAG expansion is deferred; returning summary hits without an expansion
@@ -1863,6 +1871,7 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
                 results.append(_shape_summary_hit(node))
         except Exception as exc:
             logger.warning("Node search failed: %s", exc)
+            search_failures.append(f"summary search failed: {exc}")
 
     externalized_scan: dict[str, Any] | None = None
     externalized_results_omitted = False
@@ -2102,6 +2111,10 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
         response["externalized_refs"] = externalized_refs
     if externalized_scan is not None:
         response["externalized_scan"] = externalized_scan
+    if search_failures:
+        response["degraded"] = True
+        response["degraded_reason"] = "; ".join(search_failures)
+        response["search_failures"] = search_failures
     return json.dumps(response)
 
 
@@ -2842,8 +2855,18 @@ def _lcm_recall_positive_int(value: Any) -> int | None:
     return parsed if parsed > 0 else None
 
 
+def _lcm_recall_require_deadline(deadline: float, stage: str) -> None:
+    if time.monotonic() >= deadline:
+        raise TimeoutError(f"citation hydration deadline exhausted during {stage}")
+
+
 def _lcm_recall_summary_source_ids(
-    engine: "LCMEngine", node_id: Any, *, max_nodes: int = 64, max_sources: int = 64
+    engine: "LCMEngine",
+    node_id: Any,
+    *,
+    deadline: float,
+    max_nodes: int = 64,
+    max_sources: int = 64,
 ) -> list[int]:
     """Resolve one summary to bounded raw-source ids without trusting its refs."""
     root = _lcm_recall_positive_int(node_id)
@@ -2853,14 +2876,19 @@ def _lcm_recall_summary_source_ids(
     seen_nodes: set[int] = set()
     source_ids: list[int] = []
     while queue and len(seen_nodes) < max_nodes and len(source_ids) < max_sources:
+        _lcm_recall_require_deadline(deadline, "summary lineage lookup")
         current = queue.pop(0)
         if current in seen_nodes:
             continue
         seen_nodes.add(current)
         try:
             node = engine._dag.get_node(current)
+        except TimeoutError:
+            raise
         except Exception:  # malformed/corrupt lineage is uncitable, not fatal
+            _lcm_recall_require_deadline(deadline, "summary lineage lookup")
             continue
+        _lcm_recall_require_deadline(deadline, "summary lineage lookup")
         if node is None or not isinstance(node.source_ids, list):
             continue
         if node.source_type == "messages":
@@ -2878,31 +2906,89 @@ def _lcm_recall_summary_source_ids(
     return source_ids
 
 
+def _lcm_recall_relevant_summary_row(
+    rows: dict[int, dict[str, Any]],
+    candidate_ids: list[int],
+    *,
+    query: str,
+    matched_summary: str,
+    deadline: float,
+) -> dict[str, Any] | None:
+    """Choose query-relevant raw evidence; fail closed when none supports it."""
+    query_terms = extract_search_terms(query)
+    query_phrases = extract_quoted_phrases(query)
+    summary_terms = extract_search_terms(matched_summary)
+    summary_phrases = extract_quoted_phrases(matched_summary)
+    best: tuple[tuple[float, float, float, int], dict[str, Any]] | None = None
+    for index, source_id in enumerate(candidate_ids):
+        _lcm_recall_require_deadline(deadline, "summary evidence scoring")
+        row = rows.get(source_id)
+        if row is None:
+            continue
+        content = str(row.get("content") or "")
+        if not content:
+            continue
+        query_score = compute_directness_score(content, query_terms, query_phrases)
+        summary_score = compute_directness_score(
+            content, summary_terms, summary_phrases
+        )
+        if query_score > 0:
+            rank = (2.0, query_score, summary_score, -index)
+        elif summary_score > 0:
+            rank = (1.0, summary_score, 0.0, -index)
+        else:
+            continue
+        if best is None or rank > best[0]:
+            best = (rank, row)
+    _lcm_recall_require_deadline(deadline, "summary evidence scoring")
+    return best[1] if best is not None else None
+
+
 def _lcm_recall_citable_hit(
-    engine: "LCMEngine", hit: dict[str, Any]
+    engine: "LCMEngine",
+    hit: dict[str, Any],
+    *,
+    query: str,
+    deadline: float,
 ) -> dict[str, Any] | None:
     """Hydrate an untrusted candidate to one exact, expandable raw message."""
+    _lcm_recall_require_deadline(deadline, "candidate hydration")
     source_node_id: int | None = None
     if hit.get("kind") == "summary":
         source_node_id = _lcm_recall_positive_int(hit.get("node_id"))
-        candidate_ids = _lcm_recall_summary_source_ids(engine, source_node_id)
+        candidate_ids = _lcm_recall_summary_source_ids(
+            engine, source_node_id, deadline=deadline
+        )
     else:
         store_id = _lcm_recall_positive_int(hit.get("store_id"))
         candidate_ids = [store_id] if store_id is not None else []
     if not candidate_ids:
         return None
+    _lcm_recall_require_deadline(deadline, "message batch lookup")
     try:
         rows = engine._store.get_batch(candidate_ids)
+    except TimeoutError:
+        raise
     except Exception:
         return None
-    row = next(
-        (
-            rows[source_id]
-            for source_id in candidate_ids
-            if source_id in rows and str(rows[source_id].get("content") or "")
-        ),
-        None,
-    )
+    _lcm_recall_require_deadline(deadline, "message batch lookup")
+    if source_node_id is not None:
+        row = _lcm_recall_relevant_summary_row(
+            rows,
+            candidate_ids,
+            query=query,
+            matched_summary=str(hit.get("snippet") or ""),
+            deadline=deadline,
+        )
+    else:
+        row = next(
+            (
+                rows[source_id]
+                for source_id in candidate_ids
+                if source_id in rows and str(rows[source_id].get("content") or "")
+            ),
+            None,
+        )
     if row is None:
         return None
     store_id = _lcm_recall_positive_int(row.get("store_id"))
@@ -2911,15 +2997,25 @@ def _lcm_recall_citable_hit(
     content = str(row.get("content") or "")
     content_offset = 0
     excerpt = content[:_LCM_RECALL_SNIPPET_CHARS]
-    span = hit.get("chunk_span")
-    if isinstance(span, dict):
-        start = _lcm_recall_positive_int(span.get("char_start"))
-        if span.get("char_start") == 0 and not isinstance(span.get("char_start"), bool):
-            start = 0
-        end = _lcm_recall_positive_int(span.get("char_end"))
-        if start is not None and end is not None and 0 <= start < end <= len(content):
-            content_offset = start
-            excerpt = content[start:end][:_LCM_RECALL_SNIPPET_CHARS]
+    if "chunk_span" in hit:
+        span = hit.get("chunk_span")
+        if not isinstance(span, dict):
+            return None
+        start = span.get("char_start")
+        end = span.get("char_end")
+        if (
+            isinstance(start, bool)
+            or not isinstance(start, int)
+            or isinstance(end, bool)
+            or not isinstance(end, int)
+            or not 0 <= start < end <= len(content)
+        ):
+            return None
+        content_offset = start
+        excerpt = content[start:end][:_LCM_RECALL_SNIPPET_CHARS]
+        if not excerpt:
+            return None
+    _lcm_recall_require_deadline(deadline, "candidate hydration")
     citable = {
         "kind": "message_excerpt",
         "store_id": store_id,
@@ -2995,6 +3091,11 @@ def _lcm_recall_fts_arm(
     )
     if "error" in payload:
         return [], payload
+    if payload.get("degraded"):
+        return [], {
+            "error": payload.get("degraded_reason") or "full-text search degraded",
+            "timeout": bool(payload.get("timeout")),
+        }
     hits: list[dict[str, Any]] = []
     for row in payload.get("results", []):
         store_id = row.get("store_id")
@@ -3492,7 +3593,14 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     for entry in ordered:
         hit = entry["hit"]
         if detail == "answer_ready":
-            citable = _lcm_recall_citable_hit(engine, hit)
+            try:
+                citable = _lcm_recall_citable_hit(
+                    engine, hit, query=query, deadline=deadline
+                )
+            except TimeoutError:
+                timed_out = True
+                degraded_reasons.append("citation hydration timed out")
+                break
             if citable is None:
                 omitted_uncitable += 1
                 continue

--- a/tools.py
+++ b/tools.py
@@ -3093,6 +3093,27 @@ def _lcm_recall_relevant_summary_row(
     return best[1] if best is not None else None
 
 
+def _lcm_recall_summary_evidence_window(
+    content: str,
+    matched_summary: str,
+) -> tuple[int, str] | None:
+    """Locate the tightest bounded window supported by the selected source row."""
+    folded_content = content.casefold()
+    overlapping_terms: list[str] = []
+    seen: set[str] = set()
+    for term in extract_search_terms(matched_summary):
+        cleaned = term.strip().replace('"', " ")
+        key = cleaned.casefold()
+        if not cleaned or key in seen or key not in folded_content:
+            continue
+        seen.add(key)
+        overlapping_terms.append(cleaned)
+    if not overlapping_terms:
+        return None
+    evidence_query = " AND ".join(f'"{term}"' for term in overlapping_terms)
+    return _content_window_for_query_match_or_none(content, evidence_query)
+
+
 def _lcm_recall_citable_hit(
     engine: "LCMEngine",
     hit: dict[str, Any],
@@ -3102,6 +3123,9 @@ def _lcm_recall_citable_hit(
 ) -> dict[str, Any] | None:
     """Hydrate an untrusted candidate to one exact, expandable raw message."""
     _lcm_recall_require_deadline(deadline, "candidate hydration")
+    matched_summary = str(
+        hit.get("_matched_summary") or hit.get("snippet") or ""
+    )
     source_node_id: int | None = None
     if hit.get("kind") == "summary":
         source_node_id = _lcm_recall_positive_int(hit.get("node_id"))
@@ -3126,7 +3150,7 @@ def _lcm_recall_citable_hit(
             rows,
             candidate_ids,
             query=query,
-            matched_summary=str(hit.get("snippet") or ""),
+            matched_summary=matched_summary,
             deadline=deadline,
         )
     else:
@@ -3166,9 +3190,14 @@ def _lcm_recall_citable_hit(
         else:
             window = _content_window_for_query_match_or_none(chunk_content, query)
             if window is None:
-                window = _content_window_for_query_match_or_none(
-                    chunk_content, str(hit.get("snippet") or "")
-                )
+                if source_node_id is not None:
+                    window = _lcm_recall_summary_evidence_window(
+                        chunk_content, matched_summary
+                    )
+                else:
+                    window = _content_window_for_query_match_or_none(
+                        chunk_content, str(hit.get("snippet") or "")
+                    )
             if window is None:
                 return None
             local_offset, excerpt = window
@@ -3176,8 +3205,8 @@ def _lcm_recall_citable_hit(
     else:
         window = _content_window_for_query_match_or_none(content, query)
         if window is None and source_node_id is not None:
-            window = _content_window_for_query_match_or_none(
-                content, str(hit.get("snippet") or "")
+            window = _lcm_recall_summary_evidence_window(
+                content, matched_summary
             )
         if window is None:
             return None
@@ -3211,15 +3240,14 @@ def _lcm_recall_bounded_reason(
 ) -> str:
     """Degraded-reasons text for a ``coverage='bounded'`` arm (SCAN-1).
 
-    Names the arm and the scanned/total ratio so a caller can see that the arm
-    scored only the most-recent slice of the corpus (older archived vectors were
-    excluded by the recency-bounded candidate scan), rather than the truncation
-    being silent.
+    Names the arm and the scored/total ratio without assuming why coverage was
+    incomplete. Bounded candidate scans can exclude older vectors, while exact
+    scans can skip malformed live rows that cannot be scored.
     """
     if scanned is not None and total is not None:
         return (
-            f"{arm} arm coverage bounded: scored the {scanned} most-recent of "
-            f"{total} vectors (older vectors excluded)"
+            f"{arm} arm coverage bounded: scored {scanned} of {total} vectors; "
+            "some live vectors were excluded or unreadable"
         )
     return (
         f"{arm} arm coverage bounded: scored only the most-recent slice of the "
@@ -3342,6 +3370,7 @@ def _lcm_recall_summary_arm(
             "node_id": node.node_id,
             "session_id": node.session_id,
             "timestamp": node.latest_at or node.created_at or 0,
+            "_matched_summary": node.summary or "",
             "snippet": (node.summary or "")[:_LCM_RECALL_SNIPPET_CHARS],
             "from_current_session": bool(current) and node.session_id == current,
         }

--- a/tools.py
+++ b/tools.py
@@ -2828,6 +2828,119 @@ def _lcm_recall_excerpt_expand_hint(hit: dict[str, Any]) -> str:
     return f"lcm_expand(store_id={hit.get('store_id')}, content_offset={offset})"
 
 
+def _lcm_recall_positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    if isinstance(value, str) and not value.strip().isdigit():
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _lcm_recall_summary_source_ids(
+    engine: "LCMEngine", node_id: Any, *, max_nodes: int = 64, max_sources: int = 64
+) -> list[int]:
+    """Resolve one summary to bounded raw-source ids without trusting its refs."""
+    root = _lcm_recall_positive_int(node_id)
+    if root is None:
+        return []
+    queue = [root]
+    seen_nodes: set[int] = set()
+    source_ids: list[int] = []
+    while queue and len(seen_nodes) < max_nodes and len(source_ids) < max_sources:
+        current = queue.pop(0)
+        if current in seen_nodes:
+            continue
+        seen_nodes.add(current)
+        try:
+            node = engine._dag.get_node(current)
+        except Exception:  # malformed/corrupt lineage is uncitable, not fatal
+            continue
+        if node is None or not isinstance(node.source_ids, list):
+            continue
+        if node.source_type == "messages":
+            for value in node.source_ids:
+                source_id = _lcm_recall_positive_int(value)
+                if source_id is not None and source_id not in source_ids:
+                    source_ids.append(source_id)
+                    if len(source_ids) >= max_sources:
+                        break
+        elif node.source_type == "nodes":
+            for value in node.source_ids:
+                child_id = _lcm_recall_positive_int(value)
+                if child_id is not None and child_id not in seen_nodes:
+                    queue.append(child_id)
+    return source_ids
+
+
+def _lcm_recall_citable_hit(
+    engine: "LCMEngine", hit: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Hydrate an untrusted candidate to one exact, expandable raw message."""
+    source_node_id: int | None = None
+    if hit.get("kind") == "summary":
+        source_node_id = _lcm_recall_positive_int(hit.get("node_id"))
+        candidate_ids = _lcm_recall_summary_source_ids(engine, source_node_id)
+    else:
+        store_id = _lcm_recall_positive_int(hit.get("store_id"))
+        candidate_ids = [store_id] if store_id is not None else []
+    if not candidate_ids:
+        return None
+    try:
+        rows = engine._store.get_batch(candidate_ids)
+    except Exception:
+        return None
+    row = next(
+        (
+            rows[source_id]
+            for source_id in candidate_ids
+            if source_id in rows and str(rows[source_id].get("content") or "")
+        ),
+        None,
+    )
+    if row is None:
+        return None
+    store_id = _lcm_recall_positive_int(row.get("store_id"))
+    if store_id is None:
+        return None
+    content = str(row.get("content") or "")
+    content_offset = 0
+    excerpt = content[:_LCM_RECALL_SNIPPET_CHARS]
+    span = hit.get("chunk_span")
+    if isinstance(span, dict):
+        start = _lcm_recall_positive_int(span.get("char_start"))
+        if span.get("char_start") == 0 and not isinstance(span.get("char_start"), bool):
+            start = 0
+        end = _lcm_recall_positive_int(span.get("char_end"))
+        if start is not None and end is not None and 0 <= start < end <= len(content):
+            content_offset = start
+            excerpt = content[start:end][:_LCM_RECALL_SNIPPET_CHARS]
+    citable = {
+        "kind": "message_excerpt",
+        "store_id": store_id,
+        "session_id": row.get("session_id"),
+        "timestamp": row.get("timestamp") or 0,
+        "snippet": excerpt,
+        "content_offset": content_offset,
+        "from_current_session": bool(engine.current_session_id)
+        and row.get("session_id") == engine.current_session_id,
+    }
+    if source_node_id is not None:
+        citable["source_node_id"] = source_node_id
+    citable["expand_hint"] = _lcm_recall_excerpt_expand_hint(citable)
+    citable["citation"] = {
+        "tool": "lcm_expand",
+        "store_id": store_id,
+        "content_offset": content_offset,
+    }
+    return citable
+
+
 def _lcm_recall_bounded_reason(
     arm: str, scanned: int | None, total: int | None
 ) -> str:
@@ -2925,6 +3038,9 @@ def _lcm_recall_summary_arm(
             source=None,
             vector_store_cls=VectorStore,
             scan_rows=max(1, int(getattr(engine._config, "recall_scan_rows", 25_000))),
+            full_scan=bool(
+                getattr(engine._config, "recall_full_corpus_scan_enabled", True)
+            ),
         ),
         remaining_s=deadline - time.monotonic(),
         name="lcm-recall-summary-knn",
@@ -2981,6 +3097,9 @@ def _lcm_recall_chunk_arm(
             source=None,
             vector_store_cls=VectorStore,
             scan_rows=max(1, int(getattr(engine._config, "recall_scan_rows", 25_000))),
+            full_scan=bool(
+                getattr(engine._config, "recall_full_corpus_scan_enabled", True)
+            ),
         ),
         remaining_s=deadline - time.monotonic(),
         name="lcm-recall-chunk-knn",
@@ -3104,6 +3223,17 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     include = str(args.get("include") or "all").strip().lower()
     if include not in _LCM_RECALL_VALID_INCLUDE:
         return json.dumps({"error": "include must be one of: all, summaries, verbatim"})
+    requested_detail = str(args.get("detail") or "snippets").strip().lower()
+    if requested_detail not in {"snippets", "answer_ready"}:
+        return json.dumps({"error": "detail must be one of: snippets, answer_ready"})
+    reference_strict_enabled = bool(
+        getattr(engine._config, "recall_reference_strict", True)
+    )
+    detail = (
+        requested_detail
+        if requested_detail != "answer_ready" or reference_strict_enabled
+        else "snippets"
+    )
 
     # lcm_recall fans out three arms + fusion/hydration/rerank, so it uses its own
     # (larger) budget rather than lcm_grep's single-arm query deadline (sprint-opt-2).
@@ -3142,7 +3272,7 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
             timed_out = timed_out or bool(fts_error.get("timeout"))
         else:
             arm_hits["fts"] = hits
-            coverage["fts"] = "ok"
+            coverage["fts"] = "full"
 
     # -- Vector arms. Local/same-model corpora share one query embedding;
     # Voyage's context chunk corpus resolves and embeds with its own model. --
@@ -3357,8 +3487,20 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     # -- Response shaping (char-capped) --
     hits_out: list[dict[str, Any]] = []
     response_chars = 0
+    omitted_uncitable = 0
+    delivered_store_ids: set[int] = set()
     for entry in ordered:
         hit = entry["hit"]
+        if detail == "answer_ready":
+            citable = _lcm_recall_citable_hit(engine, hit)
+            if citable is None:
+                omitted_uncitable += 1
+                continue
+            store_id = int(citable["store_id"])
+            if store_id in delivered_store_ids:
+                continue
+            delivered_store_ids.add(store_id)
+            hit = citable
         arms = sorted({arm_order[index] for index in entry["ranks"].keys()})
         item: dict[str, Any] = {
             "kind": hit.get("kind"),
@@ -3376,6 +3518,10 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
             item["store_id"] = hit.get("store_id")
             if hit.get("chunk_span"):
                 item["chunk_span"] = hit["chunk_span"]
+            if hit.get("source_node_id") is not None:
+                item["source_node_id"] = hit["source_node_id"]
+            if hit.get("citation"):
+                item["citation"] = hit["citation"]
         item_chars = len(json.dumps(item, ensure_ascii=False))
         if hits_out and response_chars + item_chars > _LCM_RECALL_RESPONSE_CHAR_CAP:
             break
@@ -3390,6 +3536,7 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
         "limit": limit,
         "scope_bias": scope_bias,
         "include": include,
+        "detail": detail,
         "total_results": len(hits_out),
         "hits": hits_out,
         "provenance": {
@@ -3397,6 +3544,10 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
             "arm_weights": {name: arm_weights[i] for i, name in enumerate(arm_order)},
             "coverage": coverage,
             "rerank": rerank_status,
+            "reference_strict": {
+                "enabled": reference_strict_enabled,
+                "omitted_uncitable": omitted_uncitable,
+            },
             "ordering": (
                 "rrf-fusion -> scope/recency prior -> rerank reorder (top window); "
                 "the reported score is the scope/recency-adjusted RRF score, and "

--- a/tools.py
+++ b/tools.py
@@ -457,12 +457,64 @@ def _query_terms_for_match_window(query: str | None) -> list[str]:
 def _content_offset_for_query_match_or_none(
     content: str, query: str | None
 ) -> int | None:
-    folded = content.casefold()
+    match = _query_match_span_or_none(content, query)
+    return None if match is None else match[0]
+
+
+def _casefold_with_original_offsets(text: str) -> tuple[str, list[int]]:
+    """Casefold text while retaining a map back to Python character offsets."""
+    folded_parts: list[str] = []
+    offsets: list[int] = []
+    for index, char in enumerate(text):
+        folded = char.casefold()
+        folded_parts.append(folded)
+        offsets.extend([index] * len(folded))
+    return "".join(folded_parts), offsets
+
+
+def _query_match_span_or_none(
+    content: str, query: str | None
+) -> tuple[int, int] | None:
+    """Return one verified query-match span in original character offsets."""
+    if not content or not query:
+        return None
+    folded, original_offsets = _casefold_with_original_offsets(content)
+    if not folded or not original_offsets:
+        return None
     for term in _query_terms_for_match_window(query):
-        index = folded.find(term.casefold())
-        if index >= 0:
-            return index
+        needle = term.casefold()
+        if not needle:
+            continue
+        folded_start = folded.find(needle)
+        if folded_start < 0:
+            continue
+        folded_end = folded_start + len(needle)
+        return original_offsets[folded_start], original_offsets[folded_end - 1] + 1
     return None
+
+
+def _content_window_for_query_match_or_none(
+    content: str,
+    query: str | None,
+    *,
+    max_chars: int = _LCM_RECALL_SNIPPET_CHARS,
+) -> tuple[int, str] | None:
+    """Return a bounded evidence window that fully contains a verified match."""
+    match = _query_match_span_or_none(content, query)
+    if match is None:
+        return None
+    match_start, match_end = match
+    if match_end <= max_chars:
+        # Preserve the historical offset-0 window whenever the complete match
+        # fits; callers already rely on that compatibility behavior.
+        return 0, content[:max_chars]
+    if match_end - match_start > max_chars:
+        return None
+    window_start = match_start
+    window_end = min(len(content), window_start + max_chars)
+    if not (window_start <= match_start and match_end <= window_end):
+        return None
+    return window_start, content[window_start:window_end]
 
 
 def _content_offset_for_query_match(content: str, query: str | None) -> int:
@@ -1833,6 +1885,7 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
     has_current_session = bool(current_session_id)
     results: list[Dict[str, Any]] = []
     search_failures: list[str] = []
+    message_search_coverage = "full"
 
     if content_scope in {"history", "both"}:
         try:
@@ -1846,6 +1899,9 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
                 role=role,
                 time_from=time_from,
                 time_to=time_to,
+            )
+            message_search_coverage = str(
+                getattr(msg_hits, "coverage", "full") or "full"
             )
             for hit in msg_hits:
                 results.append(
@@ -2121,6 +2177,8 @@ def _lcm_grep_full_text(args: Dict[str, Any], **kwargs) -> str:
         response["degraded"] = True
         response["degraded_reason"] = "; ".join(search_failures)
         response["search_failures"] = search_failures
+    if str(args.get("mode") or "").lower() == "recall":
+        response["_message_search_coverage"] = message_search_coverage
     return json.dumps(response)
 
 
@@ -3015,22 +3073,30 @@ def _lcm_recall_citable_hit(
             or not 0 <= start < end <= len(content)
         ):
             return None
-        content_offset = start
-        excerpt = content[start:end][:_LCM_RECALL_SNIPPET_CHARS]
+        chunk_content = content[start:end]
+        if len(chunk_content) <= _LCM_RECALL_SNIPPET_CHARS:
+            # A valid chunk span is authoritative and can be cited whole.
+            content_offset = start
+            excerpt = chunk_content
+        else:
+            window = _content_window_for_query_match_or_none(chunk_content, query)
+            if window is None:
+                window = _content_window_for_query_match_or_none(
+                    chunk_content, str(hit.get("snippet") or "")
+                )
+            if window is None:
+                return None
+            local_offset, excerpt = window
+            content_offset = start + local_offset
     else:
-        match_offset = _content_offset_for_query_match_or_none(content, query)
-        if match_offset is None and source_node_id is not None:
-            match_offset = _content_offset_for_query_match_or_none(
+        window = _content_window_for_query_match_or_none(content, query)
+        if window is None and source_node_id is not None:
+            window = _content_window_for_query_match_or_none(
                 content, str(hit.get("snippet") or "")
             )
-        if match_offset is None:
+        if window is None:
             return None
-        content_offset = (
-            match_offset if match_offset >= _LCM_RECALL_SNIPPET_CHARS else 0
-        )
-        excerpt = content[
-            content_offset:content_offset + _LCM_RECALL_SNIPPET_CHARS
-        ]
+        content_offset, excerpt = window
     if not excerpt:
         return None
     _lcm_recall_require_deadline(deadline, "candidate hydration")
@@ -3109,6 +3175,9 @@ def _lcm_recall_fts_arm(
     )
     if "error" in payload:
         return [], payload
+    message_coverage = str(
+        payload.get("_message_search_coverage") or "full"
+    )
     if payload.get("degraded"):
         return [], {
             "error": payload.get("degraded_reason") or "full-text search degraded",
@@ -3132,6 +3201,8 @@ def _lcm_recall_fts_arm(
         }
         hit["expand_hint"] = _lcm_recall_excerpt_expand_hint(hit)
         hits.append(hit)
+    if message_coverage != "full":
+        return hits, {"coverage": message_coverage}
     return hits, None
 
 
@@ -3380,18 +3451,28 @@ def lcm_recall(args: Dict[str, Any], **kwargs) -> str:
     # -- FTS arm (the default-on value: works with embeddings disabled) --
     if run_fts:
         try:
-            hits, fts_error = _lcm_recall_fts_arm(
+            hits, fts_status = _lcm_recall_fts_arm(
                 engine, query, candidate_limit=candidate_limit, deadline=deadline
             )
         except (_WorkerCapacityError, TimeoutError) as exc:
-            hits, fts_error = [], {"error": str(exc)}
-        if fts_error is not None:
+            hits, fts_status = [], {"error": str(exc)}
+        if fts_status is not None and "error" in fts_status:
             coverage["fts"] = "none"
             degraded_reasons.append("full-text arm unavailable")
-            timed_out = timed_out or bool(fts_error.get("timeout"))
+            timed_out = timed_out or bool(fts_status.get("timeout"))
         else:
             arm_hits["fts"] = hits
-            coverage["fts"] = "full"
+            fts_coverage = (
+                str(fts_status.get("coverage") or "bounded")
+                if fts_status is not None
+                else "full"
+            )
+            coverage["fts"] = fts_coverage
+            if fts_coverage != "full":
+                degraded_reasons.append(
+                    "full-text arm coverage bounded: LIKE fallback did not scan "
+                    "the complete all-time candidate set"
+                )
 
     # -- Vector arms. Local/same-model corpora share one query embedding;
     # Voyage's context chunk corpus resolves and embeds with its own model. --

--- a/vector_store.py
+++ b/vector_store.py
@@ -235,9 +235,10 @@ class KNNResult(list[tuple[str, float, str]]):
         super().__init__(rows)
         self.coverage = coverage
         self.reason = reason
-        # Bounded-coverage provenance: how many of the corpus's live vectors were
-        # actually scored (``scanned``) out of the total live for the identity
-        # (``total``), so a caller can surface partial-archive coverage (SCAN-1).
+        # Coverage provenance: how many of the corpus's live vectors were actually
+        # scored (``scanned``) out of the total live rows examined (``total``).
+        # This surfaces both recency bounds and malformed rows skipped by an exact
+        # full scan instead of overstating either path as complete.
         self.scanned = scanned
         self.total = total
 
@@ -1491,7 +1492,9 @@ class VectorStore:
         )
         batch_size = min(1024, max(1, int(self.bounded_scan_rows or 1)))
         last_rowid = 0
-        scanned = 0
+        total = 0
+        scored = 0
+        skipped = 0
         best: list[tuple[int, str, float, str]] = []
         summary_columns = self._table_columns("summary_nodes")
         suppression = (
@@ -1547,7 +1550,7 @@ class VectorStore:
                 if not rows:
                     break
                 last_rowid = int(rows[-1]["rowid"])
-                scanned += len(rows)
+                total += len(rows)
                 rowids: list[int] = []
                 embedded_ids: list[str] = []
                 kinds: list[str] = []
@@ -1562,13 +1565,16 @@ class VectorStore:
                     try:
                         vector = self._decode_stored_vec(bytes(row["vec"]), dim, dtype)
                     except (TypeError, ValueError):
+                        skipped += 1
                         continue
                     if vector is None:
+                        skipped += 1
                         continue
                     rowids.append(int(row["rowid"]))
                     embedded_ids.append(str(row["embedded_id"]))
                     kinds.append(str(row["embedded_kind"]))
                     vectors.append(vector)
+                scored += len(vectors)
                 if vectors:
                     if numpy is not None:
                         assert query_array is not None
@@ -1604,11 +1610,13 @@ class VectorStore:
             (str(embedded_id), float(score), str(kind))
             for _, embedded_id, score, kind in best
         ]
+        coverage = "none" if not scored else "bounded" if skipped else "full"
         return KNNResult(
             candidates,
-            coverage="full" if scanned else "none",
-            scanned=scanned,
-            total=scanned,
+            coverage=coverage,
+            reason="malformed_vectors_skipped" if skipped else None,
+            scanned=scored,
+            total=total,
         )
 
     def _source_allowed_ids(self, table: str, source: str) -> set[str]:

--- a/vector_store.py
+++ b/vector_store.py
@@ -1593,7 +1593,11 @@ class VectorStore:
                         key=lambda row: (-float(row[2]), -int(row[0]), str(row[1])),
                     )[:k]
         finally:
-            if started_read_transaction and conn.in_transaction:
+            # The caller may have installed a deadline progress handler. Once
+            # cleanup starts it must not interrupt ROLLBACK and strand this
+            # pooled connection on the scan's read snapshot.
+            conn.set_progress_handler(None, 0)
+            if conn.in_transaction:
                 conn.rollback()
 
         candidates = [

--- a/vector_store.py
+++ b/vector_store.py
@@ -13,6 +13,7 @@ import math
 import sqlite3
 import struct
 import threading
+import time
 import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -1459,6 +1460,153 @@ class VectorStore:
             for _, embedded_id, score, kind in ranked[:limit]
         ]
 
+    def _full_scan_exact(
+        self,
+        *,
+        identity_hash: str,
+        dim: int,
+        dtype: str,
+        query: Sequence[float],
+        k: int,
+        chunk: bool,
+        deadline: float | None,
+    ) -> KNNResult:
+        """Score every live vector in bounded batches and retain exact top-k.
+
+        The keyset cursor prevents OFFSET rescans, while the fixed batch ceiling
+        bounds decoded-vector memory even when the legacy recency bound is large.
+        This path is intentionally filter-free: lcm_recall is the all-time,
+        all-conversation caller; filtered lcm_grep keeps its existing bounded
+        candidate contract. A read transaction holds one SQLite snapshot across
+        all batches, so concurrent writers cannot create a partial-corpus view.
+        """
+        try:
+            numpy = _load_numpy()
+        except ImportError:
+            numpy = None
+        query_array = (
+            numpy.asarray(query, dtype=numpy.float32)
+            if numpy is not None
+            else None
+        )
+        batch_size = min(1024, max(1, int(self.bounded_scan_rows or 1)))
+        last_rowid = 0
+        scanned = 0
+        best: list[tuple[int, str, float, str]] = []
+        summary_columns = self._table_columns("summary_nodes")
+        suppression = (
+            " AND sn.suppressed_at IS NULL"
+            if "suppressed_at" in summary_columns
+            else ""
+        )
+        conn = self._conn
+        if conn is None:  # pragma: no cover - guarded by the public methods
+            return KNNResult(coverage="none")
+        started_read_transaction = not conn.in_transaction
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError("full-corpus vector scan deadline exhausted")
+        if started_read_transaction:
+            conn.execute("BEGIN")
+        try:
+            while True:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise TimeoutError("full-corpus vector scan deadline exhausted")
+                if chunk:
+                    rows = conn.execute(
+                        """
+                        SELECT v.rowid, v.chunk_id AS embedded_id,
+                               'chunk' AS embedded_kind, v.vec
+                        FROM lcm_chunk_vectors v
+                        JOIN lcm_chunk_meta cm
+                          ON cm.chunk_id = v.chunk_id
+                         AND cm.identity_hash = v.identity_hash
+                        JOIN messages msg ON msg.store_id = cm.store_id
+                        WHERE v.identity_hash = ? AND cm.archived = 0 AND v.rowid > ?
+                        ORDER BY v.rowid ASC
+                        LIMIT ?
+                        """,
+                        (identity_hash, last_rowid, batch_size),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        f"""
+                        SELECT v.rowid, v.embedded_id, m.embedded_kind, v.vec
+                        FROM lcm_embedding_vectors v
+                        JOIN lcm_embedding_meta m
+                          ON m.embedded_id = v.embedded_id
+                         AND m.identity_hash = v.identity_hash
+                        JOIN summary_nodes sn
+                          ON sn.node_id = CAST(v.embedded_id AS INTEGER)
+                        WHERE v.identity_hash = ? AND m.archived = 0 AND v.rowid > ?
+                              {suppression}
+                        ORDER BY v.rowid ASC
+                        LIMIT ?
+                        """,
+                        (identity_hash, last_rowid, batch_size),
+                    ).fetchall()
+                if not rows:
+                    break
+                last_rowid = int(rows[-1]["rowid"])
+                scanned += len(rows)
+                rowids: list[int] = []
+                embedded_ids: list[str] = []
+                kinds: list[str] = []
+                vectors: list[tuple[float, ...]] = []
+                for index, row in enumerate(rows):
+                    if (
+                        deadline is not None
+                        and index % 64 == 0
+                        and time.monotonic() >= deadline
+                    ):
+                        raise TimeoutError("full-corpus vector scan deadline exhausted")
+                    try:
+                        vector = self._decode_stored_vec(bytes(row["vec"]), dim, dtype)
+                    except (TypeError, ValueError):
+                        continue
+                    if vector is None:
+                        continue
+                    rowids.append(int(row["rowid"]))
+                    embedded_ids.append(str(row["embedded_id"]))
+                    kinds.append(str(row["embedded_kind"]))
+                    vectors.append(vector)
+                if vectors:
+                    if numpy is not None:
+                        assert query_array is not None
+                        matrix = numpy.asarray(vectors, dtype=numpy.float32)
+                        batch_scores = matrix @ query_array
+                    else:
+                        batch_scores = [
+                            sum(
+                                value * query_value
+                                for value, query_value in zip(vector, query)
+                            )
+                            for vector in vectors
+                        ]
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise TimeoutError("full-corpus vector scan deadline exhausted")
+                    batch_best = sorted(
+                        zip(rowids, embedded_ids, batch_scores, kinds),
+                        key=lambda row: (-float(row[2]), -int(row[0]), str(row[1])),
+                    )[:k]
+                    best = sorted(
+                        [*best, *batch_best],
+                        key=lambda row: (-float(row[2]), -int(row[0]), str(row[1])),
+                    )[:k]
+        finally:
+            if started_read_transaction and conn.in_transaction:
+                conn.rollback()
+
+        candidates = [
+            (str(embedded_id), float(score), str(kind))
+            for _, embedded_id, score, kind in best
+        ]
+        return KNNResult(
+            candidates,
+            coverage="full" if scanned else "none",
+            scanned=scanned,
+            total=scanned,
+        )
+
     def _source_allowed_ids(self, table: str, source: str) -> set[str]:
         """Root candidate ids whose source subtree reaches a message with ``source``.
 
@@ -1852,6 +2000,8 @@ class VectorStore:
         conversation_ids: Sequence[str] | None = None,
         source: str | None = None,
         provider: str | None = None,
+        full_scan: bool = False,
+        deadline: float | None = None,
     ) -> KNNResult:
         k = int(k)
         if k <= 0:
@@ -1879,6 +2029,22 @@ class VectorStore:
         dim = int(profile["dim"])
         dtype = str(profile["dtype"])
         query = self._normalized(query_vec, expected_dim=dim)
+        if (
+            full_scan
+            and since is None
+            and until is None
+            and conversation_ids is None
+            and source is None
+        ):
+            return self._full_scan_exact(
+                identity_hash=identity,
+                dim=dim,
+                dtype=dtype,
+                query=query,
+                k=k,
+                chunk=False,
+                deadline=deadline,
+            )
         try:
             numpy = _load_numpy()
         except ImportError:
@@ -2381,6 +2547,8 @@ class VectorStore:
         conversation_ids: Sequence[str] | None = None,
         source: str | None = None,
         provider: str | None = None,
+        full_scan: bool = False,
+        deadline: float | None = None,
     ) -> KNNResult:
         """Bounded-candidate chunk KNN with the summary coverage contract.
 
@@ -2412,6 +2580,22 @@ class VectorStore:
         dim = int(profile["dim"])
         dtype = str(profile["dtype"])
         query = self._normalized(query_vec, expected_dim=dim)
+        if (
+            full_scan
+            and since is None
+            and until is None
+            and conversation_ids is None
+            and source is None
+        ):
+            return self._full_scan_exact(
+                identity_hash=identity,
+                dim=dim,
+                dtype=dtype,
+                query=query,
+                k=k,
+                chunk=True,
+                deadline=deadline,
+            )
         try:
             numpy = _load_numpy()
         except ImportError:


### PR DESCRIPTION
## Relationship to PR #436 and contributor credit

This PR is a deliberately narrow, fresh-main successor to Andy's broader work as `100yenadmin` in #436. It is not a replacement for #436 and does not represent all of Andy's contribution.

The retrieval-scaling and reference-strict citable-delivery direction here builds on work and evidence Andy developed in #436. This branch was assembled against current `main` and subsequently hardened under Stephen's branch to isolate one reviewable first slice. GitHub's commit authorship on this successor reflects branch assembly and repairs, not sole origination of the underlying work.

Covered here: exact full-corpus summary/chunk vector scanning, truthful FTS coverage, answer-ready citations backed by raw messages, and rollback flags.

Not covered: trajectory/experience memory, assertions, adaptive retrieval, query views, compilers, provider-backed selection, non-minimal durable sidecars, and benchmark/release material from #436. Those areas require separate explicit disposition; this PR does not claim they are superseded or rejected.

## Summary
- Add exact, keyset-paginated full-corpus scoring for the summary and chunk vector recall arms while surfacing existing full-index FTS coverage explicitly.
- Add opt-in `detail="answer_ready"` delivery that returns only citations backed by existing raw message rows, omitting malformed, stale, or uncitable candidates without crashing.
- Add process-local rollback flags for restoring the prior bounded vector scan and legacy snippet shaping without a schema or stored-data migration.

## Why
- Recency-bounded vector candidate windows can miss the strongest older match, and retrieval output needs a strict path from every delivered citation back to an expandable raw message.
- This keeps the change to one retrieval-only commit and leaves adaptive retrieval, provider-backed selection, trajectory memory, assertions, query views, compilers, and non-minimal durable sidecars out of scope.

## Validation
- [x] Focused validation: `pytest -q tests/test_vector_store.py tests/test_chunk_vector_store.py tests/test_lcm_recall.py tests/test_tool_contracts.py tests/test_embedding_search_modes.py -o addopts=''` -> `142 passed`
- [x] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [x] `PYTHONPATH=. pytest -q` -> `2304 passed, 12 xfailed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- The unchecked default commands were not run separately for this exact candidate. Changed Python runtime modules passed `py_compile`, and all changed Python files passed Ruff.
- No workflow files changed, so `actionlint` is not applicable.
- Exact vector scans are intentionally linear. Local evidence covers a bounded 25,000-summary-vector and 25,000-chunk-vector fixture at dimension 384; it is not a generalized performance claim.
- Rollback is available with `LCM_RECALL_FULL_CORPUS_SCAN_ENABLED=false` and `LCM_RECALL_REFERENCE_STRICT=false`, followed by a process restart.

