### PR TITLE
chore: prepare v0.21.0-rc2 release candidate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Version and branch
       description: hermes-lcm version, branch, commit, or release tag.
-      placeholder: v0.21.0-rc1, main, or commit SHA
+      placeholder: v0.21.0-rc2, main, or commit SHA
     validations:
       required: true
 

--- a/.github/release-notes/v0.21.0-rc2.md
+++ b/.github/release-notes/v0.21.0-rc2.md
@@ -1,0 +1,16 @@
+# hermes-lcm v0.21.0-rc2
+
+Lossless Context Management for Hermes: a release candidate limited to the merged CJK-safe trajectory-state token chunking correction.
+
+## Highlights
+
+- Preserves UTF-8 character boundaries when the optional `tiktoken` path splits oversized trajectory-state documents.
+- Keeps each decoded chunk within the requested token budget and fails explicitly when that budget cannot contain one complete Unicode character.
+
+## Changes
+
+- #492 corrects fixed-width token-ID slicing that could split a multibyte character and introduce U+FFFD replacement characters when chunks were decoded independently.
+
+## Contributors
+
+- @stephenschoettler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 No additional changes yet.
 
+## v0.21.0-rc2 - 2026-08-05
+
+### Changed
+
+- #492 corrects the optional `tiktoken` trajectory-state chunking path to
+  preserve UTF-8 character boundaries while keeping each decoded chunk within
+  its token budget. If the budget cannot contain one complete Unicode
+  character, the path fails explicitly instead of emitting replacement
+  characters.
+
 ## v0.21.0-rc1 - 2026-08-03
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc1 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -244,7 +244,7 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
-For the `v0.21.0-rc1` line, take a normal backup of `lcm.db` before updating,
+For the `v0.21.0-rc2` line, take a normal backup of `lcm.db` before updating,
 then update the checkout and restart Hermes. No manual core migration or
 backfill is required: the core schema remains version 5. New assertion,
 query-view, and adaptive-retrieval state is additive, created only after the
@@ -252,7 +252,7 @@ corresponding opt-in is enabled, and stored in the same profile database under
 named feature markers. The five new query/evidence tool schemas are visible in
 the tool list on stock installs, but automatic extraction, pre-answer evidence,
 assertion storage, query-view storage, and adaptive retrieval remain off. See
-[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0200-to-v0210-rc1)
+[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0200-to-v0210-rc2)
 before enabling them.
 
 ## Commands and tools

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -79,7 +79,7 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
-## Upgrade from v0.20.0 to v0.21.0-rc1
+## Upgrade from v0.20.0 to v0.21.0-rc2
 
 1. While the old runtime is running, run `/lcm backup`. If Hermes or any other
    SQLite writer may still be running, this is the only supported online backup
@@ -91,7 +91,7 @@ Restart Hermes after updating.
    live.
 3. Update the plugin checkout to the RC and restart Hermes.
 4. Send one normal message, then confirm `lcm_status` reports plugin version
-   `0.21.0-rc1` and the expected database path.
+   `0.21.0-rc2` and the expected database path.
 5. For a migration-shape audit, query that database with
    `SELECT value FROM metadata WHERE key = 'schema_version';`; the expected
    result is `5`.
@@ -135,7 +135,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc1 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.21.0-rc1
+version: 0.21.0-rc2
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -417,7 +417,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.21.0-rc1" in result
+    assert "plugin_version: 0.21.0-rc2" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -457,7 +457,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.21.0-rc1" in result
+    assert "plugin_version: 0.21.0-rc2" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
     assert "triage_guidance:\n- none" in result

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1139,7 +1139,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.21.0-rc1"
+    assert identity["plugin_version"] == "0.21.0-rc2"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -1165,11 +1165,11 @@ def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
 
     initial = identity_mod._plugin_metadata()
     assert initial["name"] == "hermes-lcm"
-    assert initial["version"] == "0.21.0-rc1"
+    assert initial["version"] == "0.21.0-rc2"
 
-    updated = original.replace('version: "0.21.0-rc1"', 'version: "9.9.9-test"')
+    updated = original.replace('version: "0.21.0-rc2"', 'version: "9.9.9-test"')
     if updated == original:
-        updated = original.replace('version: 0.21.0-rc1', 'version: 9.9.9-test')
+        updated = original.replace('version: 0.21.0-rc2', 'version: 9.9.9-test')
     assert updated != original
 
     try:
@@ -1207,7 +1207,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.21.0-rc1"
+    assert payload["runtime_identity"]["plugin_version"] == "0.21.0-rc2"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -377,7 +377,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.21.0-rc1"
+    assert identity["plugin_version"] == "0.21.0-rc2"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
-RELEASE_VERSION = "0.21.0-rc1"
+RELEASE_VERSION = "0.21.0-rc2"
 RELEASE_NOTES = REPO_ROOT / ".github" / "release-notes" / f"v{RELEASE_VERSION}.md"
 
 
@@ -72,9 +72,9 @@ def test_release_candidate_notes_cover_only_the_merged_release_scope():
     notes = RELEASE_NOTES.read_text(encoding="utf-8")
 
     assert notes.startswith(f"# hermes-lcm v{RELEASE_VERSION}\n")
-    assert all(f"#{number}" in notes for number in (361, 436, 440, 446, 447))
+    assert "#492" in notes
     assert "## Highlights" in notes
     assert "## Changes" in notes
     assert "## Contributors" in notes
-    assert "documented harness and corpus" in notes
+    assert "UTF-8 character boundaries" in notes
     assert len(notes.splitlines()) <= 60


### PR DESCRIPTION
## Summary
- Advance canonical release identity from `0.21.0-rc1` to `0.21.0-rc2` across the manifest, docs, issue template, and direct identity assertions.
- Add RC2 release notes limited to merged #492's CJK-safe optional-`tiktoken` trajectory-state chunking correction.

## Why
- #492 landed after the RC1 candidate and fixes UTF-8 boundary handling in oversized trajectory-state chunks. RC2 needs a consistent version identity and narrowly scoped release notes for that merged correction.

## Validation
- [x] Focused validation: `PYTHONPATH=<hermes-agent-checkout> uv run --with pytest --with tiktoken pytest tests/test_release_workflow.py <runtime-identity tests> <CJK chunking regressions> -q` -> `14 passed`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- Exact candidate: `8591f500c1a1865f6d0249e42018721b1d4a2100`, one commit over `e1977c68503d8a862da20b6cf12d054977dcc1c2`.
- `scripts/validate_release.sh --keep-going` passed on the exact candidate, including compile checks, focused pytest, benchmark smoke, and stress smoke.
- Independent review also passed focused tests, release smoke, changed-test lint, object identity, and transport rehydration for this exact candidate.
- Full-suite validation was not repeated for this metadata-only candidate. The required Python 3.11/3.12/3.13 CI matrix remains authoritative.
- No workflow or runtime implementation files changed, so `actionlint` is not applicable.

Refs #492
