### PR TITLE
fix: close finalized LCM engine clones

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -78,6 +78,33 @@ def _ensure_engine_bound_to_session(
         )
 
 
+def _make_session_finalize_handler(prototype_engine, resolve_active_lcm_engine):
+    """Close the exact per-agent LCM clone retired by a host session boundary."""
+
+    def _on_session_finalize(**payload) -> None:
+        session_id = str(payload.get("session_id") or "")
+        platform = str(payload.get("platform") or "").strip().lower()
+        if not session_id or platform == "cli":
+            # Interactive CLI /new finalizes the old session while reusing the
+            # same agent and context engine. Process exit closes its resources.
+            return
+
+        active_engine = resolve_active_lcm_engine(session_id=session_id)
+        if (
+            active_engine is None
+            or active_engine is prototype_engine
+            or _engine_bound_session_id(active_engine) != session_id
+        ):
+            return
+
+        try:
+            active_engine.shutdown()
+        except Exception as exc:
+            logger.debug("LCM finalized-clone shutdown failed: %s", exc)
+
+    return _on_session_finalize
+
+
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
@@ -126,6 +153,16 @@ def register(ctx):
             logger.info(
                 "LCM explicit subagent-lineage hooks unavailable on this Hermes "
                 "host; auxiliary detection uses the legacy frame-walk fallback: %s",
+                exc,
+            )
+        try:
+            register_hook(
+                "on_session_finalize",
+                _make_session_finalize_handler(engine, resolve_active_lcm_engine),
+            )
+        except Exception as exc:
+            logger.info(
+                "LCM finalized-clone cleanup hook unavailable on this Hermes host: %s",
                 exc,
             )
 

--- a/tests/test_plugin_lifecycle_cleanup.py
+++ b/tests/test_plugin_lifecycle_cleanup.py
@@ -1,0 +1,94 @@
+"""Plugin-owned cleanup for finalized per-agent LCM clones."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_plugin_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name,
+        str(REPO_ROOT / "__init__.py"),
+        submodule_search_locations=[str(REPO_ROOT)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _registered_plugin(tmp_path, monkeypatch, module_name: str):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    module = _load_plugin_module(module_name)
+    hooks = {}
+
+    class _Ctx:
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_hook(self, name, callback):
+            hooks[name] = callback
+
+    ctx = _Ctx()
+    module.register(ctx)
+    return ctx.engine, hooks
+
+
+def test_finalize_closes_only_the_clone_bound_to_that_session(tmp_path, monkeypatch):
+    prototype, hooks = _registered_plugin(
+        tmp_path,
+        monkeypatch,
+        "hermes_lcm_finalize_exact_clone",
+    )
+    clone_a = prototype.clone_for_agent()
+    clone_b = prototype.clone_for_agent()
+    clone_a.on_session_start("session-a", platform="desktop")
+    clone_b.on_session_start("session-b", platform="desktop")
+
+    try:
+        hooks["on_session_finalize"](
+            session_id="session-a",
+            platform="desktop",
+            reason="tui_close",
+        )
+
+        assert clone_a._store._conn is None
+        assert clone_a._dag._conn is None
+        assert clone_a._lifecycle._conn is None
+        assert clone_b._store._conn is not None
+        assert clone_b._dag._conn is not None
+        assert clone_b._lifecycle._conn is not None
+        assert prototype._store._conn is not None
+        assert prototype._dag._conn is not None
+        assert prototype._lifecycle._conn is not None
+    finally:
+        clone_a.shutdown()
+        clone_b.shutdown()
+        prototype.shutdown()
+
+
+def test_cli_finalize_keeps_the_reused_clone_open(tmp_path, monkeypatch):
+    prototype, hooks = _registered_plugin(
+        tmp_path,
+        monkeypatch,
+        "hermes_lcm_finalize_cli_reuse",
+    )
+    clone = prototype.clone_for_agent()
+    clone.on_session_start("cli-session", platform="cli")
+
+    try:
+        hooks["on_session_finalize"](
+            session_id="cli-session",
+            platform="cli",
+            reason="session_boundary",
+        )
+
+        assert clone._store._conn is not None
+        assert clone._dag._conn is not None
+        assert clone._lifecycle._conn is not None
+    finally:
+        clone.shutdown()
+        prototype.shutdown()

--- a/tests/test_plugin_lifecycle_cleanup.py
+++ b/tests/test_plugin_lifecycle_cleanup.py
@@ -14,6 +14,8 @@ def _load_plugin_module(name: str):
         str(REPO_ROOT / "__init__.py"),
         submodule_search_locations=[str(REPO_ROOT)],
     )
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary

- register a supported `on_session_finalize` plugin hook
- resolve the exact per-agent LCM clone by durable session ID
- shut down only that finalized clone, leaving other active clones and the plugin prototype untouched
- preserve interactive CLI `/new`, which reuses its agent/context engine

## Why

Hermes deep-copies the registered context-engine prototype for each `AIAgent`. In long-lived Desktop and gateway processes, retiring an agent does not currently guarantee that the clone's SQLite-backed LCM helpers are closed. Finalized sessions can therefore leave Store, DAG, and lifecycle descriptors open.

The plugin already owns an exact weak session-to-engine registry and an idempotent `shutdown()` boundary. This change connects those existing pieces through Hermes' supported hard session-boundary hook; it does not patch Hermes core or sweep unrelated engines.

## Verification

- focused plugin lifecycle, hook registration, and packaging matrix: 33 passed
- 12-cycle Linux FD soak while retaining references to every finalized clone: post-warm-up LCM FD count returned from 13 to the steady baseline of 10 after every cycle
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed

## Scope

This closes plugin-owned LCM SQLite resources. It does not claim to close Hermes-owned `state.db` connections.

## Automated review

GitHub Copilot reviewed the identical diff in [bennybuoy/hermes-lcm#24](https://github.com/bennybuoy/hermes-lcm/pull/24), because fork contributors cannot request reviewers on the upstream repository. Its initial test-helper suggestion was addressed in `085d6ee`; a second review of that commit covered both changed files and generated no new comments.
