### PR TITLE
fix(reconcile): filter standalone model-switch notes from stored-tail replay

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -123,7 +123,11 @@ from .fresh_tail import FreshTailBoundary, resolve_fresh_tail_boundary
 from .message_patterns import compile_message_patterns, matches_message_pattern
 from .aux_session import AuxiliarySessionMixin
 from .placeholder_ledger import PlaceholderLedgerMixin
-from .reconcile import ReconcileMixin, _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
+from .reconcile import (
+    ReconcileMixin,
+    _MODEL_SWITCH_NOTIFICATION_PREFIX,
+    _PRESERVED_OBJECTIVE_CONTEXT_PREFIX,
+)
 from .compaction import CompactionMixin
 from .reset_state import ResetStateMixin
 from .bypass import BypassMixin
@@ -4179,6 +4183,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
         if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return True
+        # A model-switch note injected as a STANDALONE message (no user
+        # content after the closing bracket) is ephemeral host scaffolding:
+        # LCM persists it, but the host removes the row from the active list
+        # on the next turn.  The stored tail then has a row the incoming
+        # replay lacks — suffix matching shifts, cursor=0, full re-ingest.
+        # A note PREPENDED to a real user message is NOT scaffolding — the
+        # user's content after the bracket is durable.
+        if content.lstrip().startswith(_MODEL_SWITCH_NOTIFICATION_PREFIX):
+            _bracket_end = content.find("]")
+            _remainder = (
+                content[_bracket_end + 1:].lstrip("\n") if _bracket_end != -1 else content
+            )
+            if not _remainder.strip():
+                return True
         if "[Expand for details:" not in content:
             return False
         return bool(

--- a/reconcile.py
+++ b/reconcile.py
@@ -50,6 +50,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+# The host injects this as a standalone user message when the model changes
+# mid-session, then removes it from the active list on the next turn.
+_MODEL_SWITCH_NOTIFICATION_PREFIX = "[Note: model was just switched from "
 
 
 class ReconcileMixin:
@@ -849,6 +852,7 @@ class ReconcileMixin:
             row
             for row in stored_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
+            and not self._is_replayed_context_scaffold_message(row)
         ]
         stored_tail = [
             self._message_replay_identity(row, stored_row=True)

--- a/tests/test_reconcile_standalone_model_switch.py
+++ b/tests/test_reconcile_standalone_model_switch.py
@@ -46,8 +46,8 @@ from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 
 STANDALONE_NOTE = (
-    "[Note: model was just switched from kimi-k3 to deepseek-v4-flash "
-    "via OpenCode Go. Adjust your self-identification accordingly.]"
+    "[Note: model was just switched from model-a to model-b "
+    "via the router. Adjust your self-identification accordingly.]"
 )
 
 

--- a/tests/test_reconcile_standalone_model_switch.py
+++ b/tests/test_reconcile_standalone_model_switch.py
@@ -1,0 +1,148 @@
+"""Standalone model-switch notes must not break replay reconciliation.
+
+The host injects "[Note: model was just switched from X to Y ...]" as a
+STANDALONE user message (not merely a prefix on a real user message)
+when the model changes mid-session.  LCM persists that row.  On the
+next turn the host removes the note from its active list entirely — the
+note was ephemeral.  The stored tail therefore contains a row the
+incoming replay lacks; suffix matching shifts, cursor falls to 0 and the
+whole session is re-ingested (duplication).
+
+Fix: standalone model-switch notes are recognised as replay scaffolding
+and filtered from the stored-tail row set used for reconciliation, so
+the stored tail and the incoming replay align.
+
+All tests use synthetic messages.  No real session data.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+if "agent.context_engine" not in sys.modules:
+    _agent_mod = ModuleType("agent")
+    _agent_mod.__path__ = []
+    _ce_mod = ModuleType("agent.context_engine")
+
+    class _StubContextEngine:
+        def __init__(self, **kwargs):
+            self.compression_count = 0
+            self.last_prompt_tokens = 0
+
+        def get_status(self):
+            return {}
+
+    _ce_mod.ContextEngine = _StubContextEngine
+    sys.modules["agent"] = _agent_mod
+    sys.modules["agent.context_engine"] = _ce_mod
+
+_existing = sys.modules.get("hermes_lcm.engine")
+if _existing is not None and not hasattr(_existing, "LCMEngine"):
+    sys.modules.pop("hermes_lcm.engine", None)
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+STANDALONE_NOTE = (
+    "[Note: model was just switched from kimi-k3 to deepseek-v4-flash "
+    "via OpenCode Go. Adjust your self-identification accordingly.]"
+)
+
+
+def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    defaults = dict(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=False,
+        fresh_tail_count=64,
+    )
+    defaults.update(overrides)
+    config = LCMConfig(**defaults)
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "standalone-note-test",
+        platform="cli",
+        context_length=1000000,
+    )
+    return engine
+
+
+class TestStandaloneModelSwitchNote:
+    """Standalone model-switch notes are identity-transparent scaffolding."""
+
+    def test_standalone_note_is_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {"role": "user", "content": STANDALONE_NOTE}
+            assert engine._is_replayed_context_scaffold_message(msg) is True
+        finally:
+            engine.shutdown()
+
+    def test_note_with_user_content_not_scaffold(self, tmp_path):
+        """Control: prefix + real user content stays a real message."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {
+                "role": "user",
+                "content": STANDALONE_NOTE + "\n\nPlease continue the audit.",
+            }
+            assert engine._is_replayed_context_scaffold_message(msg) is False
+        finally:
+            engine.shutdown()
+
+    def test_standalone_note_stripped_no_reingest(self, tmp_path):
+        """Stored with note, replayed without note -> no re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            turn1 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "tool", "tool_call_id": "c1", "content": '{"output": "ok"}'},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": STANDALONE_NOTE},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("standalone-note-test") == 5
+
+            # Host strips the note from the replay and adds one new turn.
+            turn2 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "tool", "tool_call_id": "c1", "content": '{"output": "ok"}'},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": "Continue"},
+            ]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("standalone-note-test")
+            assert count == 6, (
+                f"Expected 6 (5 stored + 1 new), got {count}. "
+                "Standalone model-switch note broke suffix matching -> "
+                "cursor=0 -> full re-ingest."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_standalone_note_present_on_both_sides(self, tmp_path):
+        """Note still in the replay (same turn) must also stay clean."""
+        engine = _make_engine(tmp_path)
+        try:
+            turn1 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "user", "content": STANDALONE_NOTE},
+                {"role": "assistant", "content": "Done."},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("standalone-note-test") == 4
+
+            turn2 = turn1 + [{"role": "user", "content": "Verify"}]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("standalone-note-test")
+            assert count == 5, f"Expected 5, got {count}"
+        finally:
+            engine.shutdown()


### PR DESCRIPTION
## Problem

The host injects `[Note: model was just switched from X to Y ...]` as a **standalone user message** when the model changes mid-session. LCM persists that row; on the next turn the host removes the note from its active list entirely. The stored tail then contains a row the incoming replay lacks — suffix matching shifts, cursor falls to 0 and the whole session is re-ingested (duplication).

Reproduced from production forensics: a session with a model switch accumulated five copies of the standalone note and re-ingested hundreds of rows every turn; the loop only stopped when the notes fell out of the stored-tail window. A fresh resume after the switch re-ingested the entire session (299 rows, 272 already stored; the batch restarted from the session's first message).

## Fix

Two-part:

1. `_is_replayed_context_scaffold_message` recognises a model-switch note with **no user content after the closing bracket** as scaffolding. A note PREPENDED to a real user message is NOT scaffolding — the user's content after the bracket is durable.
2. `_reconcile_ingest_cursor_from_store` filters scaffold rows from the `stored_tail_rows` set, so the stored tail and the incoming replay align.

## Tests

- `tests/test_reconcile_standalone_model_switch.py` (new): standalone note is scaffold; note + user content is not; no re-ingest when the note is stripped from the replay; no re-ingest when present on both sides. **Verified failing (2 of 4) on the unfixed tree** before the fix was applied.
- `test_lcm_core`: 308 passed.