### PR TITLE
perf: defer noncritical LCM preflight maintenance

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -158,7 +158,18 @@ class CompactionMixin:
                 ),
             )
             if eligible:
-                return self._mark_preflight_compression_requested()
+                if self.threshold_tokens > 0 and replay_rough >= self.threshold_tokens:
+                    return self._mark_preflight_compression_requested()
+                self._refresh_raw_backlog_debt(
+                    replay_messages,
+                    observed_tokens=replay_rough,
+                )
+                if self._critical_budget_pressure_reached(
+                    observed_tokens=replay_rough,
+                    messages=replay_messages,
+                ):
+                    return self._mark_preflight_compression_requested()
+                return False
             if self._has_ignored_backlog_outside_fresh_tail(replay_messages):
                 return self._mark_preflight_compression_requested()
             if self.threshold_tokens > 0 and replay_rough >= self.threshold_tokens:
@@ -169,7 +180,16 @@ class CompactionMixin:
                 logger.info("LCM preflight compression no-op: %s", reason)
                 return False
             self._refresh_raw_backlog_debt(replay_messages, observed_tokens=replay_rough)
-            if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
+            # A disabled critical-pressure ratio intentionally leaves this debt
+            # deferred until threshold, overflow, cleanup, ignored-backlog, or
+            # another explicit required trigger makes preflight synchronous.
+            if self._critical_budget_pressure_reached(
+                observed_tokens=replay_rough,
+                messages=replay_messages,
+            ) and self._should_run_deferred_maintenance(
+                replay_messages,
+                observed_tokens=replay_rough,
+            ):
                 return self._mark_preflight_compression_requested()
             return False
         if self._compression_boundary_cooldown_active():
@@ -197,7 +217,15 @@ class CompactionMixin:
             logger.info("LCM preflight compression no-op: %s", reason)
             return False
         self._refresh_raw_backlog_debt(messages, observed_tokens=rough)
-        if self._should_run_deferred_maintenance(messages, observed_tokens=rough):
+        # With critical pressure disabled, routine debt remains recorded until
+        # another required preflight trigger is reached.
+        if self._critical_budget_pressure_reached(
+            observed_tokens=rough,
+            messages=messages,
+        ) and self._should_run_deferred_maintenance(
+            messages,
+            observed_tokens=rough,
+        ):
             return self._mark_preflight_compression_requested()
         return False
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1722,6 +1722,72 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_preflight_defers_noncritical_under_threshold_raw_backlog_after_ingest(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_deferred_noncritical.db"),
+            fresh_tail_count=4,
+            leaf_chunk_tokens=20,
+            deferred_maintenance_enabled=True,
+            critical_budget_pressure_ratio=0.90,
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("test-session", platform="cli", context_length=10_000)
+        instance.context_length = 10_000
+        instance.threshold_tokens = 5_000
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old backlog " + "x" * 200},
+            {"role": "assistant", "content": "old answer " + "y" * 200},
+            {"role": "user", "content": "fresh " + "a" * 50},
+            {"role": "assistant", "content": "fresh " + "b" * 50},
+            {"role": "user", "content": "fresh " + "c" * 50},
+        ]
+        monkeypatch.setattr(
+            lcm_engine,
+            "summarize_with_escalation",
+            lambda **_kwargs: (_ for _ in ()).throw(AssertionError("summarizer called")),
+        )
+        try:
+            assert count_messages_tokens(messages) < instance.threshold_tokens
+            assert instance.should_compress_preflight(messages) is False
+            assert instance._store.count_session_load_messages(instance.current_session_id) == len(messages)
+            state = instance._lifecycle.get_by_conversation(instance._conversation_id)
+            assert state is not None
+            assert state.debt_kind == "raw_backlog"
+            assert state.debt_size_estimate > 0
+        finally:
+            instance.shutdown()
+
+    def test_preflight_required_sibling_branches_remain_synchronous(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_required_siblings.db"),
+            fresh_tail_count=2,
+            leaf_chunk_tokens=20,
+            deferred_maintenance_enabled=True,
+            critical_budget_pressure_ratio=0.50,
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start("required-session", platform="cli", context_length=1_000)
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old " + "x" * 500},
+            {"role": "assistant", "content": "old " + "y" * 500},
+            {"role": "user", "content": "fresh"},
+        ]
+        try:
+            instance.threshold_tokens = 1
+            assert instance.should_compress_preflight(messages) is True
+
+            instance.threshold_tokens = 100_000
+            instance.context_length = 50
+            assert instance.should_compress_preflight(messages) is True
+
+            monkeypatch.setattr(instance, "_ingest_messages", lambda _messages: _messages[:-1])
+            instance.context_length = 100_000
+            assert instance.should_compress_preflight(messages) is True
+        finally:
+            instance.shutdown()
+
     def test_preflight_requests_compaction_for_deferred_maintenance_under_critical_pressure(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_preflight_deferred_critical.db"),
@@ -1733,7 +1799,7 @@ class TestEngineABC:
         instance = LCMEngine(config=config)
         instance._bind_lifecycle_state("test-session")
         instance.context_length = 200
-        instance.threshold_tokens = 100
+        instance.threshold_tokens = 10_000
         messages = [
             {"role": "system", "content": "system"},
             {"role": "user", "content": "tiny old backlog"},
@@ -1744,7 +1810,11 @@ class TestEngineABC:
         ]
         try:
             rough = count_messages_tokens(messages)
-            assert rough >= instance.threshold_tokens
+            assert rough < instance.threshold_tokens
+            assert instance._critical_budget_pressure_reached(
+                observed_tokens=rough,
+                messages=messages,
+            )
             eligible, reason = instance._leaf_compaction_candidate_status(messages)
             assert not eligible
             assert "below leaf chunk threshold" in reason
@@ -20323,7 +20393,7 @@ class TestDeferredMaintenanceDebt:
         assert state is not None
         assert state.debt_kind == "raw_backlog"
         assert state.debt_size_estimate > 0
-        assert engine.should_compress_preflight(compressed) is True
+        assert engine.should_compress_preflight(compressed) is False
         refreshed = engine._lifecycle.get_by_conversation(engine._conversation_id)
         assert refreshed is not None
         assert refreshed.debt_kind == "raw_backlog"


### PR DESCRIPTION
## Summary

LCM can currently enter synchronous maintenance compaction before the first model call even when the prompt remains below the configured threshold and there is no critical pressure. This change keeps that routine debt recorded but defers the model work until an existing required trigger makes compression necessary.

Refs #496.

Hermes-Session: `20260804_101014_c509f5f7`

## Why

Pre-model latency is user-visible. Eligible raw backlog should remain tracked, but ordinary under-threshold maintenance should not block the live turn merely because debt exists.

This is intentionally narrower than asynchronous compaction. It changes only the preflight decision for noncritical, under-threshold maintenance and preserves synchronous behavior where capacity or an explicit request requires it.

## Implementation

- Continue recording and refreshing maintenance debt for eligible raw backlog.
- Return from real preflight without starting compression when the prompt is below threshold and configured pressure is noncritical.
- Preserve synchronous compression for threshold, overflow, cleanup, ignored-backlog, explicit-required, and critical-pressure paths.
- Exercise the real preflight path and prove the deferred branch makes no summary-model call.

## Behavioral contract

- Noncritical under-threshold backlog records debt and returns without synchronous compression.
- Required sibling branches remain synchronous.
- Deferred debt remains available for a later required trigger.
- If the critical-pressure ratio is disabled, debt may wait until threshold, overflow, cleanup, ignored-backlog, or an explicit required trigger.

## Verification

Final clean branch `3ece8ce19d540f95a53728d04ad9d821f460ee82`:

- `python -m ruff check compaction.py tests/test_lcm_engine.py` — passed
- focused real-preflight maintenance/threshold/pressure tests — 7 passed
- grouped implementation gate before clean replay — affected engine and API/package tests passed
- `git diff --check origin/main...HEAD` — passed

The repository's broad suite has known failures on pristine `6b7dbb1`; none of the bounded failures was unique to this feature branch.

## Relationship to existing work

- This preserves maintenance-debt accounting rather than replacing it.
- It preserves critical-pressure escape behavior.
- It is separate from session-start rollup deferral.
- It does not implement the broader asynchronous compaction proposal.

## Scope

This PR contains only the preflight decision change and its behavioral tests. It does not add a worker, queue, timer, configuration surface, or background-maintenance architecture.
