### PR TITLE
fix(reconcile): normalize Hermes-generated replay scaffolding

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -123,7 +123,11 @@ from .fresh_tail import FreshTailBoundary, resolve_fresh_tail_boundary
 from .message_patterns import compile_message_patterns, matches_message_pattern
 from .aux_session import AuxiliarySessionMixin
 from .placeholder_ledger import PlaceholderLedgerMixin
-from .reconcile import ReconcileMixin, _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
+from .reconcile import (
+    ReconcileMixin,
+    _MODEL_SWITCH_NOTIFICATION_PREFIX,
+    _PRESERVED_OBJECTIVE_CONTEXT_PREFIX,
+)
 from .compaction import CompactionMixin
 from .reset_state import ResetStateMixin
 from .bypass import BypassMixin
@@ -4172,6 +4176,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """Return true for active-context scaffolding that should not be re-ingested."""
         role = str(msg.get("role") or "")
         content = normalize_content_value(msg.get("content")) or ""
+        # Tool results are never scaffolding: they carry real durable content
+        # (delegation receipts, session links, summary excerpts quoted inside
+        # tool output).  A tool payload that happens to contain an
+        # "[Expand for details:" / "Summary (d0, node N)" excerpt must not be
+        # dropped from replay identity — doing so shifts suffix matching and
+        # forces cursor=0 → full re-ingest (duplication).
+        if role == "tool":
+            return False
         if role == "system":
             return (
                 "[Note: This conversation uses Lossless Context Management (LCM)." in content
@@ -4179,6 +4191,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             )
         if content.lstrip().startswith(_PRESERVED_OBJECTIVE_CONTEXT_PREFIX):
             return True
+        if content.lstrip().startswith(_PRESERVED_TODO_CONTEXT_PREFIX):
+            return True
+        # A model-switch note injected as a STANDALONE message (no user
+        # content after the closing bracket) is ephemeral host scaffolding:
+        # LCM persists it, but the host removes the row from the active list
+        # on the next turn.  The stored tail then has a row the incoming
+        # replay lacks — suffix matching shifts, cursor=0, full re-ingest.
+        # A note PREPENDED to a real user message is NOT scaffolding — the
+        # user's content after the bracket is durable.
+        if content.lstrip().startswith(_MODEL_SWITCH_NOTIFICATION_PREFIX):
+            _bracket_end = content.find("]")
+            _remainder = (
+                content[_bracket_end + 1:].lstrip("\n") if _bracket_end != -1 else content
+            )
+            if not _remainder.strip():
+                return True
         if "[Expand for details:" not in content:
             return False
         return bool(

--- a/reconcile.py
+++ b/reconcile.py
@@ -50,6 +50,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+_PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
+_MODEL_SWITCH_NOTIFICATION_PREFIX = "[Note: model was just switched from "
+# When the user sends a message mid-turn, the host appends it to the tool
+# output currently being delivered, wrapped in this block.  LCM persists the
+# row WITH the block; on resume/restart the host replays the tool result
+# WITHOUT it (the user message was already delivered separately).  Strip the
+# block from the replay identity so matching survives the delivery split.
+_OOB_MESSAGE_BLOCK_RE = re.compile(
+    r"\[OUT-OF-BAND USER MESSAGE[^\]]*\].*?\[/OUT-OF-BAND USER MESSAGE\]",
+    re.DOTALL,
+)
 
 
 class ReconcileMixin:
@@ -127,6 +138,32 @@ class ReconcileMixin:
     def _message_replay_identity(self, msg: Dict[str, Any], *, stored_row: bool = False) -> tuple[str, str, str, str]:
         role = str(msg.get("role") or "unknown")
         content = normalize_content_value(msg.get("content")) or ""
+        # Strip volatile compaction scaffolding suffixes so identity matching
+        # survives compression cycles.  The host appends a task-list annotation
+        # to the last user message during context compression; the annotation
+        # changes on every cycle (task statuses update), so including it in the
+        # replay identity causes reconciliation to fail and triggers full
+        # re-ingest of already-stored messages (duplication bug).
+        _todo_idx = content.find(_PRESERVED_TODO_CONTEXT_PREFIX)
+        if _todo_idx > 0:
+            content = content[:_todo_idx].rstrip()
+        # Model-switch notifications are ephemeral host scaffolding: the
+        # host prepends "[Note: model was just switched from X to Y...]"
+        # to the user's message, then strips the prefix on the next turn.
+        # The stored row keeps the prefix; the incoming row does not.
+        # Strip ONLY the prefix (up to and including the closing "]" and
+        # trailing newlines) so the user's actual content survives and
+        # identity matching works across the switch boundary.
+        if content.startswith(_MODEL_SWITCH_NOTIFICATION_PREFIX):
+            _bracket_end = content.find("]")
+            if _bracket_end != -1:
+                content = content[_bracket_end + 1:].lstrip("\n")
+        # Out-of-band user messages appended mid-turn are delivery scaffolding:
+        # the stored row carries them, the replayed row does not (or vice
+        # versa).  Removing every such block keeps identities stable across
+        # the delivery split.
+        if "[OUT-OF-BAND USER MESSAGE" in content:
+            content = _OOB_MESSAGE_BLOCK_RE.sub("", content).rstrip()
         if (
             role == "tool"
             and _is_hermes_persisted_output_marker(content)
@@ -849,6 +886,7 @@ class ReconcileMixin:
             row
             for row in stored_rows
             if not self._matches_ignore_message_patterns(row, stored_row=True)
+            and not self._is_replayed_context_scaffold_message(row)
         ]
         stored_tail = [
             self._message_replay_identity(row, stored_row=True)

--- a/tests/test_reconcile_model_switch.py
+++ b/tests/test_reconcile_model_switch.py
@@ -22,7 +22,7 @@ from types import ModuleType
 from hermes_lcm.config import LCMConfig
 
 
-def _make_engine(tmp_path: Path, *, session_id: str = "model-switch") -> LCMEngine:
+def _make_engine(tmp_path: Path, *, session_id: str = "model-switch"):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.

--- a/tests/test_reconcile_model_switch.py
+++ b/tests/test_reconcile_model_switch.py
@@ -1,0 +1,247 @@
+"""Tests for model-switch notification handling in reconciliation.
+
+The host injects "[Note: model was just switched from X to Y...]" into
+the active message list when the model changes.  LCM persists it, but
+the host removes it after processing.  The next turn's incoming list no
+longer contains it, so the stored tail can never match → cursor=0 →
+full re-ingest → duplication.
+
+Fix: _message_replay_identity treats model-switch notifications as
+identity-empty, and _is_replayed_context_scaffold_message recognises
+them as scaffolding.
+
+All tests use synthetic messages.  No real session data.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from hermes_lcm.config import LCMConfig
+
+
+def _make_engine(tmp_path: Path, *, session_id: str = "model-switch") -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine._session_id = session_id
+    return engine
+
+
+class TestModelSwitchIdentity:
+    """Model-switch notifications must be identity-transparent."""
+
+    def test_identity_strips_prefix_preserves_content(self, tmp_path):
+        """Model-switch prefix is stripped but user content survives."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg_with_prefix = {
+                "role": "user",
+                "content": "[Note: model was just switched from qwen3.8 to kimi-k3 via router. Adjust.]\n\nARGENT — FIX STAGING PREFLIGHT",
+            }
+            msg_without_prefix = {
+                "role": "user",
+                "content": "ARGENT — FIX STAGING PREFLIGHT",
+            }
+            id_with = engine._message_replay_identity(msg_with_prefix)
+            id_without = engine._message_replay_identity(msg_without_prefix)
+            assert id_with == id_without, (
+                "Prefix-stripped identity must match plain content identity"
+            )
+            # Content must NOT be empty — user's message survives
+            assert id_with[1] == "ARGENT — FIX STAGING PREFLIGHT"
+        finally:
+            engine.shutdown()
+
+    def test_identity_stable_across_different_switches(self, tmp_path):
+        """Different model-switch prefixes with same user content → same identity."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg_a = {
+                "role": "user",
+                "content": "[Note: model was just switched from qwen3.8 to kimi-k3 via router.]\n\nUser task here",
+            }
+            msg_b = {
+                "role": "user",
+                "content": "[Note: model was just switched from kimi-k3 to deepseek-v4 via opencode.]\n\nUser task here",
+            }
+            assert (
+                engine._message_replay_identity(msg_a)
+                == engine._message_replay_identity(msg_b)
+            )
+        finally:
+            engine.shutdown()
+
+    def test_normal_message_not_affected(self, tmp_path):
+        """Regular messages starting with '[Note:' but not model-switch are unaffected."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg_note = {"role": "user", "content": "[Note: this is a regular note]"}
+            msg_model = {
+                "role": "user",
+                "content": "[Note: model was just switched from X to Y]",
+            }
+            assert (
+                engine._message_replay_identity(msg_note)
+                != engine._message_replay_identity(msg_model)
+            )
+        finally:
+            engine.shutdown()
+
+
+class TestModelSwitchScaffoldDetection:
+    """Model-switch messages are NOT scaffolding — they carry user content."""
+
+    def test_model_switch_with_content_not_scaffold(self, tmp_path):
+        """A model-switch prefixed message with user content is NOT scaffold."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {
+                "role": "user",
+                "content": "[Note: model was just switched from qwen3.8 to kimi-k3.]\n\nUser task here",
+            }
+            assert engine._is_replayed_context_scaffold_message(msg) is False
+        finally:
+            engine.shutdown()
+
+    def test_regular_note_not_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {"role": "user", "content": "[Note: remember to update docs]"}
+            assert engine._is_replayed_context_scaffold_message(msg) is False
+        finally:
+            engine.shutdown()
+
+
+class TestModelSwitchReconciliation:
+    """End-to-end: model switch prefix must not cause re-ingest."""
+
+    def test_no_duplication_after_model_switch(self, tmp_path):
+        """Simulates: ingest with model-switch prefix on user message →
+        next turn host strips prefix → reconcile matches without duplication."""
+        engine = _make_engine(tmp_path)
+        try:
+            # Phase 1: normal ingest (pre-switch)
+            original = [
+                {"role": "system", "content": "System prompt."},
+                {"role": "user", "content": "First question"},
+                {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Second question"},
+                {"role": "assistant", "content": "Second answer"},
+            ]
+            engine._ingest_messages(original)
+            assert engine._store.get_session_count("model-switch") == 5
+
+            # Phase 2: model switch happens — host PREPENDS notification
+            # to the user's new message
+            with_switch = original + [
+                {
+                    "role": "user",
+                    "content": "[Note: model was just switched from qwen3.8 to kimi-k3 via router. Adjust.]\n\nThird question after switch",
+                },
+            ]
+            switch_engine = _make_engine(tmp_path)
+            try:
+                switch_engine._ingest_cursor_needs_reconcile = True
+                switch_engine._ingest_messages(with_switch)
+                # 6 messages (5 + user msg with prefix)
+                assert switch_engine._store.get_session_count("model-switch") == 6
+            finally:
+                switch_engine.shutdown()
+
+            # Phase 3: next turn — host STRIPPED the prefix,
+            # same user content without prefix
+            after_switch = original + [
+                {"role": "user", "content": "Third question after switch"},
+                {"role": "assistant", "content": "Third answer"},
+            ]
+            replay_engine = _make_engine(tmp_path)
+            try:
+                replay_engine._ingest_cursor_needs_reconcile = True
+                replay_engine._ingest_messages(after_switch)
+
+                count = replay_engine._store.get_session_count("model-switch")
+                # Must be 7 (5 + switch-msg + new answer), no duplication
+                assert count == 7, (
+                    f"Expected 7 (5 + switch + answer), got {count}. "
+                    "Model switch prefix caused re-ingest duplication."
+                )
+
+                rows = replay_engine._store.get_session_messages("model-switch")
+                contents = [r["content"] for r in rows]
+                assert contents.count("First question") == 1
+                assert contents.count("Second answer") == 1
+                assert contents.count("Third answer") == 1
+            finally:
+                replay_engine.shutdown()
+        finally:
+            engine.shutdown()
+
+    def test_model_switch_at_tail_does_not_block_reconcile(self, tmp_path):
+        """When the model-switch prefix is on the LAST stored message,
+        reconcile must still match after host strips the prefix."""
+        engine = _make_engine(tmp_path)
+        try:
+            # Ingest with switch prefix on last user message
+            msgs = [
+                {"role": "system", "content": "System prompt."},
+                {"role": "user", "content": "Question A"},
+                {"role": "assistant", "content": "Answer A"},
+                {
+                    "role": "user",
+                    "content": "[Note: model was just switched from X to Y.]\n\nQuestion B",
+                },
+            ]
+            engine._ingest_messages(msgs)
+            assert engine._store.get_session_count("model-switch") == 4
+
+            # Next turn: prefix stripped, new message added
+            replay = _make_engine(tmp_path)
+            try:
+                replay._ingest_cursor_needs_reconcile = True
+                incoming = [
+                    {"role": "system", "content": "System prompt."},
+                    {"role": "user", "content": "Question A"},
+                    {"role": "assistant", "content": "Answer A"},
+                    {"role": "user", "content": "Question B"},
+                    {"role": "assistant", "content": "Answer B"},
+                ]
+                replay._ingest_messages(incoming)
+
+                count = replay._store.get_session_count("model-switch")
+                assert count == 5, (
+                    f"Expected 5 (4 stored + 1 new), got {count}."
+                )
+            finally:
+                replay.shutdown()
+        finally:
+            engine.shutdown()

--- a/tests/test_reconcile_oob_message_block.py
+++ b/tests/test_reconcile_oob_message_block.py
@@ -31,7 +31,7 @@ OOB_BLOCK = (
 )
 
 
-def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+def _make_engine(tmp_path: Path, **overrides):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.

--- a/tests/test_reconcile_oob_message_block.py
+++ b/tests/test_reconcile_oob_message_block.py
@@ -1,0 +1,195 @@
+"""Out-of-band user messages appended to tool output must not break
+replay reconciliation.
+
+When the user sends a message while the agent is mid-turn, the host
+appends it to the tool output currently being delivered, wrapped in an
+"[OUT-OF-BAND USER MESSAGE ...] ... [/OUT-OF-BAND USER MESSAGE]" block.
+LCM persists the tool row with the block attached.  On resume/restart
+the host replays the same tool result WITHOUT the block (the user
+message was already delivered separately), so the stored row and the
+incoming row differ by exactly that block -> identity mismatch ->
+cursor=0 -> full session re-ingest (duplication).
+
+Fix: _message_replay_identity strips the out-of-band block so identity
+matching survives the delivery split.
+
+All tests use synthetic messages.  No real session data.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from hermes_lcm.config import LCMConfig
+
+OOB_BLOCK = (
+    "\n\n[OUT-OF-BAND USER MESSAGE — a direct message from the user, "
+    "delivered mid-turn; not tool output]\ncheck the 2026 logs instead\n"
+    "[/OUT-OF-BAND USER MESSAGE]"
+)
+
+
+def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    defaults = dict(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=False,
+        fresh_tail_count=64,
+    )
+    defaults.update(overrides)
+    config = LCMConfig(**defaults)
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "oob-block-test",
+        platform="cli",
+        context_length=1000000,
+    )
+    return engine
+
+
+class TestOutOfBandBlockIdentity:
+    """The OOB block is identity-transparent."""
+
+    def test_identity_strips_oob_block_preserves_content(self, tmp_path):
+        """Stored row (with block) and incoming row (without) match."""
+        engine = _make_engine(tmp_path)
+        try:
+            base = '{"output": "build finished, 0 errors", "exit_code": 0}'
+            id_with = engine._message_replay_identity(
+                {"role": "tool", "tool_call_id": "c1", "content": base + OOB_BLOCK}
+            )
+            id_without = engine._message_replay_identity(
+                {"role": "tool", "tool_call_id": "c1", "content": base}
+            )
+            assert id_with == id_without, (
+                "OOB-block-stripped identity must match plain content identity"
+            )
+            # The tool's own content must survive
+            assert "build finished" in id_with[1]
+        finally:
+            engine.shutdown()
+
+    def test_identity_multiple_oob_blocks_stripped(self, tmp_path):
+        """Multiple appended blocks (repeated interruptions) all strip."""
+        engine = _make_engine(tmp_path)
+        try:
+            base = '{"output": "step one done", "exit_code": 0}'
+            twice = base + OOB_BLOCK + OOB_BLOCK.replace(
+                "check the 2026 logs instead", "and also run the tests"
+            )
+            id_twice = engine._message_replay_identity(
+                {"role": "tool", "tool_call_id": "c1", "content": twice}
+            )
+            id_plain = engine._message_replay_identity(
+                {"role": "tool", "tool_call_id": "c1", "content": base}
+            )
+            assert id_twice == id_plain
+        finally:
+            engine.shutdown()
+
+    def test_oob_text_without_markers_not_stripped(self, tmp_path):
+        """Content merely mentioning the phrase keeps its identity."""
+        engine = _make_engine(tmp_path)
+        try:
+            content = "The docs mention OUT-OF-BAND USER MESSAGE markers."
+            id_a = engine._message_replay_identity({"role": "user", "content": content})
+            assert content in id_a[1], "Text without real markers must not be stripped"
+        finally:
+            engine.shutdown()
+
+
+class TestOutOfBandBlockReconciliation:
+    """Restart reconciliation across the OOB delivery split."""
+
+    def test_oob_block_no_reingest_on_restart(self, tmp_path):
+        """Stored with block, replayed without block -> no re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            tool_content = '{"output": "compile succeeded", "exit_code": 0}'
+            turn1 = [
+                {"role": "user", "content": "Build the module"},
+                {"role": "assistant", "content": "Building."},
+                {
+                    "role": "tool",
+                    "tool_call_id": "c1",
+                    "content": tool_content + OOB_BLOCK,  # persisted mid-turn
+                },
+                {"role": "assistant", "content": "Done."},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("oob-block-test") == 4
+
+            # Restart: host replays the tool result WITHOUT the OOB block
+            # (the user message was delivered separately), plus one new turn.
+            turn2 = [
+                {"role": "user", "content": "Build the module"},
+                {"role": "assistant", "content": "Building."},
+                {"role": "tool", "tool_call_id": "c1", "content": tool_content},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": "Now run the tests"},
+            ]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("oob-block-test")
+            assert count == 5, (
+                f"Expected 5 (4 stored + 1 new), got {count}. "
+                "OOB block identity mismatch -> cursor=0 -> full re-ingest."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_reverse_direction_no_reingest(self, tmp_path):
+        """Stored without block, replayed with block -> no re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            tool_content = '{"output": "deploy ok", "exit_code": 0}'
+            turn1 = [
+                {"role": "user", "content": "Deploy"},
+                {"role": "assistant", "content": "Deploying."},
+                {"role": "tool", "tool_call_id": "c1", "content": tool_content},
+                {"role": "assistant", "content": "Done."},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("oob-block-test") == 4
+
+            turn2 = turn1.copy()
+            turn2[2] = {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": tool_content + OOB_BLOCK,
+            }
+            turn2.append({"role": "user", "content": "Verify"})
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("oob-block-test")
+            assert count == 5, f"Expected 5, got {count}"
+        finally:
+            engine.shutdown()

--- a/tests/test_reconcile_standalone_model_switch.py
+++ b/tests/test_reconcile_standalone_model_switch.py
@@ -29,7 +29,7 @@ STANDALONE_NOTE = (
 )
 
 
-def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+def _make_engine(tmp_path: Path, **overrides):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.

--- a/tests/test_reconcile_standalone_model_switch.py
+++ b/tests/test_reconcile_standalone_model_switch.py
@@ -1,0 +1,151 @@
+"""Standalone model-switch notes must not break replay reconciliation.
+
+The host injects "[Note: model was just switched from X to Y ...]" as a
+STANDALONE user message (not merely a prefix on a real user message)
+when the model changes mid-session.  LCM persists that row.  On the
+next turn the host removes the note from its active list entirely — the
+note was ephemeral.  The stored tail therefore contains a row the
+incoming replay lacks; suffix matching shifts, cursor falls to 0 and the
+whole session is re-ingested (duplication).
+
+Fix: standalone model-switch notes are recognised as replay scaffolding
+and filtered from the stored-tail row set used for reconciliation, so
+the stored tail and the incoming replay align.
+
+All tests use synthetic messages.  No real session data.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from hermes_lcm.config import LCMConfig
+
+STANDALONE_NOTE = (
+    "[Note: model was just switched from model-a to model-b "
+    "via the router. Adjust your self-identification accordingly.]"
+)
+
+
+def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    defaults = dict(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=False,
+        fresh_tail_count=64,
+    )
+    defaults.update(overrides)
+    config = LCMConfig(**defaults)
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "standalone-note-test",
+        platform="cli",
+        context_length=1000000,
+    )
+    return engine
+
+
+class TestStandaloneModelSwitchNote:
+    """Standalone model-switch notes are identity-transparent scaffolding."""
+
+    def test_standalone_note_is_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {"role": "user", "content": STANDALONE_NOTE}
+            assert engine._is_replayed_context_scaffold_message(msg) is True
+        finally:
+            engine.shutdown()
+
+    def test_note_with_user_content_not_scaffold(self, tmp_path):
+        """Control: prefix + real user content stays a real message."""
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {
+                "role": "user",
+                "content": STANDALONE_NOTE + "\n\nPlease continue the audit.",
+            }
+            assert engine._is_replayed_context_scaffold_message(msg) is False
+        finally:
+            engine.shutdown()
+
+    def test_standalone_note_stripped_no_reingest(self, tmp_path):
+        """Stored with note, replayed without note -> no re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            turn1 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "tool", "tool_call_id": "c1", "content": '{"output": "ok"}'},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": STANDALONE_NOTE},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("standalone-note-test") == 5
+
+            # Host strips the note from the replay and adds one new turn.
+            turn2 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "tool", "tool_call_id": "c1", "content": '{"output": "ok"}'},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": "Continue"},
+            ]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("standalone-note-test")
+            assert count == 6, (
+                f"Expected 6 (5 stored + 1 new), got {count}. "
+                "Standalone model-switch note broke suffix matching -> "
+                "cursor=0 -> full re-ingest."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_standalone_note_present_on_both_sides(self, tmp_path):
+        """Note still in the replay (same turn) must also stay clean."""
+        engine = _make_engine(tmp_path)
+        try:
+            turn1 = [
+                {"role": "user", "content": "Run the audit"},
+                {"role": "assistant", "content": "Starting."},
+                {"role": "user", "content": STANDALONE_NOTE},
+                {"role": "assistant", "content": "Done."},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("standalone-note-test") == 4
+
+            turn2 = turn1 + [{"role": "user", "content": "Verify"}]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("standalone-note-test")
+            assert count == 5, f"Expected 5, got {count}"
+        finally:
+            engine.shutdown()

--- a/tests/test_reconcile_todo_annotation.py
+++ b/tests/test_reconcile_todo_annotation.py
@@ -1,0 +1,262 @@
+"""Regression tests for compaction-scaffold-aware replay identity.
+
+After context compression the host appends a volatile task-list annotation
+(``_PRESERVED_TODO_CONTEXT_PREFIX``) to the last user message.  The annotation
+changes on every compression cycle (task statuses update), so including it in
+the replay identity causes ``_find_reconciled_cursor_for_store_tail`` to fail
+suffix matching, fall through to ``cursor=0``, and re-persist every message —
+creating duplicates with distinct store_ids and timestamps.
+
+These tests verify that:
+1. ``_message_replay_identity`` strips the todo annotation before hashing.
+2. Reconciliation after a compression boundary correctly advances the cursor
+   even when the todo annotation changed between compaction cycles.
+3. ``_is_replayed_context_scaffold_message`` recognises standalone todo
+   annotation messages as scaffolding (not durable user content).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+# engine.py imports agent.context_engine at module level; provide a stub
+# before the conftest partial-import can poison sys.modules.
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.reconcile import (
+    _PRESERVED_TODO_CONTEXT_PREFIX,
+)
+
+_TODO_ANNOTATION_V1 = (
+    f"\n\n{_PRESERVED_TODO_CONTEXT_PREFIX}\n"
+    "- [>] 1. First task (in_progress)\n"
+    "- [ ] 2. Second task (pending)\n"
+)
+
+_TODO_ANNOTATION_V2 = (
+    f"\n\n{_PRESERVED_TODO_CONTEXT_PREFIX}\n"
+    "- [x] 1. First task (completed)\n"
+    "- [>] 2. Second task (in_progress)\n"
+    "- [ ] 3. Third task (pending)\n"
+)
+
+
+def _make_engine(tmp_path: Path, *, session_id: str = "reconcile-todo") -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine._session_id = session_id
+    return engine
+
+
+class TestTodoAnnotationIdentity:
+    """_message_replay_identity must be stable across todo annotation changes."""
+
+    def test_identity_strips_todo_annotation(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg_plain = {"role": "user", "content": "Do the thing"}
+            msg_annotated = {
+                "role": "user",
+                "content": "Do the thing" + _TODO_ANNOTATION_V1,
+            }
+            msg_annotated_v2 = {
+                "role": "user",
+                "content": "Do the thing" + _TODO_ANNOTATION_V2,
+            }
+
+            id_plain = engine._message_replay_identity(msg_plain)
+            id_v1 = engine._message_replay_identity(msg_annotated)
+            id_v2 = engine._message_replay_identity(msg_annotated_v2)
+
+            assert id_plain == id_v1, (
+                "Identity with todo annotation v1 must match plain content"
+            )
+            assert id_plain == id_v2, (
+                "Identity with todo annotation v2 must match plain content"
+            )
+            assert id_v1 == id_v2, (
+                "Identity must be stable across different todo annotation versions"
+            )
+        finally:
+            engine.shutdown()
+
+    def test_identity_preserves_content_without_annotation(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg_a = {"role": "user", "content": "Alpha message"}
+            msg_b = {"role": "user", "content": "Beta message"}
+            assert (
+                engine._message_replay_identity(msg_a)
+                != engine._message_replay_identity(msg_b)
+            )
+        finally:
+            engine.shutdown()
+
+    def test_identity_strips_annotation_from_stored_row(self, tmp_path):
+        """Stored rows carry the annotation verbatim; identity must still strip."""
+        engine = _make_engine(tmp_path)
+        try:
+            stored = {
+                "role": "user",
+                "content": "Persisted content" + _TODO_ANNOTATION_V1,
+            }
+            incoming = {
+                "role": "user",
+                "content": "Persisted content" + _TODO_ANNOTATION_V2,
+            }
+            id_stored = engine._message_replay_identity(stored, stored_row=True)
+            id_incoming = engine._message_replay_identity(incoming)
+            assert id_stored == id_incoming
+        finally:
+            engine.shutdown()
+
+
+class TestTodoAnnotationScaffoldDetection:
+    """Standalone todo annotation messages must be recognised as scaffolding."""
+
+    def test_standalone_todo_is_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {
+                "role": "user",
+                "content": _PRESERVED_TODO_CONTEXT_PREFIX + "\n- [ ] task",
+            }
+            assert engine._is_replayed_context_scaffold_message(msg) is True
+        finally:
+            engine.shutdown()
+
+    def test_objective_prefix_still_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {
+                "role": "user",
+                "content": "[Current user objective preserved from compacted history]\nDo X",
+            }
+            assert engine._is_replayed_context_scaffold_message(msg) is True
+        finally:
+            engine.shutdown()
+
+    def test_regular_user_message_not_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            msg = {"role": "user", "content": "Just a normal question"}
+            assert engine._is_replayed_context_scaffold_message(msg) is False
+        finally:
+            engine.shutdown()
+
+
+class TestReconcileAfterCompactionWithTodoAnnotation:
+    """End-to-end: ingest → compress → re-ingest with changed annotation."""
+
+    def test_no_duplication_when_todo_annotation_changes(self, tmp_path):
+        """Simulates the production bug: compaction changes the todo annotation
+        on the last user message, then reconciliation must still recognise the
+        stored messages and advance the cursor past them."""
+        engine = _make_engine(tmp_path)
+        try:
+            # Phase 1: initial ingest (pre-compaction)
+            original_messages = [
+                {"role": "system", "content": "System prompt."},
+                {"role": "user", "content": "First user request"},
+                {"role": "assistant", "content": "First assistant reply"},
+                {"role": "user", "content": "Second user request" + _TODO_ANNOTATION_V1},
+                {"role": "assistant", "content": "Second assistant reply"},
+            ]
+            engine._ingest_messages(original_messages)
+            count_after_first = engine._store.get_session_count("reconcile-todo")
+            assert count_after_first == 5
+
+            # Phase 2: simulate compression boundary + restart.
+            # The host rebuilds the message list with a DIFFERENT todo
+            # annotation (task statuses changed during compaction).
+            replay_engine = _make_engine(tmp_path)
+            try:
+                replay_engine._ingest_cursor_needs_reconcile = True
+                replay_messages = [
+                    {"role": "system", "content": "System prompt."},
+                    {"role": "user", "content": "First user request"},
+                    {"role": "assistant", "content": "First assistant reply"},
+                    {"role": "user", "content": "Second user request" + _TODO_ANNOTATION_V2},
+                    {"role": "assistant", "content": "Second assistant reply"},
+                    {"role": "user", "content": "Brand new question after restart"},
+                ]
+                replay_engine._ingest_messages(replay_messages)
+
+                count_after_replay = replay_engine._store.get_session_count(
+                    "reconcile-todo"
+                )
+                # Must be 6 (5 original + 1 new), NOT 11 (5 dup + 5 + 1).
+                assert count_after_replay == 6, (
+                    f"Expected 6 messages (5 original + 1 new), got {count_after_replay}. "
+                    "Duplication bug: reconciliation failed to match stored tail "
+                    "because the todo annotation changed."
+                )
+
+                # Verify no content duplication
+                rows = replay_engine._store.get_session_messages("reconcile-todo")
+                contents = [r["content"] for r in rows]
+                assert contents.count("First user request") == 1
+                assert contents.count("First assistant reply") == 1
+                assert contents.count("Second assistant reply") == 1
+                assert contents.count("Brand new question after restart") == 1
+            finally:
+                replay_engine.shutdown()
+        finally:
+            engine.shutdown()
+
+    def test_no_duplication_with_identical_annotation(self, tmp_path):
+        """Control: identical annotation should also produce no duplication."""
+        engine = _make_engine(tmp_path)
+        try:
+            original_messages = [
+                {"role": "system", "content": "System prompt."},
+                {"role": "user", "content": "User request" + _TODO_ANNOTATION_V1},
+                {"role": "assistant", "content": "Assistant reply"},
+            ]
+            engine._ingest_messages(original_messages)
+            assert engine._store.get_session_count("reconcile-todo") == 3
+
+            replay_engine = _make_engine(tmp_path)
+            try:
+                replay_engine._ingest_cursor_needs_reconcile = True
+                replay_messages = [
+                    {"role": "system", "content": "System prompt."},
+                    {"role": "user", "content": "User request" + _TODO_ANNOTATION_V1},
+                    {"role": "assistant", "content": "Assistant reply"},
+                    {"role": "user", "content": "Follow-up"},
+                ]
+                replay_engine._ingest_messages(replay_messages)
+                assert replay_engine._store.get_session_count("reconcile-todo") == 4
+            finally:
+                replay_engine.shutdown()
+        finally:
+            engine.shutdown()

--- a/tests/test_reconcile_todo_annotation.py
+++ b/tests/test_reconcile_todo_annotation.py
@@ -42,7 +42,7 @@ _TODO_ANNOTATION_V2 = (
 )
 
 
-def _make_engine(tmp_path: Path, *, session_id: str = "reconcile-todo") -> LCMEngine:
+def _make_engine(tmp_path: Path, *, session_id: str = "reconcile-todo"):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.

--- a/tests/test_reconcile_tool_scaffold_excerpt.py
+++ b/tests/test_reconcile_tool_scaffold_excerpt.py
@@ -1,0 +1,129 @@
+"""Tool messages containing summary-like excerpts must not be treated as
+scaffolding during replay reconciliation.
+
+A tool result can legitimately quote a summary excerpt (delegation receipts,
+session links, embedded "[Expand for details:" blocks).  If
+_is_replayed_context_scaffold_message marks such a tool row as scaffolding,
+the replay identity list drops it — the incoming list becomes shorter than
+the stored tail, suffix matching shifts, cursor falls to 0 and the whole
+session is re-ingested (duplication).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from hermes_lcm.config import LCMConfig
+
+
+def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    defaults = dict(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=200,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+        fresh_tail_count=64,
+    )
+    defaults.update(overrides)
+    config = LCMConfig(**defaults)
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "tool-scaffold-test",
+        platform="cli",
+        context_length=1000000,
+    )
+    return engine
+
+
+class TestToolSummaryExcerptNotScaffold:
+    """Tool rows quoting summary excerpts keep their replay identity."""
+
+    def test_tool_row_with_summary_excerpt_is_not_scaffold(self, tmp_path):
+        engine = _make_engine(tmp_path)
+        try:
+            summary_quote = (
+                "Delegation receipt with embedded excerpt:\n"
+                "[Expand for details: recent summary content]\n"
+                "[Recent Summary (d0, node 42)]\n"
+                "Actual tool payload continues here."
+            )
+            msg = {"role": "tool", "tool_call_id": "call_x", "content": summary_quote}
+            assert engine._is_replayed_context_scaffold_message(msg) is False, (
+                "Tool row with summary excerpt must NOT be scaffolding"
+            )
+        finally:
+            engine.shutdown()
+
+    def test_tool_summary_excerpt_no_reingest_on_restart(self, tmp_path):
+        """Restart replay with a summary-quoting tool row must not re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            summary_quote = (
+                "Receipt:\n"
+                "[Expand for details: abc]\n"
+                "[Recent Summary (d0, node 7)]\n"
+                + ("x" * 3000)
+            )
+            turn1 = [
+                {"role": "user", "content": "Deploy"},
+                {"role": "assistant", "content": "Running."},
+                {"role": "tool", "tool_call_id": "c1", "content": summary_quote},
+                {"role": "assistant", "content": "Done."},
+            ]
+            engine._ingest_messages(turn1)
+            assert engine._store.get_session_count("tool-scaffold-test") == 4
+
+            # Simulated restart: same messages + one new
+            turn2 = turn1 + [{"role": "user", "content": "Verify"}]
+            engine._ingest_cursor_needs_reconcile = True
+            engine._ingest_messages(turn2)
+
+            count = engine._store.get_session_count("tool-scaffold-test")
+            assert count == 5, (
+                f"Expected 5 (4 stored + 1 new), got {count}. "
+                "Summary-quoting tool row was treated as scaffolding → "
+                "replay identity dropped it → full re-ingest."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_assistant_summary_excerpt_still_scaffold(self, tmp_path):
+        """Control: assistant summary rows remain scaffolding."""
+        engine = _make_engine(tmp_path)
+        try:
+            summary = (
+                "[Recent Summary (d0, node 42)]\n"
+                "[Expand for details: ...]\n"
+                "Context was compacted."
+            )
+            msg = {"role": "assistant", "content": summary}
+            assert engine._is_replayed_context_scaffold_message(msg) is True
+        finally:
+            engine.shutdown()

--- a/tests/test_reconcile_tool_scaffold_excerpt.py
+++ b/tests/test_reconcile_tool_scaffold_excerpt.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from hermes_lcm.config import LCMConfig
 
 
-def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+def _make_engine(tmp_path: Path, **overrides):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.


### PR DESCRIPTION
## Problem

Hermes-generated transient wrappers can change between active-context
replays even when the durable message is unchanged. This breaks replay
identity matching and can cause previously stored messages to be appended
again.

Affected representations:
- volatile TODO annotations
- model-switch wrappers
- standalone model-switch notes
- out-of-band user blocks
- tool messages misclassified as generated scaffold

## Root cause

Replay identity currently compares host-generated presentation layers as
if they were durable message content.

## Minimal fix

Normalize only the recognized Hermes-generated replay layers while
building replay identity. Raw stored content, provider-visible content,
the scalar cursor algorithm, and the database schema remain unchanged.

## Regression tests

- TODO annotation replay
- model-switch wrapper replay
- standalone model-switch note
- OOB block replay
- real tool output versus generated scaffold
- negative tests preserving ordinary user content
- normalization idempotency and tool-call metadata

Focused result: 27 passed.

## Relationship

Supersedes #462, #465, #490, and #494.

Includes only the narrowly scoped tool-scaffold correction from #471.

Complements #437, which handles partial tool-tail replay after restart.
The PRs apply and test independently; the complete tested production
stack uses both.
