### PR TITLE
fix: share LCM storage across runtime clones

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -360,6 +360,34 @@ _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across co
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
 
 
+class _StorageBundle:
+    """Reference-counted SQLite helpers shared by engine runtime clones."""
+
+    def __init__(self, *helpers: Any) -> None:
+        self.helpers = tuple(helpers)
+        self._lock = threading.Lock()
+        self._refs = 1
+
+    def acquire(self) -> "_StorageBundle":
+        with self._lock:
+            if self._refs <= 0:
+                raise RuntimeError("cannot acquire a closed LCM storage bundle")
+            self._refs += 1
+        return self
+
+    def release(self) -> None:
+        with self._lock:
+            if self._refs <= 0:
+                return
+            self._refs -= 1
+            if self._refs:
+                return
+        for helper in self.helpers:
+            close = getattr(helper, "close", None)
+            if callable(close):
+                close()
+
+
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
     """Lossless Context Management engine.
 
@@ -379,7 +407,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     """
 
     def __init__(self, config: LCMConfig | None = None,
-                 hermes_home: str = ""):
+                 hermes_home: str = "", *, _bind_storage: bool = True):
         self._config = config or LCMConfig.from_env()
         self._hermes_home = hermes_home
         self._assertion_extraction_metrics_lock = threading.RLock()
@@ -396,9 +424,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._assertion_extraction_last_duration_ms = 0.0
         self._assertion_extraction_last_error = ""
         self._assertion_extraction_last_model = ""
+        self._storage_bundle: _StorageBundle | None = None
+        self._store: Any = None
+        self._dag: Any = None
+        self._lifecycle: Any = None
+        self._assertions: Any = None
+        self._query_views: Any = None
+        self._adaptive_retrieval: Any = None
+        self._assertion_extractor: Any = None
 
         db_path = self._resolve_db_path(hermes_home)
-        self._bind_storage(db_path, hermes_home)
+        if _bind_storage:
+            self._bind_storage(db_path, hermes_home)
 
         self._session_id: str = ""
         self._session_platform: str = ""
@@ -626,7 +663,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         clone = type(self)(
             config=copy.deepcopy(self._config),
             hermes_home=self._hermes_home,
+            _bind_storage=False,
         )
+        clone._adopt_storage_bundle(self._storage_bundle)
+        if bool(getattr(clone._config, "adaptive_retrieval_enabled", False)):
+            clone._adaptive_retrieval = AdaptiveRetrievalRegistry(clone._query_views)
+        if (
+            clone._assertions is not None
+            and bool(getattr(clone._config, "assertion_extraction_enabled", False))
+        ):
+            clone._assertion_extractor = ModelAssertionExtractor(
+                clone._assertions,
+                model=clone._assertion_extraction_model(),
+                timeout_seconds=clone._assertion_extraction_timeout(),
+            )
         clone.model = self.model
         clone.base_url = self.base_url
         clone.api_key = self.api_key
@@ -721,20 +771,44 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     model=self._assertion_extraction_model(),
                     timeout_seconds=self._assertion_extraction_timeout(),
                 )
+            self._storage_bundle = _StorageBundle(
+                self._store,
+                self._dag,
+                self._lifecycle,
+                self._assertions,
+                self._query_views,
+            )
         except Exception:
             self._close_storage()
             raise
 
+    def _adopt_storage_bundle(self, bundle: _StorageBundle | None) -> None:
+        if bundle is None:
+            raise RuntimeError("LCM engine has no storage bundle to share")
+        self._storage_bundle = bundle.acquire()
+        self._store, self._dag, self._lifecycle, self._assertions, self._query_views = bundle.helpers
+
     def _close_storage(self) -> None:
         """Best-effort close of currently bound SQLite helpers."""
-        for attr in (
-            "_adaptive_retrieval",
-            "_store",
-            "_dag",
-            "_lifecycle",
-            "_assertions",
-            "_query_views",
-        ):
+        adaptive = getattr(self, "_adaptive_retrieval", None)
+        close = getattr(adaptive, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                logger.debug("LCM failed closing adaptive retrieval during storage close", exc_info=True)
+        self._adaptive_retrieval = None
+
+        bundle = getattr(self, "_storage_bundle", None)
+        if bundle is not None:
+            self._storage_bundle = None
+            try:
+                bundle.release()
+            except Exception:
+                logger.debug("LCM failed closing shared storage bundle", exc_info=True)
+            return
+
+        for attr in ("_store", "_dag", "_lifecycle", "_assertions", "_query_views"):
             helper = getattr(self, attr, None)
             close = getattr(helper, "close", None)
             if callable(close):
@@ -6519,12 +6593,4 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def shutdown(self):
         self._unregister_active_engine_binding()
-        if self._adaptive_retrieval is not None:
-            self._adaptive_retrieval.close()
-        self._store.close()
-        self._dag.close()
-        self._lifecycle.close()
-        if self._assertions is not None:
-            self._assertions.close()
-        if self._query_views is not None:
-            self._query_views.close()
+        self._close_storage()

--- a/engine.py
+++ b/engine.py
@@ -382,10 +382,23 @@ class _StorageBundle:
             self._refs -= 1
             if self._refs:
                 return
-        for helper in self.helpers:
+        first_error: BaseException | None = None
+        for index, helper in enumerate(self.helpers):
             close = getattr(helper, "close", None)
             if callable(close):
-                close()
+                try:
+                    close()
+                except BaseException as exc:
+                    if first_error is None:
+                        first_error = exc
+                    logger.warning(
+                        "LCM storage helper %d failed to close: %s",
+                        index,
+                        exc,
+                        exc_info=True,
+                    )
+        if first_error is not None:
+            raise first_error
 
 
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
@@ -665,18 +678,25 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             hermes_home=self._hermes_home,
             _bind_storage=False,
         )
-        clone._adopt_storage_bundle(self._storage_bundle)
-        if bool(getattr(clone._config, "adaptive_retrieval_enabled", False)):
-            clone._adaptive_retrieval = AdaptiveRetrievalRegistry(clone._query_views)
-        if (
-            clone._assertions is not None
-            and bool(getattr(clone._config, "assertion_extraction_enabled", False))
-        ):
-            clone._assertion_extractor = ModelAssertionExtractor(
-                clone._assertions,
-                model=clone._assertion_extraction_model(),
-                timeout_seconds=clone._assertion_extraction_timeout(),
-            )
+        try:
+            clone._adopt_storage_bundle(self._storage_bundle)
+            if bool(getattr(clone._config, "adaptive_retrieval_enabled", False)):
+                clone._adaptive_retrieval = AdaptiveRetrievalRegistry(clone._query_views)
+            if (
+                clone._assertions is not None
+                and bool(getattr(clone._config, "assertion_extraction_enabled", False))
+            ):
+                clone._assertion_extractor = ModelAssertionExtractor(
+                    clone._assertions,
+                    model=clone._assertion_extraction_model(),
+                    timeout_seconds=clone._assertion_extraction_timeout(),
+                )
+        except Exception:
+            # The bundle reference is acquired before optional runtime helpers
+            # are constructed.  Release it if any helper constructor rejects
+            # the clone, without masking the original failure.
+            clone._close_storage()
+            raise
         clone.model = self.model
         clone.base_url = self.base_url
         clone.api_key = self.api_key
@@ -703,6 +723,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         clone._update_model_pending_session_start = False
         clone._lcm_current_start_allows_bypass_lineage = False
         return clone
+
+    def create_runtime(self) -> "LCMEngine":
+        """Create the isolated, agent-owned runtime required by Hermes core."""
+        return self.clone_for_agent()
 
     def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
         """Copy the plugin runtime without pickling SQLite-backed helpers.
@@ -6592,5 +6616,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     # -- Lifecycle ---------------------------------------------------------
 
     def shutdown(self):
+        self.close()
+
+    def close(self) -> None:
+        """Release this runtime's shared storage bundle at agent teardown."""
         self._unregister_active_engine_binding()
         self._close_storage()

--- a/engine.py
+++ b/engine.py
@@ -438,6 +438,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._assertion_extraction_last_error = ""
         self._assertion_extraction_last_model = ""
         self._storage_bundle: _StorageBundle | None = None
+        # Runtime-owned lifecycle boundary: a runtime releases its bundle at
+        # most once. A repeated close must not fall through and close helpers
+        # owned by the prototype or sibling runtimes.
+        self._storage_closed = False
         self._store: Any = None
         self._dag: Any = None
         self._lifecycle: Any = None
@@ -695,7 +699,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             # The bundle reference is acquired before optional runtime helpers
             # are constructed.  Release it if any helper constructor rejects
             # the clone, without masking the original failure.
-            clone._close_storage()
+            clone._close_storage(suppress_errors=True)
             raise
         clone.model = self.model
         clone.base_url = self.base_url
@@ -752,6 +756,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def _bind_storage(self, db_path: str | Path, hermes_home: str = "") -> None:
         """Bind store/DAG/lifecycle helpers to one SQLite database."""
+        # A successful bind starts a fresh runtime-owned storage lease.  This
+        # matters when profile rebinding follows a prior close or a failed
+        # construction attempt.
+        self._storage_closed = False
         self._assertions = None
         self._query_views = None
         self._adaptive_retrieval = None
@@ -803,23 +811,37 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 self._query_views,
             )
         except Exception:
-            self._close_storage()
+            self._close_storage(suppress_errors=True)
             raise
 
     def _adopt_storage_bundle(self, bundle: _StorageBundle | None) -> None:
         if bundle is None:
             raise RuntimeError("LCM engine has no storage bundle to share")
-        self._storage_bundle = bundle.acquire()
+        acquired = bundle.acquire()
+        self._storage_closed = False
+        self._storage_bundle = acquired
         self._store, self._dag, self._lifecycle, self._assertions, self._query_views = bundle.helpers
 
-    def _close_storage(self) -> None:
-        """Best-effort close of currently bound SQLite helpers."""
+    def _close_storage(self, *, suppress_errors: bool = False) -> None:
+        """Release this runtime's storage exactly once.
+
+        Suppression is used only while unwinding construction, where a
+        cleanup error must not replace the constructor's original exception.
+        Normal runtime teardown preserves the first real close error after
+        attempting all applicable cleanup.
+        """
+        if self._storage_closed:
+            return
+        self._storage_closed = True
+        first_error: BaseException | None = None
+
         adaptive = getattr(self, "_adaptive_retrieval", None)
         close = getattr(adaptive, "close", None)
         if callable(close):
             try:
                 close()
-            except Exception:
+            except BaseException as exc:
+                first_error = exc
                 logger.debug("LCM failed closing adaptive retrieval during storage close", exc_info=True)
         self._adaptive_retrieval = None
 
@@ -828,18 +850,24 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._storage_bundle = None
             try:
                 bundle.release()
-            except Exception:
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
                 logger.debug("LCM failed closing shared storage bundle", exc_info=True)
-            return
+        else:
+            for attr in ("_store", "_dag", "_lifecycle", "_assertions", "_query_views"):
+                helper = getattr(self, attr, None)
+                close = getattr(helper, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except BaseException as exc:
+                        if first_error is None:
+                            first_error = exc
+                        logger.debug("LCM failed closing %s during profile rebind", attr, exc_info=True)
 
-        for attr in ("_store", "_dag", "_lifecycle", "_assertions", "_query_views"):
-            helper = getattr(self, attr, None)
-            close = getattr(helper, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    logger.debug("LCM failed closing %s during profile rebind", attr, exc_info=True)
+        if first_error is not None and not suppress_errors:
+            raise first_error
 
     def _assertion_extraction_model(self) -> str:
         return str(
@@ -933,6 +961,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
         self._close_storage()
         self._hermes_home = hermes_home
+        self._storage_closed = False
         self._bind_storage(db_path, hermes_home)
         self._reset_profile_runtime_state()
         logger.info("LCM rebound storage for Hermes home %s", hermes_home)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,34 @@ import sys
 import importlib
 from pathlib import Path
 
-# Make the repo root importable (for agent.context_engine etc.)
-repo_root = str(Path(__file__).resolve().parent.parent.parent.parent)
-if repo_root not in sys.path:
+# Find the Hermes agent module (agent.context_engine)
+# Try common locations where the agent module might be
+potential_roots = [
+    str(Path(__file__).resolve().parent.parent.parent.parent),  # coder profile root
+    str(Path(__file__).resolve().parent.parent.parent.parent.parent),  # one level up
+    "/home/hermes/hermes-agent-qwen-pr",  # explicit hermes-agent location
+    "/home/hermes/hermes-agent",  # alternative hermes-agent location
+]
+
+repo_root = None
+for root in potential_roots:
+    agent_module = Path(root) / "agent" / "context_engine.py"
+    if agent_module.exists():
+        repo_root = root
+        break
+
+if repo_root is None:
+    # Fallback: try to find agent module by searching upward
+    current = Path(__file__).resolve()
+    for _ in range(6):  # Search up to 6 levels up
+        parent = current.parent
+        agent_check = parent / "agent" / "context_engine.py"
+        if agent_check.exists():
+            repo_root = str(parent)
+            break
+        current = parent
+
+if repo_root and repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
 # Register the plugin directory as a proper package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,39 +3,24 @@
 Patches the plugin modules so they can be imported both as a package
 (relative imports during plugin loading) and directly during testing.
 """
+import os
 import sys
 import importlib
 from pathlib import Path
 
-# Find the Hermes agent module (agent.context_engine)
-# Try common locations where the agent module might be
-potential_roots = [
-    str(Path(__file__).resolve().parent.parent.parent.parent),  # coder profile root
-    str(Path(__file__).resolve().parent.parent.parent.parent.parent),  # one level up
-    "/home/hermes/hermes-agent-qwen-pr",  # explicit hermes-agent location
-    "/home/hermes/hermes-agent",  # alternative hermes-agent location
-]
-
-repo_root = None
-for root in potential_roots:
-    agent_module = Path(root) / "agent" / "context_engine.py"
-    if agent_module.exists():
-        repo_root = root
-        break
-
-if repo_root is None:
-    # Fallback: try to find agent module by searching upward
-    current = Path(__file__).resolve()
-    for _ in range(6):  # Search up to 6 levels up
-        parent = current.parent
-        agent_check = parent / "agent" / "context_engine.py"
-        if agent_check.exists():
-            repo_root = str(parent)
-            break
-        current = parent
-
-if repo_root and repo_root not in sys.path:
-    sys.path.insert(0, repo_root)
+# The standalone CI bootstrap places its hermes-agent stub in this checkout.
+# A host integration run may explicitly point at a real hermes-agent checkout;
+# never discover one by searching unrelated parent directories.
+plugin_dir = Path(__file__).resolve().parent.parent
+repo_root = Path(os.environ.get("HERMES_AGENT_ROOT", plugin_dir)).resolve()
+if not (repo_root / "agent" / "context_engine.py").is_file():
+    if "HERMES_AGENT_ROOT" in os.environ:
+        raise RuntimeError(
+            "HERMES_AGENT_ROOT must contain agent/context_engine.py: "
+            f"{repo_root}"
+        )
+else:
+    sys.path.insert(0, str(repo_root))
 
 # Register the plugin directory as a proper package
 plugin_dir = Path(__file__).resolve().parent.parent

--- a/tests/test_fd_hygiene.py
+++ b/tests/test_fd_hygiene.py
@@ -1,0 +1,54 @@
+"""Regression tests for bounded SQLite file-descriptor usage."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _db_fd_count(db_path: Path) -> int:
+    """Count this process's descriptors for the database and its WAL files."""
+    if os.name != "posix":
+        pytest.skip("/proc/self/fd is POSIX-only")
+    return sum(
+        1
+        for fd in Path("/proc/self/fd").iterdir()
+        if db_path.name in os.path.realpath(fd)
+    )
+
+
+def test_cloned_engines_keep_lcm_fd_count_bounded(tmp_path: Path):
+    """Clones must not retain one SQLite connection set per agent."""
+    db_path = tmp_path / "lcm.db"
+    prototype = LCMEngine(
+        config=LCMConfig(database_path=str(db_path)),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    clones = []
+    try:
+        baseline = _db_fd_count(db_path)
+        for index in range(50):
+            clone = prototype.clone_for_agent()
+            clones.append(clone)
+            clone.on_session_start(
+                f"session-{index}",
+                platform="test",
+                conversation_id=f"conversation-{index}",
+            )
+            clone.ingest([{"role": "user", "content": f"message-{index}"}])
+
+        # A clone has independent session state, but storage is shared. Allow
+        # the small fixed set of WAL/shm descriptors owned by that storage.
+        assert _db_fd_count(db_path) <= baseline + 3
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 50
+    finally:
+        for clone in clones:
+            clone.shutdown()
+        prototype.shutdown()

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -7646,21 +7646,30 @@ def test_context_engine_runtime_contract_shares_storage_and_closes_bundle(tmp_pa
         config=LCMConfig(database_path=str(tmp_path / "runtime.db")),
         hermes_home=str(tmp_path / "hermes"),
     )
+    sibling = None
     try:
         bundle = prototype._storage_bundle
         assert bundle is not None
         assert bundle._refs == 1
 
         runtime = prototype.create_runtime()
+        sibling = prototype.create_runtime()
         assert runtime is not prototype
         assert runtime._store is prototype._store
-        assert bundle._refs == 2
+        assert bundle._refs == 3
 
         runtime.close()
-        assert bundle._refs == 1
+        assert bundle._refs == 2
         runtime.close()
-        assert bundle._refs == 1
+        assert bundle._refs == 2
+
+        # Repeated close must not release storage owned by the live prototype
+        # or sibling runtime. Exercise both database handles after it.
+        prototype.ingest([{"role": "user", "content": "prototype remains live"}])
+        sibling.ingest([{"role": "user", "content": "sibling remains live"}])
     finally:
+        if sibling is not None:
+            sibling.close()
         prototype.close()
 
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -7254,9 +7254,9 @@ class TestLCMEngineCloning:
 
             assert clone is not prototype
             assert isinstance(clone, LCMEngine)
-            assert clone._store is not prototype._store
-            assert clone._dag is not prototype._dag
-            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._store is prototype._store
+            assert clone._dag is prototype._dag
+            assert clone._lifecycle is prototype._lifecycle
             assert clone._config.database_path == prototype._config.database_path
             assert clone._hermes_home == prototype._hermes_home
         finally:
@@ -7297,9 +7297,9 @@ class TestLCMEngineCloning:
             assert isinstance(clone, LCMEngine)
             assert clone.name == "lcm"
             assert clone is not prototype
-            assert clone._store is not prototype._store
-            assert clone._dag is not prototype._dag
-            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._store is prototype._store
+            assert clone._dag is prototype._dag
+            assert clone._lifecycle is prototype._lifecycle
             assert clone._session_id == ""
             assert clone._conversation_id == ""
             assert clone.model == prototype.model

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -7611,3 +7611,98 @@ class TestSummaryDagLikeSanitization:
             assert emoji_only in {node.node_id for node in results}
         finally:
             dag.close()
+
+
+class _CloseProbe:
+    def __init__(self, error=None):
+        self.error = error
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+        if self.error is not None:
+            raise self.error
+
+
+def test_storage_bundle_closes_all_helpers_after_first_failure(caplog):
+    from hermes_lcm.engine import _StorageBundle
+
+    first = _CloseProbe(RuntimeError("first helper failed"))
+    second = _CloseProbe()
+    bundle = _StorageBundle(first, second)
+
+    with pytest.raises(RuntimeError, match="first helper failed"):
+        bundle.release()
+
+    assert first.closed is True
+    assert second.closed is True
+    assert "storage helper 0 failed to close" in caplog.text
+
+
+def test_context_engine_runtime_contract_shares_storage_and_closes_bundle(tmp_path):
+    from hermes_lcm.engine import LCMEngine
+
+    prototype = LCMEngine(
+        config=LCMConfig(database_path=str(tmp_path / "runtime.db")),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    try:
+        bundle = prototype._storage_bundle
+        assert bundle is not None
+        assert bundle._refs == 1
+
+        runtime = prototype.create_runtime()
+        assert runtime is not prototype
+        assert runtime._store is prototype._store
+        assert bundle._refs == 2
+
+        runtime.close()
+        assert bundle._refs == 1
+        runtime.close()
+        assert bundle._refs == 1
+    finally:
+        prototype.close()
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "helper_name", "failure"),
+    [
+        (
+            {"adaptive_retrieval_enabled": True},
+            "AdaptiveRetrievalRegistry",
+            "adaptive constructor failed",
+        ),
+        (
+            {"assertions_enabled": True, "assertion_extraction_enabled": True},
+            "ModelAssertionExtractor",
+            "assertion constructor failed",
+        ),
+    ],
+)
+def test_runtime_constructor_failure_releases_acquired_storage_bundle(
+    tmp_path, monkeypatch, config_kwargs, helper_name, failure
+):
+    import hermes_lcm.engine as engine_module
+
+    prototype = engine_module.LCMEngine(
+        config=LCMConfig(
+            database_path=str(tmp_path / f"{helper_name}.db"),
+            **config_kwargs,
+        ),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    try:
+        bundle = prototype._storage_bundle
+        assert bundle is not None
+        refs_before = bundle._refs
+
+        def fail_constructor(*args, **kwargs):
+            raise RuntimeError(failure)
+
+        monkeypatch.setattr(engine_module, helper_name, fail_constructor)
+        with pytest.raises(RuntimeError, match=failure):
+            prototype.create_runtime()
+
+        assert bundle._refs == refs_before
+    finally:
+        prototype.close()


### PR DESCRIPTION
## Summary
- Add a reference-counted `_StorageBundle` for the SQLite helpers shared by cloned LCM runtimes.
- Adopt the shared bundle in `clone_for_agent()` and release it during shutdown, while preserving per-agent session state.
- Add FD-hygiene coverage for 50 clones and update clone identity assertions.
- Make the plugin test bootstrap locate the Hermes host module from a standalone worktree.

This is the distinct LCM storage-lifecycle half of the descriptor-lifecycle work. It is not the generic `SessionDB` fix in hermes-agent#72822.

## Tracking
- hermes-agent#79537 — descriptor-lifecycle implementation
- hermes-agent#79538 — plugin packaging
- hermes-agent#72782 — parent work item
- Distinct from hermes-agent#72822 — generic SessionDB fix

## Verification
- `python3 -m pytest -q tests/test_fd_hygiene.py` — 1 passed
- `python3 -m pytest -q tests/test_lcm_core.py` — 308 passed
- `python3 -m compileall -q engine.py tests/test_fd_hygiene.py tests/test_lcm_core.py` — passed
- `git diff --check` — passed

## Scope
Fresh branch from `origin/main`; only `engine.py`, `tests/conftest.py`, `tests/test_lcm_core.py`, and `tests/test_fd_hygiene.py` are included. No generated files or unrelated existing work are included.