### PR TITLE
fix: log hermes_cli import failure instead of silently swallowing it

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -339,8 +339,8 @@ def register(ctx):
     try:
         from hermes_cli.config import get_hermes_home
         hermes_home = str(get_hermes_home())
-    except Exception:
-        import os
+    except Exception as exc:
+        logger.warning("hermes-lcm: could not import get_hermes_home (%s); falling back to env", exc)
         hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
 
     engine = LCMEngine(config=config, hermes_home=hermes_home)


### PR DESCRIPTION
## Problem

The `register()` function in `__init__.py` used a bare `except Exception:` with no logging when importing `get_hermes_home` from `hermes_cli.config`. This silently swallowed import errors, making it impossible to debug profile-scoped storage issues — if the import failed, the plugin fell back to the `HERMES_HOME` env var with zero indication of why.

## Fix

Capture the exception and log a warning with the exception details before falling back to the environment:

```python
except Exception as exc:
    logger.warning("hermes-lcm: could not import get_hermes_home (%s); falling back to env", exc)
    hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
```

## Scope

One file changed, 2 lines. No behavioral change on the happy path; only adds observability on the error path.