### PR TITLE
fix: preserve Unicode boundaries in tiktoken state chunks

### DIFF
--- a/tests/test_trajectory_state_semantic_expansion.py
+++ b/tests/test_trajectory_state_semantic_expansion.py
@@ -650,9 +650,32 @@ def test_fallback_chunks_obey_the_shared_token_estimator(tmp_path, monkeypatch):
     assert all(token_module._fallback_token_estimate(chunk) <= 5 for chunk in chunks)
 
 
-def test_chunked_path_pools_oversize_documents(tmp_path):
-    """Every document over the test-lowered token budget takes the chunk path
-    and each state still yields exactly one usable vector."""
+def test_tiktoken_chunks_preserve_multibyte_boundaries(monkeypatch):
+    tiktoken = pytest.importorskip("tiktoken")
+    encoder = tiktoken.get_encoding("cl100k_base")
+    monkeypatch.setattr(token_module, "_get_encoder", lambda: encoder)
+    store = object.__new__(TrajectoryStore)
+    document = "漢字かな交じり文" * 20
+    token_budget = 7
+
+    token_ids = encoder.encode(document)
+    naive_rejoin = "".join(
+        encoder.decode(token_ids[start:start + token_budget])
+        for start in range(0, len(token_ids), token_budget)
+    )
+    assert "\ufffd" in naive_rejoin
+
+    chunks = store._state_token_chunks(document, token_budget=token_budget)
+
+    assert "".join(chunks) == document
+    assert all("\ufffd" not in chunk for chunk in chunks)
+    assert len(chunks) > 1
+    assert all(len(encoder.encode(chunk)) <= token_budget for chunk in chunks)
+
+
+def test_exact_budget_document_stays_normal_and_oversize_is_chunked(tmp_path):
+    """The exact-budget document remains normal while only the oversized state
+    takes the chunk path; both still yield exactly one usable vector."""
     asset_root = tmp_path / "assets"
     asset_root.mkdir()
     provider = StateVectorProvider()
@@ -660,24 +683,29 @@ def test_chunked_path_pools_oversize_documents(tmp_path):
         tmp_path / "lcm.db", _identity(), asset_root=asset_root,
         embedding_provider=provider,
     )
-    long_text = "alpha-answer " + ("token " * 400)  # well over a 5-token budget
+    exact_budget_text = "widget configuration export panel form"
+    document_token_budget = token_module.count_tokens(exact_budget_text)
+    long_text = "alpha-answer " + ("token " * 400)  # well over the exact fixture
     store.insert(_source(
         asset_root,
         trajectory_id="answerpath",
         ordinal=0,
         goal="Update the account settings",
         texts=(
-            "widget configuration export panel form",
+            exact_budget_text,
             long_text,
         ),
     ))
     store.finalize(["answerpath"])
     stats = store.build_state_semantic_index(
-        provider, document_token_budget=5, batch_token_budget=50, batch_max_items=4
+        provider,
+        document_token_budget=document_token_budget,
+        batch_token_budget=50,
+        batch_max_items=4,
     )
-    # Both documents exceed five cl100k tokens; the old expectation of one
-    # chunked state confused word count with the provider tokenizer.
-    assert stats["chunked_states"] == 2
+    assert token_module.count_tokens(exact_budget_text) == document_token_budget
+    assert token_module.count_tokens(long_text) > document_token_budget
+    assert stats["chunked_states"] == 1
     assert stats["states_embedded"] == 2
     oversize = _state_id(store, "answerpath", 1)
     row = store._conn.execute(

--- a/trajectory_store.py
+++ b/trajectory_store.py
@@ -1580,6 +1580,8 @@ class TrajectoryStore:
         character window if the encoder is unavailable."""
         from .tokens import _fallback_token_estimate, _get_encoder
 
+        if token_budget < 1:
+            raise ValueError("token_budget must be positive")
         encoder = _get_encoder()
         if encoder is None:
             # Use the shared estimator itself rather than ``budget * 4``:
@@ -1607,11 +1609,37 @@ class TrajectoryStore:
                 start += accepted
             return chunks or [document]
         token_ids = encoder.encode(document)
+        encoded = bytearray()
+        token_byte_offsets = [0]
+        for token_id in token_ids:
+            encoded.extend(encoder.decode_single_token_bytes(token_id))
+            token_byte_offsets.append(len(encoded))
+
         chunks: list[str] = []
-        for start in range(0, len(token_ids), token_budget):
-            piece = encoder.decode(token_ids[start:start + token_budget])
-            if piece:
-                chunks.append(piece)
+        start = 0
+        while start < len(token_ids):
+            end = min(len(token_ids), start + token_budget)
+            while end > start:
+                piece_bytes = encoded[
+                    token_byte_offsets[start]:token_byte_offsets[end]
+                ]
+                try:
+                    piece = piece_bytes.decode("utf-8", errors="strict")
+                except UnicodeDecodeError:
+                    end -= 1
+                    continue
+                # Re-encoding a boundary-safe piece can differ from slicing the
+                # full-document token stream. Keep the provider-facing budget
+                # authoritative rather than assuming the sliced count survives.
+                if len(encoder.encode(piece)) <= token_budget:
+                    chunks.append(piece)
+                    start = end
+                    break
+                end -= 1
+            else:
+                raise ValueError(
+                    "token_budget is too small to preserve a Unicode character boundary"
+                )
         return chunks or [document]
 
     def build_state_semantic_index(


### PR DESCRIPTION
## Summary
- Preserve UTF-8 character boundaries when the optional `tiktoken` path splits oversized trajectory-state documents.
- Re-encode each boundary-safe chunk so the provider-facing token budget remains authoritative.
- Add a real-`tiktoken` CJK regression and correct the exact-budget versus oversized semantic-index test.

## Why
- Fixed-width token-ID slices were decoded independently. A slice can end inside a multibyte character, which introduced U+FFFD replacement characters and made the concatenated chunks differ from the source text.
- The correction assembles exact token bytes, shrinks to a strict UTF-8 boundary, and verifies the resulting text still fits the requested token budget. If the budget cannot contain one complete Unicode character, the path fails explicitly instead of emitting corrupt or over-budget text.

## Validation
- [x] Focused validation: `pytest tests/test_trajectory_state_semantic_expansion.py -q` -> `25 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> included in the repository release validator; focused release gate `476 passed`
  - [x] `pytest -q` -> `2793 passed, 12 xfailed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `2793 passed, 12 xfailed`
  - [x] `python -m compileall -q .` -> passed
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> passed
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> passed
  - [x] `git diff --check` -> passed
- [x] Independent exact-candidate review: PASS for `b3cb1da33b33a125f8bef715d20f590bc5e2f035`, including real `tiktoken 0.13.0` CJK, emoji, combining-mark, and mixed-script probes.

## Notes
- Scope is limited to trajectory-state token chunking and its regression tests: `trajectory_store.py` and `tests/test_trajectory_state_semantic_expansion.py`.
- This establishes exact source rejoin and truthful per-chunk budgets for this optional-`tiktoken` chunking path; it does not make a broader losslessness claim.
