### PR TITLE
test: compare against the resolved temp base so path tests pass on macOS

### DIFF
--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -22,7 +22,11 @@ def test_path_containment_within_allowed_base(monkeypatch):
         # Should succeed without raising
         path = _state_db_path_for_engine(engine)
         assert path.is_absolute()
-        assert str(path).startswith(tmpdir)
+        # Compare against the RESOLVED base: on macOS tempfile hands back
+        # /var/folders/... while the implementation resolves symlinks to
+        # /private/var/folders/..., so a raw startswith on the unresolved
+        # tmpdir fails there while passing on Linux.
+        assert str(path).startswith(str(Path(tmpdir).resolve()))
 
 
 def test_path_containment_outside_allowed_base(monkeypatch):

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -48,7 +48,11 @@ def test_configured_externalization_path_inside_allowed_base_accepted():
 
             path = get_large_output_storage_dir(FakeConfig(), "", create=False)
             assert path.is_absolute()
-            assert str(path).startswith(tmpdir)
+            # Compare against the RESOLVED base: on macOS tempfile hands back
+            # /var/folders/... while the implementation resolves symlinks to
+            # /private/var/folders/..., so a raw startswith on the unresolved
+            # tmpdir fails there while passing on Linux.
+            assert str(path).startswith(str(Path(tmpdir).resolve()))
         finally:
             del os.environ["LCM_HERMES_BASE_DIR"]
 


### PR DESCRIPTION
## Summary
- Resolve the temp-directory base before the containment prefix check in two path tests, so they pass on macOS as well as Linux.

## Why

Both assertions compare a **resolved** path against an **unresolved** tempfile base:

```python
assert str(path).startswith(tmpdir)
```

On macOS `TemporaryDirectory()` returns `/var/folders/...`, while `_state_db_path_for_engine` and `get_large_output_storage_dir` both resolve symlinks and return `/private/var/folders/...` (`/var` is a symlink to `/private/var`). The prefix check fails there and passes on Linux, where `/var` is a real directory.

The implementations are correct — resolving before a containment check is exactly right, since comparing unresolved paths is how traversal bugs slip through. Only the assertions are unportable, so this resolves the expected side too rather than relaxing what is being asserted.

Noticed while validating an unrelated change on macOS: these two show up in every local `pytest -q` run and are easy to mistake for damage caused by the branch under test.

## Validation
- [x] Focused validation: `pytest tests/test_path_containment.py tests/test_path_security.py -q` -> before `2 failed, 9 passed`, after `11 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> unaffected by this change (tests-only, different files)
  - [x] `ruff check .` (pinned 0.15.13) -> `All checks passed!`
  - [x] `git diff --check` -> clean
  - [ ] `pytest -q` — full suite still shows the unrelated wall-clock deadline flakes on macOS (`test_embedding_provider.py`, `test_embedding_search_modes.py`); untouched here, see Notes
  - [ ] `python -m py_compile scripts/import_lossless_claw.py` — not run, no scripts touched
  - [ ] `bash -n scripts/install.sh scripts/update.sh` — not run, no shell scripts touched
- [x] Workflow validation: n/a, no workflows changed

## Notes

Tests-only; no library code changes. On Linux `Path(tmpdir).resolve() == tmpdir`, so CI behavior is unchanged.

The other local macOS failures are a separate family — wall-clock deadline assertions (`assert elapsed < 0.06` and similar) whose membership varies run to run under load. Those are a real portability wart too, but fixing them means moving those tests onto an injected clock, which is a much larger and unrelated change. Happy to open that separately if you want it — I did not want to bundle it here.
