### PR TITLE
feat: add durable message retrieval-reference adapter

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -15,8 +15,9 @@ import shutil
 import sqlite3
 import threading
 import time
+import uuid
 from contextlib import contextmanager
-from typing import Iterable, Sequence
+from typing import Callable, Iterable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,28 @@ REQUIRED_CORE_TABLES = (
     "messages_fts",
     "nodes_fts",
 )
+
+DATABASE_UUID_METADATA_KEY = "database_uuid"
+DATABASE_UUID_MIGRATION = "database_uuid_v1"
+RETRIEVAL_REFERENCES_MIGRATION = "retrieval_references_v1"
+RETRIEVAL_REFERENCES_TABLE = "retrieval_references_v1"
+RETRIEVAL_REFERENCE_KINDS = (
+    "message",
+    "summary_node",
+    "externalized_payload",
+    "source_cursor",
+    "content_cursor",
+    "session_cursor",
+)
+RETRIEVAL_REFERENCE_CONSISTENCIES = ("live", "high_watermark", "snapshot")
+
+
+class DatabaseIdentityError(RuntimeError):
+    """Raised when a migrated database no longer has a valid authority UUID."""
+
+
+class RetrievalReferenceSchemaError(RuntimeError):
+    """Raised when the named V1 registry exists with an incompatible shape."""
 
 
 class ExternalContentFtsSpec:
@@ -416,6 +439,7 @@ def classify_version_mismatch(conn: sqlite3.Connection) -> str:
     # The feature table's *internal* shape is intentionally NOT checked here — an
     # early-variant feature table is still an interim stamp, repaired on apply.
     allowed = set(_V5_CORE_TABLE_COLUMNS) | set(_V5_CORE_PRESENCE_ONLY)
+    allowed.add(RETRIEVAL_REFERENCES_TABLE)
     for fts in _V5_CORE_PRESENCE_ONLY:
         allowed.update(get_fts_shadow_table_names(fts))
     for table in tables:
@@ -424,6 +448,29 @@ def classify_version_mismatch(conn: sqlite3.Connection) -> str:
         if any(table.startswith(prefix) for prefix in _KNOWN_FEATURE_TABLE_PREFIXES):
             continue
         return VERSION_MISMATCH_GENUINELY_NEWER
+
+    identity_marked = _migration_marker_exists(conn, DATABASE_UUID_MIGRATION)
+    database_uuid_value = _read_database_uuid_value(conn)
+    if identity_marked != (database_uuid_value is not None):
+        return VERSION_MISMATCH_GENUINELY_NEWER
+    if identity_marked and not _is_canonical_uuid4(database_uuid_value):
+        return VERSION_MISMATCH_GENUINELY_NEWER
+
+    registry_present = RETRIEVAL_REFERENCES_TABLE in tables
+    registry_marked = _migration_marker_exists(
+        conn, RETRIEVAL_REFERENCES_MIGRATION
+    )
+    if registry_present != registry_marked:
+        # Table names and exact shapes are not provenance. A V1 registry is known
+        # to this build only when its named completion marker is present too.
+        return VERSION_MISMATCH_GENUINELY_NEWER
+    if registry_present:
+        if verify_retrieval_references_schema(conn):
+            return VERSION_MISMATCH_GENUINELY_NEWER
+        try:
+            get_database_uuid(conn)
+        except DatabaseIdentityError:
+            return VERSION_MISMATCH_GENUINELY_NEWER
 
     # A present feature-family table that carries an EXTRA column this build does
     # not recognise is a newer-build signature, not an early interim variant —
@@ -564,6 +611,367 @@ def ensure_migration_state_table(conn: sqlite3.Connection) -> None:
         )
         """
     )
+
+
+def _is_canonical_uuid4(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, ValueError, TypeError):
+        return False
+    return parsed.version == 4 and str(parsed) == value
+
+
+def _migration_marker_exists(conn: sqlite3.Connection, step_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM lcm_migration_state WHERE step_name = ?",
+        (step_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _read_database_uuid_value(conn: sqlite3.Connection) -> object | None:
+    row = conn.execute(
+        "SELECT value FROM metadata WHERE key = ?",
+        (DATABASE_UUID_METADATA_KEY,),
+    ).fetchone()
+    return None if row is None else row[0]
+
+
+@contextmanager
+def _named_migration_ownership(conn: sqlite3.Connection, name: str):
+    """Serialize a named migration while preserving caller transaction ownership."""
+    savepoint = quote_sql_identifier(name)
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    else:
+        conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        yield
+    except BaseException:
+        if owns_transaction:
+            conn.rollback()
+        else:
+            try:
+                conn.execute(f"ROLLBACK TO {savepoint}")
+            finally:
+                conn.execute(f"RELEASE {savepoint}")
+        raise
+    else:
+        if owns_transaction:
+            conn.commit()
+        else:
+            conn.execute(f"RELEASE {savepoint}")
+
+
+def _ensure_database_uuid_migration(conn: sqlite3.Connection) -> str:
+    marker_exists = _migration_marker_exists(conn, DATABASE_UUID_MIGRATION)
+    value = _read_database_uuid_value(conn)
+    if value is None:
+        registry_marker_exists = _migration_marker_exists(
+            conn, RETRIEVAL_REFERENCES_MIGRATION
+        )
+        registry_table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (RETRIEVAL_REFERENCES_TABLE,),
+        ).fetchone() is not None
+        if marker_exists or registry_marker_exists or registry_table_exists:
+            raise DatabaseIdentityError(
+                "LCM retrieval-reference state exists without its database_uuid "
+                "authority identity; refusing to generate a replacement identity"
+            )
+        value = str(uuid.uuid4())
+        conn.execute(
+            """
+            INSERT INTO metadata(key, value) VALUES(?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (DATABASE_UUID_METADATA_KEY, value),
+        )
+    elif not _is_canonical_uuid4(value):
+        raise DatabaseIdentityError(
+            "LCM database_uuid is missing or corrupt; refusing to regenerate authority identity"
+        )
+    mark_migration_step_complete(conn, DATABASE_UUID_MIGRATION)
+    return str(value)
+
+
+def _ensure_retrieval_references_table(conn: sqlite3.Connection) -> None:
+    kinds = ", ".join(repr(kind) for kind in RETRIEVAL_REFERENCE_KINDS)
+    consistencies = ", ".join(repr(value) for value in RETRIEVAL_REFERENCE_CONSISTENCIES)
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {RETRIEVAL_REFERENCES_TABLE} (
+            token_digest TEXT NOT NULL PRIMARY KEY
+                CHECK(length(token_digest) = 64
+                      AND token_digest NOT GLOB '*[^0-9a-f]*'),
+            kind TEXT NOT NULL CHECK(kind IN ({kinds})),
+            target_json TEXT NOT NULL,
+            scope_json TEXT NOT NULL,
+            revision_json TEXT NOT NULL,
+            consistency TEXT NOT NULL CHECK(consistency IN ({consistencies})),
+            issued_at REAL NOT NULL,
+            expires_at REAL,
+            revoked_at REAL
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{RETRIEVAL_REFERENCES_TABLE}_kind_state
+            ON {RETRIEVAL_REFERENCES_TABLE}(kind, revoked_at, expires_at)
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{RETRIEVAL_REFERENCES_TABLE}_scope
+            ON {RETRIEVAL_REFERENCES_TABLE}(kind, scope_json)
+        """
+    )
+
+
+def verify_retrieval_references_schema(conn: sqlite3.Connection) -> list[str]:
+    """Return structural defects in the V1 registry, without mutating it."""
+    table = RETRIEVAL_REFERENCES_TABLE
+    table_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    if table_row is None:
+        return [f"missing table:{table}"]
+
+    expected = {
+        "token_digest": ("TEXT", 1, 1),
+        "kind": ("TEXT", 1, 0),
+        "target_json": ("TEXT", 1, 0),
+        "scope_json": ("TEXT", 1, 0),
+        "revision_json": ("TEXT", 1, 0),
+        "consistency": ("TEXT", 1, 0),
+        "issued_at": ("REAL", 1, 0),
+        "expires_at": ("REAL", 0, 0),
+        "revoked_at": ("REAL", 0, 0),
+    }
+    actual = {
+        str(row[1]): (str(row[2]).upper(), int(row[3] or 0), int(row[5] or 0))
+        for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+    errors: list[str] = []
+    if actual != expected:
+        errors.append(f"malformed table:{table}")
+
+    normalized_sql = re.sub(r"\s+", "", str(table_row[0] or "").lower())
+    if "check(kindin('message','summary_node','externalized_payload','source_cursor','content_cursor','session_cursor'))" not in normalized_sql:
+        errors.append(f"missing kind check:{table}")
+    if "check(consistencyin('live','high_watermark','snapshot'))" not in normalized_sql:
+        errors.append(f"missing consistency check:{table}")
+    if "length(token_digest)=64" not in normalized_sql:
+        errors.append(f"missing digest check:{table}")
+    if "token_digestnotglob'*[^0-9a-f]*'" not in normalized_sql:
+        errors.append(f"missing digest character check:{table}")
+
+    expected_indexes = {
+        f"idx_{table}_kind_state": ("kind", "revoked_at", "expires_at"),
+        f"idx_{table}_scope": ("kind", "scope_json"),
+    }
+    for index_name, columns in expected_indexes.items():
+        row = conn.execute(
+            "SELECT tbl_name FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()
+        actual_columns = [
+            str(item[2])
+            for item in conn.execute(f"PRAGMA index_info({index_name})").fetchall()
+        ] if row is not None else []
+        if (
+            row is None
+            or str(row[0]) != table
+            or actual_columns != list(columns)
+        ):
+            errors.append(f"malformed index:{index_name}")
+    return sorted(set(errors))
+
+
+def _completed_retrieval_reference_migrations(
+    conn: sqlite3.Connection,
+) -> str | None:
+    """Validate known V1 provenance or identify a completely fresh boundary."""
+    identity_complete = _migration_marker_exists(conn, DATABASE_UUID_MIGRATION)
+    registry_complete = _migration_marker_exists(
+        conn, RETRIEVAL_REFERENCES_MIGRATION
+    )
+    database_uuid_value = _read_database_uuid_value(conn)
+    registry_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (RETRIEVAL_REFERENCES_TABLE,),
+    ).fetchone() is not None
+
+    if not identity_complete:
+        if (
+            database_uuid_value is not None
+            or registry_complete
+            or registry_table_exists
+        ):
+            raise DatabaseIdentityError(
+                "unmarked retrieval-reference authority state cannot be adopted"
+            )
+        return None
+
+    database_uuid = get_database_uuid(conn)
+    if not registry_complete:
+        if registry_table_exists:
+            raise RetrievalReferenceSchemaError(
+                "unmarked retrieval_references_v1 table cannot be adopted"
+            )
+        return None
+
+    errors = verify_retrieval_references_schema(conn)
+    if errors:
+        raise RetrievalReferenceSchemaError(
+            "completed retrieval_references_v1 migration is damaged: "
+            + "; ".join(errors)
+        )
+    return database_uuid
+
+
+def ensure_retrieval_reference_migrations(conn: sqlite3.Connection) -> str:
+    """Install and validate the V1 authority identity and reference registry.
+
+    The two named migrations share one ownership transaction. A failed schema
+    check or UUID write rolls back both, and the numeric core schema remains v5.
+    """
+    # Direct callers receive the same pre-DDL newer-schema refusal as the main
+    # migration ladder; named helpers must not bypass that authority boundary.
+    refuse_schema_version_too_new(conn)
+    prerequisite_tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?)",
+            ("metadata", "lcm_migration_state"),
+        ).fetchall()
+    }
+    if prerequisite_tables == {"metadata", "lcm_migration_state"}:
+        complete = _completed_retrieval_reference_migrations(conn)
+        if complete is not None:
+            return complete
+
+    ensure_metadata_table(conn)
+    ensure_migration_state_table(conn)
+
+    complete = _completed_retrieval_reference_migrations(conn)
+    if complete is not None:
+        return complete
+
+    with _named_migration_ownership(conn, "lcm_retrieval_references_v1"):
+        # Another constructor may have completed the named migration while this
+        # connection waited for ownership. Accept that winner without replaying
+        # DDL or rewriting identity metadata.
+        complete = _completed_retrieval_reference_migrations(conn)
+        if complete is not None:
+            return complete
+
+        database_uuid = _ensure_database_uuid_migration(conn)
+        _ensure_retrieval_references_table(conn)
+        errors = verify_retrieval_references_schema(conn)
+        if errors:
+            raise RetrievalReferenceSchemaError(
+                "retrieval_references_v1 schema validation failed: " + "; ".join(errors)
+            )
+        mark_migration_step_complete(conn, RETRIEVAL_REFERENCES_MIGRATION)
+    return database_uuid
+
+
+def get_retrieval_reference_authority(conn: sqlite3.Connection) -> str:
+    """Read and validate the complete V1 authority without installing it."""
+    required_tables = {
+        "metadata",
+        "lcm_migration_state",
+        RETRIEVAL_REFERENCES_TABLE,
+    }
+    present_tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?)",
+            tuple(sorted(required_tables)),
+        ).fetchall()
+    }
+    if present_tables != required_tables:
+        raise DatabaseIdentityError(
+            "retrieval-reference authority migrations have not completed"
+        )
+    complete = _completed_retrieval_reference_migrations(conn)
+    if complete is None:
+        raise DatabaseIdentityError(
+            "retrieval-reference authority migrations have not completed"
+        )
+    return complete
+
+
+def get_database_uuid(conn: sqlite3.Connection) -> str:
+    """Return the migrated logical authority UUID, failing closed if damaged."""
+    if not _migration_marker_exists(conn, DATABASE_UUID_MIGRATION):
+        raise DatabaseIdentityError("LCM database_uuid migration has not completed")
+    value = _read_database_uuid_value(conn)
+    if not _is_canonical_uuid4(value):
+        raise DatabaseIdentityError(
+            "migrated LCM database is missing or has a corrupt database_uuid"
+        )
+    return str(value)
+
+
+def rotate_database_uuid(
+    conn: sqlite3.Connection,
+    *,
+    authorization_context: object = None,
+    authorize_rotation: Callable[[object], bool] | None = None,
+    revoked_at: float | None = None,
+) -> str:
+    """Rotate authority identity and revoke copied V1 references atomically."""
+    try:
+        rotation_allowed = bool(
+            authorization_context is not None
+            and authorize_rotation is not None
+            and authorize_rotation(authorization_context)
+        )
+    except Exception:
+        rotation_allowed = False
+    if not rotation_allowed:
+        raise PermissionError("explicit clone rotation is not authorized")
+    timestamp = time.time() if revoked_at is None else float(revoked_at)
+    if not math.isfinite(timestamp):
+        raise ValueError("revoked_at must be finite")
+    new_uuid = str(uuid.uuid4())
+    with _named_migration_ownership(conn, "lcm_clone_rotation_v1"):
+        current = get_retrieval_reference_authority(conn)
+        cursor = conn.execute(
+            """
+            UPDATE metadata SET value = ?
+            WHERE key = ? AND value = ?
+            """,
+            (new_uuid, DATABASE_UUID_METADATA_KEY, current),
+        )
+        if cursor.rowcount != 1:
+            raise DatabaseIdentityError(
+                "database_uuid authority changed during explicit clone rotation"
+            )
+        conn.execute(
+            f"UPDATE {RETRIEVAL_REFERENCES_TABLE} SET revoked_at=? WHERE revoked_at IS NULL",
+            (timestamp,),
+        )
+    return new_uuid
+
+
+def rotate_database_identity(
+    conn: sqlite3.Connection,
+    **kwargs: object,
+) -> str:
+    """Compatibility name for the explicit clone authority rotation primitive."""
+    return rotate_database_uuid(conn, **kwargs)
+
+
+def ensure_database_identity(conn: sqlite3.Connection) -> str:
+    """Return the authority UUID after the named V1 migrations have been validated."""
+    return ensure_retrieval_reference_migrations(conn)
 
 
 def ensure_lifecycle_state_table(conn: sqlite3.Connection) -> None:
@@ -2494,11 +2902,8 @@ def ensure_external_content_fts(
 def run_versioned_migrations(conn: sqlite3.Connection) -> None:
     refuse_schema_version_too_new(conn)
 
-    ensure_metadata_table(conn)
-    ensure_migration_state_table(conn)
-
-    refuse_schema_version_too_new(conn)
-    current_version = get_schema_version(conn)
+    ensure_retrieval_reference_migrations(conn)
+    current_version = read_existing_schema_version(conn)
     if current_version < 2:
         mark_migration_step_complete(conn, "v2_external_content_fts_triggers")
         current_version = 2
@@ -2529,4 +2934,5 @@ def run_versioned_migrations(conn: sqlite3.Connection) -> None:
     # feature materialized lazily by VectorStore (recorded via the named
     # ``embeddings_v1`` marker), so a disabled install stays at v5 with no
     # embedding tables and the numeric counter is free for the temporal train.
-    set_schema_version(conn, current_version)
+    if read_existing_schema_version(conn) != current_version:
+        set_schema_version(conn, current_version)

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -15,6 +15,7 @@ import shutil
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from typing import Iterable, Sequence
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,32 @@ class ExternalContentFtsSpec:
         self.content_rowid = content_rowid
         self.indexed_column = indexed_column
         self.trigger_sqls = tuple(trigger_sqls)
+
+
+def _is_sqlite_lock_error(exc: BaseException) -> bool:
+    """Return True when an exception chain represents SQLite lock contention."""
+    lock_codes = {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}
+    lock_messages = (
+        "database is locked",
+        "database table is locked",
+        "database schema is locked",
+        "database is busy",
+        "database table is busy",
+        "database schema is busy",
+    )
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, sqlite3.Error):
+            error_code = getattr(current, "sqlite_errorcode", None)
+            if isinstance(error_code, int) and (error_code & 0xFF) in lock_codes:
+                return True
+            detail = str(current).lower()
+            if any(message in detail for message in lock_messages):
+                return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def configure_connection(conn: sqlite3.Connection) -> None:
@@ -1798,7 +1825,12 @@ def _fts_needs_rebuild_structural(conn: sqlite3.Connection, spec: ExternalConten
         ).fetchone()[0]
         if int(content_count or 0) != int(fts_count or 0):
             return True
-    except sqlite3.DatabaseError:
+    except sqlite3.DatabaseError as exc:
+        # A busy/locked snapshot is an availability problem, not FTS
+        # corruption. Let the bounded caller transaction report it instead of
+        # turning lock exhaustion into destructive repair.
+        if _is_sqlite_lock_error(exc):
+            raise
         return True
 
     return False
@@ -2306,6 +2338,53 @@ def external_content_fts_needs_repair(conn: sqlite3.Connection, spec: ExternalCo
     return _fts_needs_rebuild_structural(conn, spec) or _fts_missing_triggers(conn, spec)
 
 
+@contextmanager
+def _fts_repair_ownership(conn: sqlite3.Connection):
+    """Own the short FTS structural-repair transaction.
+
+    Fresh startup connections are normally outside a transaction, so
+    ``BEGIN IMMEDIATE`` serializes the structural recheck and all FTS DDL
+    across independent processes. A caller that already owns a transaction
+    gets a savepoint instead; committing that caller-owned transaction remains
+    the historical behavior of the repair helper.
+    """
+    if conn.in_transaction:
+        savepoint = quote_sql_identifier("lcm_fts_repair_ownership")
+        conn.execute(f"SAVEPOINT {savepoint}")
+        try:
+            yield False
+        except BaseException:
+            try:
+                conn.execute(f"ROLLBACK TO {savepoint}")
+            finally:
+                conn.execute(f"RELEASE {savepoint}")
+            raise
+        else:
+            conn.execute(f"RELEASE {savepoint}")
+        return
+
+    previous_timeout = conn.execute("PRAGMA busy_timeout").fetchone()
+    previous_timeout_ms = int(previous_timeout[0]) if previous_timeout else 0
+    conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+    try:
+        # A loser waits for the winner, then takes a current write snapshot and
+        # rechecks the complete FTS state before deciding whether to repair.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield True
+        except BaseException:
+            conn.rollback()
+            raise
+        else:
+            try:
+                conn.commit()
+            except BaseException:
+                conn.rollback()
+                raise
+    finally:
+        conn.execute(f"PRAGMA busy_timeout={previous_timeout_ms}")
+
+
 def repair_external_content_fts(
     conn: sqlite3.Connection,
     spec: ExternalContentFtsSpec,
@@ -2315,51 +2394,92 @@ def repair_external_content_fts(
 ) -> dict[str, bool]:
     rebuilt = False
     degraded = False
-    if _fts_needs_rebuild(conn, spec, now=now, throttle=throttle):
-        db_path = conn.execute("PRAGMA database_list").fetchone()
-        if db_path:
-            db_file = db_path[2]
-            if db_file and not _check_disk_space(db_file):
+    structural_repair_needed = external_content_fts_needs_repair(conn, spec)
+    deep_repair_needed = False
+    if not structural_repair_needed:
+        # Preserve the cheap startup path and its background integrity-scan
+        # behavior. Only a caller that observed repair-worthy state enters the
+        # write-ownership boundary below.
+        deep_repair_needed = _fts_needs_rebuild(conn, spec, now=now, throttle=throttle)
+        if not deep_repair_needed:
+            # A trigger can disappear after the initial complete-state check.
+            # Return on the healthy fast path only while it is still complete;
+            # any observed trigger repair must pass through write ownership below.
+            if not _fts_missing_triggers(conn, spec):
+                _clear_integrity_failed(conn, spec)
+                conn.commit()
+                return {
+                    "rebuilt": False,
+                    "degraded": False,
+                    "triggers_recreated": False,
+                }
+
+    with _fts_repair_ownership(conn) as owns_transaction:
+        # This is the decisive cross-process recheck. If another process won
+        # while we waited, accept its complete table/shadow/trigger state and do
+        # not drop or recreate it.
+        winner_state_needs_repair = external_content_fts_needs_repair(conn, spec)
+        owner_rebuild_needed = (
+            _fts_needs_rebuild_structural(conn, spec) if winner_state_needs_repair else False
+        )
+        if not owner_rebuild_needed and not structural_repair_needed and deep_repair_needed:
+            # Explicit repair (and synchronous startup when background scans are
+            # disabled) must revalidate same-row-count token drift while owning
+            # the write boundary. A repaired winner is accepted without a second
+            # destructive rebuild.
+            owner_rebuild_needed = _fts_needs_rebuild(
+                conn, spec, now=now, throttle=False
+            )
+        if owner_rebuild_needed:
+            db_path = conn.execute("PRAGMA database_list").fetchone()
+            low_disk = False
+            if db_path:
+                db_file = db_path[2]
+                low_disk = bool(db_file and not _check_disk_space(db_file))
+            if low_disk:
                 logger.warning(
                     "Low disk space for FTS rebuild of '%s' (%d MB needed), degrading to LIKE search",
                     spec.table_name,
                     _MIN_DISK_SPACE_BYTES // (1024 * 1024),
                 )
                 _drop_fts_artifacts(conn, spec)
-                # The corrupt index is gone (degraded to LIKE search); a stale
-                # integrity-failed flag would otherwise keep `/lcm doctor`
-                # reporting issues-found for an index that no longer exists.
-                _clear_integrity_failed(conn, spec)
-                conn.commit()
-                return {"rebuilt": False, "degraded": True, "triggers_recreated": False}
-        _drop_fts_table(conn, spec.table_name)
-        conn.execute(
-            f"""
-            CREATE VIRTUAL TABLE {quote_sql_identifier(spec.table_name)} USING fts5(
-                {quote_sql_identifier(spec.indexed_column)},
-                content={quote_sql_identifier(spec.content_table)},
-                content_rowid={quote_sql_identifier(spec.content_rowid)}
-            )
-            """
-        )
-        conn.execute(
-            f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
-        )
-        rebuilt = True
+                degraded = True
+            else:
+                _drop_fts_table(conn, spec.table_name)
+                conn.execute(
+                    f"""
+                    CREATE VIRTUAL TABLE {quote_sql_identifier(spec.table_name)} USING fts5(
+                        {quote_sql_identifier(spec.indexed_column)},
+                        content={quote_sql_identifier(spec.content_table)},
+                        content_rowid={quote_sql_identifier(spec.content_rowid)}
+                    )
+                    """
+                )
+                conn.execute(
+                    f"INSERT INTO {quote_sql_identifier(spec.table_name)}({quote_sql_identifier(spec.table_name)}) VALUES('rebuild')"
+                )
+                rebuilt = True
 
-    triggers_were_missing = _fts_missing_triggers(conn, spec)
-    for trigger_sql in spec.trigger_sqls:
-        conn.execute(trigger_sql)
-    if rebuilt:
-        # A freshly rebuilt index is known-consistent; record the marker so the
-        # next startup can skip the deep integrity-check within the interval.
-        _record_integrity_checked(conn, spec, now=now)
-    # A completed repair resolves any prior background-scan corruption flag: clear
-    # it in the SAME transaction that commits the rebuild so `/lcm doctor` stops
-    # reporting issues-found (and the next self-healing scan is not pushed out a
-    # full interval). Without this an explicit `repair apply` left the flag stuck.
-    _clear_integrity_failed(conn, spec)
-    conn.commit()
+        if degraded:
+            triggers_were_missing = False
+        else:
+            triggers_were_missing = _fts_missing_triggers(conn, spec)
+            for trigger_sql in spec.trigger_sqls:
+                conn.execute(trigger_sql)
+        if rebuilt:
+            # A freshly rebuilt index is known-consistent; record the marker so
+            # the next startup can skip the deep integrity-check within the
+            # interval.
+            _record_integrity_checked(conn, spec, now=now)
+        # A completed repair resolves any prior background-scan corruption flag:
+        # clear it in the SAME transaction that commits the rebuild.
+        _clear_integrity_failed(conn, spec)
+
+    if not owns_transaction:
+        # Preserve the helper's historical behavior for callers that supplied an
+        # already-active transaction while keeping the startup path's ownership
+        # boundary isolated and rollback-safe.
+        conn.commit()
     return {"rebuilt": rebuilt, "degraded": degraded, "triggers_recreated": triggers_were_missing}
 
 

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -348,6 +348,30 @@ The script is intentionally conservative:
 
 This is a local archive migration path. It does not make LCM a general memory provider, and it does not change the current-session retrieval contract for agent tools.
 
+## Message retrieval-reference V1 adapter
+
+The narrow `hermes_lcm.message_references` adapter binds one existing
+`messages.store_id` to a V1 opaque `kind="message"` envelope. It accepts a
+caller-supplied canonical scope and computes a SHA-256 semantic revision over
+normalized session/source/conversation/role/content/tool metadata and the
+finite timestamp. `pinned` and `token_estimate` are operational metadata and do
+not affect the revision.
+
+Use `issue_message_reference(...)` with the trusted host
+`authorization_context`, mandatory `authorize_target` callback, and
+`authorize_issue` callback. Target preauthorization runs before any transaction
+or `messages` lookup, so denied existing and missing IDs are indistinguishable;
+foundation issue authorization then validates the loaded target/revision before
+registry insertion. Use `resolve_message_reference(...)` with both foundation
+authorization callbacks. Resolution authorizes the opaque envelope and stored
+scope before selecting the message row, and verifies the current semantic
+revision in one stable read snapshot. Issuance uses one `BEGIN IMMEDIATE`
+transaction when the caller has no active transaction; caller-owned transactions
+remain rollbackable. The adapter returns only the foundation's closed V1 error
+codes and does not add public tool emission, pagination, session cursors,
+summary-node/sidecar references, principal/tenant policy, signing, or schema
+changes.
+
 ## Related references
 
 - [Embeddings setup — free and local options](./embeddings-setup.md) — provider configuration for the `semantic` / `hybrid` modes

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -262,6 +262,66 @@ Cross-session externalized search remains unsupported. Search the historical
 row first, load the intended session, or recover a known current-session ref
 directly with `lcm_expand`.
 
+## Strong retrieval references V1 foundation
+
+The V1 foundation is additive and intentionally narrower than the existing
+legacy locators. It does not change any public tool schema or emit references
+from tools yet; message, summary-node, sidecar, and cursor adapters are later
+packets.
+
+A migrated database has one canonical UUIDv4 authority in `metadata` under
+`database_uuid`. The `database_uuid_v1` named migration creates it exactly once
+for a fresh or pre-V1 database and fails closed if a completed migration later
+finds a missing or malformed value. The numeric core schema remains v5.
+
+The named `retrieval_references_v1` registry stores only the non-null SHA-256 hex
+digest of a random `rh1_` + 256-bit opaque token. Target, scope, and revision
+bindings are canonical JSON held server-side. V1 kinds are `message`,
+`summary_node`, `externalized_payload`, `source_cursor`, `content_cursor`, and
+`session_cursor`; consistency is `live`, `high_watermark`, or `snapshot`.
+Every issue, resolve, revoke, and explicit-clone operation read-validates both
+named migration markers plus the exact registry schema; an unmarked, orphaned,
+or damaged authority fails closed rather than being adopted or repaired by an
+operation.
+
+The wire envelope is:
+
+```json
+{"v":1,"kind":"message","database_uuid":"...","token":"rh1_..."}
+```
+
+Resolution requires trusted host context and two explicit authorization boundaries. A
+preauthorization callback is invoked after parsing/version validation but before
+the registry row is read, so an unauthenticated or categorically unauthorized
+caller cannot probe target, scope, revision, existence, or replacement content.
+After lookup, a separate scope callback receives only the canonical stored scope
+and must authorize that binding before target or revision JSON is decoded or
+returned. Omitting either callback fails closed. `expected_scope` remains an
+additional trusted-adapter constraint; it is not a substitute for host scope
+authorization. Before stored-scope authorization succeeds, missing, malformed,
+wrong-kind, revoked, and expired registry states are normalized to
+`reference_forbidden`; detailed lifecycle and kind errors are available only
+after the caller is authorized for that scope. Target and revision columns are
+fetched only after those checks. Revocation uses the same two gates and does not
+decode or return target/revision data. Issuance requires a separate trusted
+operation callback over canonical kind, target, scope, and revision before
+registry publication. The caller must not emit the envelope before its
+transaction is durable. Explicit clone rotation requires its own administrative
+callback and is an operator/database-boundary operation, not a user reference
+action. The stable
+strong error codes are `invalid_request`, `reference_invalid`,
+`reference_unsupported_version`, `reference_database_mismatch`,
+`reference_kind_mismatch`, `reference_scope_mismatch`, `reference_forbidden`,
+`reference_not_found`, and `reference_stale`; structured failures retain a
+human-readable `error` field.
+
+Ordinary restart and byte-for-byte restore preserve the authority UUID and
+registry. A replacement database has a different UUID. A raw byte copy remains
+indistinguishable from a restore until an explicit clone operation rotates the
+UUID and atomically revokes copied V1 rows. This foundation does not claim that
+legacy scalar IDs are safe, and it provides no principal/tenant, signing/MAC,
+key-management, target loading, revision adapter, or pagination behavior.
+
 ### lossless-claw/OpenClaw import utility
 
 `hermes-lcm` includes an opt-in operator script for backfilling raw message rows from a lossless-claw/OpenClaw LCM SQLite database into the local hermes-lcm SQLite store:

--- a/message_references.py
+++ b/message_references.py
@@ -1,0 +1,514 @@
+"""Message-row adapter for the V1 opaque retrieval-reference foundation.
+
+This module is intentionally one adapter vertical: it binds a durable
+``messages.store_id`` to a caller-supplied scope and a semantic message
+revision.  It does not add public tools, pagination, cursors, summary-node or
+sidecar references, principals, tenants, or schema migrations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sqlite3
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .message_content import normalize_content_value
+from .retrieval_references import (
+    ReferenceEnvelope,
+    ReferenceError,
+    ReferenceErrorCode,
+    ReferenceRecord,
+    ReferenceResult,
+    canonical_json,
+    issue_reference,
+    resolve_reference,
+)
+
+MESSAGE_REFERENCE_KIND = "message"
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_UNSET = object()
+_MESSAGE_SELECT = (
+    "store_id, session_id, source, conversation_id, role, content, "
+    "tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned"
+)
+
+
+MessageReferenceError = ReferenceError
+
+
+@dataclass(frozen=True)
+class MessageReferenceResult:
+    """Safe message resolution result with the foundation's typed error code."""
+
+    ok: bool
+    message: dict[str, Any] | None = None
+    record: ReferenceRecord | None = None
+    error_code: str | None = None
+    error: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def to_dict(self) -> dict[str, object]:
+        if not self.ok:
+            return {
+                "error_code": self.error_code or ReferenceErrorCode.REFERENCE_INVALID.value,
+                "error": self.error or "message reference resolution failed",
+            }
+        return {"ok": True, "message": self.message}
+
+    def get(self, key: str, default: object = None) -> object:
+        return self.to_dict().get(key, default)
+
+    def __getitem__(self, key: str) -> object:
+        return self.to_dict()[key]
+
+
+class MessageReferenceAdapter:
+    """Connection-bound facade for the message reference adapter."""
+
+    def __init__(self, store_or_connection: object):
+        self._store_or_connection = store_or_connection
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return _connection_for(self._store_or_connection)
+
+    def issue(self, store_id: object, scope: object, **kwargs: object) -> ReferenceEnvelope:
+        return issue_message_reference(self._store_or_connection, store_id, scope, **kwargs)
+
+    def resolve(self, envelope: object, **kwargs: object) -> MessageReferenceResult:
+        return resolve_message_reference(self._store_or_connection, envelope, **kwargs)
+
+
+def _connection_for(store_or_connection: object) -> sqlite3.Connection:
+    if isinstance(store_or_connection, sqlite3.Connection):
+        return store_or_connection
+    connection = getattr(store_or_connection, "connection", None)
+    if isinstance(connection, sqlite3.Connection):
+        return connection
+    raise ReferenceError(
+        ReferenceErrorCode.INVALID_REQUEST,
+        "message reference adapter requires a live SQLite connection",
+    )
+
+
+def _store_lock(store_or_connection: object, *, write: bool):
+    # MessageStore serializes writes to its shared connection with this lock. Use
+    # it when available without making the adapter depend on MessageStore.
+    lock = getattr(store_or_connection, "_write_lock", None) if write else None
+    return lock if lock is not None else nullcontext()
+
+
+@contextmanager
+def _write_transaction(conn: sqlite3.Connection):
+    """Own a writer transaction only when the caller does not already own one."""
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+    except BaseException:
+        if owns_transaction and conn.in_transaction:
+            conn.rollback()
+        raise
+    else:
+        if owns_transaction and conn.in_transaction:
+            conn.commit()
+
+
+@contextmanager
+def _read_snapshot(conn: sqlite3.Connection):
+    """Pin a read snapshot while preserving any caller-owned transaction."""
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        # An explicit deferred BEGIN is required: sqlite3 does not begin a
+        # transaction for a SELECT under its default isolation behavior.
+        conn.execute("BEGIN")
+    try:
+        yield
+    except BaseException:
+        if owns_transaction and conn.in_transaction:
+            conn.rollback()
+        raise
+    else:
+        if owns_transaction and conn.in_transaction:
+            conn.commit()
+
+
+def _positive_store_id(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            "message reference store_id must be a positive integer",
+        )
+    return value
+
+
+def _normalize_source(value: object) -> str:
+    normalized = "" if value is None else str(value).strip()
+    return normalized or "unknown"
+
+
+def _normalize_conversation_id(value: object) -> str:
+    return ("" if value is None else str(value)).strip()
+
+
+def _reject_nonfinite_json(value: str) -> object:
+    raise ValueError(f"non-finite JSON constant: {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _semantic_tool_calls(value: object) -> object:
+    """Parse every valid JSON value, retaining invalid/ambiguous raw strings."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(
+            value,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return value
+
+
+def _finite_timestamp(value: object) -> float:
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message row has an invalid timestamp",
+        ) from exc
+    if not math.isfinite(timestamp):
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message row has an invalid timestamp",
+        )
+    return timestamp
+
+
+def _row_mapping(row: sqlite3.Row | tuple[object, ...]) -> dict[str, Any]:
+    values = dict(zip(
+        (
+            "store_id",
+            "session_id",
+            "source",
+            "conversation_id",
+            "role",
+            "content",
+            "tool_call_id",
+            "tool_calls",
+            "tool_name",
+            "timestamp",
+            "token_estimate",
+            "pinned",
+        ),
+        tuple(row),
+    ))
+    values["source"] = _normalize_source(values.get("source"))
+    values["conversation_id"] = _normalize_conversation_id(values.get("conversation_id"))
+    values["content"] = normalize_content_value(values.get("content"))
+    values["tool_calls"] = _semantic_tool_calls(values.get("tool_calls"))
+    return values
+
+
+def _load_message(conn: sqlite3.Connection, store_id: int) -> dict[str, Any] | None:
+    row = conn.execute(
+        f"SELECT {_MESSAGE_SELECT} FROM messages WHERE store_id = ?",
+        (store_id,),
+    ).fetchone()
+    return _row_mapping(row) if row is not None else None
+
+
+def message_revision_preimage(message: Mapping[str, object]) -> dict[str, object]:
+    """Return the exact normalized object hashed by :func:`message_revision`."""
+    try:
+        timestamp = _finite_timestamp(message.get("timestamp"))
+    except AttributeError as exc:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message row is not a mapping",
+        ) from exc
+    normalized = {
+        "session_id": message.get("session_id"),
+        "source": _normalize_source(message.get("source")),
+        "conversation_id": _normalize_conversation_id(message.get("conversation_id")),
+        "role": message.get("role"),
+        "content": normalize_content_value(message.get("content")),
+        "tool_call_id": message.get("tool_call_id"),
+        "tool_calls": _semantic_tool_calls(message.get("tool_calls")),
+        "tool_name": message.get("tool_name"),
+        "timestamp": timestamp,
+    }
+    try:
+        canonical_json(normalized)
+    except ReferenceError as exc:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message row contains values that are not canonical JSON",
+        ) from exc
+    return normalized
+
+
+def message_revision(message: Mapping[str, object]) -> dict[str, str]:
+    """Compute the frozen SHA-256 semantic revision for one message row."""
+    preimage = message_revision_preimage(message)
+    digest = hashlib.sha256(canonical_json(preimage).encode("utf-8")).hexdigest()
+    return {"algorithm": "sha256", "semantic_digest": digest}
+
+
+# Explicit aliases make the adapter's semantic operation discoverable without
+# creating a second revision algorithm or public integration surface.
+compute_message_revision = message_revision
+message_semantic_revision = message_revision
+semantic_message_revision = message_revision
+
+
+def _message_target(record_target: object) -> int:
+    if (
+        not isinstance(record_target, Mapping)
+        or set(record_target) != {"store_id"}
+        or isinstance(record_target.get("store_id"), bool)
+        or not isinstance(record_target.get("store_id"), int)
+        or record_target.get("store_id") <= 0
+    ):
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message reference target is malformed",
+        )
+    return int(record_target["store_id"])
+
+
+def _message_revision(record_revision: object) -> dict[str, str]:
+    if not isinstance(record_revision, Mapping) or set(record_revision) != {
+        "algorithm",
+        "semantic_digest",
+    }:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message reference revision is malformed",
+        )
+    if record_revision.get("algorithm") != "sha256":
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message reference revision is malformed",
+        )
+    digest = record_revision.get("semantic_digest")
+    if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "message reference revision is malformed",
+        )
+    return {"algorithm": "sha256", "semantic_digest": digest}
+
+
+def _result_failure(code: ReferenceErrorCode | str, error: str) -> MessageReferenceResult:
+    return MessageReferenceResult(
+        ok=False,
+        error_code=ReferenceErrorCode(code).value,
+        error=str(error),
+    )
+
+
+def _foundation_failure(result: ReferenceResult) -> MessageReferenceResult:
+    return _result_failure(
+        result.error_code or ReferenceErrorCode.REFERENCE_INVALID.value,
+        result.error or "reference resolution failed",
+    )
+
+
+def _authorize_message_target(
+    authorization_context: object,
+    store_id: int,
+    scope: object,
+    authorize_target,
+) -> None:
+    try:
+        allowed = authorize_target is not None and bool(
+            authorize_target(authorization_context, store_id, scope)
+        )
+    except Exception:
+        allowed = False
+    if not allowed:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "message reference issuance is not authorized by the host",
+        )
+
+
+def issue_message_reference(
+    store_or_connection: object,
+    store_id: object,
+    scope: object,
+    *,
+    authorization_context: object = None,
+    authorize_target=None,
+    authorize_issue=None,
+    consistency: str = "live",
+    issued_at: float | None = None,
+    expires_at: float | None = None,
+) -> ReferenceEnvelope:
+    """Issue a ``kind=message`` reference for an existing message row.
+
+    Target preauthorization runs before any transaction or message lookup. The
+    row read, semantic digest, foundation authorization, and registry savepoint
+    then run inside one adapter-owned ``BEGIN IMMEDIATE`` or the caller's
+    already-active transaction.
+    """
+    store_id = _positive_store_id(store_id)
+    _authorize_message_target(
+        authorization_context,
+        store_id,
+        scope,
+        authorize_target,
+    )
+    conn = _connection_for(store_or_connection)
+    with _store_lock(store_or_connection, write=True):
+        with _write_transaction(conn):
+            message = _load_message(conn, store_id)
+            if message is None:
+                raise ReferenceError(
+                    ReferenceErrorCode.REFERENCE_NOT_FOUND,
+                    "message was not found",
+                )
+            revision = message_revision(message)
+            return issue_reference(
+                conn,
+                MESSAGE_REFERENCE_KIND,
+                {"store_id": store_id},
+                scope,
+                revision,
+                authorization_context=authorization_context,
+                authorize_issue=authorize_issue,
+                consistency=consistency,
+                issued_at=issued_at,
+                expires_at=expires_at,
+            )
+
+
+def resolve_message_reference(
+    store_or_connection: object,
+    envelope: object,
+    *,
+    authorization_context: object = None,
+    authorize=None,
+    authorize_scope=None,
+    expected_scope: object = _UNSET,
+    now: float | None = None,
+) -> MessageReferenceResult:
+    """Resolve and hydrate one message after both foundation authorization gates."""
+    conn = _connection_for(store_or_connection)
+    with _store_lock(store_or_connection, write=True):
+        with _read_snapshot(conn):
+            try:
+                kwargs: dict[str, object] = {
+                    "authorization_context": authorization_context,
+                    "authorize": authorize,
+                    "authorize_scope": authorize_scope,
+                    "expected_kind": MESSAGE_REFERENCE_KIND,
+                    "now": now,
+                }
+                if expected_scope is not _UNSET:
+                    kwargs["expected_scope"] = expected_scope
+                foundation = resolve_reference(conn, envelope, **kwargs)
+            except sqlite3.DatabaseError:
+                return _result_failure(
+                    ReferenceErrorCode.REFERENCE_INVALID,
+                    "reference resolution failed",
+                )
+            if not foundation.ok:
+                return _foundation_failure(foundation)
+            if foundation.record is None:
+                return _result_failure(
+                    ReferenceErrorCode.REFERENCE_INVALID,
+                    "reference resolution returned no binding",
+                )
+            try:
+                store_id = _message_target(foundation.record.target)
+                stored_revision = _message_revision(foundation.record.revision)
+            except ReferenceError as exc:
+                return _result_failure(exc.code, exc.error)
+
+            try:
+                message = _load_message(conn, store_id)
+            except sqlite3.DatabaseError:
+                return _result_failure(
+                    ReferenceErrorCode.REFERENCE_INVALID,
+                    "message lookup failed",
+                )
+            if message is None:
+                return _result_failure(
+                    ReferenceErrorCode.REFERENCE_NOT_FOUND,
+                    "message was not found",
+                )
+            try:
+                current_revision = message_revision(message)
+            except ReferenceError as exc:
+                return _result_failure(exc.code, exc.error)
+            if current_revision != stored_revision:
+                return _result_failure(
+                    ReferenceErrorCode.REFERENCE_STALE,
+                    "message reference is stale",
+                )
+            return MessageReferenceResult(
+                ok=True,
+                message=message,
+                record=foundation.record,
+            )
+
+
+def resolve_message_reference_or_raise(
+    store_or_connection: object,
+    envelope: object,
+    **kwargs: object,
+) -> dict[str, Any]:
+    result = resolve_message_reference(store_or_connection, envelope, **kwargs)
+    if not result.ok:
+        raise ReferenceError(
+            result.error_code or ReferenceErrorCode.REFERENCE_INVALID.value,
+            result.error or "message reference resolution failed",
+        )
+    assert result.message is not None
+    return result.message
+
+
+# Noun-order aliases for callers that use the retrieval-reference terminology.
+issue_message_retrieval_reference = issue_message_reference
+resolve_message_retrieval_reference = resolve_message_reference
+resolve_message_retrieval_reference_or_raise = resolve_message_reference_or_raise
+
+
+__all__ = [
+    "MESSAGE_REFERENCE_KIND",
+    "MessageReferenceAdapter",
+    "MessageReferenceError",
+    "MessageReferenceResult",
+    "compute_message_revision",
+    "issue_message_reference",
+    "issue_message_retrieval_reference",
+    "message_revision",
+    "message_revision_preimage",
+    "message_semantic_revision",
+    "resolve_message_reference",
+    "resolve_message_reference_or_raise",
+    "resolve_message_retrieval_reference",
+    "resolve_message_retrieval_reference_or_raise",
+    "semantic_message_revision",
+]

--- a/retrieval_references.py
+++ b/retrieval_references.py
@@ -1,0 +1,908 @@
+"""V1 opaque retrieval-reference foundation.
+
+This module deliberately stops at the durable reference registry.  It does not
+load messages, DAG nodes, sidecars, cursors, principals, or tenants.  A caller
+supplies a trusted host authorization context and, after successful resolution,
+may hand the server-side binding to a later target adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import secrets
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Mapping
+
+from .db_bootstrap import (
+    DATABASE_UUID_MIGRATION,
+    RETRIEVAL_REFERENCE_CONSISTENCIES,
+    RETRIEVAL_REFERENCE_KINDS,
+    RETRIEVAL_REFERENCES_TABLE,
+    DatabaseIdentityError,
+    RetrievalReferenceSchemaError,
+    get_retrieval_reference_authority,
+    rotate_database_uuid,
+)
+
+TOKEN_PREFIX = "rh1_"
+_TOKEN_RE = re.compile(r"^rh1_[0-9a-f]{64}$")
+_UNSET = object()
+
+
+class ReferenceErrorCode(str, Enum):
+    """Closed V1 error vocabulary shared by strong-reference paths."""
+
+    INVALID_REQUEST = "invalid_request"
+    REFERENCE_INVALID = "reference_invalid"
+    REFERENCE_UNSUPPORTED_VERSION = "reference_unsupported_version"
+    REFERENCE_DATABASE_MISMATCH = "reference_database_mismatch"
+    REFERENCE_KIND_MISMATCH = "reference_kind_mismatch"
+    REFERENCE_SCOPE_MISMATCH = "reference_scope_mismatch"
+    REFERENCE_FORBIDDEN = "reference_forbidden"
+    REFERENCE_NOT_FOUND = "reference_not_found"
+    REFERENCE_STALE = "reference_stale"
+
+
+class ReferenceKind(str, Enum):
+    MESSAGE = "message"
+    SUMMARY_NODE = "summary_node"
+    EXTERNALIZED_PAYLOAD = "externalized_payload"
+    SOURCE_CURSOR = "source_cursor"
+    CONTENT_CURSOR = "content_cursor"
+    SESSION_CURSOR = "session_cursor"
+
+
+class ReferenceConsistency(str, Enum):
+    LIVE = "live"
+    HIGH_WATERMARK = "high_watermark"
+    SNAPSHOT = "snapshot"
+
+
+class ReferenceError(ValueError):
+    """Typed strong-reference failure with a stable code and human message."""
+
+    def __init__(self, code: ReferenceErrorCode | str, error: str):
+        self.code = ReferenceErrorCode(code)
+        self.error = str(error)
+        super().__init__(self.error)
+
+    @property
+    def error_code(self) -> str:
+        return self.code.value
+
+    def as_dict(self) -> dict[str, object]:
+        return {"error_code": self.error_code, "error": self.error}
+
+
+@dataclass(frozen=True)
+class ReferenceEnvelope:
+    """The complete V1 wire value; target, scope, and revision stay server-side."""
+
+    kind: str
+    database_uuid: str
+    token: str
+    v: int = 1
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "v": self.v,
+            "kind": self.kind,
+            "database_uuid": self.database_uuid,
+            "token": self.token,
+        }
+
+    def to_json(self) -> str:
+        return canonical_json(self.to_dict())
+
+    def __getitem__(self, key: str) -> object:
+        return self.to_dict()[key]
+
+
+@dataclass(frozen=True)
+class ReferenceRecord:
+    """Validated server-side registry binding returned after authorization."""
+
+    token_digest: str
+    kind: str
+    target: object
+    scope: object
+    revision: object
+    consistency: str
+    issued_at: float
+    expires_at: float | None
+    revoked_at: float | None
+
+    @property
+    def target_json(self) -> str:
+        return canonical_json(self.target)
+
+    @property
+    def scope_json(self) -> str:
+        return canonical_json(self.scope)
+
+    @property
+    def revision_json(self) -> str:
+        return canonical_json(self.revision)
+
+
+@dataclass(frozen=True)
+class ReferenceResult:
+    """Structured resolution/mutation result retaining a human-readable error."""
+
+    ok: bool
+    record: ReferenceRecord | None = None
+    error_code: str | None = None
+    error: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def to_dict(self) -> dict[str, object]:
+        if not self.ok:
+            return {
+                "error_code": self.error_code or ReferenceErrorCode.REFERENCE_INVALID.value,
+                "error": self.error or "reference operation failed",
+            }
+        if self.record is None:
+            return {"ok": True}
+        return {
+            "ok": True,
+            "kind": self.record.kind,
+            "target": self.record.target,
+            "scope": self.record.scope,
+            "revision": self.record.revision,
+            "consistency": self.record.consistency,
+            "issued_at": self.record.issued_at,
+            "expires_at": self.record.expires_at,
+        }
+
+    def get(self, key: str, default: object = None) -> object:
+        return self.to_dict().get(key, default)
+
+    def __getitem__(self, key: str) -> object:
+        return self.to_dict()[key]
+
+
+@dataclass(frozen=True)
+class AuthorizationRequest:
+    """Callback input containing only trusted context and the opaque envelope."""
+
+    trusted_context: object
+    envelope: ReferenceEnvelope
+
+
+AuthorizationCallback = Callable[[object, ReferenceEnvelope], bool]
+ScopeAuthorizationCallback = Callable[[object, ReferenceEnvelope, object], bool]
+IssueAuthorizationCallback = Callable[[object, str, object, object, object], bool]
+
+
+def canonical_json(value: object) -> str:
+    """Serialize JSON with one deterministic V1 representation."""
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            "reference binding contains values that are not canonical JSON",
+        ) from exc
+
+
+def _json_object_without_duplicate_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope contains a duplicate JSON key",
+            )
+        result[key] = value
+    return result
+
+
+def _canonical_uuid4(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return parsed.version == 4 and str(parsed) == value
+
+
+def _coerce_kind(value: object) -> str:
+    kind = value.value if isinstance(value, Enum) else value
+    if not isinstance(kind, str) or kind not in RETRIEVAL_REFERENCE_KINDS:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            "reference kind is not supported by V1",
+        )
+    return kind
+
+
+def _coerce_consistency(value: object) -> str:
+    consistency = value.value if isinstance(value, Enum) else value
+    if not isinstance(consistency, str) or consistency not in RETRIEVAL_REFERENCE_CONSISTENCIES:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            "reference consistency is not supported by V1",
+        )
+    return consistency
+
+
+def generate_reference_token() -> str:
+    """Return a random 256-bit V1 wire token; only its digest is persisted."""
+    return TOKEN_PREFIX + secrets.token_bytes(32).hex()
+
+
+def reference_token_digest(token: str) -> str:
+    if not isinstance(token, str) or _TOKEN_RE.fullmatch(token) is None:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_INVALID,
+            "reference token is malformed",
+        )
+    return hashlib.sha256(token.encode("ascii")).hexdigest()
+
+
+def encode_reference_envelope(
+    *, kind: str, database_uuid: str, token: str
+) -> ReferenceEnvelope:
+    kind = _coerce_kind(kind)
+    if not _canonical_uuid4(database_uuid):
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_INVALID,
+            "reference database_uuid is malformed",
+        )
+    reference_token_digest(token)
+    return ReferenceEnvelope(kind=kind, database_uuid=database_uuid, token=token)
+
+
+def encode_envelope(*, kind: str, database_uuid: str, token: str) -> dict[str, object]:
+    """Return the JSON-object form used by additive strong-reference fields."""
+    return encode_reference_envelope(
+        kind=kind, database_uuid=database_uuid, token=token
+    ).to_dict()
+
+
+def serialize_reference_envelope(envelope: ReferenceEnvelope | Mapping[str, object]) -> str:
+    return decode_reference_envelope(envelope).to_json()
+
+
+def decode_reference_envelope(value: object) -> ReferenceEnvelope:
+    if isinstance(value, ReferenceEnvelope):
+        if not isinstance(value.v, int) or isinstance(value.v, bool) or value.v != 1:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_UNSUPPORTED_VERSION,
+                "reference envelope version is not supported",
+            )
+        try:
+            envelope = encode_reference_envelope(
+                kind=value.kind,
+                database_uuid=value.database_uuid,
+                token=value.token,
+            )
+        except ReferenceError as exc:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope contains an invalid binding",
+            ) from exc
+    else:
+        parsed: object = value
+        if isinstance(value, (str, bytes, bytearray)):
+            try:
+                parsed = json.loads(
+                    value,
+                    object_pairs_hook=_json_object_without_duplicate_keys,
+                )
+            except ReferenceError:
+                raise
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise ReferenceError(
+                    ReferenceErrorCode.REFERENCE_INVALID,
+                    "reference envelope is not valid JSON",
+                ) from exc
+        if not isinstance(parsed, Mapping):
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope must be a JSON object",
+            )
+        required = {"v", "kind", "database_uuid", "token"}
+        if set(parsed) != required:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope has an invalid shape",
+            )
+        version = parsed.get("v")
+        if not isinstance(version, int) or isinstance(version, bool) or version != 1:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_UNSUPPORTED_VERSION,
+                "reference envelope version is not supported",
+            )
+        try:
+            envelope = encode_reference_envelope(
+                kind=parsed["kind"],
+                database_uuid=parsed["database_uuid"],
+                token=parsed["token"],
+            )
+        except KeyError as exc:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope is missing a required field",
+            ) from exc
+        except ReferenceError as exc:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference envelope contains an invalid binding",
+            ) from exc
+    if envelope.v != 1:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_UNSUPPORTED_VERSION,
+            "reference envelope version is not supported",
+        )
+    return envelope
+
+
+# Concise aliases for callers that use the contract's noun rather than the
+# implementation's longer function names.
+decode_envelope = decode_reference_envelope
+serialize_envelope = serialize_reference_envelope
+
+
+@contextmanager
+def _registry_write_transaction(conn):
+    savepoint = "lcm_retrieval_reference_write"
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    else:
+        conn.execute(f'SAVEPOINT "{savepoint}"')
+    try:
+        yield
+    except BaseException:
+        if owns_transaction:
+            conn.rollback()
+        else:
+            try:
+                conn.execute(f'ROLLBACK TO "{savepoint}"')
+            finally:
+                conn.execute(f'RELEASE "{savepoint}"')
+        raise
+    else:
+        if owns_transaction:
+            conn.commit()
+        else:
+            conn.execute(f'RELEASE "{savepoint}"')
+
+
+def _finite_time(value: object, field: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            f"{field} must be a finite timestamp",
+        ) from exc
+    if not math.isfinite(result):
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            f"{field} must be a finite timestamp",
+        )
+    return result
+
+
+def issue_reference(
+    conn,
+    kind: str,
+    target: object,
+    scope: object,
+    revision: object,
+    *,
+    authorization_context: object = None,
+    authorize_issue: IssueAuthorizationCallback | None = None,
+    consistency: str = "live",
+    issued_at: float | None = None,
+    expires_at: float | None = None,
+) -> ReferenceEnvelope:
+    """Persist one server-side binding and return its opaque V1 envelope."""
+    kind = _coerce_kind(kind)
+    consistency = _coerce_consistency(consistency)
+    target_json = canonical_json(target)
+    scope_json = canonical_json(scope)
+    revision_json = canonical_json(revision)
+    if authorize_issue is None or authorization_context is None:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference issuance is not authorized by the host",
+        )
+    try:
+        issue_allowed = bool(
+            authorize_issue(
+                authorization_context,
+                kind,
+                json.loads(target_json),
+                json.loads(scope_json),
+                json.loads(revision_json),
+            )
+        )
+    except Exception:
+        issue_allowed = False
+    if not issue_allowed:
+        raise ReferenceError(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference issuance is not authorized by the host",
+        )
+    issued = _finite_time(time.time() if issued_at is None else issued_at, "issued_at")
+    expires = None if expires_at is None else _finite_time(expires_at, "expires_at")
+    if expires is not None and expires < issued:
+        raise ReferenceError(
+            ReferenceErrorCode.INVALID_REQUEST,
+            "expires_at cannot precede issued_at",
+        )
+
+    token = generate_reference_token()
+    digest = reference_token_digest(token)
+    with _registry_write_transaction(conn):
+        # Identity, migration provenance, and registry publication share one
+        # writer snapshot so clone rotation cannot leave a live row paired with
+        # an envelope for the old database authority.
+        database_uuid = get_retrieval_reference_authority(conn)
+        conn.execute(
+            f"""
+            INSERT INTO {RETRIEVAL_REFERENCES_TABLE}(
+                token_digest, kind, target_json, scope_json, revision_json,
+                consistency, issued_at, expires_at, revoked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                digest,
+                kind,
+                target_json,
+                scope_json,
+                revision_json,
+                consistency,
+                issued,
+                expires,
+            ),
+        )
+    return encode_reference_envelope(
+        kind=kind, database_uuid=database_uuid, token=token
+    )
+
+
+def _failure(code: ReferenceErrorCode | str, message: str) -> ReferenceResult:
+    return ReferenceResult(False, error_code=ReferenceErrorCode(code).value, error=message)
+
+
+def _safe_decode(value: object) -> tuple[ReferenceEnvelope | None, ReferenceResult | None]:
+    try:
+        return decode_reference_envelope(value), None
+    except ReferenceError as exc:
+        return None, _failure(exc.code, exc.error)
+
+
+def _authorize(
+    envelope: ReferenceEnvelope,
+    *,
+    authorization_context: object,
+    authorize: AuthorizationCallback | None,
+) -> ReferenceResult | None:
+    """Run host authorization before any registry SELECT or binding disclosure."""
+    if authorize is None or authorization_context is None:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference use is not authorized by the host",
+        )
+    request = AuthorizationRequest(authorization_context, envelope)
+    try:
+        allowed = bool(authorize(request.trusted_context, request.envelope))
+    except Exception:
+        allowed = False
+    if not allowed:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference use is not authorized by the host",
+        )
+    return None
+
+
+def _authorize_scope(
+    envelope: ReferenceEnvelope,
+    scope: object,
+    *,
+    authorization_context: object,
+    authorize_scope: ScopeAuthorizationCallback | None,
+) -> ReferenceResult | None:
+    """Authorize the stored scope before target or revision data is decoded."""
+    if authorize_scope is None:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference scope is not authorized by the host",
+        )
+    try:
+        allowed = bool(authorize_scope(authorization_context, envelope, scope))
+    except Exception:
+        allowed = False
+    if not allowed:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference scope is not authorized by the host",
+        )
+    return None
+
+
+def resolve_reference(
+    conn,
+    envelope: object,
+    *,
+    authorization_context: object = None,
+    authorize: AuthorizationCallback | None = None,
+    authorize_scope: ScopeAuthorizationCallback | None = None,
+    expected_kind: str | None = None,
+    expected_scope: object = _UNSET,
+    now: float | None = None,
+) -> ReferenceResult:
+    """Validate a reference in contract order and return its server-side binding.
+
+    The preauthorization callback receives only trusted context and the parsed
+    opaque envelope before any registry SELECT. After lookup, the scope callback
+    receives only the canonical stored scope; it must authorize that binding
+    before target or revision data is decoded or returned.
+    """
+    parsed, failure = _safe_decode(envelope)
+    if failure is not None:
+        return failure
+    assert parsed is not None
+
+    denied = _authorize(
+        parsed,
+        authorization_context=authorization_context,
+        authorize=authorize,
+    )
+    if denied is not None:
+        return denied
+
+    try:
+        database_uuid = get_retrieval_reference_authority(conn)
+    except (DatabaseIdentityError, RetrievalReferenceSchemaError):
+        return _failure(
+            ReferenceErrorCode.REFERENCE_INVALID,
+            "reference authority identity is unavailable",
+        )
+    if parsed.database_uuid != database_uuid:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_DATABASE_MISMATCH,
+            "reference belongs to a different database authority",
+        )
+
+    digest = reference_token_digest(parsed.token)
+    row = conn.execute(
+        f"""
+        SELECT token_digest, kind, scope_json, consistency,
+               issued_at, expires_at, revoked_at
+        FROM {RETRIEVAL_REFERENCES_TABLE}
+        WHERE token_digest = ?
+        """,
+        (digest,),
+    ).fetchone()
+    if row is None:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference scope is not authorized by the host",
+        )
+
+    try:
+        scope_json = str(row[2])
+        authorization_scope = json.loads(scope_json)
+        if canonical_json(authorization_scope) != scope_json:
+            raise ValueError("non-canonical registry JSON")
+    except (TypeError, ValueError, json.JSONDecodeError, ReferenceError):
+        return _failure(
+            ReferenceErrorCode.REFERENCE_FORBIDDEN,
+            "reference scope is not authorized by the host",
+        )
+
+    scope_denied = _authorize_scope(
+        parsed,
+        authorization_scope,
+        authorization_context=authorization_context,
+        authorize_scope=authorize_scope,
+    )
+    if scope_denied is not None:
+        return scope_denied
+
+    if str(row[1]) != parsed.kind:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_KIND_MISMATCH,
+            "reference kind does not match its registry binding",
+        )
+
+    try:
+        current = _finite_time(time.time() if now is None else now, "now")
+    except ReferenceError as exc:
+        return _failure(exc.code, exc.error)
+    try:
+        issued_at = _finite_time(row[4], "issued_at")
+        expires_at = (
+            None if row[5] is None else _finite_time(row[5], "expires_at")
+        )
+        if expires_at is not None and expires_at < issued_at:
+            raise ReferenceError(
+                ReferenceErrorCode.REFERENCE_STALE,
+                "reference binding is no longer valid",
+            )
+    except ReferenceError:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "reference binding is no longer valid",
+        )
+    if row[6] is not None:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_NOT_FOUND,
+            "reference was not found",
+        )
+    if expires_at is not None and current >= expires_at:
+        return _failure(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "reference has expired",
+        )
+
+    if expected_kind is not None:
+        try:
+            expected = _coerce_kind(expected_kind)
+        except ReferenceError as exc:
+            return _failure(exc.code, exc.error)
+        if str(row[1]) != expected:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_KIND_MISMATCH,
+                "reference kind does not match the requested adapter kind",
+            )
+
+    if expected_scope is not _UNSET:
+        try:
+            expected_scope_json = canonical_json(expected_scope)
+        except ReferenceError as exc:
+            return _failure(exc.code, exc.error)
+        if scope_json != expected_scope_json:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_SCOPE_MISMATCH,
+                "reference scope does not match the requested scope",
+            )
+
+    try:
+        binding = conn.execute(
+            f"""
+            SELECT target_json, revision_json
+            FROM {RETRIEVAL_REFERENCES_TABLE}
+            WHERE token_digest = ?
+            """,
+            (digest,),
+        ).fetchone()
+        if binding is None:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_NOT_FOUND,
+                "reference was not found",
+            )
+        target = json.loads(str(binding[0]))
+        scope = json.loads(scope_json)
+        revision = json.loads(str(binding[1]))
+        if (
+            canonical_json(target) != str(binding[0])
+            or canonical_json(revision) != str(binding[1])
+        ):
+            raise ValueError("non-canonical registry JSON")
+    except (TypeError, ValueError, json.JSONDecodeError, ReferenceError):
+        return _failure(
+            ReferenceErrorCode.REFERENCE_STALE,
+            "reference binding is no longer valid",
+        )
+
+    return ReferenceResult(
+        True,
+        record=ReferenceRecord(
+            token_digest=str(row[0]),
+            kind=str(row[1]),
+            target=target,
+            scope=scope,
+            revision=revision,
+            consistency=str(row[3]),
+            issued_at=issued_at,
+            expires_at=expires_at,
+            revoked_at=None,
+        ),
+    )
+
+
+def resolve_reference_or_raise(conn, envelope: object, **kwargs: object) -> ReferenceRecord:
+    result = resolve_reference(conn, envelope, **kwargs)
+    if not result.ok:
+        raise ReferenceError(
+            result.error_code or ReferenceErrorCode.REFERENCE_INVALID.value,
+            result.error or "reference resolution failed",
+        )
+    assert result.record is not None
+    return result.record
+
+
+def revoke_reference(
+    conn,
+    envelope: object,
+    *,
+    authorization_context: object = None,
+    authorize: AuthorizationCallback | None = None,
+    authorize_scope: ScopeAuthorizationCallback | None = None,
+    revoked_at: float | None = None,
+) -> ReferenceResult:
+    """Authorize and revoke a V1 row without exposing its target or revision."""
+    parsed, failure = _safe_decode(envelope)
+    if failure is not None:
+        return failure
+    assert parsed is not None
+
+    denied = _authorize(
+        parsed,
+        authorization_context=authorization_context,
+        authorize=authorize,
+    )
+    if denied is not None:
+        return denied
+
+    try:
+        timestamp = _finite_time(
+            time.time() if revoked_at is None else revoked_at, "revoked_at"
+        )
+    except ReferenceError as exc:
+        return _failure(exc.code, exc.error)
+    digest = reference_token_digest(parsed.token)
+    with _registry_write_transaction(conn):
+        try:
+            database_uuid = get_retrieval_reference_authority(conn)
+        except (DatabaseIdentityError, RetrievalReferenceSchemaError):
+            return _failure(
+                ReferenceErrorCode.REFERENCE_INVALID,
+                "reference authority identity is unavailable",
+            )
+        if parsed.database_uuid != database_uuid:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_DATABASE_MISMATCH,
+                "reference belongs to a different database authority",
+            )
+        row = conn.execute(
+            f"""
+            SELECT kind, scope_json, revoked_at
+            FROM {RETRIEVAL_REFERENCES_TABLE}
+            WHERE token_digest = ?
+            """,
+            (digest,),
+        ).fetchone()
+        if row is None:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_FORBIDDEN,
+                "reference scope is not authorized by the host",
+            )
+        try:
+            scope = json.loads(str(row[1]))
+            if canonical_json(scope) != str(row[1]):
+                raise ValueError("non-canonical registry JSON")
+        except (TypeError, ValueError, json.JSONDecodeError, ReferenceError):
+            return _failure(
+                ReferenceErrorCode.REFERENCE_FORBIDDEN,
+                "reference scope is not authorized by the host",
+            )
+        scope_denied = _authorize_scope(
+            parsed,
+            scope,
+            authorization_context=authorization_context,
+            authorize_scope=authorize_scope,
+        )
+        if scope_denied is not None:
+            return scope_denied
+        if row[2] is not None:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_NOT_FOUND,
+                "reference was not found",
+            )
+        if str(row[0]) != parsed.kind:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_KIND_MISMATCH,
+                "reference kind does not match its registry binding",
+            )
+        cursor = conn.execute(
+            f"""
+            UPDATE {RETRIEVAL_REFERENCES_TABLE}
+            SET revoked_at = ?
+            WHERE token_digest = ? AND revoked_at IS NULL
+            """,
+            (timestamp, digest),
+        )
+        if cursor.rowcount != 1:
+            return _failure(
+                ReferenceErrorCode.REFERENCE_NOT_FOUND,
+                "reference was not found",
+            )
+    return ReferenceResult(True)
+
+
+def rotate_explicit_clone(conn, **kwargs: object) -> str:
+    """Explicit clone boundary: rotate UUID and revoke copied references atomically."""
+    return rotate_database_uuid(conn, **kwargs)
+
+
+# Public aliases used by callers that name the operation as a clone rather than
+# as a database-UUID rotation.
+rotate_clone = rotate_explicit_clone
+rotate_database_identity = rotate_explicit_clone
+
+
+# Public aliases used by callers that name the operation as a retrieval rather
+# than as a registry implementation detail.
+issue_retrieval_reference = issue_reference
+resolve_retrieval_reference = resolve_reference
+revoke_retrieval_reference = revoke_reference
+
+
+class ReferenceRegistry:
+    """Small connection-bound facade for the V1 primitives."""
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def issue(self, kind: str, target: object, scope: object, revision: object, **kwargs: object) -> ReferenceEnvelope:
+        return issue_reference(self.conn, kind, target, scope, revision, **kwargs)
+
+    def resolve(self, envelope: object, **kwargs: object) -> ReferenceResult:
+        return resolve_reference(self.conn, envelope, **kwargs)
+
+    def revoke(self, envelope: object, **kwargs: object) -> ReferenceResult:
+        return revoke_reference(self.conn, envelope, **kwargs)
+
+    def rotate_clone(self, **kwargs: object) -> str:
+        return rotate_explicit_clone(self.conn, **kwargs)
+
+
+__all__ = [
+    "AuthorizationCallback",
+    "AuthorizationRequest",
+    "DatabaseIdentityError",
+    "DATABASE_UUID_MIGRATION",
+    "IssueAuthorizationCallback",
+    "ReferenceEnvelope",
+    "ReferenceError",
+    "ReferenceErrorCode",
+    "ReferenceKind",
+    "ReferenceConsistency",
+    "ReferenceRecord",
+    "ReferenceRegistry",
+    "ReferenceResult",
+    "ScopeAuthorizationCallback",
+    "canonical_json",
+    "decode_envelope",
+    "decode_reference_envelope",
+    "encode_envelope",
+    "encode_reference_envelope",
+    "generate_reference_token",
+    "issue_reference",
+    "issue_retrieval_reference",
+    "reference_token_digest",
+    "resolve_reference",
+    "resolve_retrieval_reference",
+    "resolve_reference_or_raise",
+    "revoke_reference",
+    "revoke_retrieval_reference",
+    "rotate_clone",
+    "rotate_database_identity",
+    "rotate_explicit_clone",
+    "serialize_envelope",
+    "serialize_reference_envelope",
+]

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -12,12 +12,25 @@ subsequent startups of an existing, structurally-sound index. The tests build
 the index first, then exercise the existing-index path.
 """
 
+import json
+import multiprocessing as mp
 import sqlite3
+import subprocess
+import sys
 import threading
 import time
+import traceback
 import types
+from pathlib import Path
 
 import pytest
+
+
+if "hermes_lcm" not in sys.modules:
+    package = types.ModuleType("hermes_lcm")
+    package.__path__ = [str(Path(__file__).resolve().parents[1])]
+    package.__package__ = "hermes_lcm"
+    sys.modules["hermes_lcm"] = package
 
 from hermes_lcm import command, db_bootstrap
 from hermes_lcm.db_bootstrap import (
@@ -52,6 +65,218 @@ def _spec():
         indexed_column="content",
         trigger_sqls=(),
     )
+
+
+def _spawn_message_store_worker(db_path, start_barrier, repair_barrier, queue, worker):
+    """Construct and append after all children observe incomplete FTS state."""
+    store = None
+    try:
+        start_barrier.wait(timeout=30)
+        from hermes_lcm import db_bootstrap as worker_db_bootstrap
+        from hermes_lcm.store import MessageStore
+
+        original_structural_check = worker_db_bootstrap._fts_needs_rebuild_structural
+        synchronized = False
+
+        def synchronized_structural_check(conn, spec):
+            nonlocal synchronized
+            result = original_structural_check(conn, spec)
+            if result and not synchronized:
+                synchronized = True
+                repair_barrier.wait(timeout=30)
+            return result
+
+        worker_db_bootstrap._fts_needs_rebuild_structural = synchronized_structural_check
+        store = MessageStore(db_path)
+        messages = [
+            {
+                "role": "user",
+                "content": f"ftsbootstrapworker{worker} token{index}",
+            }
+            for index in range(4)
+        ]
+        ids = store.append_batch(
+            f"session-{worker}",
+            messages,
+            [1] * len(messages),
+            source="spawn-regression",
+            conversation_id=f"conversation-{worker}",
+        )
+        queue.put({"ok": True, "worker": worker, "ids": ids})
+    except BaseException as exc:  # pragma: no cover - exercised in child
+        queue.put(
+            {
+                "ok": False,
+                "worker": worker,
+                "error": repr(exc),
+                "trace": traceback.format_exc(),
+            }
+        )
+    finally:
+        if store is not None:
+            store.close()
+
+
+def _run_spawn_message_store_probe(db_path):
+    workers = 6
+    ctx = mp.get_context("spawn")
+    start_barrier = ctx.Barrier(workers + 1)
+    repair_barrier = ctx.Barrier(workers)
+    queue = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_spawn_message_store_worker,
+            args=(db_path, start_barrier, repair_barrier, queue, worker),
+        )
+        for worker in range(workers)
+    ]
+    started_processes = []
+    results = []
+    deadline = time.monotonic() + 90
+    try:
+        for process in processes:
+            process.start()
+            started_processes.append(process)
+        start_barrier.wait(timeout=max(0.1, min(30, deadline - time.monotonic())))
+        while len(results) < workers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(f"timed out waiting for workers: {results!r}")
+            results.append(queue.get(timeout=remaining))
+    finally:
+        join_deadline = time.monotonic() + 10
+        for process in started_processes:
+            process.join(timeout=max(0, join_deadline - time.monotonic()))
+        alive = [process for process in started_processes if process.is_alive()]
+        for process in alive:
+            process.terminate()
+        terminate_deadline = time.monotonic() + 10
+        for process in alive:
+            process.join(timeout=max(0, terminate_deadline - time.monotonic()))
+        queue.close()
+        queue.join_thread()
+
+    return {
+        "results": results,
+        "exitcodes": [process.exitcode for process in started_processes],
+    }
+
+
+if __name__ == "__main__" and sys.argv[1:2] == ["--spawn-fts-bootstrap"]:
+    print(json.dumps(_run_spawn_message_store_probe(sys.argv[2])))
+    raise SystemExit(0)
+
+
+def test_spawned_message_store_startup_serializes_fresh_fts_repair(tmp_path):
+    """Independent constructors accept one winner's complete FTS state."""
+    from hermes_lcm.store import MessageStore, build_message_fts_spec
+
+    workers = 6
+    db_path = str(tmp_path / "spawn-fresh-fts.db")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--spawn-fts-bootstrap",
+            db_path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    probe = json.loads(completed.stdout)
+    results = probe["results"]
+    assert all(result["ok"] for result in results), results
+    assert all(exitcode == 0 for exitcode in probe["exitcodes"]), probe["exitcodes"]
+
+    # This is a fresh product-store reopen after the contention round, not only
+    # a direct SQLite audit of the winner's file.
+    store = MessageStore(db_path)
+    try:
+        conn = store.connection
+        assert conn is not None
+        spec = build_message_fts_spec()
+        assert db_bootstrap.check_external_content_fts_integrity(conn, spec)["status"] == "pass"
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == workers * 4
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == workers * 4
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == workers * 4
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        for worker in range(workers):
+            matches = store.search(f"ftsbootstrapworker{worker}", limit=10)
+            assert len(matches) == 4
+            assert all(f"ftsbootstrapworker{worker}" in row["content"] for row in matches)
+    finally:
+        store.close()
+
+
+def test_trigger_disappearing_on_fast_path_reenters_repair_ownership(
+    tmp_path, monkeypatch
+):
+    """Trigger DDL observed after the healthy precheck runs only under ownership."""
+    from hermes_lcm.store import MessageStore, build_message_fts_spec
+
+    db_path = str(tmp_path / "trigger-race.db")
+    store = MessageStore(db_path)
+    try:
+        conn = store.connection
+        assert conn is not None
+        assert conn.in_transaction is False
+        spec = build_message_fts_spec()
+        trigger_name = db_bootstrap._extract_trigger_name(spec.trigger_sqls[0])
+        assert trigger_name is not None
+        assert db_bootstrap._fts_missing_triggers(conn, spec) is False
+
+        original_deep_check = db_bootstrap._fts_needs_rebuild
+        trigger_dropped = False
+
+        def deep_check_then_drop_trigger(conn_arg, spec_arg, *, now=None, throttle=False):
+            nonlocal trigger_dropped
+            result = original_deep_check(
+                conn_arg, spec_arg, now=now, throttle=throttle
+            )
+            if not trigger_dropped:
+                trigger_dropped = True
+                other = sqlite3.connect(db_path)
+                try:
+                    other.execute(
+                        f"DROP TRIGGER {db_bootstrap.quote_sql_identifier(trigger_name)}"
+                    )
+                    other.commit()
+                finally:
+                    other.close()
+            return result
+
+        monkeypatch.setattr(
+            db_bootstrap, "_fts_needs_rebuild", deep_check_then_drop_trigger
+        )
+        trigger_create_transaction_states = []
+
+        def trace_trigger_ddl(sql):
+            if sql.lstrip().upper().startswith("CREATE TRIGGER"):
+                trigger_create_transaction_states.append(conn.in_transaction)
+
+        conn.set_trace_callback(trace_trigger_ddl)
+        try:
+            result = db_bootstrap.repair_external_content_fts(
+                conn, spec, throttle=True
+            )
+        finally:
+            conn.set_trace_callback(None)
+
+        assert trigger_dropped is True
+        assert result == {
+            "rebuilt": False,
+            "degraded": False,
+            "triggers_recreated": True,
+        }
+        assert trigger_create_transaction_states
+        assert all(trigger_create_transaction_states)
+        assert db_bootstrap._fts_missing_triggers(conn, spec) is False
+    finally:
+        store.close()
 
 
 def _make_future_schema_db(db_path):
@@ -325,6 +550,33 @@ def test_is_fts_corruption_error_classification():
     assert not db_bootstrap._is_fts_corruption_error("query timeout expired")
 
 
+def test_sqlite_lock_error_classification_uses_codes_and_lock_messages():
+    coded_busy = sqlite3.OperationalError("synthetic non-lock message")
+    coded_busy.sqlite_errorcode = sqlite3.SQLITE_BUSY | (1 << 8)
+    assert db_bootstrap._is_sqlite_lock_error(coded_busy)
+
+    assert db_bootstrap._is_sqlite_lock_error(
+        sqlite3.OperationalError("database is locked")
+    )
+    assert db_bootstrap._is_sqlite_lock_error(
+        sqlite3.OperationalError("database table is locked: sqlite_master")
+    )
+
+    wrapped = RuntimeError("startup failed")
+    wrapped.__cause__ = sqlite3.OperationalError("database schema is locked")
+    assert db_bootstrap._is_sqlite_lock_error(wrapped)
+
+
+def test_sqlite_lock_error_classification_rejects_unrelated_timeout_text():
+    assert not db_bootstrap._is_sqlite_lock_error(
+        sqlite3.IntegrityError("constraint timeout while validating data")
+    )
+    assert not db_bootstrap._is_sqlite_lock_error(
+        sqlite3.OperationalError("busy parsing application expression")
+    )
+    assert not db_bootstrap._is_sqlite_lock_error(TimeoutError("query timeout"))
+
+
 def test_integrity_check_lock_error_is_unchecked_not_corruption(tmp_path, monkeypatch):
     """A transient lock/busy error classifies as 'unchecked', never 'fail' (F3).
 
@@ -353,6 +605,25 @@ def test_integrity_check_malformed_error_is_fail(tmp_path, monkeypatch):
     result = db_bootstrap.check_external_content_fts_integrity(fake, spec)
     assert result["status"] == "fail"
     conn.close()
+
+
+def test_fts_repair_lock_budget_propagates_without_destructive_repair(tmp_path, monkeypatch):
+    """A bounded ownership failure is not reclassified as FTS corruption."""
+    conn = _make_conn(tmp_path)
+    locker = sqlite3.connect(_db_file(tmp_path), timeout=1.0)
+    try:
+        locker.execute("BEGIN IMMEDIATE")
+        monkeypatch.setattr(db_bootstrap, "SQLITE_BUSY_TIMEOUT_MS", 25)
+        with pytest.raises(sqlite3.OperationalError, match="locked|busy"):
+            ensure_external_content_fts(conn, _spec())
+
+        tables = _table_names(_db_file(tmp_path))
+        assert "messages_fts" not in tables
+        assert "messages_fts_docsize" not in tables
+    finally:
+        conn.close()
+        locker.rollback()
+        locker.close()
 
 
 def test_doctor_repair_apply_joins_background_scans_first(tmp_path, monkeypatch):

--- a/tests/test_message_references.py
+++ b/tests/test_message_references.py
@@ -1,0 +1,641 @@
+"""Contract tests for the V1 durable-message retrieval-reference adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.db_bootstrap import (
+    RETRIEVAL_REFERENCES_TABLE,
+    get_database_uuid,
+    rotate_database_uuid,
+)
+from hermes_lcm.message_references import (
+    MESSAGE_REFERENCE_KIND,
+    MessageReferenceAdapter,
+    MessageReferenceResult,
+    issue_message_reference,
+    message_revision,
+    message_revision_preimage,
+    resolve_message_reference,
+)
+from hermes_lcm.retrieval_references import (
+    ReferenceError,
+    ReferenceErrorCode,
+    revoke_reference,
+)
+from hermes_lcm.store import MessageStore
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Every adapter test gets a fresh home and explicit database path."""
+    home = tmp_path / "hermes-home"
+    db_path = home / "lcm.db"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("LCM_DATABASE_PATH", str(db_path))
+    message_store = MessageStore(db_path, hermes_home=str(home))
+    try:
+        yield message_store
+    finally:
+        message_store.close()
+
+
+def _allow_issue(context, kind, target, scope, revision):
+    return (
+        context == "issuer"
+        and kind == MESSAGE_REFERENCE_KIND
+        and target.keys() == {"store_id"}
+        and isinstance(scope, dict)
+        and revision["algorithm"] == "sha256"
+    )
+
+
+def _allow_target(context, store_id, scope):
+    return (
+        context == "issuer"
+        and isinstance(store_id, int)
+        and store_id > 0
+        and scope == {"session_id": "session-a"}
+    )
+
+
+def _allow(context, envelope):
+    return context == "reader" and envelope.kind == MESSAGE_REFERENCE_KIND
+
+
+def _allow_scope(context, envelope, scope):
+    return context == "reader" and scope == {"session_id": "session-a"}
+
+
+def _seed(store: MessageStore, *, session_id: str = "session-a", source: str = "") -> int:
+    store_id = store.append(
+        session_id,
+        {
+            "role": "user",
+            "content": "hello",
+            "tool_call_id": None,
+            "tool_name": None,
+        },
+        token_estimate=3,
+        source=source,
+        conversation_id="conversation-a",
+    )
+    store.connection.execute(
+        "UPDATE messages SET timestamp = ?, tool_calls = ? WHERE store_id = ?",
+        (100.0, '{"b": 2, "a": 1}', store_id),
+    )
+    store.connection.commit()
+    return store_id
+
+
+def _issue(store: MessageStore, store_id: int, *, expires_at=None):
+    return issue_message_reference(
+        store,
+        store_id,
+        {"session_id": "session-a"},
+        authorization_context="issuer",
+        authorize_target=_allow_target,
+        authorize_issue=_allow_issue,
+        issued_at=100.0,
+        expires_at=expires_at,
+    )
+
+
+def _resolve(store: MessageStore, envelope, **kwargs):
+    return resolve_message_reference(
+        store,
+        envelope,
+        authorization_context="reader",
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        **kwargs,
+    )
+
+
+def test_connection_bound_facade_works_with_a_raw_sqlite_connection(store):
+    store_id = _seed(store)
+    adapter = MessageReferenceAdapter(store.connection)
+    envelope = adapter.issue(
+        store_id,
+        {"session_id": "session-a"},
+        authorization_context="issuer",
+        authorize_target=_allow_target,
+        authorize_issue=_allow_issue,
+        issued_at=100.0,
+    )
+
+    result = adapter.resolve(
+        envelope,
+        authorization_context="reader",
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+    )
+
+    assert result.ok
+    assert result.message is not None
+    assert result.message["store_id"] == store_id
+
+
+def test_round_trip_returns_normalized_message_and_exact_revision(store):
+    store_id = _seed(store, source=" ")
+    envelope = _issue(store, store_id)
+
+    result = _resolve(store, envelope, expected_scope={"session_id": "session-a"})
+
+    assert result.ok
+    assert result.record is not None
+    assert result.message is not None
+    assert result.record.kind == "message"
+    assert result.record.target == {"store_id": store_id}
+    assert result.record.revision == message_revision(result.message)
+    assert result.message["source"] == "unknown"
+    assert result.message["conversation_id"] == "conversation-a"
+    assert result.message["tool_calls"] == {"a": 1, "b": 2}
+    assert set(result.message) == {
+        "store_id",
+        "session_id",
+        "source",
+        "conversation_id",
+        "role",
+        "content",
+        "tool_call_id",
+        "tool_calls",
+        "tool_name",
+        "timestamp",
+        "token_estimate",
+        "pinned",
+    }
+
+
+def test_registry_persists_only_digest_not_wire_token(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    digest = hashlib.sha256(envelope.token.encode("ascii")).hexdigest()
+    row = store.connection.execute(
+        f"SELECT token_digest, target_json, scope_json, revision_json FROM {RETRIEVAL_REFERENCES_TABLE} WHERE token_digest = ?",
+        (digest,),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == digest
+    assert envelope.token not in json.dumps(tuple(row))
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("content", "rewritten"),
+        ("session_id", "session-b"),
+        ("source", "other-source"),
+        ("conversation_id", "conversation-b"),
+        ("role", "assistant"),
+        ("tool_call_id", "call-b"),
+        ("tool_name", "other-tool"),
+        ("timestamp", 101.0),
+        ("tool_calls", '[{"id":"call-b"}]'),
+    ],
+)
+def test_semantic_message_mutations_stale_the_reference(store, column, value):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    store.connection.execute(
+        f"UPDATE messages SET {column} = ? WHERE store_id = ?",
+        (value, store_id),
+    )
+    store.connection.commit()
+
+    result = _resolve(store, envelope)
+
+    assert result.to_dict() == {
+        "error_code": ReferenceErrorCode.REFERENCE_STALE.value,
+        "error": "message reference is stale",
+    }
+
+
+def test_externalized_tool_gc_rewrite_is_stale_but_operational_changes_are_not(store):
+    store_id = _seed(store)
+    store.connection.execute(
+        "UPDATE messages SET role = 'tool', tool_call_id = 'call-a' WHERE store_id = ?",
+        (store_id,),
+    )
+    store.connection.commit()
+    envelope = _issue(store, store_id)
+    store.pin(store_id)
+    store.connection.execute(
+        "UPDATE messages SET token_estimate = ?, pinned = 1 WHERE store_id = ?",
+        (999, store_id),
+    )
+    store.connection.commit()
+    assert _resolve(store, envelope).ok
+
+    store.unpin(store_id)
+    assert store.gc_externalized_tool_result(store_id, "[externalized output gc]")
+    stale = _resolve(store, envelope)
+
+    assert stale.error_code == ReferenceErrorCode.REFERENCE_STALE.value
+
+
+def test_malformed_message_timestamp_fails_closed_as_stale(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    store.connection.execute(
+        "UPDATE messages SET timestamp = ? WHERE store_id = ?",
+        ("not-a-finite-timestamp", store_id),
+    )
+    store.connection.commit()
+
+    result = _resolve(store, envelope)
+
+    assert result.error_code == ReferenceErrorCode.REFERENCE_STALE.value
+    assert "timestamp" in (result.error or "")
+
+
+def test_deleted_message_is_not_found_after_authorization(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    store.connection.execute("DELETE FROM messages WHERE store_id = ?", (store_id,))
+    store.connection.commit()
+
+    result = _resolve(store, envelope)
+
+    assert result.error_code == ReferenceErrorCode.REFERENCE_NOT_FOUND.value
+
+
+def test_denial_runs_no_registry_or_message_select_and_discloses_nothing(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    statements: list[str] = []
+    store.connection.set_trace_callback(statements.append)
+
+    denied = resolve_message_reference(
+        store,
+        envelope,
+        authorization_context="reader",
+        authorize=lambda _context, _envelope: False,
+        authorize_scope=_allow_scope,
+    )
+
+    assert denied.to_dict() == {
+        "error_code": ReferenceErrorCode.REFERENCE_FORBIDDEN.value,
+        "error": "reference use is not authorized by the host",
+    }
+    assert "target" not in denied.to_dict()
+    assert "revision" not in denied.to_dict()
+    assert not any("FROM messages" in statement.upper() for statement in statements)
+    assert not any(
+        f"FROM {RETRIEVAL_REFERENCES_TABLE}" in statement.upper()
+        for statement in statements
+    )
+
+
+def test_stored_scope_denial_runs_no_message_select(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    statements: list[str] = []
+    store.connection.set_trace_callback(statements.append)
+
+    denied = resolve_message_reference(
+        store,
+        envelope,
+        authorization_context="reader",
+        authorize=_allow,
+        authorize_scope=lambda _context, _envelope, _scope: False,
+    )
+
+    assert denied.error_code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    assert not any("FROM messages" in statement.upper() for statement in statements)
+
+
+def test_wrong_kind_malformed_binding_scope_and_lifecycle_fail_closed(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+
+    wrong_kind = resolve_message_reference(
+        store,
+        replace(envelope, kind="summary_node"),
+        authorization_context="reader",
+        authorize=lambda context, _envelope: context == "reader",
+        authorize_scope=_allow_scope,
+    )
+    assert wrong_kind.error_code == ReferenceErrorCode.REFERENCE_KIND_MISMATCH.value
+
+    from hermes_lcm.retrieval_references import reference_token_digest
+
+    digest = reference_token_digest(envelope.token)
+    store.connection.execute(
+        f"UPDATE {RETRIEVAL_REFERENCES_TABLE} SET target_json = ? WHERE token_digest = ?",
+        ('{"store_id":0}', digest),
+    )
+    store.connection.commit()
+    assert _resolve(store, envelope).error_code == ReferenceErrorCode.REFERENCE_STALE.value
+
+    store.connection.execute(
+        f"UPDATE {RETRIEVAL_REFERENCES_TABLE} SET target_json = ?, revision_json = ? WHERE token_digest = ?",
+        (json.dumps({"store_id": store_id}), json.dumps({"algorithm": "sha256", "semantic_digest": "BAD"}), digest),
+    )
+    store.connection.commit()
+    assert _resolve(store, envelope).error_code == ReferenceErrorCode.REFERENCE_STALE.value
+
+    expired = _issue(store, store_id, expires_at=101.0)
+    assert _resolve(store, expired, now=101.0).error_code == ReferenceErrorCode.REFERENCE_STALE.value
+    assert _resolve(store, envelope, expected_scope={"session_id": "session-b"}).error_code == ReferenceErrorCode.REFERENCE_SCOPE_MISMATCH.value
+
+    clone = _issue(store, store_id)
+    old_uuid = get_database_uuid(store.connection)
+    rotate_database_uuid(
+        store.connection,
+        authorization_context="admin",
+        authorize_rotation=lambda context: context == "admin",
+        revoked_at=200.0,
+    )
+    assert get_database_uuid(store.connection) != old_uuid
+    assert _resolve(store, clone).error_code == ReferenceErrorCode.REFERENCE_DATABASE_MISMATCH.value
+
+
+def test_revocation_uses_foundation_taxonomy(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    revoked = revoke_reference(
+        store.connection,
+        envelope,
+        authorization_context="reader",
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        revoked_at=110.0,
+    )
+
+    assert revoked.ok
+    assert _resolve(store, envelope).error_code == ReferenceErrorCode.REFERENCE_NOT_FOUND.value
+
+
+def test_issue_rejects_non_positive_or_boolean_store_ids_without_a_row_read(store):
+    statements: list[str] = []
+    store.connection.set_trace_callback(statements.append)
+
+    with pytest.raises(ReferenceError) as zero:
+        issue_message_reference(
+            store,
+            0,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_issue=_allow_issue,
+        )
+    with pytest.raises(ReferenceError) as boolean:
+        issue_message_reference(
+            store,
+            True,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_issue=_allow_issue,
+        )
+
+    assert zero.value.code == ReferenceErrorCode.INVALID_REQUEST
+    assert boolean.value.code == ReferenceErrorCode.INVALID_REQUEST
+    assert not any("FROM messages" in statement.upper() for statement in statements)
+
+
+def test_issue_missing_message_is_reference_not_found(store):
+    with pytest.raises(ReferenceError) as error:
+        _issue(store, 999999)
+
+    assert error.value.code == ReferenceErrorCode.REFERENCE_NOT_FOUND
+    assert store.connection.in_transaction is False
+
+
+@pytest.mark.parametrize("target_exists", [True, False])
+def test_issue_target_preauthorization_hides_message_existence(store, target_exists):
+    store_id = _seed(store) if target_exists else 999999
+    statements: list[str] = []
+    calls: list[tuple[object, int, object]] = []
+    store.connection.set_trace_callback(statements.append)
+
+    def deny_target(context, candidate_store_id, scope):
+        calls.append((context, candidate_store_id, scope))
+        return False
+
+    with pytest.raises(ReferenceError) as denied:
+        issue_message_reference(
+            store,
+            store_id,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_target=deny_target,
+            authorize_issue=_allow_issue,
+        )
+
+    assert denied.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN
+    assert calls == [("issuer", store_id, {"session_id": "session-a"})]
+    assert not any("BEGIN" in statement.upper() for statement in statements)
+    assert not any("FROM MESSAGES" in statement.upper() for statement in statements)
+    assert store.connection.in_transaction is False
+
+
+def test_issue_requires_target_preauthorization(store):
+    store_id = _seed(store)
+    statements: list[str] = []
+    store.connection.set_trace_callback(statements.append)
+
+    with pytest.raises(ReferenceError) as denied:
+        issue_message_reference(
+            store,
+            store_id,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_issue=_allow_issue,
+        )
+
+    assert denied.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN
+    assert not statements
+
+
+def test_caller_transaction_rollback_removes_issued_row(store):
+    store_id = _seed(store)
+    store.connection.execute("BEGIN")
+    _issue(store, store_id)
+    assert store.connection.in_transaction
+    store.connection.rollback()
+
+    assert store.connection.execute(
+        f"SELECT COUNT(*) FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (0,)
+
+
+def test_callback_failures_roll_back_owned_issue_and_keep_caller_transaction(store):
+    store_id = _seed(store)
+    with pytest.raises(ReferenceError) as denied:
+        issue_message_reference(
+            store,
+            store_id,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_target=_allow_target,
+            authorize_issue=lambda *_args: (_ for _ in ()).throw(RuntimeError("policy")),
+        )
+    assert denied.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN
+    assert store.connection.in_transaction is False
+
+    store.connection.execute("BEGIN")
+    with pytest.raises(ReferenceError):
+        issue_message_reference(
+            store,
+            store_id,
+            {"session_id": "session-a"},
+            authorization_context="issuer",
+            authorize_target=_allow_target,
+            authorize_issue=lambda *_args: False,
+        )
+    assert store.connection.in_transaction is True
+    store.connection.rollback()
+
+
+def test_legacy_blank_and_semantic_tool_call_normalization_is_deterministic(store):
+    store_id = _seed(store)
+    store.connection.execute(
+        "UPDATE messages SET source = ?, conversation_id = ?, tool_calls = ? WHERE store_id = ?",
+        (" \t\n", " \n", " false ", store_id),
+    )
+    store.connection.commit()
+    row = store.connection.execute(
+        f"SELECT {_MESSAGE_COLUMNS_FOR_TEST} FROM messages WHERE store_id = ?",
+        (store_id,),
+    ).fetchone()
+    # The preimage uses the same normalized values for legacy SQL rows and
+    # already-normalized adapter input, including a valid falsy JSON value.
+    from hermes_lcm.message_references import _row_mapping
+
+    message = _row_mapping(row)
+    assert message_revision_preimage(message)["source"] == "unknown"
+    assert message_revision_preimage(message)["conversation_id"] == ""
+    assert message_revision_preimage(message)["tool_calls"] is False
+    assert message_revision(message) == message_revision(
+        {
+            **message,
+            "source": None,
+            "conversation_id": None,
+            "tool_calls": False,
+        }
+    )
+
+
+def test_invalid_tool_call_json_is_hashed_as_the_stored_string(store):
+    store_id = _seed(store)
+    store.connection.execute(
+        "UPDATE messages SET tool_calls = ? WHERE store_id = ?",
+        ("not-json", store_id),
+    )
+    store.connection.commit()
+    row = store.connection.execute(
+        f"SELECT {_MESSAGE_COLUMNS_FOR_TEST} FROM messages WHERE store_id = ?",
+        (store_id,),
+    ).fetchone()
+    from hermes_lcm.message_references import _row_mapping
+
+    message = _row_mapping(row)
+    assert message_revision_preimage(message)["tool_calls"] == "not-json"
+
+
+def test_wal_race_keeps_one_resolve_snapshot_then_next_call_is_stale(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    db_path = Path(store.db_path)
+    other = sqlite3.connect(db_path, timeout=5.0, check_same_thread=False)
+    other.execute("PRAGMA journal_mode=WAL")
+    other.execute("PRAGMA busy_timeout=5000")
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+    results: list[MessageReferenceResult] = []
+
+    def pause_scope(context, parsed, scope):
+        assert context == "reader"
+        callback_entered.set()
+        assert release_callback.wait(5.0)
+        return scope == {"session_id": "session-a"}
+
+    def resolve_in_thread():
+        results.append(
+            resolve_message_reference(
+                store.connection,
+                envelope,
+                authorization_context="reader",
+                authorize=_allow,
+                authorize_scope=pause_scope,
+            )
+        )
+
+    worker = threading.Thread(target=resolve_in_thread)
+    worker.start()
+    assert callback_entered.wait(5.0)
+    other.execute("UPDATE messages SET content = ? WHERE store_id = ?", ("rewritten", store_id))
+    other.commit()
+    release_callback.set()
+    worker.join(5.0)
+    try:
+        assert len(results) == 1
+        assert results[0].ok
+        assert results[0].message is not None
+        assert results[0].message["content"] == "hello"
+        assert _resolve(store, envelope).error_code == ReferenceErrorCode.REFERENCE_STALE.value
+    finally:
+        other.close()
+
+
+def test_resolve_snapshot_holds_message_store_write_lock(store):
+    store_id = _seed(store)
+    envelope = _issue(store, store_id)
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+    writer_finished = threading.Event()
+    results: list[MessageReferenceResult] = []
+
+    def pause_scope(context, parsed, scope):
+        assert context == "reader"
+        callback_entered.set()
+        assert release_callback.wait(5.0)
+        return scope == {"session_id": "session-a"}
+
+    def resolve_in_thread():
+        results.append(
+            resolve_message_reference(
+                store,
+                envelope,
+                authorization_context="reader",
+                authorize=_allow,
+                authorize_scope=pause_scope,
+            )
+        )
+
+    def write_in_thread():
+        store.append(
+            "session-a",
+            {"role": "user", "content": "later"},
+            source="test",
+        )
+        writer_finished.set()
+
+    resolver = threading.Thread(target=resolve_in_thread)
+    resolver.start()
+    assert callback_entered.wait(5.0)
+    writer = threading.Thread(target=write_in_thread)
+    writer.start()
+    assert not writer_finished.wait(0.1)
+    release_callback.set()
+    resolver.join(5.0)
+    writer.join(5.0)
+
+    assert len(results) == 1
+    assert results[0].ok
+    assert writer_finished.is_set()
+
+
+_MESSAGE_COLUMNS_FOR_TEST = (
+    "store_id, session_id, source, conversation_id, role, content, "
+    "tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned"
+)

--- a/tests/test_retrieval_reference_contract.py
+++ b/tests/test_retrieval_reference_contract.py
@@ -1,0 +1,1081 @@
+"""Contract tests for the frozen #476 V1 retrieval-reference foundation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm import db_bootstrap
+from hermes_lcm.db_bootstrap import (
+    DATABASE_UUID_MIGRATION,
+    RETRIEVAL_REFERENCES_MIGRATION,
+    RETRIEVAL_REFERENCES_TABLE,
+    SCHEMA_VERSION,
+    DatabaseIdentityError,
+    RetrievalReferenceSchemaError,
+    SchemaVersionTooNewError,
+    VERSION_MISMATCH_GENUINELY_NEWER,
+    classify_version_mismatch,
+    ensure_retrieval_reference_migrations,
+    get_database_uuid,
+    get_schema_version,
+    rotate_database_uuid,
+    run_versioned_migrations,
+    verify_retrieval_references_schema,
+)
+from hermes_lcm.retrieval_references import (
+    ReferenceError,
+    ReferenceErrorCode,
+    canonical_json,
+    decode_reference_envelope,
+    issue_reference,
+    reference_token_digest,
+    resolve_reference,
+    revoke_reference,
+    rotate_explicit_clone,
+    serialize_reference_envelope,
+)
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    run_versioned_migrations(conn)
+    conn.commit()
+    return conn
+
+
+def _migration_markers(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT step_name FROM lcm_migration_state WHERE step_name IN (?, ?)",
+            (DATABASE_UUID_MIGRATION, RETRIEVAL_REFERENCES_MIGRATION),
+        ).fetchall()
+    }
+
+
+def _issue(conn, *, expires_at=None, kind="message", scope=None):
+    return issue_reference(
+        conn,
+        kind,
+        {"store_id": 7, "source": "test"},
+        {"session_id": "session-a"} if scope is None else scope,
+        {"content_digest": "rev-1"},
+        authorization_context={"trusted": True},
+        authorize_issue=_allow_issue,
+        consistency="live",
+        issued_at=100.0,
+        expires_at=expires_at,
+    )
+
+
+def _allow_issue(context, kind, target, scope, revision):
+    return (
+        context == {"trusted": True}
+        and isinstance(kind, str)
+        and isinstance(target, dict)
+        and isinstance(scope, dict)
+        and isinstance(revision, dict)
+    )
+
+
+def _allow_rotation(context):
+    return context == {"admin": True}
+
+
+def _allow(context, envelope):
+    assert context == {"trusted": True}
+    assert envelope.kind == "message"
+    return True
+
+
+def _allow_scope(context, envelope, scope):
+    assert context == {"trusted": True}
+    assert envelope.kind == "message"
+    return scope == {"session_id": "session-a"}
+
+
+def test_fresh_and_populated_pre_v1_initialization_preserves_data(tmp_path):
+    fresh = _open(tmp_path / "fresh.db")
+    try:
+        assert get_schema_version(fresh) == SCHEMA_VERSION
+        assert get_database_uuid(fresh)
+        assert verify_retrieval_references_schema(fresh) == []
+    finally:
+        fresh.close()
+
+    populated_path = tmp_path / "populated.db"
+    old = sqlite3.connect(populated_path)
+    old.execute("CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT)")
+    old.execute("INSERT INTO metadata(key, value) VALUES('schema_version', '5')")
+    old.execute("CREATE TABLE preserved(id INTEGER PRIMARY KEY, value TEXT)")
+    old.execute("INSERT INTO preserved(value) VALUES('before-v1')")
+    old.commit()
+    old.close()
+
+    populated = _open(populated_path)
+    try:
+        assert populated.execute("SELECT value FROM preserved").fetchone() == ("before-v1",)
+        markers = {
+            row[0]
+            for row in populated.execute(
+                "SELECT step_name FROM lcm_migration_state WHERE step_name IN (?, ?)",
+                (DATABASE_UUID_MIGRATION, RETRIEVAL_REFERENCES_MIGRATION),
+            )
+        }
+        assert markers == {DATABASE_UUID_MIGRATION, RETRIEVAL_REFERENCES_MIGRATION}
+    finally:
+        populated.close()
+
+
+def test_database_uuid_is_canonical_and_persists_across_restart(tmp_path):
+    path = tmp_path / "restart.db"
+    first = _open(path)
+    first_uuid = get_database_uuid(first)
+    first.close()
+
+    second = _open(path)
+    try:
+        assert get_database_uuid(second) == first_uuid
+    finally:
+        second.close()
+
+
+def test_completed_named_migrations_use_read_only_healthy_fast_path(tmp_path):
+    conn = _open(tmp_path / "healthy.db")
+    statements = []
+    conn.set_trace_callback(statements.append)
+    try:
+        run_versioned_migrations(conn)
+    finally:
+        conn.close()
+
+    normalized = [" ".join(statement.upper().split()) for statement in statements]
+    assert not any("BEGIN IMMEDIATE" in statement for statement in normalized)
+    assert not any(
+        "CREATE TABLE IF NOT EXISTS METADATA" in statement
+        or "CREATE TABLE IF NOT EXISTS LCM_MIGRATION_STATE" in statement
+        for statement in normalized
+    )
+    assert not any(
+        RETRIEVAL_REFERENCES_TABLE.upper() in statement
+        and ("CREATE TABLE" in statement or "CREATE INDEX" in statement)
+        for statement in normalized
+    )
+
+
+def test_missing_or_corrupt_post_migration_uuid_fails_closed(tmp_path):
+    path = tmp_path / "identity.db"
+    conn = _open(path)
+    conn.execute("DELETE FROM metadata WHERE key='database_uuid'")
+    conn.commit()
+    conn.close()
+
+    missing = sqlite3.connect(path)
+    with pytest.raises(DatabaseIdentityError):
+        run_versioned_migrations(missing)
+    missing.close()
+
+    corrupt = sqlite3.connect(path)
+    corrupt.execute("INSERT OR REPLACE INTO metadata(key, value) VALUES('database_uuid', 'not-a-uuid')")
+    corrupt.commit()
+    corrupt.close()
+
+    reopened = sqlite3.connect(path)
+    with pytest.raises(DatabaseIdentityError):
+        run_versioned_migrations(reopened)
+    reopened.close()
+
+
+def test_existing_registry_state_without_identity_is_not_adopted(tmp_path):
+    path = tmp_path / "orphaned-registry.db"
+    conn = _open(path)
+    conn.execute("DELETE FROM metadata WHERE key='database_uuid'")
+    conn.execute(
+        "DELETE FROM lcm_migration_state WHERE step_name=?",
+        (DATABASE_UUID_MIGRATION,),
+    )
+    conn.commit()
+    with pytest.raises(DatabaseIdentityError, match="unmarked"):
+        run_versioned_migrations(conn)
+    assert conn.execute(
+        "SELECT value FROM metadata WHERE key='database_uuid'"
+    ).fetchone() is None
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    ("remove_identity_marker", "remove_registry_marker", "drop_registry", "error"),
+    [
+        (True, True, False, DatabaseIdentityError),
+        (True, True, True, DatabaseIdentityError),
+        (False, True, False, RetrievalReferenceSchemaError),
+    ],
+)
+def test_unmarked_authority_or_registry_state_is_never_adopted(
+    tmp_path,
+    remove_identity_marker,
+    remove_registry_marker,
+    drop_registry,
+    error,
+):
+    conn = _open(tmp_path / "unmarked-state.db")
+    if remove_identity_marker:
+        conn.execute(
+            "DELETE FROM lcm_migration_state WHERE step_name=?",
+            (DATABASE_UUID_MIGRATION,),
+        )
+    if remove_registry_marker:
+        conn.execute(
+            "DELETE FROM lcm_migration_state WHERE step_name=?",
+            (RETRIEVAL_REFERENCES_MIGRATION,),
+        )
+    if drop_registry:
+        conn.execute(f"DROP TABLE {RETRIEVAL_REFERENCES_TABLE}")
+    conn.commit()
+
+    with pytest.raises(error, match="unmarked"):
+        ensure_retrieval_reference_migrations(conn)
+    assert _migration_markers(conn) == {
+        marker
+        for marker, removed in (
+            (DATABASE_UUID_MIGRATION, remove_identity_marker),
+            (RETRIEVAL_REFERENCES_MIGRATION, remove_registry_marker),
+        )
+        if not removed
+    }
+    conn.close()
+
+
+def test_valid_identity_only_state_completes_registry_without_rotating_uuid(tmp_path):
+    conn = _open(tmp_path / "identity-only.db")
+    database_uuid = get_database_uuid(conn)
+    conn.execute(f"DROP TABLE {RETRIEVAL_REFERENCES_TABLE}")
+    conn.execute(
+        "DELETE FROM lcm_migration_state WHERE step_name=?",
+        (RETRIEVAL_REFERENCES_MIGRATION,),
+    )
+    conn.commit()
+
+    assert ensure_retrieval_reference_migrations(conn) == database_uuid
+    assert get_database_uuid(conn) == database_uuid
+    assert _migration_markers(conn) == {
+        DATABASE_UUID_MIGRATION,
+        RETRIEVAL_REFERENCES_MIGRATION,
+    }
+    assert verify_retrieval_references_schema(conn) == []
+    conn.close()
+
+
+def test_public_operations_require_complete_registry_provenance(tmp_path):
+    conn = _open(tmp_path / "unmarked-public-operations.db")
+    database_uuid = get_database_uuid(conn)
+    envelope = _issue(conn)
+    conn.execute(
+        "DELETE FROM lcm_migration_state WHERE step_name=?",
+        (RETRIEVAL_REFERENCES_MIGRATION,),
+    )
+    conn.commit()
+
+    with pytest.raises(RetrievalReferenceSchemaError, match="unmarked"):
+        _issue(conn)
+    resolved = resolve_reference(
+        conn,
+        envelope,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+    )
+    assert resolved.to_dict() == {
+        "error_code": ReferenceErrorCode.REFERENCE_INVALID.value,
+        "error": "reference authority identity is unavailable",
+    }
+    revoked = revoke_reference(
+        conn,
+        envelope,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+    )
+    assert revoked.to_dict() == resolved.to_dict()
+    with pytest.raises(RetrievalReferenceSchemaError, match="unmarked"):
+        rotate_database_uuid(
+            conn,
+            authorization_context={"admin": True},
+            authorize_rotation=_allow_rotation,
+            revoked_at=200.0,
+        )
+
+    assert get_database_uuid(conn) == database_uuid
+    assert conn.execute(
+        f"SELECT COUNT(*), MAX(revoked_at) FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (1, None)
+    assert not conn.in_transaction
+    conn.close()
+
+
+def test_direct_named_helper_refuses_too_new_schema_before_ddl(tmp_path):
+    conn = _open(tmp_path / "too-new-helper.db")
+    conn.execute("UPDATE metadata SET value=? WHERE key='schema_version'", ("99",))
+    conn.commit()
+    before = conn.execute(
+        "SELECT name, sql FROM sqlite_master ORDER BY name"
+    ).fetchall()
+    with pytest.raises(SchemaVersionTooNewError):
+        ensure_retrieval_reference_migrations(conn)
+    assert conn.execute(
+        "SELECT name, sql FROM sqlite_master ORDER BY name"
+    ).fetchall() == before
+    conn.close()
+
+
+def test_too_new_exact_unmarked_registry_is_genuinely_newer(tmp_path):
+    conn = _open(tmp_path / "unmarked-too-new.db")
+    conn.execute(
+        "DELETE FROM lcm_migration_state WHERE step_name=?",
+        (RETRIEVAL_REFERENCES_MIGRATION,),
+    )
+    conn.execute("UPDATE metadata SET value=? WHERE key='schema_version'", ("99",))
+    conn.commit()
+    assert classify_version_mismatch(conn) == VERSION_MISMATCH_GENUINELY_NEWER
+    conn.close()
+
+
+@pytest.mark.parametrize("damage", ["missing-marker", "missing-value"])
+def test_too_new_classifier_requires_database_uuid_provenance(tmp_path, damage):
+    conn = _open(tmp_path / f"too-new-identity-{damage}.db")
+    conn.execute(f"DROP TABLE {RETRIEVAL_REFERENCES_TABLE}")
+    conn.execute(
+        "DELETE FROM lcm_migration_state WHERE step_name=?",
+        (RETRIEVAL_REFERENCES_MIGRATION,),
+    )
+    if damage == "missing-marker":
+        conn.execute(
+            "DELETE FROM lcm_migration_state WHERE step_name=?",
+            (DATABASE_UUID_MIGRATION,),
+        )
+    else:
+        conn.execute("DELETE FROM metadata WHERE key='database_uuid'")
+    conn.execute(
+        "UPDATE metadata SET value=? WHERE key='schema_version'",
+        (str(SCHEMA_VERSION + 94),),
+    )
+    conn.commit()
+    assert classify_version_mismatch(conn) == VERSION_MISMATCH_GENUINELY_NEWER
+    conn.close()
+
+
+def test_completed_registry_marker_does_not_recreate_missing_table(tmp_path):
+    path = tmp_path / "missing-registry.db"
+    conn = _open(path)
+    conn.execute(f"DROP TABLE {RETRIEVAL_REFERENCES_TABLE}")
+    conn.commit()
+    with pytest.raises(RetrievalReferenceSchemaError, match="completed.*damaged"):
+        run_versioned_migrations(conn)
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (RETRIEVAL_REFERENCES_TABLE,),
+    ).fetchone() is None
+    conn.close()
+
+
+def test_token_is_random_rh1_256_bit_and_registry_is_digest_only(tmp_path):
+    conn = _open(tmp_path / "tokens.db")
+    try:
+        first = _issue(conn)
+        second = _issue(conn)
+        assert first.token.startswith("rh1_")
+        assert len(first.token) == len("rh1_") + 64
+        assert first.token != second.token
+        digest = hashlib.sha256(first.token.encode("ascii")).hexdigest()
+        row = conn.execute(
+            f"SELECT token_digest, target_json, scope_json, revision_json FROM {RETRIEVAL_REFERENCES_TABLE} WHERE token_digest=?",
+            (digest,),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == digest
+        assert first.token not in json.dumps(row)
+        token_column = {
+            str(item[1]): (str(item[2]).upper(), int(item[3]), int(item[5]))
+            for item in conn.execute(
+                f"PRAGMA table_info({RETRIEVAL_REFERENCES_TABLE})"
+            ).fetchall()
+        }["token_digest"]
+        assert token_column == ("TEXT", 1, 1)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                f"""
+                INSERT INTO {RETRIEVAL_REFERENCES_TABLE}(
+                    token_digest, kind, target_json, scope_json, revision_json,
+                    consistency, issued_at
+                ) VALUES (NULL, 'message', '{{}}', '{{}}', '{{}}', 'live', 100.0)
+                """
+            )
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def test_issue_and_clone_rotation_require_explicit_operation_authorization(tmp_path):
+    conn = _open(tmp_path / "operation-authorization.db")
+    original_uuid = get_database_uuid(conn)
+    with pytest.raises(ReferenceError) as issue_error:
+        issue_reference(
+            conn,
+            "message",
+            {"store_id": 7},
+            {"session_id": "session-a"},
+            {"content_digest": "rev-1"},
+        )
+    assert issue_error.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    with pytest.raises(ReferenceError) as missing_context_error:
+        issue_reference(
+            conn,
+            "message",
+            {"store_id": 7},
+            {"session_id": "session-a"},
+            {"content_digest": "rev-1"},
+            authorize_issue=lambda context, kind, target, scope, revision: True,
+        )
+    assert missing_context_error.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+
+    observed_issue = []
+
+    def deny_issue(context, kind, target, scope, revision):
+        observed_issue.append((context, kind, target, scope, revision))
+        return False
+
+    with pytest.raises(ReferenceError) as denied_issue_error:
+        issue_reference(
+            conn,
+            "message",
+            {"z": 2, "a": 1},
+            {"tenant": "tenant-a"},
+            {"content_digest": "rev-1"},
+            authorization_context={"trusted": True},
+            authorize_issue=deny_issue,
+        )
+    assert denied_issue_error.value.code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    assert list(observed_issue[0][2]) == ["a", "z"]
+    assert observed_issue == [
+        (
+            {"trusted": True},
+            "message",
+            {"a": 1, "z": 2},
+            {"tenant": "tenant-a"},
+            {"content_digest": "rev-1"},
+        )
+    ]
+    assert conn.execute(
+        f"SELECT COUNT(*) FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (0,)
+
+    with pytest.raises(PermissionError, match="not authorized"):
+        rotate_database_uuid(conn)
+    with pytest.raises(PermissionError, match="not authorized"):
+        rotate_database_uuid(conn, authorize_rotation=lambda context: True)
+    with pytest.raises(PermissionError, match="not authorized"):
+        rotate_database_uuid(
+            conn,
+            authorization_context={"admin": False},
+            authorize_rotation=_allow_rotation,
+        )
+    assert get_database_uuid(conn) == original_uuid
+    conn.close()
+
+
+def test_issue_revoke_and_clone_validate_identity_inside_write_transaction(tmp_path):
+    conn = _open(tmp_path / "transaction-order.db")
+
+    issue_statements = []
+    conn.set_trace_callback(issue_statements.append)
+    envelope = _issue(conn)
+    issue_sql = [statement.upper() for statement in issue_statements]
+    issue_begin = next(i for i, sql in enumerate(issue_sql) if "BEGIN IMMEDIATE" in sql)
+    issue_identity = next(
+        i
+        for i, sql in enumerate(issue_sql)
+        if "SELECT VALUE FROM METADATA" in sql and "DATABASE_UUID" in sql
+    )
+    issue_insert = next(
+        i
+        for i, sql in enumerate(issue_sql)
+        if f"INSERT INTO {RETRIEVAL_REFERENCES_TABLE}".upper() in sql
+    )
+    assert issue_begin < issue_identity < issue_insert
+
+    revoke_statements = []
+    conn.set_trace_callback(revoke_statements.append)
+    assert revoke_reference(
+        conn,
+        envelope,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        revoked_at=120.0,
+    ).ok
+    revoke_sql = [statement.upper() for statement in revoke_statements]
+    revoke_begin = next(i for i, sql in enumerate(revoke_sql) if "BEGIN IMMEDIATE" in sql)
+    revoke_identity = next(
+        i
+        for i, sql in enumerate(revoke_sql)
+        if "SELECT VALUE FROM METADATA" in sql and "DATABASE_UUID" in sql
+    )
+    revoke_update = next(
+        i
+        for i, sql in enumerate(revoke_sql)
+        if f"UPDATE {RETRIEVAL_REFERENCES_TABLE}".upper() in sql
+    )
+    assert revoke_begin < revoke_identity < revoke_update
+
+    clone_statements = []
+    conn.set_trace_callback(clone_statements.append)
+    rotate_explicit_clone(
+        conn,
+        authorization_context={"admin": True},
+        authorize_rotation=_allow_rotation,
+        revoked_at=130.0,
+    )
+    clone_sql = [statement.upper() for statement in clone_statements]
+    clone_begin = next(i for i, sql in enumerate(clone_sql) if "BEGIN IMMEDIATE" in sql)
+    clone_identity = next(
+        i
+        for i, sql in enumerate(clone_sql)
+        if "SELECT VALUE FROM METADATA" in sql and "DATABASE_UUID" in sql
+    )
+    clone_update = next(
+        i
+        for i, sql in enumerate(clone_sql)
+        if "UPDATE METADATA SET VALUE" in sql
+    )
+    assert clone_begin < clone_identity < clone_update
+    conn.close()
+
+
+def test_canonical_json_and_wire_envelope_round_trip(tmp_path):
+    conn = _open(tmp_path / "codec.db")
+    try:
+        envelope = _issue(conn)
+        assert canonical_json({"b": 2, "a": [1, True]}) == '{"a":[1,true],"b":2}'
+        assert serialize_reference_envelope(envelope) == (
+            '{"database_uuid":"%s","kind":"message","token":"%s","v":1}'
+            % (envelope.database_uuid, envelope.token)
+        )
+        assert decode_reference_envelope(envelope.to_json()) == envelope
+    finally:
+        conn.close()
+
+
+def test_malformed_and_unsupported_envelopes_are_typed():
+    malformed = resolve_reference(None, {"v": 1}, authorization_context={"trusted": True}, authorize=_allow)
+    assert malformed.to_dict() == {
+        "error_code": ReferenceErrorCode.REFERENCE_INVALID.value,
+        "error": "reference envelope has an invalid shape",
+    }
+    unsupported = resolve_reference(
+        None,
+        {"v": 2, "kind": "message", "database_uuid": "00000000-0000-4000-8000-000000000000", "token": "rh1_" + "0" * 64},
+        authorization_context={"trusted": True},
+        authorize=_allow,
+    )
+    assert unsupported.error_code == ReferenceErrorCode.REFERENCE_UNSUPPORTED_VERSION.value
+    assert unsupported.error
+
+    duplicate = resolve_reference(
+        None,
+        '{"v":1,"kind":"message","database_uuid":"00000000-0000-4000-8000-000000000000",'
+        '"token":"rh1_0000000000000000000000000000000000000000000000000000000000000000",'
+        '"token":"rh1_ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}',
+        authorization_context={"trusted": True},
+        authorize=_allow,
+    )
+    assert duplicate.error_code == ReferenceErrorCode.REFERENCE_INVALID.value
+    assert duplicate.error == "reference envelope contains a duplicate JSON key"
+
+
+def test_database_replacement_mismatch_precedes_registry_disclosure(tmp_path):
+    first = _open(tmp_path / "first.db")
+    envelope = _issue(first)
+    first.close()
+
+    replacement = _open(tmp_path / "replacement.db")
+    statements = []
+    replacement.set_trace_callback(statements.append)
+    try:
+        result = resolve_reference(
+            replacement,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=lambda context, parsed: True,
+        )
+        assert result.error_code == ReferenceErrorCode.REFERENCE_DATABASE_MISMATCH.value
+        assert not any(
+            f"FROM {RETRIEVAL_REFERENCES_TABLE}" in statement.upper()
+            for statement in statements
+        )
+    finally:
+        replacement.close()
+
+
+def test_kind_and_scope_mismatch_do_not_return_binding_details(tmp_path):
+    conn = _open(tmp_path / "scope.db")
+    envelope = _issue(conn, scope={"session_id": "session-a"})
+    try:
+        wrong_kind = resolve_reference(
+            conn,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+            expected_kind="summary_node",
+        )
+        wrong_scope = resolve_reference(
+            conn,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+            expected_scope={"session_id": "session-b"},
+        )
+        assert wrong_kind.error_code == ReferenceErrorCode.REFERENCE_KIND_MISMATCH.value
+        assert wrong_scope.error_code == ReferenceErrorCode.REFERENCE_SCOPE_MISMATCH.value
+        assert "target" not in wrong_kind.to_dict()
+        assert "scope" not in wrong_scope.to_dict()
+    finally:
+        conn.close()
+
+
+def test_expiry_and_revocation_have_stable_errors(tmp_path):
+    conn = _open(tmp_path / "lifecycle.db")
+    try:
+        expired = _issue(conn, expires_at=150.0)
+        expired_result = resolve_reference(
+            conn,
+            expired,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+            now=150.0,
+        )
+        assert expired_result.error_code == ReferenceErrorCode.REFERENCE_STALE.value
+
+        live = _issue(conn)
+        assert revoke_reference(
+            conn,
+            live,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+            revoked_at=120.0,
+        ).ok
+        revoked = resolve_reference(
+            conn,
+            live,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+            now=120.0,
+        )
+        assert revoked.error_code == ReferenceErrorCode.REFERENCE_NOT_FOUND.value
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("issued_at", "not-a-number"),
+        ("issued_at", "NaN"),
+        ("expires_at", "not-a-number"),
+        ("expires_at", "NaN"),
+        ("expires_at", 99.0),
+    ],
+)
+def test_malformed_registry_timestamps_fail_closed_as_stale(
+    tmp_path, column, value
+):
+    conn = _open(tmp_path / f"malformed-{column}-{value}.db")
+    envelope = _issue(conn)
+    digest = reference_token_digest(envelope.token)
+    conn.execute(
+        f"UPDATE {RETRIEVAL_REFERENCES_TABLE} SET {column}=? WHERE token_digest=?",
+        (value, digest),
+    )
+    conn.commit()
+
+    result = resolve_reference(
+        conn,
+        envelope,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        now=100.0,
+    )
+    assert result.to_dict() == {
+        "error_code": ReferenceErrorCode.REFERENCE_STALE.value,
+        "error": "reference binding is no longer valid",
+    }
+    conn.close()
+
+
+def test_authorization_callback_runs_before_registry_and_denial_is_indistinguishable(tmp_path):
+    conn = _open(tmp_path / "auth.db")
+    existing = _issue(conn)
+    missing = existing.to_dict() | {"token": "rh1_" + "f" * 64}
+    events = []
+    statements = []
+    conn.set_trace_callback(statements.append)
+
+    def deny(context, envelope):
+        events.append((context, envelope.kind))
+        assert not any(f"FROM {RETRIEVAL_REFERENCES_TABLE}" in sql.upper() for sql in statements)
+        return False
+
+    try:
+        denied_existing = resolve_reference(conn, existing, authorization_context="trusted", authorize=deny)
+        denied_missing = resolve_reference(conn, missing, authorization_context="trusted", authorize=deny)
+        assert denied_existing.to_dict() == denied_missing.to_dict()
+        assert denied_existing.error_code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+        assert events == [("trusted", "message"), ("trusted", "message")]
+    finally:
+        conn.close()
+
+
+def test_stored_scope_requires_host_authorization_before_binding_disclosure(tmp_path):
+    conn = _open(tmp_path / "scope-authorization.db")
+    envelope = _issue(conn, scope={"tenant": "tenant-b"})
+
+    missing_scope_guard = resolve_reference(
+        conn,
+        envelope,
+        authorization_context={"tenant": "tenant-a"},
+        authorize=lambda context, parsed: bool(context),
+    )
+    assert missing_scope_guard.error_code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    assert "target" not in missing_scope_guard.to_dict()
+    assert "scope" not in missing_scope_guard.to_dict()
+    assert "revision" not in missing_scope_guard.to_dict()
+
+    observed_scopes = []
+
+    def authorize_tenant(context, parsed, scope):
+        observed_scopes.append(scope)
+        return context.get("tenant") == scope.get("tenant")
+
+    denied = resolve_reference(
+        conn,
+        envelope,
+        authorization_context={"tenant": "tenant-a"},
+        authorize=lambda context, parsed: True,
+        authorize_scope=authorize_tenant,
+    )
+    assert denied.error_code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    assert "target" not in denied.to_dict()
+    assert "scope" not in denied.to_dict()
+    assert "revision" not in denied.to_dict()
+
+    allowed = resolve_reference(
+        conn,
+        envelope,
+        authorization_context={"tenant": "tenant-b"},
+        authorize=lambda context, parsed: True,
+        authorize_scope=authorize_tenant,
+    )
+    assert allowed.ok
+    assert allowed.record is not None
+    assert allowed.record.target == {"source": "test", "store_id": 7}
+    assert observed_scopes == [{"tenant": "tenant-b"}, {"tenant": "tenant-b"}]
+    conn.close()
+
+
+def test_scope_denial_normalizes_missing_kind_and_state_oracles(tmp_path):
+    conn = _open(tmp_path / "scope-oracles.db")
+    active = _issue(conn)
+    expired = _issue(conn, expires_at=110.0)
+    revoked = _issue(conn)
+    assert revoke_reference(
+        conn,
+        revoked,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        revoked_at=120.0,
+    ).ok
+
+    missing = active.to_dict()
+    missing["token"] = "rh1_" + "0" * 64
+    wrong_kind = active.to_dict()
+    wrong_kind["kind"] = "summary_node"
+    statements = []
+    conn.set_trace_callback(statements.append)
+    failures = [
+        resolve_reference(
+            conn,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=lambda context, parsed: True,
+            authorize_scope=lambda context, parsed, scope: False,
+            now=150.0,
+        ).to_dict()
+        for envelope in (missing, wrong_kind, expired, revoked)
+    ]
+    assert failures == [
+        {
+            "error_code": ReferenceErrorCode.REFERENCE_FORBIDDEN.value,
+            "error": "reference scope is not authorized by the host",
+        }
+    ] * 4
+    assert not any(
+        "TARGET_JSON" in statement.upper() or "REVISION_JSON" in statement.upper()
+        for statement in statements
+    )
+    conn.close()
+
+
+def test_revocation_denial_precedes_registry_lookup(tmp_path):
+    conn = _open(tmp_path / "revoke-authorization.db")
+    envelope = _issue(conn)
+    statements = []
+    conn.set_trace_callback(statements.append)
+
+    denied = revoke_reference(
+        conn,
+        envelope,
+        authorization_context={"trusted": False},
+        authorize=lambda context, parsed: False,
+        authorize_scope=lambda context, parsed, scope: True,
+        revoked_at=120.0,
+    )
+    assert denied.error_code == ReferenceErrorCode.REFERENCE_FORBIDDEN.value
+    assert not any(
+        f"FROM {RETRIEVAL_REFERENCES_TABLE}" in statement.upper()
+        for statement in statements
+    )
+    assert conn.execute(
+        f"SELECT revoked_at FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (None,)
+    conn.close()
+
+
+def test_issue_failure_rolls_back_registry_insert(tmp_path):
+    conn = _open(tmp_path / "rollback.db")
+    try:
+        conn.execute(
+            f"""
+            CREATE TRIGGER fail_retrieval_issue
+            BEFORE INSERT ON {RETRIEVAL_REFERENCES_TABLE}
+            BEGIN SELECT RAISE(ABORT, 'injected issue failure'); END
+            """
+        )
+        conn.commit()
+        with pytest.raises(sqlite3.IntegrityError, match="injected issue failure"):
+            _issue(conn)
+        assert conn.execute(f"SELECT COUNT(*) FROM {RETRIEVAL_REFERENCES_TABLE}").fetchone() == (0,)
+    finally:
+        conn.close()
+
+
+def test_explicit_clone_rotation_changes_uuid_and_revokes_copied_rows_atomically(tmp_path):
+    path = tmp_path / "clone.db"
+    conn = _open(path)
+    envelope = _issue(conn)
+    old_uuid = get_database_uuid(conn)
+    new_uuid = rotate_explicit_clone(
+        conn,
+        authorization_context={"admin": True},
+        authorize_rotation=_allow_rotation,
+        revoked_at=200.0,
+    )
+    try:
+        assert new_uuid != old_uuid
+        assert get_database_uuid(conn) == new_uuid
+        assert conn.execute(
+            f"SELECT revoked_at FROM {RETRIEVAL_REFERENCES_TABLE}"
+        ).fetchone() == (200.0,)
+        result = resolve_reference(
+            conn,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+        )
+        assert result.error_code == ReferenceErrorCode.REFERENCE_DATABASE_MISMATCH.value
+    finally:
+        conn.close()
+
+    rollback = _open(tmp_path / "clone-rollback.db")
+    _issue(rollback)
+    rollback_uuid = get_database_uuid(rollback)
+    rollback.execute(
+        """
+        CREATE TRIGGER fail_clone_rotation
+        BEFORE UPDATE ON metadata WHEN OLD.key='database_uuid'
+        BEGIN SELECT RAISE(ABORT, 'injected clone failure'); END
+        """
+    )
+    rollback.commit()
+    with pytest.raises(sqlite3.IntegrityError, match="injected clone failure"):
+        rotate_database_uuid(
+            rollback,
+            authorization_context={"admin": True},
+            authorize_rotation=_allow_rotation,
+            revoked_at=300.0,
+        )
+    assert get_database_uuid(rollback) == rollback_uuid
+    assert rollback.execute(
+        f"SELECT revoked_at FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (None,)
+    rollback.close()
+
+
+def test_registry_writes_respect_caller_transaction_rollback(tmp_path):
+    conn = _open(tmp_path / "caller-transaction.db")
+    original_uuid = get_database_uuid(conn)
+
+    conn.execute("BEGIN")
+    _issue(conn)
+    assert conn.in_transaction
+    conn.rollback()
+    assert conn.execute(
+        f"SELECT COUNT(*) FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (0,)
+
+    durable = _issue(conn)
+    conn.execute("BEGIN")
+    revoked = revoke_reference(
+        conn,
+        durable,
+        authorization_context={"trusted": True},
+        authorize=_allow,
+        authorize_scope=_allow_scope,
+        revoked_at=310.0,
+    )
+    assert revoked.ok
+    assert conn.in_transaction
+    conn.rollback()
+    assert conn.execute(
+        f"SELECT revoked_at FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (None,)
+
+    conn.execute("BEGIN")
+    transient_uuid = rotate_database_uuid(
+        conn,
+        authorization_context={"admin": True},
+        authorize_rotation=_allow_rotation,
+        revoked_at=320.0,
+    )
+    assert transient_uuid != original_uuid
+    assert conn.in_transaction
+    conn.rollback()
+    assert get_database_uuid(conn) == original_uuid
+    assert conn.execute(
+        f"SELECT revoked_at FROM {RETRIEVAL_REFERENCES_TABLE}"
+    ).fetchone() == (None,)
+    conn.close()
+
+
+def test_byte_restore_preserves_uuid_and_registry(tmp_path):
+    original_path = tmp_path / "original.db"
+    original = _open(original_path)
+    envelope = _issue(original)
+    original_uuid = get_database_uuid(original)
+    original.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    original.close()
+    restored_path = tmp_path / "restored.db"
+    shutil.copy2(original_path, restored_path)
+
+    restored = _open(restored_path)
+    try:
+        assert get_database_uuid(restored) == original_uuid
+        result = resolve_reference(
+            restored,
+            envelope,
+            authorization_context={"trusted": True},
+            authorize=_allow,
+            authorize_scope=_allow_scope,
+        )
+        assert result.ok
+        assert result.record is not None
+        assert result.record.target == {"source": "test", "store_id": 7}
+    finally:
+        restored.close()
+
+
+def test_registry_constraints_indexes_and_numeric_schema_version(tmp_path):
+    conn = _open(tmp_path / "schema.db")
+    try:
+        assert get_schema_version(conn) == 5
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (RETRIEVAL_REFERENCES_TABLE,),
+        ).fetchone()[0].lower()
+        assert "check" in sql
+        indexes = {
+            row[1]
+            for row in conn.execute(
+                f"PRAGMA index_list({RETRIEVAL_REFERENCES_TABLE})"
+            ).fetchall()
+        }
+        assert f"idx_{RETRIEVAL_REFERENCES_TABLE}_kind_state" in indexes
+        assert f"idx_{RETRIEVAL_REFERENCES_TABLE}_scope" in indexes
+        assert verify_retrieval_references_schema(conn) == []
+    finally:
+        conn.close()
+
+
+def test_registry_index_names_cannot_be_owned_by_another_table(tmp_path):
+    conn = _open(tmp_path / "foreign-index-owner.db")
+    kind_index = f"idx_{RETRIEVAL_REFERENCES_TABLE}_kind_state"
+    scope_index = f"idx_{RETRIEVAL_REFERENCES_TABLE}_scope"
+    conn.execute(f"DROP INDEX {kind_index}")
+    conn.execute(f"DROP INDEX {scope_index}")
+    conn.execute(
+        "CREATE TABLE other(kind TEXT, revoked_at REAL, expires_at REAL, scope_json TEXT)"
+    )
+    conn.execute(
+        f"CREATE INDEX {kind_index} ON other(kind, revoked_at, expires_at)"
+    )
+    conn.execute(f"CREATE INDEX {scope_index} ON other(kind, scope_json)")
+    conn.commit()
+
+    assert verify_retrieval_references_schema(conn) == [
+        f"malformed index:{kind_index}",
+        f"malformed index:{scope_index}",
+    ]
+    with pytest.raises(RetrievalReferenceSchemaError, match="completed.*damaged"):
+        run_versioned_migrations(conn)
+    assert conn.execute(
+        "SELECT name, tbl_name FROM sqlite_master WHERE name IN (?, ?) ORDER BY name",
+        (kind_index, scope_index),
+    ).fetchall() == [(kind_index, "other"), (scope_index, "other")]
+    conn.close()
+
+
+def test_named_migration_failure_rolls_back_identity_and_new_registry(tmp_path, monkeypatch):
+    conn = sqlite3.connect(tmp_path / "migration-rollback.db")
+    original_verify = db_bootstrap.verify_retrieval_references_schema
+    monkeypatch.setattr(
+        db_bootstrap,
+        "verify_retrieval_references_schema",
+        lambda connection: ["injected schema failure"],
+    )
+    try:
+        with pytest.raises(RetrievalReferenceSchemaError, match="injected schema failure"):
+            run_versioned_migrations(conn)
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='retrieval_references_v1'"
+        ).fetchone() is None
+        assert conn.execute(
+            "SELECT value FROM metadata WHERE key='database_uuid'"
+        ).fetchone() is None
+        assert conn.execute(
+            "SELECT 1 FROM lcm_migration_state WHERE step_name=?",
+            (DATABASE_UUID_MIGRATION,),
+        ).fetchone() is None
+    finally:
+        monkeypatch.setattr(db_bootstrap, "verify_retrieval_references_schema", original_verify)
+        conn.close()


### PR DESCRIPTION
## Summary

- add one internal `message` retrieval-reference adapter over the V1 authority foundation in #487;
- bind each opaque reference to exact positive `messages.store_id`, caller-supplied authorization scope, and a SHA-256 semantic revision;
- normalize legacy blank source/conversation fields, content, valid JSON `tool_calls`, and finite timestamps before hashing;
- treat content/session/source/conversation/role/tool/timestamp changes, GC tombstones, malformed rows, and malformed registry bindings as typed stale/not-found failures;
- exclude operational `pinned` and `token_estimate` fields from semantic staleness;
- require host target preauthorization before any transaction/message lookup, making denied existing and missing IDs indistinguishable;
- preserve authorization-before-registry/message disclosure and the foundation's kind/scope/authority/expiry/revocation taxonomy;
- issue atomically under `BEGIN IMMEDIATE` or a caller-owned transaction;
- resolve under one stable read snapshot and hold `MessageStore`'s re-entrant write lock so shared-connection writers cannot interleave; raw SQLite callers retain caller-managed concurrency;
- document the adapter boundary without changing public tools, schemas, pagination, principals, or tenants.

## Why

#487 establishes a product-neutral opaque authority but intentionally does not load target rows. Before strong mutation-safe pagination (#477) can reuse that authority, one target adapter must prove exact target/revision binding, authorization-before-disclosure, transactional rollback, and mutation behavior end to end.

This PR is that single vertical. It does **not** change `tools.py`, public schemas, or numeric schema version 5.

## Verification

Sandboxed root matrix with both `HERMES_HOME` and `LCM_DATABASE_PATH` isolated:

```bash
python -m pytest -q -p no:cacheprovider \
  tests/test_message_references.py \
  tests/test_retrieval_reference_contract.py \
  tests/test_db_bootstrap_fts.py \
  tests/test_schema_stamp_remediation.py \
  tests/test_packaging_install.py
```

Result: **147 passed** (including packaging/install coverage).

Focused adapter suite: **30 passed**, including:

- round trip and exact normalized revision;
- digest-only registry persistence;
- authorization denial before registry/message SELECT;
- equal no-I/O forbidden behavior for denied existing/missing issuance targets;
- content, scope, role, tool, timestamp, GC, delete, expiry, revoke, clone, kind, and malformed-binding behavior;
- caller rollback and callback-denial behavior;
- WAL mutation snapshot stability;
- same-connection MessageStore writer exclusion;
- raw SQLite connection facade.

```bash
python -m ruff check message_references.py retrieval_references.py db_bootstrap.py \
  tests/test_message_references.py tests/test_retrieval_reference_contract.py
python -m py_compile message_references.py retrieval_references.py db_bootstrap.py \
  tests/test_message_references.py tests/test_retrieval_reference_contract.py
git diff --check
git diff --cached --check
```

All clean.

## Stack and scope

- Depends on #487 (`bf44dc81982ff507ce86a8f46fb96077a6394b5f`), which is stacked on #486.
- No public-tool or schema fan-out.
- No pagination/cursor implementation.
- No principal/tenant policy.

Refs #476.
