### PR TITLE
docs: fix lcm_recent scope example

### DIFF
--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -193,7 +193,10 @@ even when the sources still belong to the previous session.
 `lcm_recent` accepts `today`, `yesterday`, `Nd`, `week`, `month`,
 `date:YYYY-MM-DD`, and `last Nh`. All periods are normalized to UTC `[start,
 end)` windows. Results are newest-first, limited to 200 sections, and bounded to
-the same 20,000-character response ceiling used by the retrieval tools.
+the same 20,000-character response ceiling used by the retrieval tools. The
+current schema supports only the active conversation: omit `scope` to use the
+default, or pass `scope: "conversation"` explicitly. Cross-session/global
+rollups remain future work.
 
 ```json
 {"period": "today"}
@@ -204,7 +207,7 @@ the same 20,000-character response ceiling used by the retrieval tools.
 ```
 
 ```json
-{"period": "date:2026-07-15", "scope": "global"}
+{"period": "date:2026-07-15", "scope": "conversation"}
 ```
 
 When temporal rollups are enabled and `ready` rollups cover the **entire**


### PR DESCRIPTION
Fixes #472.

## Summary

- replace the unsupported `lcm_recent(scope="global")` retrieval-guide example with the schema-valid `scope="conversation"`
- state explicitly that omitting `scope` uses the active conversation and that cross-session/global rollups remain future work

## Why

Current `schemas.py::LCM_RECENT` accepts only:

```python
"enum": ["conversation"]
```

The old documentation example was guaranteed to fail validation. Runtime behavior and the schema are unchanged; this corrects the agent-facing reference to match the shipped contract.

## Validation

```text
python -m pytest -q tests/test_lcm_recent.py
50 passed
```

An additional local contract probe parsed all three JSON examples in the natural-time retrieval section and checked their effective `scope` values against `LCM_RECENT`'s schema enum:

```text
validated 3 lcm_recent JSON examples against schema scope ['conversation']
```

`git diff --check` also passed.
