### PR TITLE
fix(lcm): make request pressure fresh-tail aware

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -201,6 +201,53 @@ class CompactionMixin:
             return self._mark_preflight_compression_requested()
         return False
 
+    def should_compress_request_pressure(self, messages, prompt_tokens: int) -> bool:
+        """Message-aware mid-turn pressure check for protected fresh tails.
+
+        Hermes core calls this after it has estimated the full provider request
+        (system prompt, tool schemas, and messages). That pressure can be over
+        threshold even when LCM has no raw backlog outside the protected latest
+        user/fresh tail, so a normal leaf compaction would be a no-op. Decline in
+        that case and let the host proceed to tool-tail spill or terminal
+        handoff instead of burning repeated compression attempts.
+        """
+        self._maybe_reclassify_late_auxiliary_before_compaction_write()
+        if self._bypasses_lcm_context_management():
+            self._remember_lcm_bypass_message_prefix(self._bypass_lcm_session_id(), messages)
+            if self._compression_boundary_cooldown_active():
+                return False
+            if self._should_force_overflow_recovery(
+                observed_tokens=prompt_tokens,
+                messages=messages,
+            ):
+                return True
+            return self.threshold_tokens > 0 and prompt_tokens >= self.threshold_tokens
+
+        if self._compression_boundary_cooldown_active():
+            return False
+        if self._should_force_overflow_recovery(
+            observed_tokens=prompt_tokens,
+            messages=messages,
+        ):
+            return True
+        if self.threshold_tokens > 0 and prompt_tokens >= self.threshold_tokens:
+            eligible, reason = self._leaf_compaction_candidate_status(
+                messages,
+                allow_partial_leaf=self._config.threshold_full_sweep_enabled,
+            )
+            if eligible:
+                return True
+            if self._has_ignored_backlog_outside_fresh_tail(messages):
+                return True
+            if self._should_run_deferred_maintenance(messages, observed_tokens=prompt_tokens):
+                return True
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = reason
+            logger.info("LCM request-pressure compression no-op: %s", reason)
+            return False
+        self._refresh_raw_backlog_debt(messages, observed_tokens=prompt_tokens)
+        return self._should_run_deferred_maintenance(messages, observed_tokens=prompt_tokens)
+
     def _replay_diff_requests_ingest_cleanup(
         self,
         original_messages: List[Dict[str, Any]],

--- a/config.py
+++ b/config.py
@@ -496,9 +496,10 @@ class LCMConfig:
     # -- Assembly guardrails ---
     # Hard cap for the assembled active context (0 = disabled)
     max_assembly_tokens: int = 0
-    # Reserve this many tokens from the model context window before assembly
-    # (0 = disabled). Effective cap becomes context_length - reserve_tokens_floor.
-    reserve_tokens_floor: int = 0
+    # Reserve this many tokens from the model context window before assembly.
+    # -1 = automatic reserve for large model windows, 0 = disabled, >0 = explicit.
+    # Effective cap becomes context_length - reserve_tokens_floor.
+    reserve_tokens_floor: int = -1
 
     # -- Session and message filtering ---
     # Sessions to exclude from LCM storage entirely.

--- a/engine.py
+++ b/engine.py
@@ -6161,14 +6161,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         if self._config.max_assembly_tokens > 0:
             caps.append(self._config.max_assembly_tokens)
 
-        if self.context_length > 0 and self._config.reserve_tokens_floor > 0:
-            reserve_cap = self.context_length - self._config.reserve_tokens_floor
+        reserve_tokens_floor = self._config.reserve_tokens_floor
+        if reserve_tokens_floor < 0:
+            reserve_tokens_floor = self._automatic_reserve_tokens_floor(self.context_length)
+        if self.context_length > 0 and reserve_tokens_floor > 0:
+            reserve_cap = self.context_length - reserve_tokens_floor
             if reserve_cap > 0:
                 caps.append(reserve_cap)
             else:
                 logger.warning(
                     "LCM reserve_tokens_floor=%d disables reserve-based assembly cap because context_length=%d",
-                    self._config.reserve_tokens_floor,
+                    reserve_tokens_floor,
                     self.context_length,
                 )
 
@@ -6176,6 +6179,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return None
 
         return max(1, min(caps))
+
+    @staticmethod
+    def _automatic_reserve_tokens_floor(context_length: int) -> int:
+        if context_length < 65_536:
+            return 0
+        return max(1, min(24_000, int(context_length * 0.10)))
 
     # -- Internal: helpers -------------------------------------------------
 

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -701,7 +701,7 @@ class TestConfig:
         assert c.leaf_chunk_tokens == 20_000
         assert c.context_threshold == 0.35
         assert c.max_assembly_tokens == 0
-        assert c.reserve_tokens_floor == 0
+        assert c.reserve_tokens_floor == -1
         assert c.expansion_context_tokens == 32_000
         assert c.critical_budget_pressure_ratio == 0.0
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -458,7 +458,7 @@ def test_codex_oauth_context_cap_keeps_explicit_lcm_threshold(tmp_path):
         assert engine.context_length == 272_000
         assert engine.context_threshold == 0.68
         assert engine.threshold_tokens == int(272_000 * 0.68)
-        assert engine._effective_assembly_token_cap() is None
+        assert engine._effective_assembly_token_cap() == 248_000
 
         status = engine.get_status()
         assert status["context_threshold_source"] == "env:LCM_CONTEXT_THRESHOLD"
@@ -20532,6 +20532,60 @@ class TestConfigCleanup:
 
 
 class TestAssemblyGuardrails:
+    def test_default_reserve_tokens_floor_auto_caps_large_context(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "auto-reserve.db"))
+        instance = LCMEngine(config=config)
+        instance.context_length = 272_000
+
+        assert config.reserve_tokens_floor == -1
+        assert instance._effective_assembly_token_cap() == 248_000
+
+    def test_explicit_zero_reserve_tokens_floor_disables_auto_cap(self, tmp_path):
+        config = LCMConfig(
+            database_path=str(tmp_path / "zero-reserve.db"),
+            reserve_tokens_floor=0,
+        )
+        instance = LCMEngine(config=config)
+        instance.context_length = 272_000
+
+        assert instance._effective_assembly_token_cap() is None
+
+    def test_auto_reserve_tokens_floor_does_not_cap_small_contexts(self, tmp_path):
+        config = LCMConfig(database_path=str(tmp_path / "small-auto-reserve.db"))
+        instance = LCMEngine(config=config)
+        instance.context_length = 32_000
+
+        assert instance._effective_assembly_token_cap() is None
+
+    def test_request_pressure_declines_when_only_protected_tail_is_large(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "request-pressure-tail-only.db"),
+            reserve_tokens_floor=0,
+        )
+        instance = LCMEngine(config=config)
+        instance.threshold_tokens = 50
+        messages = [
+            {"role": "user", "content": "latest question"},
+            {"role": "tool", "content": "x" * 1000},
+        ]
+
+        assert instance.should_compress_request_pressure(messages, 1_000) is False
+        assert instance.last_compression_was_noop
+        assert "fresh tail" in instance.last_compression_noop_reason
+
+    def test_request_pressure_forces_recovery_when_auto_cap_is_exceeded(self, tmp_path):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "request-pressure-auto-cap.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance.context_length = 272_000
+        instance.threshold_tokens = 204_000
+        messages = [{"role": "user", "content": "latest question"}]
+
+        assert instance.should_compress_request_pressure(messages, 260_000) is True
+
     def test_max_assembly_tokens_caps_recent_tail(self, tmp_path, monkeypatch):
         import importlib
 


### PR DESCRIPTION
## Summary
- make LCM request-pressure decisions aware of protected/fresh-tail compressibility
- enable an automatic assembly reserve for real large context windows by default (`reserve_tokens_floor=-1`; explicit `0` still disables it)
- keep small-context tests uncapped while preventing large provider requests from assembling up to the exact model limit
- add regression coverage for protected-tail-only overflows and auto-reserve behavior

## Why
Hermes Agent can ask the context engine whether request pressure is actually compressible before retrying compression. LCM protects the latest user/fresh tail, so when pressure is caused only by protected recent messages, another compression pass is a no-op. This PR lets LCM decline that no-op path and caps assembly by default with headroom for provider overhead.

Related Hermes Agent draft PR: https://github.com/NousResearch/hermes-agent/pull/79717
Related Hermes issue: https://github.com/NousResearch/hermes-agent/issues/64382

## Test Plan
- `PYTHONPATH=/tmp/hermes-lcm-protected-tail-upstream:/tmp/hermes-context-overflow-upstream python3 -m pytest tests/test_lcm_engine.py tests/test_lcm_core.py::TestConfig -q`
  - `779 passed, 1477 warnings`
- `git diff --check`
