### PR TITLE
docs: correct backup and pre-answer provider contracts

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -81,12 +81,18 @@ Restart Hermes after updating.
 
 ## Upgrade from v0.20.0 to v0.21.0-rc1
 
-1. Back up the profile's `lcm.db` and its `-wal`/`-shm` companions, or run
-   `/lcm backup` from the old runtime.
-2. Update the plugin checkout to the RC and restart Hermes.
-3. Send one normal message, then confirm `lcm_status` reports plugin version
+1. While the old runtime is running, run `/lcm backup`. If Hermes or any other
+   SQLite writer may still be running, this is the only supported online backup
+   path.
+2. Alternatively, stop Hermes and every other process that can write the
+   database. After all writers are fully stopped, copy the profile's `lcm.db`
+   plus any existing `lcm.db-wal` and `lcm.db-shm` companions together as one
+   quiescent snapshot. Do not copy these files separately while a writer is
+   live.
+3. Update the plugin checkout to the RC and restart Hermes.
+4. Send one normal message, then confirm `lcm_status` reports plugin version
    `0.21.0-rc1` and the expected database path.
-4. For a migration-shape audit, query that database with
+5. For a migration-shape audit, query that database with
    `SELECT value FROM metadata WHERE key = 'schema_version';`; the expected
    result is `5`.
 
@@ -259,16 +265,23 @@ engine. Exposure is not activation. On a stock install:
 | `LCM_ADAPTIVE_RETRIEVAL_ENABLED` | `false` | Enable `lcm_retrieve` and bind query views for evidence reuse. Episodes are bounded to existing retrieval tools and store evidence/traces, never final prose. |
 | `LCM_PREANSWER_EVIDENCE_ENABLED` | `false` | Enable the automatic pre-answer evidence hook. Disabled preserves the ordinary hook context and performs no retrieval or computation. |
 | `LCM_PREANSWER_EVIDENCE_MODE` | empty | When the master flag is enabled, empty selects legacy selective behavior; explicit values are `off`, `legacy_selective`, or `requirements_v1`. |
-| `LCM_SELECTIVE_COMPILER_ENABLED` | `false` | Separately opt into the semantic selector for code-derived closed operations. Pre-answer evidence alone remains provider-free. |
+| `LCM_SELECTIVE_COMPILER_ENABLED` | `false` | Separately opt into the semantic selector for code-derived closed operations. Disabling the selective compiler does not prevent the pre-answer hook from retrieving a baseline. |
 | `LCM_SELECTIVE_COMPILER_MODEL` | empty | Optional model override for the selective compiler. |
+
+When no caller-supplied baseline is available, routed pre-answer turns may call
+`lcm_recall` to build one. If embeddings are enabled, this retrieval inherits
+the configured embedding provider and may send the current question to that
+provider. Disabling the selective compiler prevents its selector and answering
+model calls; it does not disable this retrieval path.
 
 Privacy boundary: assertion and query-view records live in the selected
 profile's existing `lcm.db` and may include exact quotes, spans, and dependency
 refs. Provider-neutral evidence tools do not upload them by themselves.
-Embedding-backed retrieval, assertion extraction, and the optional selective
-compiler can send configured content to their selected providers. Review those
-provider and redaction settings before opting in; sensitive-pattern redaction is
-also default-off and is forward-only.
+Embedding-backed retrieval, including automatic pre-answer baseline retrieval,
+assertion extraction, and the optional selective compiler can send configured
+content to their selected providers. Review those provider and redaction
+settings before opting in; sensitive-pattern redaction is also default-off and
+is forward-only.
 
 Advanced compaction, assembly, and extraction knobs are defined in `config.py`.
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -42,6 +42,32 @@ def test_release_candidate_identity_surfaces_are_synchronized():
     assert f"v{RELEASE_VERSION}, main, or commit SHA" in bug_report
 
 
+def test_upgrade_guide_requires_sqlite_safe_backup_semantics():
+    operator_guide = " ".join(
+        (REPO_ROOT / "docs" / "operator-guide.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "the only supported online backup path" in operator_guide
+    assert "stop Hermes and every other process that can write the database" in operator_guide
+    assert "`lcm.db-wal` and `lcm.db-shm`" in operator_guide
+    assert "one quiescent snapshot" in operator_guide
+
+
+def test_preanswer_guide_discloses_inherited_embedding_provider_behavior():
+    operator_guide = " ".join(
+        (REPO_ROOT / "docs" / "operator-guide.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "may call `lcm_recall`" in operator_guide
+    assert "may send the current question to that provider" in operator_guide
+    assert "Disabling the selective compiler does not prevent" in operator_guide
+    assert "Pre-answer evidence alone remains provider-free." not in operator_guide
+
+
 def test_release_candidate_notes_cover_only_the_merged_release_scope():
     notes = RELEASE_NOTES.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Correct the v0.21.0-rc1 upgrade guide so `/lcm backup` is the only supported online SQLite backup path while any writer may be running, and file copying is limited to one quiescent database/WAL/SHM snapshot after every writer stops.
- Correct the pre-answer privacy contract: without a caller-supplied baseline, routed turns may call `lcm_recall`; when embeddings are enabled, that retrieval inherits the configured embedding provider and may send the current question to it.
- Add narrow documentation-contract assertions for both corrections without changing runtime policy.

## Why
- Merged PR #491 introduced two independently confirmed P1 operator-documentation defects that block the v0.21.0-rc1 release gate.
- This is the reviewed cumulative documentation repair, not a retrieval-policy redesign.

## Validation
- [x] Focused validation: `/home/w0lf/miniconda3/envs/frontdesk/bin/pytest -q tests/test_release_workflow.py` -> `6 passed in 0.02s` on the exact candidate
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- Exact base: `4553a917b45a610533e97d6b5edaf4dc4803039d`
- Exact candidate: `059b5db69196926bbee5a70e1e0b393b0e6369c7`
- Scope is one commit changing only `docs/operator-guide.md` and `tests/test_release_workflow.py`.
- Independent exact-candidate review passed. Its `scripts/validate_release.sh --keep-going` smoke covered focused pytest, benchmark/stress, compilation, shell, and diff gates; the implementation evidence recorded 476 focused tests passing. The unchecked default commands above were not separately run verbatim on this publication checkout.
- No workflow files or runtime source files changed.

Refs #491
