### PR TITLE
chore: prepare v0.21.0-rc1 release candidate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Version and branch
       description: hermes-lcm version, branch, commit, or release tag.
-      placeholder: v0.20.0, main, or commit SHA
+      placeholder: v0.21.0-rc1, main, or commit SHA
     validations:
       required: true
 

--- a/.github/release-notes/v0.21.0-rc1.md
+++ b/.github/release-notes/v0.21.0-rc1.md
@@ -1,0 +1,25 @@
+# hermes-lcm v0.21.0-rc1
+
+Lossless Context Management for Hermes: an RC for the merged experience-memory, exact-evidence, citable-retrieval, and large-store reliability wave.
+
+## Highlights
+
+- Adds the trajectory/experience-memory subsystem plus opt-in assertion, query-view, pre-answer evidence, and adaptive-retrieval paths; stock installs retain the previous behavior until operators enable those paths.
+- Keeps the core SQLite schema at version 5. New feature stores use additive named migrations in the same profile database; existing v0.20 databases need no manual migration or embedding backfill.
+- Hardens large-store and startup behavior with bounded vector/metadata work, WAL-conversion lock retry, and eventual background temporal-rollup maintenance.
+- Carries reference-strict citable delivery, direct source identity for summary recall hits, and configurable query embedding spend limits. Committed benchmark results apply only to their documented harness and corpus.
+
+## Changes
+
+- #436 Consolidate trajectory/experience memory, exact evidence, citable retrieval, privacy, scaling, and release-validation work.
+- #361 Retry WAL conversion on lock contention during connection setup.
+- #440 Defer temporal-rollup maintenance from the session-start critical path.
+- #446 Batch embedding-backfill fixture setup for release-scale validation.
+- #447 Batch large vector-metadata fixture setup for release-scale validation.
+
+## Contributors
+
+- @stephenschoettler
+- @100yenadmin
+- @ai-ag2026
+- @Tosko4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,49 +15,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate changelog
-        id: changelog
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Validate curated release notes
         run: |
-          CURRENT_TAG="${{ github.ref_name }}"
-          PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -1)
-
-          if [ -z "$PREV_TAG" ]; then
-            RANGE="$CURRENT_TAG"
-          else
-            RANGE="$PREV_TAG..$CURRENT_TAG"
+          NOTES_FILE=".github/release-notes/${GITHUB_REF_NAME}.md"
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "Missing curated release notes: $NOTES_FILE" >&2
+            exit 1
           fi
-
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "Initial release." >> "$GITHUB_OUTPUT"
-          else
-            git log --pretty=format:"- %s (%h)" "$RANGE" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "" >> "$GITHUB_OUTPUT"
-          echo "## Contributors" >> "$GITHUB_OUTPUT"
-          if [ -n "$PREV_TAG" ]; then
-            CONTRIBUTORS=$(curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}" \
-              | jq -r '[.commits[].author.login // empty] | unique | .[] | "- @\(.)"')
-            if [ -n "$CONTRIBUTORS" ]; then
-              printf '%s\n' "$CONTRIBUTORS" >> "$GITHUB_OUTPUT"
-            else
-              echo "- No GitHub usernames found" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "- No GitHub usernames found" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          body: ${{ steps.changelog.outputs.body }}
+          body_path: .github/release-notes/${{ github.ref_name }}.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,44 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 ## Unreleased
 
-### Benchmark-driven retrieval scaling, evidence provenance, and citable delivery (PR stephenschoettler/hermes-lcm#436)
+No additional changes yet.
 
-- Removed the large-corpus recall ceilings: full summary/chunk corpus scans in bounded batches (was a 25k-vector
-  recency window that blinded semantic recall at scale), and in-product sanitization of raw natural-language
-  FTS queries (was FTS5-reject → LIKE scan → timeout → empty results). Re-measured on a 389×-scaled store:
-  recall cliff eliminated, raw-query empty rate 100% → 0%. (#167, #168, #169)
-- Reference-strict citable delivery: no evidence hit lacking a validated source reference is delivered;
-  uncitable summary hits become non-evidence leads with citable backfill. Eliminates a measured 1.6%
-  fail-close loss at full scale (0/500 on the confirm run). (#164, #174)
-- Made the query-path embedding spend guard configurable with a generous default while preserving the exempt
-  backfill contract. (stephenschoettler/hermes-lcm#434, carried verbatim)
-- Preserved a direct source `store_id` on summary recall hits so strict evidence renderers can validate
-  source identity. (#164)
-- Four fork-side review rounds on the consolidated train (35 → 11 → 6 → 8 findings, every one fixed,
-  refuted in writing, or deferred to a filed issue):
-  absolute-deadline stops on all scan paths, exact-shape verification of preserved schema families before
-  stamp downgrades, deadline-interruptible summary lineage expansion, delta refs rebuilt after response-cap
-  eviction, spend-ledger completeness on chunked backfills, and the benchmark evidence trail (`bench/`, F20–F37).
+## v0.21.0-rc1 - 2026-08-03
+
+### Highlights
+
+- Add the trajectory/experience-memory subsystem and the opt-in assertion,
+  evidence, query-view, and adaptive-retrieval surfaces delivered by the
+  consolidated wave-1 merge (#436).
+- Keep the core SQLite schema at version 5. New feature stores use additive,
+  named migrations in the same profile database, while disabled/default-off
+  installs do not create optional assertion, query-view, or embedding tables.
+- Improve large-store and startup behavior with bounded vector/metadata work,
+  lock-contention retry during WAL conversion, and deferred temporal-rollup
+  maintenance (#361, #440, #446, #447).
+
+### Changed
+
+- #436 adds the consolidated trajectory/experience-memory, retrieval,
+  exact-evidence, citable-delivery, privacy, scale, and release-validation wave.
+  Its committed benchmark results are directional evidence for the documented
+  harness and corpus, not universal provider or workload guarantees.
+- #361 retries WAL conversion when connection setup meets lock contention.
+- #440 moves temporal-rollup maintenance off the session-start critical path;
+  bounded background work is eventual and `lcm_recent` retains its fallback.
+- #446 and #447 batch large fixture setup for embedding/vector metadata release
+  coverage without changing runtime behavior.
+
+### Upgrade notes
+
+- Back up `lcm.db`, update the plugin checkout, restart Hermes, send one normal
+  message, then verify `plugin_version: 0.21.0-rc1` and the expected database
+  path with `lcm_status`. The core schema remains version 5.
+- No manual core migration or embedding backfill is required from v0.20.0.
+- Query/evidence tool schemas are exposed after upgrade, but assertion
+  extraction, assertion storage, query-view storage, pre-answer evidence, and
+  adaptive retrieval remain opt-in. Review provider/privacy boundaries before
+  enabling model- or embedding-backed paths.
 
 ## v0.20.0 - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.20.0 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc1 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -218,7 +218,7 @@ best-effort git identity:
 
 If startup logs say LCM tools are available through `context-engine schemas` or
 mention the `Path B fallback`, that is expected on older Hermes hosts such as
-Hermes Agent v0.16. The ten `lcm_*` tools remain available through the
+Hermes Agent v0.16. All 15 `lcm_*` tools remain available through the
 context-engine path; standalone plugin-registry registration is not required
 there.
 
@@ -243,6 +243,17 @@ If you installed a symlink from a separate checkout:
 ```
 
 Restart Hermes after updating.
+
+For the `v0.21.0-rc1` line, take a normal backup of `lcm.db` before updating,
+then update the checkout and restart Hermes. No manual core migration or
+backfill is required: the core schema remains version 5. New assertion,
+query-view, and adaptive-retrieval state is additive, created only after the
+corresponding opt-in is enabled, and stored in the same profile database under
+named feature markers. The five new query/evidence tool schemas are visible in
+the tool list on stock installs, but automatic extraction, pre-answer evidence,
+assertion storage, query-view storage, and adaptive retrieval remain off. See
+[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0200-to-v0210-rc1)
+before enabling them.
 
 ## Commands and tools
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -79,6 +79,32 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
+## Upgrade from v0.20.0 to v0.21.0-rc1
+
+1. Back up the profile's `lcm.db` and its `-wal`/`-shm` companions, or run
+   `/lcm backup` from the old runtime.
+2. Update the plugin checkout to the RC and restart Hermes.
+3. Send one normal message, then confirm `lcm_status` reports plugin version
+   `0.21.0-rc1` and the expected database path.
+4. For a migration-shape audit, query that database with
+   `SELECT value FROM metadata WHERE key = 'schema_version';`; the expected
+   result is `5`.
+
+No manual core migration, data import, or embedding backfill is required. An
+existing v0.20 database opens in place and remains on core schema version 5.
+The 0.21 assertion, query-view, and trajectory families use additive named
+feature markers and create their tables only when the corresponding store or
+workflow is invoked. A stock/default-off upgrade therefore creates none of
+those optional tables. If you later enable a 0.21-only store, treat the
+pre-upgrade backup as the downgrade path rather than opening that modified
+database with an older plugin.
+
+Temporal rollup settings do not change. When rollups are enabled, maintenance
+now runs through bounded eventual background work instead of blocking session
+start. A busy or full maintenance queue defers work to a later opportunity;
+`lcm_recent` continues to fall back to bounded leaf summaries while rollups are
+missing or stale.
+
 ## Verify
 
 Run:
@@ -91,7 +117,11 @@ Expected signals:
 
 - plugin list includes `hermes-lcm`
 - selected context engine is `lcm`
-- tool list includes `lcm_grep`, `lcm_recall`, `lcm_recent`, `lcm_load_session`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, `lcm_inspect`, and `lcm_doctor`
+- tool list includes all 15 schemas: `lcm_grep`, `lcm_recall`,
+  `lcm_query_state`, `lcm_compute`, `lcm_compile_evidence`,
+  `lcm_evidence_pack`, `lcm_retrieve`, `lcm_recent`, `lcm_load_session`,
+  `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, `lcm_inspect`,
+  and `lcm_doctor`
 - ordinary skill discovery includes `hermes-lcm`; plugin-qualified explicit
   loading is `hermes-lcm:hermes-lcm` on hosts that support plugin skills
 
@@ -99,7 +129,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.20.0 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc1 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -133,7 +163,7 @@ LCM tools are still available through the context-engine schema/dispatch path
 registration (Path A) on those hosts because Path A would shadow Path B and lose
 current-turn ingest.
 
-Healthy signals are the same as above: selected context engine `lcm`, the ten
+Healthy signals are the same as above: selected context engine `lcm`, all 15
 `lcm_*` tools in the live tool list, and `lcm_status` / `lcm_inspect` / `lcm_doctor` responding
 after one normal message initializes the session.
 
@@ -202,6 +232,43 @@ environment variables:
 | `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
 | `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires (default 200 so fresh installs skip the work) |
 | `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
+
+### Evidence and adaptive retrieval (0.21 RC)
+
+Hermes exposes all 15 LCM tool schemas whenever LCM is the active context
+engine. Exposure is not activation. On a stock install:
+
+- `lcm_compute`, `lcm_compile_evidence`, and `lcm_evidence_pack` are bounded,
+  provider-neutral operations over caller-supplied exact refs. Calling them does
+  not enable a store, run an extractor, or activate an answering model.
+- `lcm_query_state` returns `status: disabled` until
+  `LCM_ASSERTIONS_ENABLED=true` creates/binds the rebuildable assertion sidecar.
+- `lcm_retrieve` returns `status: disabled` until
+  `LCM_ADAPTIVE_RETRIEVAL_ENABLED=true`. The controller itself has no model or
+  provider client, but retrieval calls it dispatches retain their existing
+  embedding-provider behavior.
+
+| Variable | Default | Use |
+|----------|---------|-----|
+| `LCM_ASSERTIONS_ENABLED` | `false` | Create and bind the same-DB assertion sidecar so `lcm_query_state` can return typed, source-cited state. This alone performs no extraction or backfill. |
+| `LCM_ASSERTION_EXTRACTION_ENABLED` | `false` | With assertions enabled, run bounded structured extraction over exact persisted rows before compaction. This may send source text to the configured extraction/summary model. |
+| `LCM_ASSERTION_EXTRACTION_MODEL` | empty | Extraction-model override; otherwise uses `LCM_EXTRACTION_MODEL`, then the summary model. |
+| `LCM_ASSERTION_EXTRACTION_MAX_SOURCES_PER_PASS` | `4` | Maximum exact source rows per extraction pass; runtime clamps to 1-8. |
+| `LCM_ASSERTION_EXTRACTION_TIMEOUT_SECONDS` | `30` | Timeout for each exact-source extraction call; runtime clamps to 0.1-120 seconds. |
+| `LCM_QUERY_VIEWS_ENABLED` | `false` | Create and bind demand-shaped evidence views without invoking a model or retrieval provider. |
+| `LCM_ADAPTIVE_RETRIEVAL_ENABLED` | `false` | Enable `lcm_retrieve` and bind query views for evidence reuse. Episodes are bounded to existing retrieval tools and store evidence/traces, never final prose. |
+| `LCM_PREANSWER_EVIDENCE_ENABLED` | `false` | Enable the automatic pre-answer evidence hook. Disabled preserves the ordinary hook context and performs no retrieval or computation. |
+| `LCM_PREANSWER_EVIDENCE_MODE` | empty | When the master flag is enabled, empty selects legacy selective behavior; explicit values are `off`, `legacy_selective`, or `requirements_v1`. |
+| `LCM_SELECTIVE_COMPILER_ENABLED` | `false` | Separately opt into the semantic selector for code-derived closed operations. Pre-answer evidence alone remains provider-free. |
+| `LCM_SELECTIVE_COMPILER_MODEL` | empty | Optional model override for the selective compiler. |
+
+Privacy boundary: assertion and query-view records live in the selected
+profile's existing `lcm.db` and may include exact quotes, spans, and dependency
+refs. Provider-neutral evidence tools do not upload them by themselves.
+Embedding-backed retrieval, assertion extraction, and the optional selective
+compiler can send configured content to their selected providers. Review those
+provider and redaction settings before opting in; sensitive-pattern redaction is
+also default-off and is forward-only.
 
 Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -30,7 +30,7 @@ Make packaging a separate implementation lane only when one of these is true:
 2. Users need version-pinned installs without direct git checkouts.
 3. Release automation needs packaged artifacts beyond GitHub tags/releases.
 
-The narrow next step would be packaging metadata plus tests that prove a packaged install still exposes `hermes-lcm`, context engine `lcm`, and all ten LCM tools through `hermes plugins`. Until then, clone/symlink remains the documented path.
+The narrow next step would be packaging metadata plus tests that prove a packaged install still exposes `hermes-lcm`, context engine `lcm`, and all 15 LCM tools through `hermes plugins`. Until then, clone/symlink remains the documented path.
 
 ## Current install and update references
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.20.0
+version: 0.21.0-rc1
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -417,7 +417,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.20.0" in result
+    assert "plugin_version: 0.21.0-rc1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -457,7 +457,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.20.0" in result
+    assert "plugin_version: 0.21.0-rc1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
     assert "triage_guidance:\n- none" in result

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1139,7 +1139,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.20.0"
+    assert identity["plugin_version"] == "0.21.0-rc1"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -1165,11 +1165,11 @@ def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
 
     initial = identity_mod._plugin_metadata()
     assert initial["name"] == "hermes-lcm"
-    assert initial["version"] == "0.20.0"
+    assert initial["version"] == "0.21.0-rc1"
 
-    updated = original.replace('version: "0.20.0"', 'version: "9.9.9-test"')
+    updated = original.replace('version: "0.21.0-rc1"', 'version: "9.9.9-test"')
     if updated == original:
-        updated = original.replace('version: 0.20.0', 'version: 9.9.9-test')
+        updated = original.replace('version: 0.21.0-rc1', 'version: 9.9.9-test')
     assert updated != original
 
     try:
@@ -1207,7 +1207,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.20.0"
+    assert payload["runtime_identity"]["plugin_version"] == "0.21.0-rc1"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -377,7 +377,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.20.0"
+    assert identity["plugin_version"] == "0.21.0-rc1"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,23 +3,52 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+RELEASE_VERSION = "0.21.0-rc1"
+RELEASE_NOTES = REPO_ROOT / ".github" / "release-notes" / f"v{RELEASE_VERSION}.md"
 
 
-def test_release_workflow_uses_env_backed_github_token_header():
+def test_release_workflow_requires_curated_tag_specific_notes():
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    github_token_expr = "$" + "{{ github.token }}"
-    shell_token_ref = "$" + "{GH_TOKEN}"
 
-    assert f"GH_TOKEN: {github_token_expr}" in workflow
-    assert f"Authorization: Bearer {shell_token_ref}" in workflow
+    assert 'NOTES_FILE=".github/release-notes/${GITHUB_REF_NAME}.md"' in workflow
+    assert 'body_path: .github/release-notes/${{ github.ref_name }}.md' in workflow
+    assert "generate_release_notes: false" in workflow
+    assert "git log --pretty" not in workflow
 
 
-def test_release_workflow_does_not_embed_malformed_token_expression():
+def test_release_workflow_marks_rc_tags_as_prereleases_not_latest():
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    shell_token_ref = "$" + "{GH_TOKEN}"
-    auth_lines = [line for line in workflow.splitlines() if "Authorization: Bearer" in line]
 
-    expected_auth = f'              -H "Authorization: Bearer {shell_token_ref}" \\'
-    assert auth_lines == [expected_auth]
-    assert all("github.token" not in line for line in auth_lines)
-    assert all("***" not in line for line in auth_lines)
+    assert "prerelease: ${{ contains(github.ref_name, '-') }}" in workflow
+    assert "make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}" in workflow
+    assert "draft: false" in workflow
+
+
+def test_release_candidate_identity_surfaces_are_synchronized():
+    manifest = (REPO_ROOT / "plugin.yaml").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    operator_guide = (REPO_ROOT / "docs" / "operator-guide.md").read_text(
+        encoding="utf-8"
+    )
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    bug_report = (
+        REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml"
+    ).read_text(encoding="utf-8")
+
+    assert f"version: {RELEASE_VERSION}" in manifest
+    assert f"hermes-lcm v{RELEASE_VERSION} (15 tools)" in readme
+    assert f"hermes-lcm v{RELEASE_VERSION} (15 tools)" in operator_guide
+    assert f"## v{RELEASE_VERSION} - " in changelog
+    assert f"v{RELEASE_VERSION}, main, or commit SHA" in bug_report
+
+
+def test_release_candidate_notes_cover_only_the_merged_release_scope():
+    notes = RELEASE_NOTES.read_text(encoding="utf-8")
+
+    assert notes.startswith(f"# hermes-lcm v{RELEASE_VERSION}\n")
+    assert all(f"#{number}" in notes for number in (361, 436, 440, 446, 447))
+    assert "## Highlights" in notes
+    assert "## Changes" in notes
+    assert "## Contributors" in notes
+    assert "documented harness and corpus" in notes
+    assert len(notes.splitlines()) <= 60


### PR DESCRIPTION
## Summary
- synchronize the prospective `v0.21.0-rc1` identity across the manifest, operator examples, issue template, changelog, packaging docs, and version assertions
- require curated tag-specific release notes and mark hyphenated tags as GitHub prereleases that do not replace the latest stable release
- document the merged-only 0.21 RC scope, opt-in/default-off behavior, evidence/query surfaces, adaptive retrieval, schema-v5 compatibility, and v0.20 upgrade expectations

## Why
- the frozen release audit found that an RC tag from current `main` would publish as a normal release, compare from a stale RC tag, and still report runtime version `0.20.0`
- generated notes would include hundreds of unrelated commits and the current changelog omitted merged #361 and #440

## Validation
- [x] Focused release/install validation -> `476 passed`
- [x] Full suite -> `2792 passed, 12 xfailed`
- [x] Low-FD full suite -> `2792 passed, 12 xfailed`
- [x] `python -m compileall -q .`
- [x] `python -m py_compile scripts/backfill_externalized_tool_outputs.py scripts/import_lossless_claw.py scripts/lcm_benchmark.py scripts/lcm_stress_check.py`
- [x] `bash -n scripts/install.sh scripts/update.sh scripts/validate_release.sh`
- [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [x] Workflow/static validation -> `actionlint` and changed-file `ruff`, `2 passed`
- [x] Benchmark smoke and stress smoke
- [x] Release-tier stress validation -> `failure_count: 0`
- [x] Isolated clean-install smoke -> global plugin/skill symlinks resolve to this checkout, manifest reports `0.21.0-rc1`, all 15 tools are declared, and a second install is idempotent
- [x] Existing v0.20 database upgrade smoke -> schema stayed at v5, existing rows remained readable, no default-off optional sidecars were created, `1 passed`

## Notes
- Curated notes include only merged #361, #436, #440, #446, and #447. Open/unmerged work and universal benchmark claims are excluded.
- This PR does not create a tag, release, announcement, or package publication.

Refs #361, #436, #440, #446, #447
