### PR TITLE
fix: merge adjacent assistant rows in active-context assembly

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -117,6 +117,7 @@ from .session_patterns import (
 from .message_analysis import (
     _is_synthetic_assistant_noise,
     _matched_tool_call_ids,
+    _merge_adjacent_assistant_messages,
     _tool_call_id,
 )
 from .fresh_tail import FreshTailBoundary, resolve_fresh_tail_boundary
@@ -5101,12 +5102,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         messages: List[Dict[str, Any]],
         *,
         insert_missing_tool_stubs: bool = True,
+        merge_adjacent_assistants: bool = True,
     ) -> List[Dict[str, Any]]:
         """Drop unsafe assistant-only noise, then repair tool sequencing.
 
         This is intentionally active-context-only: callers pass the selected
         provider replay context, and this helper never mutates stored rows,
         source mappings, or DAG nodes.
+
+        ``merge_adjacent_assistants`` collapses assistant rows left adjacent
+        after tool rows are dropped (the final emitted/persisted shape). It is
+        turned OFF for the intermediate token-budget selection pass in
+        ``_assemble_context``, where each turn must be weighed and kept/dropped
+        on its own — merging there would force an all-or-nothing decision on a
+        combined row and could drop a small tail turn glued to an oversized one.
         """
         cleaned: list[Dict[str, Any]] = []
         dropped_assistant_messages = 0
@@ -5135,10 +5144,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 stripped_assistant_messages,
             )
 
-        return self._sanitize_tool_pairs(
+        paired = self._sanitize_tool_pairs(
             cleaned,
             insert_missing_tool_stubs=insert_missing_tool_stubs,
         )
+        if not merge_adjacent_assistants:
+            return paired
+        # Merge any assistant rows left adjacent once tool rows were dropped —
+        # emit an alternation-clean active context so downstream loads don't
+        # have to repair it and the persisted message count matches replay.
+        return _merge_adjacent_assistant_messages(paired)
 
     @staticmethod
     def _active_tool_stub_content(original_content: Any, placeholder: str) -> Any:
@@ -5925,6 +5940,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             tail_for_selection = self._sanitize_active_context_messages(
                 assembly_tail_messages,
                 insert_missing_tool_stubs=False,
+                # Intermediate pass for per-turn token-budget selection: weigh
+                # each turn on its own; do NOT merge adjacent assistants here or
+                # a small tail turn glued to an oversized one gets dropped with
+                # it. The final assembled result is merged downstream.
+                merge_adjacent_assistants=False,
             )
             skipped_tail_gap = False
             for msg in reversed(tail_for_selection):

--- a/message_analysis.py
+++ b/message_analysis.py
@@ -60,3 +60,77 @@ def _is_synthetic_assistant_noise(content: str) -> bool:
     normalized = normalized.strip("`*_ ")
     bracketless = normalized.strip("[](){} ")
     return normalized in _SYNTHETIC_ASSISTANT_NOISE or bracketless in _SYNTHETIC_ASSISTANT_NOISE
+
+
+def _is_codex_interim(msg: Dict[str, Any]) -> bool:
+    """A Codex Responses interim assistant turn.
+
+    These legitimately keep multiple consecutive incomplete assistant turns in
+    history, each carrying its own encrypted continuation state
+    (``codex_reasoning_items`` / ``codex_message_items``) that must replay
+    verbatim. Merging them corrupts the Responses replay chain, so the
+    adjacent-assistant merge exempts them — the same exemption the host
+    gateway's ``repair_message_sequence`` applies.
+    """
+    return bool(
+        msg.get("codex_reasoning_items")
+        or msg.get("codex_message_items")
+        or msg.get("finish_reason") == "incomplete"
+    )
+
+
+def _merge_adjacent_assistant_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge consecutive assistant messages into one (alternation repair).
+
+    Active-context assembly drops ``tool`` rows and strips ``tool_calls`` off
+    assistant turns to shed token-heavy scaffolding. That leaves the narration
+    rows that used to be separated by tool results sitting adjacent — a strict
+    role-alternation violation (``assistant`` followed by ``assistant``) that
+    every downstream load then has to repair, and that inflates the persisted
+    message count above the count the model actually replays. Collapse them at
+    the single active-context funnel so the emitted context is
+    alternation-clean by construction.
+
+    Union ``tool_calls`` (order-preserving), concatenate plain-text content,
+    carry the first non-empty ``reasoning_content``, and exempt Codex Responses
+    interim turns. Operates only on the active replay list — the raw store and
+    DAG are untouched, so recovery granularity is preserved.
+    """
+    collapsed: List[Dict[str, Any]] = []
+    for msg in messages:
+        if (
+            collapsed
+            and isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and isinstance(collapsed[-1], dict)
+            and collapsed[-1].get("role") == "assistant"
+            and not _is_codex_interim(msg)
+            and not _is_codex_interim(collapsed[-1])
+            # Only merge plain-string narration turns. Multimodal / structured
+            # (list or dict) content stays its own turn — collapsing it risks
+            # mangling attachment/thinking blocks, and the alternation problem
+            # this repair exists for is the bare-narration case, which is
+            # always plain text.
+            and isinstance(collapsed[-1].get("content"), str)
+            and isinstance(msg.get("content"), str)
+        ):
+            prev = dict(collapsed[-1])
+            prev_calls = list(prev.get("tool_calls") or [])
+            new_calls = list(msg.get("tool_calls") or [])
+            if new_calls:
+                prev["tool_calls"] = prev_calls + new_calls
+            elif prev_calls:
+                prev["tool_calls"] = prev_calls
+            prev["content"] = "\n".join(
+                part
+                for part in (prev["content"].strip(), msg["content"].strip())
+                if part
+            )
+            if not prev.get("reasoning_content") and msg.get("reasoning_content"):
+                prev["reasoning_content"] = msg["reasoning_content"]
+            collapsed[-1] = prev
+            continue
+        collapsed.append(msg)
+    return collapsed

--- a/tests/test_active_context_alternation.py
+++ b/tests/test_active_context_alternation.py
@@ -1,0 +1,111 @@
+"""Active-context assembly must not emit consecutive assistant rows.
+
+Active-context assembly strips ``tool_calls`` off assistant turns and drops the
+``tool`` results (to shed token-heavy scaffolding), then persists that stripped
+set. On the next turn those bare rows reload and run back through
+``_sanitize_active_context_messages`` — arriving as consecutive bare assistant
+rows (no tool_calls). Each carries no tool_calls, so ``_sanitize_tool_pairs``
+leaves the adjacency untouched; the adjacent-assistant merge is what closes it.
+
+A persisted run of consecutive assistant rows is a strict role-alternation
+violation that every downstream load has to repair, and it inflates the
+persisted message count above what the model actually replays.
+
+The raw store and DAG stay lossless independent of this — granular rows remain
+recoverable; this only sanitizes the active replay context.
+"""
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "alternation.db"))
+    instance = LCMEngine(config=config, hermes_home=str(tmp_path))
+    instance._session_id = "test-session"
+    try:
+        yield instance
+    finally:
+        instance.shutdown()
+
+
+def _consecutive_assistant_runs(messages):
+    return sum(
+        1
+        for i in range(1, len(messages))
+        if messages[i].get("role") == "assistant"
+        and messages[i - 1].get("role") == "assistant"
+    )
+
+
+def _bare_assistant_run(n_steps):
+    """The shape re-ingested every turn: already-stripped bare assistant rows."""
+    msgs = [
+        {"role": "system", "content": "You are testing LCM."},
+        {"role": "user", "content": "Do the multi-step task."},
+    ]
+    for i in range(n_steps):
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": f"Step {i}: let me run the next probe.",
+                "finish_reason": None,
+            }
+        )
+    return msgs
+
+
+def test_sanitize_active_context_has_no_consecutive_assistants(engine):
+    messages = _bare_assistant_run(6)
+    sanitized = engine._sanitize_active_context_messages(
+        messages, insert_missing_tool_stubs=False
+    )
+    assert _consecutive_assistant_runs(sanitized) == 0, (
+        "active context emitted consecutive assistant rows: "
+        f"{[m.get('role') for m in sanitized]}"
+    )
+
+
+def test_merged_assistant_preserves_all_narration_text(engine):
+    messages = _bare_assistant_run(4)
+    sanitized = engine._sanitize_active_context_messages(
+        messages, insert_missing_tool_stubs=False
+    )
+    merged_text = "\n".join(
+        m["content"]
+        for m in sanitized
+        if m.get("role") == "assistant" and isinstance(m.get("content"), str)
+    )
+    for i in range(4):
+        assert f"Step {i}:" in merged_text, f"lost narration for step {i}"
+
+
+def test_codex_interim_turns_are_not_merged(engine):
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "interim 1",
+            "codex_reasoning_items": [{"id": "rs_1"}],
+            "finish_reason": "incomplete",
+        },
+        {
+            "role": "assistant",
+            "content": "interim 2",
+            "codex_reasoning_items": [{"id": "rs_2"}],
+            "finish_reason": "incomplete",
+        },
+    ]
+    sanitized = engine._sanitize_active_context_messages(
+        messages, insert_missing_tool_stubs=False
+    )
+    interim = [
+        m
+        for m in sanitized
+        if m.get("role") == "assistant" and m.get("codex_reasoning_items")
+    ]
+    assert len(interim) == 2, "codex interim turns must NOT be merged"


### PR DESCRIPTION
## Problem

`_sanitize_active_context_messages` -> `_sanitize_tool_pairs` drops `tool` rows and strips `tool_calls` off assistant turns to shed token-heavy scaffolding, but **never merges the assistant narration rows left adjacent** once the tool results between them are gone.

A long agentic turn (N tool steps, each with its own narration preamble) therefore emits — and the host persists — ~N consecutive bare assistant rows. That is a strict message-role-alternation violation: the host has to repair it on every load, and the persisted message count ends up inflated above the count the model actually replays. In our deployment this surfaced as a runtime footer (`X/Ymsgs`, from the raw persisted count) over-reading the repaired `len(history)` a session-hygiene valve enforces (1463 shown vs 1003 checked), making a working valve look broken.

## Fix

Add `_merge_adjacent_assistant_messages` (in `message_analysis.py`) and call it as the final step of `_sanitize_active_context_messages`:
- union `tool_calls` (order-preserving), concatenate content, carry first non-empty `reasoning_content`
- **only merge plain-string turns** — multimodal / structured (list/dict) content is left as its own turn so attachment/thinking blocks are never mangled
- **exempt Codex Responses interim turns** (encrypted continuation state must replay verbatim)
- the merge is turned **off** (`merge_adjacent_assistants=False`) for the intermediate token-budget selection pass in `_assemble_context`, where each turn must be weighed and kept/dropped on its own — merging there would force an all-or-nothing decision on a combined row and could drop a small tail turn glued to an oversized one

The raw store and DAG are untouched (active-context-only), so `lcm_grep` / `lcm_expand` recovery granularity is fully preserved.

## Tests

3 new tests: no-consecutive-assistants, narration-text preservation, codex-interim exemption. Full suite green except pre-existing environmental flakes (wall-clock absolute-deadline tests in `test_embedding_*`; macOS `/var`->`/private/var` in `test_path_*`) which fail identically on unpatched `main`.