### PR TITLE
fix(reconcile): tolerate compacted-out tool rows in suffix matching

### DIFF
--- a/reconcile.py
+++ b/reconcile.py
@@ -243,6 +243,17 @@ class ReconcileMixin:
         )
 
     @staticmethod
+    def _non_tool_identity_count(identities: list[tuple[str, str, str, str]]) -> int:
+        """Count non-tool identities in a replay identity list.
+
+        Leaf compaction removes tool rows from the active context while the
+        durable store keeps them, so the incoming list is shorter than the
+        stored session.  Full-replay length checks must compare non-tool
+        counts on both sides.
+        """
+        return sum(1 for identity in identities if identity[0] != "tool")
+
+    @staticmethod
     def _matches_store_tail_suffix(
         stored_tail: list[tuple[str, str, str, str]],
         candidate_prefix: list[tuple[str, str, str, str]],
@@ -252,6 +263,41 @@ class ReconcileMixin:
         if len(candidate_prefix) > len(stored_tail):
             return False
         return stored_tail[-len(candidate_prefix) :] == candidate_prefix
+
+    @staticmethod
+    def _matches_store_tail_suffix_tool_tolerant(
+        stored_tail: list[tuple[str, str, str, str]],
+        candidate_prefix: list[tuple[str, str, str, str]],
+    ) -> bool:
+        """Suffix match that tolerates compacted-out tool rows.
+
+        Leaf compaction summarizes tool results into DAG nodes and removes
+        them from the active context, while the durable store keeps the rows
+        (lossless design).  A stored tool row with no counterpart in the
+        incoming list must not break the suffix match, otherwise the cursor
+        falls to 0 and the whole session is re-ingested (duplication).
+
+        Only safe when the incoming prefix contains NO tool rows at all: a
+        normal restart replays tool rows verbatim and needs exact matching
+        (persisted-output marker identity depends on it).  This fallback is
+        therefore gated on ``candidate_has_no_tools`` by the caller.
+        """
+        if not candidate_prefix:
+            return True
+        if len(candidate_prefix) > len(stored_tail):
+            return False
+        i = len(stored_tail) - 1
+        j = len(candidate_prefix) - 1
+        while j >= 0 and i >= 0:
+            if stored_tail[i] == candidate_prefix[j]:
+                i -= 1
+                j -= 1
+                continue
+            if stored_tail[i][0] == "tool" and candidate_prefix[j][0] != "tool":
+                i -= 1
+                continue
+            return False
+        return j < 0
 
     @staticmethod
     def _strip_inline_persisted_output_generation_identity(
@@ -431,6 +477,18 @@ class ReconcileMixin:
         sanitized_replay_tail = self._stored_tail_for_sanitized_active_replay(stored_tail)
         effective_session_count = len(sanitized_replay_tail)
         sanitized_tail_collapsed = len(sanitized_replay_tail) < len(stored_tail)
+        # Leaf compaction summarizes tool results into DAG nodes and removes
+        # them from the active context, while the durable store keeps the
+        # rows.  The incoming list therefore has fewer rows than the stored
+        # session.  Length checks below ("full replay") must compare on the
+        # same basis: non-tool counts on both sides, otherwise a compaction
+        # boundary fails full-replay detection → cursor=0 → full re-ingest.
+        stored_effective_non_tool_count = sum(
+            1 for identity in sanitized_replay_tail if identity[0] != "tool"
+        )
+        stored_raw_non_tool_count = sum(
+            1 for identity in stored_tail if identity[0] != "tool"
+        )
         boundary_messages = list(stored_tail_rows or [])
         if not boundary_messages:
             for role, content, tool_call_id, tool_calls in stored_tail:
@@ -508,7 +566,28 @@ class ReconcileMixin:
                 len(candidate_prefix) <= len(sanitized_replay_tail)
                 and self._matches_store_tail_suffix(sanitized_replay_tail, candidate_prefix)
             )
+            # Tool-tolerant fallback: leaf compaction removes tool rows from
+            # the active context while the store keeps them, so after a
+            # compaction the incoming list has no tool rows at all and exact
+            # suffix matching fails.  Only engage the tolerant matcher when
+            # the FULL incoming list is genuinely tool-free — a normal restart
+            # replays tool rows verbatim and must keep exact matching.  Check
+            # the full message list, not the cursor-truncated candidate: a
+            # cursor that stops before the tool rows must not enable the
+            # fallback, or a changed tool marker would be wrongly replayed.
+            candidate_has_no_tools = not any(
+                str(msg.get("role") or "") == "tool" for msg in messages
+            )
+            matches_sanitized_tail_tool_tolerant = (
+                candidate_has_no_tools
+                and self._non_tool_identity_count(candidate_prefix) <= len(sanitized_replay_tail)
+                and self._matches_store_tail_suffix_tool_tolerant(sanitized_replay_tail, candidate_prefix)
+            )
             matches_raw_tail = self._matches_store_tail_suffix(stored_tail, candidate_prefix)
+            matches_raw_tail_tool_tolerant = (
+                candidate_has_no_tools
+                and self._matches_store_tail_suffix_tool_tolerant(stored_tail, candidate_prefix)
+            )
             matches_visible_sanitized_tail = (
                 filtered_candidate_placeholders
                 and bool(candidate_visible_prefix)
@@ -565,14 +644,16 @@ class ReconcileMixin:
                     generationless_sanitized_tail,
                     generationless_candidate_prefix,
                 )
-            raw_tail_suffix = stored_tail[-len(candidate_prefix) :] if matches_raw_tail else []
+            raw_tail_suffix = stored_tail[-len(candidate_prefix) :] if (matches_raw_tail or matches_raw_tail_tool_tolerant) else []
             raw_suffix_needs_cleanup_equivalence = any(
                 self._active_cleanup_replay_identity(identity) != identity
                 for identity in raw_tail_suffix
             )
             if (
                 not matches_sanitized_tail
+                and not matches_sanitized_tail_tool_tolerant
                 and not matches_raw_tail
+                and not matches_raw_tail_tool_tolerant
                 and not matches_inline_generation_cleanup_tail
                 and not matches_durable_persisted_output_full_replay
             ):
@@ -645,15 +726,19 @@ class ReconcileMixin:
                 )
             )
             has_filtered_full_replay = (
-                matches_sanitized_tail
+                (matches_sanitized_tail or matches_sanitized_tail_tool_tolerant)
                 and candidate_dropped_quarantine_replay_placeholder
-                and len(candidate_prefix) >= effective_session_count
+                and (
+                    self._non_tool_identity_count(candidate_prefix) >= stored_effective_non_tool_count
+                    if matches_sanitized_tail_tool_tolerant
+                    else len(candidate_prefix) >= effective_session_count
+                )
                 and effective_session_count > 0
             )
             has_inline_generation_cleanup_replay = (
                 matches_inline_generation_cleanup_tail
                 and candidate_has_unrecoverable_persisted_marker
-                and len(candidate_prefix) >= effective_session_count
+                and self._non_tool_identity_count(candidate_prefix) >= stored_effective_non_tool_count
                 and effective_session_count > 0
             )
             has_inline_persisted_generation_suffix_replay = (
@@ -684,8 +769,12 @@ class ReconcileMixin:
             )
             has_effective_full_replay = (
                 has_persisted_marker_specific_replay_evidence
-                and matches_sanitized_tail
-                and len(candidate_prefix) >= effective_session_count
+                and (matches_sanitized_tail or matches_sanitized_tail_tool_tolerant)
+                and (
+                    self._non_tool_identity_count(candidate_prefix) >= stored_effective_non_tool_count
+                    if matches_sanitized_tail_tool_tolerant
+                    else len(candidate_prefix) >= effective_session_count
+                )
                 and (
                     candidate_has_system
                     or (effective_session_count > 1 and not sanitized_tail_collapsed)
@@ -699,9 +788,13 @@ class ReconcileMixin:
             )
             has_raw_full_replay = (
                 has_persisted_marker_specific_replay_evidence
-                and matches_raw_tail
+                and (matches_raw_tail or matches_raw_tail_tool_tolerant)
                 and not has_scaffold_evidence
-                and len(candidate_messages) >= raw_session_count
+                and (
+                    self._non_tool_identity_count(candidate_prefix) >= stored_raw_non_tool_count
+                    if matches_raw_tail_tool_tolerant
+                    else len(candidate_prefix) >= raw_session_count
+                )
                 and raw_session_count > 1
             )
             has_preserved_objective_scaffold = any(

--- a/tests/test_compression_reconcile_reingest.py
+++ b/tests/test_compression_reconcile_reingest.py
@@ -24,7 +24,7 @@ from types import ModuleType
 from hermes_lcm.config import LCMConfig
 
 
-def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+def _make_engine(tmp_path: Path, **overrides):
     # engine.py imports agent.context_engine at module level; provide a
     # stub here (not at module level, so collection order of other test
     # files is unaffected), then clear any partial import left by conftest.

--- a/tests/test_compression_reconcile_reingest.py
+++ b/tests/test_compression_reconcile_reingest.py
@@ -1,0 +1,189 @@
+"""Reproduce: compression followed by reconcile must not re-ingest.
+
+Production evidence (session 20260802_180245_53f74a):
+- 19:03: compression 285→85 messages (200 compacted)
+- 19:05: 200 rows persisted immediately after, 198 of them duplicates
+- 22:38: compression 482→67 (415 compacted)
+- 22:40: 415 rows persisted, duplicates
+- Each compression re-writes exactly the compacted message count
+
+Hypothesis: after compress() shortens the list and resets
+_ingest_cursor = len(compressed), the host rebinds via on_session_start
+which sets _ingest_cursor_needs_reconcile = True.  The reconcile then
+compares the stored tail (pre-compaction rows, some externalized as
+placeholders) against the incoming list (fresh tail + summaries) and
+fails to find a suffix match → cursor=0 → full re-ingest.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from hermes_lcm.config import LCMConfig
+
+
+def _make_engine(tmp_path: Path, **overrides) -> LCMEngine:
+    # engine.py imports agent.context_engine at module level; provide a
+    # stub here (not at module level, so collection order of other test
+    # files is unaffected), then clear any partial import left by conftest.
+    if "agent.context_engine" not in sys.modules:
+        _agent_mod = ModuleType("agent")
+        _agent_mod.__path__ = []
+        _ce_mod = ModuleType("agent.context_engine")
+
+        class _StubContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        _ce_mod.ContextEngine = _StubContextEngine
+        sys.modules["agent"] = _agent_mod
+        sys.modules["agent.context_engine"] = _ce_mod
+
+    _existing = sys.modules.get("hermes_lcm.engine")
+    if _existing is not None and not hasattr(_existing, "LCMEngine"):
+        sys.modules.pop("hermes_lcm.engine", None)
+    from hermes_lcm.engine import LCMEngine
+
+    defaults = dict(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=200,
+        large_output_externalization_path=str(tmp_path / "externalized"),
+        fresh_tail_count=32,
+        leaf_chunk_tokens=100000,
+    )
+    defaults.update(overrides)
+    config = LCMConfig(**defaults)
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "compress-reconcile-test",
+        platform="cli",
+        context_length=1000000,
+    )
+    return engine
+
+
+def _turn(messages, content):
+    return messages + [{"role": "user", "content": content}]
+
+
+class TestCompressionThenReconcile:
+    """Compression must not cause full re-ingest on the next turn."""
+
+    def test_compression_no_reingest_on_next_turn(self, tmp_path):
+        """After compress() shortens the list, next ingest must only add new."""
+        engine = _make_engine(tmp_path)
+        try:
+            # Build a session of ~60 messages with some large tool outputs
+            messages = [{"role": "system", "content": "System prompt."}]
+            for i in range(60):
+                if i % 5 == 0:
+                    messages.append(
+                        {"role": "tool", "tool_call_id": f"c{i}",
+                         "content": f"BIG{i}:" + ("x" * 500)}
+                    )
+                else:
+                    role = "user" if i % 2 == 0 else "assistant"
+                    messages.append({"role": role, "content": f"msg{i}"})
+
+            engine._ingest_messages(messages)
+            count_before = engine._store.get_session_count("compress-reconcile-test")
+
+            # Compress — this is what the host calls
+            compressed = engine.compress(messages)
+            assert len(compressed) < len(messages), (
+                f"Compression should shrink: {len(messages)} -> {len(compressed)}"
+            )
+
+            # Host rebinds after compression (conversation_compression.py does this)
+            engine.on_session_start(
+                "compress-reconcile-test",
+                platform="cli",
+                context_length=1000000,
+                boundary_reason="compression",
+            )
+
+            # Next turn: compressed context + one new user message
+            next_turn = compressed + [{"role": "user", "content": "new question"}]
+            engine._ingest_messages(next_turn)
+
+            count_after = engine._store.get_session_count("compress-reconcile-test")
+            expected_new = 1  # only the new user message
+            expected_total = count_before + expected_new
+            assert count_after == expected_total, (
+                f"After compression + rebind, expected {expected_total} "
+                f"({count_before} stored + 1 new), got {count_after}. "
+                "Compression caused full re-ingest (duplication)."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_compression_with_externalized_tail_no_reingest(self, tmp_path):
+        """Compression + externalized tool rows + rebind must not re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            messages = [{"role": "system", "content": "System prompt."}]
+            for i in range(40):
+                role = "user" if i % 2 == 0 else "assistant"
+                messages.append({"role": role, "content": f"m{i}"})
+            # Large tool output that will be externalized
+            messages.append(
+                {"role": "tool", "tool_call_id": "big",
+                 "content": "HUGE:" + ("z" * 5000)}
+            )
+
+            engine._ingest_messages(messages)
+            count_before = engine._store.get_session_count("compress-reconcile-test")
+
+            compressed = engine.compress(messages)
+            assert len(compressed) < len(messages)
+
+            engine.on_session_start(
+                "compress-reconcile-test",
+                platform="cli",
+                context_length=1000000,
+                boundary_reason="compression",
+            )
+
+            next_turn = compressed + [{"role": "user", "content": "follow up"}]
+            engine._ingest_messages(next_turn)
+
+            count_after = engine._store.get_session_count("compress-reconcile-test")
+            assert count_after == count_before + 1, (
+                f"Expected {count_before + 1}, got {count_after}. "
+                "Externalized rows + compression caused re-ingest."
+            )
+        finally:
+            engine.shutdown()
+
+    def test_compression_no_rebind_no_reingest(self, tmp_path):
+        """Control: compression WITHOUT rebind must not re-ingest."""
+        engine = _make_engine(tmp_path)
+        try:
+            messages = [{"role": "system", "content": "System prompt."}]
+            for i in range(40):
+                role = "user" if i % 2 == 0 else "assistant"
+                messages.append({"role": role, "content": f"m{i}"})
+
+            engine._ingest_messages(messages)
+            count_before = engine._store.get_session_count("compress-reconcile-test")
+
+            compressed = engine.compress(messages)
+            # NO on_session_start here
+
+            next_turn = compressed + [{"role": "user", "content": "follow up"}]
+            engine._ingest_messages(next_turn)
+
+            count_after = engine._store.get_session_count("compress-reconcile-test")
+            assert count_after == count_before + 1, (
+                f"Expected {count_before + 1}, got {count_after}. "
+                "Compression alone caused re-ingest."
+            )
+        finally:
+            engine.shutdown()


### PR DESCRIPTION
## Problem

After the real compression path removes tool rows from the active replay,
the remaining user/assistant suffix can fail to match the durable store.
The scalar cursor can then treat the replayed history as new and append it
again.

## Root cause

Suffix matching currently requires tool rows that may legitimately be
absent after compression.

## Minimal fix

Allow suffix reconciliation to tolerate tool rows omitted by the real
compression path while preserving the existing scalar-cursor and storage
architecture.

## Regression tests

The regression fixture uses the real compress() path rather than manually
deleting tool rows.

Focused result: 3 passed.

## Relationship

Contains only the compacted-tool portion split from #471.

Complements #437, which handles tool-call-anchored partial restart replay.
The two patches apply and test independently.
