### PR TITLE
fix: gate opportunistic maintenance compaction on token pressure

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -66,6 +66,41 @@ class CompactionMixin:
             return False
         return tokens >= self.threshold_tokens
 
+    def _maintenance_pressure_met(self, observed_tokens: int) -> bool:
+        """Whether an OPPORTUNISTIC maintenance compaction is allowed right now.
+
+        The maintenance arms ("compactable backlog outside the fresh tail",
+        "ignored-message backlog") are tidying, not overflow protection. On the
+        divergent-replay path they run with no token gate, while the identical
+        leaf-candidate check on the non-divergent path sits behind
+        ``rough >= threshold_tokens``. Since the divergent path is entered
+        whenever ingest rewrote the replay view -- typically an externalized
+        payload (inline media, base64, a large tool result) -- a media-heavy
+        session requests compaction at any size.
+
+        Returns True (allow) when the floor is disabled, when no threshold is
+        configured, or when the session has reached the configured fraction of
+        it. Deterministic ingest-cleanup adoption returns earlier and is
+        unaffected; overflow recovery is checked before this on every path.
+        """
+        ratio = getattr(self._config, "maintenance_min_pressure_ratio", 0.0) or 0.0
+        if ratio <= 0.0:
+            return True
+        if self.threshold_tokens <= 0:
+            return True
+        floor = int(self.threshold_tokens * ratio)
+        if observed_tokens >= floor:
+            return True
+        logger.debug(
+            "LCM maintenance compaction deferred: %d tokens < %d floor "
+            "(%.0f%% of %d threshold)",
+            observed_tokens,
+            floor,
+            ratio * 100,
+            self.threshold_tokens,
+        )
+        return False
+
     def should_compress_preflight(self, messages):
         """Pre-flight check — also ingests messages into the store."""
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
@@ -157,9 +192,11 @@ class CompactionMixin:
                     and replay_rough >= self.threshold_tokens
                 ),
             )
-            if eligible:
+            if eligible and self._maintenance_pressure_met(replay_rough):
                 return self._mark_preflight_compression_requested()
-            if self._has_ignored_backlog_outside_fresh_tail(replay_messages):
+            if self._has_ignored_backlog_outside_fresh_tail(
+                replay_messages
+            ) and self._maintenance_pressure_met(replay_rough):
                 return self._mark_preflight_compression_requested()
             if self.threshold_tokens > 0 and replay_rough >= self.threshold_tokens:
                 if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):

--- a/config.py
+++ b/config.py
@@ -323,6 +323,9 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("deferred_maintenance_max_passes", "LCM_DEFERRED_MAINTENANCE_MAX_PASSES", int),
     _EnvFieldSpec("critical_budget_pressure_ratio", "LCM_CRITICAL_BUDGET_PRESSURE_RATIO", float),
     _EnvFieldSpec("threshold_full_sweep_enabled", "LCM_THRESHOLD_FULL_SWEEP_ENABLED", bool),
+    _EnvFieldSpec(
+        "maintenance_min_pressure_ratio", "LCM_MAINTENANCE_MIN_PRESSURE_RATIO", float
+    ),
     _EnvFieldSpec("summary_prefix_target_tokens", "LCM_SUMMARY_PREFIX_TARGET_TOKENS", int),
     _EnvFieldSpec("l2_budget_ratio", "LCM_L2_BUDGET_RATIO", float),
     _EnvFieldSpec("l3_truncate_tokens", "LCM_L3_TRUNCATE_TOKENS", int),
@@ -484,6 +487,20 @@ class LCMConfig:
     critical_budget_pressure_ratio: float = 0.0
     # Opt into one bounded synchronous sweep after threshold pressure is reached.
     threshold_full_sweep_enabled: bool = False
+    # Minimum fraction of ``threshold_tokens`` a session must reach before an
+    # OPPORTUNISTIC maintenance compaction (the "compactable backlog outside the
+    # fresh tail" / "ignored-message backlog" arms) may be requested on the
+    # divergent-replay path.
+    #
+    # That path is entered whenever ingest rewrote the replay view -- most often
+    # because a payload was externalized (inline media, base64, a large tool
+    # result). Today the leaf-candidate check there runs with no token gate,
+    # while the identical check on the non-divergent path below sits behind
+    # ``rough >= threshold_tokens``. The result is that a media-heavy session
+    # requests maintenance compaction at ANY size.
+    #
+    # 0.0 (default) keeps the historical behavior exactly.
+    maintenance_min_pressure_ratio: float = 0.0
     # Target frontier-summary size after a sweep (0 = derive one leaf budget).
     summary_prefix_target_tokens: int = 0
 

--- a/tests/test_maintenance_pressure_floor.py
+++ b/tests/test_maintenance_pressure_floor.py
@@ -1,0 +1,123 @@
+"""Maintenance compaction should require some token pressure.
+
+``should_compress_preflight`` reaches the leaf-candidate check two ways:
+
+* the NON-divergent path gates it behind ``rough >= threshold_tokens``
+* the divergent-replay path runs the identical check with no token gate
+
+The divergent path is entered whenever ingest rewrote the replay view, which in
+practice means an externalized payload (inline media, base64, a large tool
+result). A session that traffics in those therefore requests an opportunistic
+maintenance compaction at any size, however small.
+
+``maintenance_min_pressure_ratio`` puts a floor under the two OPPORTUNISTIC arms
+only, expressed as a fraction of ``threshold_tokens``. It defaults to 0.0, which
+preserves the historical behavior exactly.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _engine(tmp_path: Path, **overrides) -> LCMEngine:
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm.db"),
+        large_output_externalization_path=str(tmp_path / "externalized"),
+        **overrides,
+    )
+    engine = LCMEngine(config=config, hermes_home=str(tmp_path / "home"))
+    engine.on_session_start(
+        "maintenance-floor-session",
+        platform="telegram",
+        conversation_id="maintenance-floor-conversation",
+        context_length=1_000_000,
+    )
+    return engine
+
+
+def test_default_is_disabled_and_preserves_current_behavior(tmp_path):
+    """An unconfigured engine must behave exactly as it does today."""
+    engine = _engine(tmp_path)
+    assert engine._config.maintenance_min_pressure_ratio == 0.0
+    engine.threshold_tokens = 750_000
+    # every size is permitted while the floor is off
+    assert engine._maintenance_pressure_met(1) is True
+    assert engine._maintenance_pressure_met(158_262) is True
+    assert engine._maintenance_pressure_met(750_000) is True
+
+
+@pytest.mark.parametrize("observed", [129_088, 158_262, 175_730, 239_896])
+def test_small_sessions_defer_when_a_floor_is_set(tmp_path, observed):
+    """Sizes well under the threshold must not request maintenance work.
+
+    These four values are real ``requested compress()`` observations from a
+    media-heavy session: 17%, 21%, 23% and 32% of a 750,000 threshold.
+    """
+    engine = _engine(tmp_path, maintenance_min_pressure_ratio=0.5)
+    engine.threshold_tokens = 750_000
+    assert engine._maintenance_pressure_met(observed) is False
+
+
+def test_real_pressure_still_compacts(tmp_path):
+    """The floor must never suppress a session that genuinely needs work."""
+    engine = _engine(tmp_path, maintenance_min_pressure_ratio=0.5)
+    engine.threshold_tokens = 750_000
+    assert engine._maintenance_pressure_met(422_558) is True
+    assert engine._maintenance_pressure_met(750_000) is True
+    assert engine._maintenance_pressure_met(1_000_000) is True
+
+
+def test_floor_boundary_is_inclusive(tmp_path):
+    engine = _engine(tmp_path, maintenance_min_pressure_ratio=0.5)
+    engine.threshold_tokens = 750_000
+    assert engine._maintenance_pressure_met(374_999) is False
+    assert engine._maintenance_pressure_met(375_000) is True
+
+
+def test_unknown_threshold_never_blocks(tmp_path):
+    """``threshold_tokens`` of 0 means "not yet known"; do not gate on it."""
+    engine = _engine(tmp_path, maintenance_min_pressure_ratio=0.5)
+    engine.threshold_tokens = 0
+    assert engine._maintenance_pressure_met(1) is True
+
+
+def test_ratio_is_read_from_the_environment(tmp_path, monkeypatch):
+    """The knob follows the same ``LCM_*`` convention as its siblings."""
+    monkeypatch.setenv("LCM_MAINTENANCE_MIN_PRESSURE_RATIO", "0.4")
+    config = LCMConfig.from_env()
+    assert config.maintenance_min_pressure_ratio == pytest.approx(0.4)
+
+
+def test_both_opportunistic_arms_are_gated():
+    """Gate the leaf-candidate arm AND the ignored-backlog arm.
+
+    Gating only one leaves the other free to request compaction at any size, so
+    the fix would be half-inert and the symptom would persist.
+    """
+    import inspect
+
+    from hermes_lcm.compaction import CompactionMixin
+
+    source = inspect.getsource(CompactionMixin.should_compress_preflight)
+    assert source.count("_maintenance_pressure_met") >= 2
+
+
+def test_cleanup_adoption_is_not_gated():
+    """Deterministic ingest cleanup must stay available at any size.
+
+    It is already durable and costs no summarizer work; the floor exists to
+    defer expensive opportunistic summarization, not to strand a cleanup the
+    store has already committed.
+    """
+    import inspect
+
+    from hermes_lcm.compaction import CompactionMixin
+
+    source = inspect.getsource(CompactionMixin.should_compress_preflight)
+    assert source.index("if cleanup_requested:") < source.index(
+        "_maintenance_pressure_met"
+    )


### PR DESCRIPTION
## Summary
- Gate the two OPPORTUNISTIC maintenance-compaction arms on the divergent-replay path behind a token floor, so a media-heavy session stops requesting compaction at any size.
- Add `maintenance_min_pressure_ratio` (`LCM_MAINTENANCE_MIN_PRESSURE_RATIO`), a fraction of `threshold_tokens`. **Default `0.0` preserves current behavior exactly.**

## Why

`should_compress_preflight` reaches the leaf-candidate check two ways, and only one is gated.

Non-divergent path — gated:

```python
if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
    eligible, reason = self._leaf_compaction_candidate_status(messages, ...)
    if eligible:
        return self._mark_preflight_compression_requested()
```

Divergent-replay path — the identical check, no token gate:

```python
eligible, reason = self._leaf_compaction_candidate_status(replay_messages, ...)
if eligible:
    return self._mark_preflight_compression_requested()
if self._has_ignored_backlog_outside_fresh_tail(replay_messages):
    return self._mark_preflight_compression_requested()
```

That path is entered whenever ingest rewrote the replay view — in practice an externalized payload: inline media, base64, a large tool result. A session that traffics in those requests an opportunistic maintenance compaction however small it is.

Observed against a 750,000-token threshold:

| observed tokens | % of threshold |
|---|---|
| 129,088 | 17% |
| 158,262 | 21% |
| 175,730 | 23% |
| 239,896 | 32% |

Three of those landed inside eight minutes, one on a session that had just been compacted. Those passes freed **27–47%**, where pressure-driven compactions on the same deployment freed **84–86%** — and each still costs a summarizer call plus the conversation's prompt cache.

Deliberately **not** gated: deterministic ingest-cleanup adoption returns earlier and stays available at any size (already durable, no summarizer work). Overflow recovery is checked before the floor on every path.

## Validation
- [x] Focused validation: `pytest tests/test_maintenance_pressure_floor.py -q` -> `11 passed`
- [x] RED proof: reverting both call sites -> `2 failed, 9 passed` (`test_both_opportunistic_arms_are_gated`, `test_cleanup_adoption_is_not_gated`)
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `1108 passed, 1 skipped` (incl. the new file)
  - [x] `pytest -q` -> `7 failed, 2797 passed, 2 skipped, 12 xfailed` — see Notes
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> same 7, all environmental
  - [x] `python -m compileall -q .` -> exit 0
  - [ ] `python -m py_compile scripts/import_lossless_claw.py` — not run, no scripts touched
  - [ ] `bash -n scripts/install.sh scripts/update.sh` — not run, no shell scripts touched
  - [x] `git diff --check` -> clean
  - [x] `ruff check .` (pinned 0.15.13) -> `All checks passed!`
- [x] Workflow validation: n/a, no workflows changed

## Notes

**The 7 remaining failures are environmental on macOS + Python 3.14 and are not caused by this change.** Verified against a pristine `upstream/main` worktree, which fails **10** in the same two families — a superset, with shifting membership run to run:

- **Wall-clock deadline assertions** — `test_embedding_provider.py`, `test_embedding_search_modes.py` assert real elapsed time (e.g. `assert elapsed < 0.06`). Membership varies between runs, so this is a flake family rather than a fixed list.
- **macOS `/private` symlink** — `test_path_containment.py`, `test_path_security.py`. `TemporaryDirectory()` returns `/var/...` while the resolved path is `/private/var/...`, so a `startswith` containment check fails. Linux CI is unaffected.

Neither family touches compaction. Claiming *their-suite-minus-known-environmental-reds*, not full green.

Two of the 11 tests exist specifically to stop the fix going half-inert: gating only one of the two arms leaves the other free to request compaction at any size, and the cleanup-adoption ordering assertion pins that deterministic cleanup keeps working below the floor. Both fail if the change is reverted.

The floor ships **off**. Operators who want it set `LCM_MAINTENANCE_MIN_PRESSURE_RATIO=0.5` (or whatever fraction suits their workload).

All values above are from synthetic/local runs — no transcripts, credentials, or `lcm.db` contents are included.
