### PR TITLE
feat: add OpenAI-compatible embedding provider

### DIFF
--- a/config.py
+++ b/config.py
@@ -392,6 +392,12 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("embedding_model", "LCM_EMBEDDING_MODEL", str),
     _EnvFieldSpec("embedding_content_policy", "LCM_EMBED_CONTENT_POLICY", str),
     _EnvFieldSpec("ollama_base_url", "LCM_OLLAMA_BASE_URL", str),
+    _EnvFieldSpec(
+        "embedding_base_url", "LCM_EMBEDDING_BASE_URL", str
+    ),
+    _EnvFieldSpec(
+        "embedding_api_key_env", "LCM_EMBEDDING_API_KEY_ENV", str
+    ),
     _EnvFieldSpec("embedding_query_timeout_s", "LCM_EMBEDDING_QUERY_TIMEOUT_S", float),
     _EnvFieldSpec("recall_query_timeout_s", "LCM_RECALL_QUERY_TIMEOUT_S", float),
     _EnvFieldSpec("embedding_backfill_timeout_s", "LCM_EMBEDDING_BACKFILL_TIMEOUT_S", float),
@@ -710,6 +716,8 @@ class LCMConfig:
     # default in the chunker's normalize_content_policy.
     embedding_content_policy: str = "conversational"
     ollama_base_url: str = "http://localhost:11434"
+    embedding_base_url: str = ""
+    embedding_api_key_env: str = "LCM_EMBEDDING_API_KEY"
     embedding_query_timeout_s: float = 3.0
     # Dedicated deadline for lcm_recall. It fans out three sequential arms (FTS +
     # summary KNN + chunk KNN) plus fusion, hydration, and an optional rerank, so

--- a/docs/embeddings-setup.md
+++ b/docs/embeddings-setup.md
@@ -11,6 +11,7 @@ FTS-only exactly as before.
 | Voyage AI | free tier (200M tokens for the voyage-4 group), then ~$0.02–0.12 per million tokens | yes (no credit card) | none | best quality, zero local footprint |
 | fastembed | $0 | no | `pip install fastembed` (ONNX, no torch) | local default — no accounts, no daemon |
 | Ollama | $0 | no | Ollama app/daemon | you already run Ollama |
+| OpenAI-compatible | provider pricing | yes (per provider) | none | reuse an existing `/v1/embeddings` service (SiliconFlow, llama.cpp, vLLM) |
 
 All providers feed the same store. Switching provider/model is one config change plus a backfill;
 each full identity keeps its own vectors, so switching **back** to a
@@ -98,6 +99,33 @@ batch or local model load is not aborted by the interactive query policy. The
 optional `LCM_EMBEDDING_BACKFILL_BUDGET_S` still caps the whole apply run
 between batches (`0`, the default, means no whole-run cap); the lease and
 post-call ownership CAS remain authoritative independently of both timeouts.
+
+## Option 4 — OpenAI-compatible API (reuse an existing embeddings service)
+
+If you already run any OpenAI-format `/v1/embeddings` endpoint — SiliconFlow,
+llama.cpp server, vLLM, or a local embedding model on a workstation — point
+LCM at it instead of running a second embedding stack:
+
+```bash
+export LCM_EMBEDDINGS_ENABLED=true
+export LCM_EMBEDDING_PROVIDER=openai-compatible
+export LCM_EMBEDDING_MODEL=BAAI/bge-m3     # any model id your endpoint serves
+export LCM_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+export LCM_EMBEDDING_API_KEY=sk-...        # falls back to SILICONFLOW_API_KEY
+/lcm embed warmup && /lcm embed backfill --apply
+```
+
+`LCM_EMBEDDING_BASE_URL` is the API root (a trailing slash is stripped) and
+`/embeddings` is appended. The request body is the standard OpenAI shape —
+`{"model": ..., "input": [...]}` with a `Bearer` authorization header — so any
+compatible server works, including local llama.cpp/vLLM instances that cost
+nothing per call.
+
+The same deadline, spend-guard, and identity rules apply as for the other
+remote providers: `LCM_EMBEDDING_QUERY_TIMEOUT_S` bounds interactive queries,
+`LCM_EMBEDDING_BACKFILL_TIMEOUT_S` bounds each backfill batch, and vectors are
+stored under the full `(provider, model, ...)` identity so switching back to
+this provider reactivates existing vectors without re-backfilling.
 
 ## What you get
 

--- a/embedding_provider.py
+++ b/embedding_provider.py
@@ -1521,6 +1521,240 @@ def _load_fastembed():
     return TextEmbedding
 
 
+class OpenAICompatibleProvider(_ResilientProvider):
+    """OpenAI-compatible ``/v1/embeddings`` provider (SiliconFlow, etc.).
+
+    Local patch (Vocllum): hermes-lcm ships only voyage/ollama/fastembed.
+    This provider reuses any OpenAI-format embeddings endpoint — e.g.
+    SiliconFlow's ``BAAI/bge-m3`` — so the operator can share the same
+    embedding service already used by OpenViking instead of running a
+    second local model server.
+
+    Env contract (via LCMConfig):
+      LCM_EMBEDDING_PROVIDER=openai-compatible
+      LCM_EMBEDDING_MODEL=BAAI/bge-m3
+      LCM_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+      LCM_EMBEDDING_API_KEY=...   (falls back to SILICONFLOW_API_KEY)
+    """
+
+    provider_id = "openai-compatible"
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        base_url: str = "",
+        api_key_env: str = "LCM_EMBEDDING_API_KEY",
+        transport: HttpTransport | None = None,
+        timeout: float = 3.0,
+        sleeper: Callable[[float], None] = time.sleep,
+        breaker: EmbeddingCircuitBreaker | None = None,
+        spend_guard: EmbeddingSpendGuard | None = None,
+    ) -> None:
+        super().__init__(breaker=breaker, spend_guard=spend_guard)
+        self._model_id = str(model).strip()
+        if not self._model_id:
+            raise ValueError("OpenAI-compatible embedding model must not be empty")
+        self.base_url = str(base_url).strip().rstrip("/")
+        if not self.base_url:
+            raise ValueError(
+                "LCM_EMBEDDING_BASE_URL must be set for openai-compatible provider"
+            )
+        self.api_key_env = str(api_key_env).strip() or "LCM_EMBEDDING_API_KEY"
+        self._transport = transport or _default_http_transport
+        self.timeout = float(timeout)
+        self._sleep = sleeper
+        self._dim = 0
+
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def _request(
+        self,
+        texts: Sequence[str],
+        *,
+        timeout: float | None = None,
+        max_attempts: int = _MAX_ATTEMPTS,
+        deadline_budget_s: float | None = None,
+        before_transport: Callable[[], None] | None = None,
+    ) -> list[list[float]]:
+        api_key = os.environ.get(self.api_key_env, "").strip()
+        if not api_key:
+            # Convenience fallback: SiliconFlow key name used by OpenViking.
+            api_key = os.environ.get("SILICONFLOW_API_KEY", "").strip()
+        if not api_key:
+            raise EmbeddingProviderError(
+                f"{self.api_key_env} (or SILICONFLOW_API_KEY) is not set"
+            )
+        request_timeout = self.timeout if timeout is None else max(0.001, float(timeout))
+        attempts = max(1, int(max_attempts))
+        deadline = (
+            time.monotonic() + max(0.0, float(deadline_budget_s))
+            if deadline_budget_s is not None
+            else None
+        )
+        for attempt in range(attempts):
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise EmbeddingProviderError(
+                        "OpenAI-compatible operation deadline exceeded"
+                    )
+            if before_transport is not None:
+                before_transport()
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ProviderPreDispatchError(
+                        "OpenAI-compatible operation deadline exceeded before transport"
+                    )
+                attempt_timeout = min(request_timeout, remaining)
+            else:
+                attempt_timeout = request_timeout
+            try:
+                response = self._transport(
+                    url=f"{self.base_url}/embeddings",
+                    payload={
+                        "model": self.model_id,
+                        "input": list(texts),
+                    },
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=attempt_timeout,
+                )
+            except (OSError, TimeoutError, urllib.error.URLError) as exc:
+                # Transport start makes an automatic identical resend unsafe.
+                raise EmbeddingProviderError(
+                    f"OpenAI-compatible network error: {exc}"
+                ) from exc
+            if not 200 <= response.status < 300:
+                raise EmbeddingProviderError(
+                    f"OpenAI-compatible embedding request failed ({response.status})"
+                )
+            remaining = (
+                None if deadline is None else deadline - time.monotonic()
+            )
+            if remaining is not None and remaining <= 0:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible operation deadline exceeded before response processing"
+                )
+
+            def parse_success() -> list[list[float]]:
+                payload = _response_json(response, provider="OpenAI-compatible")
+                raw = payload.get("data")
+                if isinstance(raw, list):
+                    ordered = sorted(
+                        raw, key=lambda row: int(row.get("index", 0))
+                        if isinstance(row, dict)
+                        else 0
+                    )
+                    rows = [
+                        row.get("embedding")
+                        for row in ordered
+                        if isinstance(row, dict)
+                    ]
+                else:
+                    rows = None
+                parsed = _coerce_vectors(rows, provider="OpenAI-compatible")
+                if len(parsed) != len(texts):
+                    raise EmbeddingProviderError(
+                        "OpenAI-compatible returned a different number of embeddings than requested"
+                    )
+                return parsed
+
+            vectors = (
+                parse_success()
+                if remaining is None
+                else _run_blocking_with_deadline(
+                    parse_success,
+                    timeout=remaining,
+                    provider="OpenAI-compatible response processing",
+                )
+            )
+            if deadline is not None and time.monotonic() >= deadline:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible operation deadline exceeded during response processing"
+                )
+            return vectors
+        raise EmbeddingProviderError("OpenAI-compatible embedding request failed")
+
+    def _embed(
+        self,
+        texts: Sequence[str],
+        *,
+        timeout: float | None = None,
+        max_attempts: int = _MAX_ATTEMPTS,
+        deadline_budget_s: float | None = None,
+        before_transport: Callable[[], None] | None = None,
+    ) -> list[list[float]]:
+        if not texts:
+            return []
+        vectors = self._guarded(
+            lambda: self._request(
+                tuple(str(text) for text in texts),
+                timeout=timeout,
+                max_attempts=max_attempts,
+                deadline_budget_s=deadline_budget_s,
+                before_transport=before_transport,
+            )
+        )
+        for vector in vectors:
+            if not vector:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible returned an empty embedding"
+                )
+            if self._dim and len(vector) != self._dim:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible embedding dimension changed within the process"
+                )
+            self._dim = len(vector)
+        return vectors
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        return self._embed(texts, deadline_budget_s=self.timeout)
+
+    def embed_document_batches(
+        self,
+        texts: Sequence[str],
+        *,
+        before_dispatch: BeforeDispatch | None = None,
+    ) -> Iterator[EmbeddedDocumentBatch]:
+        normalized = tuple(str(text) for text in texts)
+        if not normalized:
+            return
+        indexes = tuple(range(len(normalized)))
+        vectors = self._embed(
+            normalized,
+            max_attempts=1 if before_dispatch is not None else _MAX_ATTEMPTS,
+            deadline_budget_s=self.timeout,
+            before_transport=(
+                (lambda: before_dispatch(indexes))
+                if before_dispatch is not None
+                else None
+            ),
+        )
+        yield EmbeddedDocumentBatch(
+            indexes,
+            tuple(tuple(vector) for vector in vectors),
+        )
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed((text,), deadline_budget_s=self.timeout)[0]
+
+    def embed_query_interactive(self, text: str, *, timeout: float) -> list[float]:
+        """Embed a latency-sensitive query under one absolute time budget."""
+        return self._embed(
+            (text,), timeout=timeout, deadline_budget_s=timeout
+        )[0]
+
+
 class FastembedProvider(_ResilientProvider):
     provider_id = "fastembed"
 
@@ -1748,8 +1982,17 @@ def resolve_provider(
         return FastembedProvider(
             model, timeout=timeout, spend_guard=spend_guard
         )
+    if provider in {"openai-compatible", "openai", "siliconflow"}:
+        return OpenAICompatibleProvider(
+            model,
+            base_url=getattr(config, "embedding_base_url", ""),
+            api_key_env=getattr(config, "embedding_api_key_env", "LCM_EMBEDDING_API_KEY"),
+            timeout=timeout,
+            spend_guard=spend_guard,
+        )
     raise ProviderUnavailable(
-        f"Unsupported embedding provider {provider!r}; use voyage, ollama, or fastembed"
+        f"Unsupported embedding provider {provider!r}; use voyage, ollama, "
+        "fastembed, or openai-compatible (SiliconFlow)"
     )
 
 

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -18,6 +18,7 @@ from hermes_lcm.embedding_provider import (
     EmbeddingSpendGuard,
     FastembedProvider,
     HttpResponse,
+    OpenAICompatibleProvider,
     OllamaProvider,
     ProviderCircuitOpen,
     ProviderNotWarmedUp,
@@ -1323,3 +1324,135 @@ def test_voyage_rerank_empty_documents_short_circuits(monkeypatch):
 
     assert provider.rerank("q", [], timeout=5.0) == []
     assert transport.calls == []
+
+
+def _openai_compatible_success(count: int, dim: int = 3) -> HttpResponse:
+    return _response(
+        200,
+        {
+            "data": [
+                {"index": index, "embedding": [float(index + 1)] * dim}
+                for index in range(count)
+            ]
+        },
+    )
+
+
+def test_openai_compatible_request_shape_and_success(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(_openai_compatible_success(2))
+    provider = OpenAICompatibleProvider(
+        "BAAI/bge-m3",
+        base_url="https://api.example.com/v1/",
+        transport=transport,
+    )
+
+    vectors = provider.embed_documents(["first", "second"])
+
+    assert len(vectors) == 2
+    assert provider.dim == 3
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    # Trailing slash on the base URL is stripped before joining.
+    assert call["url"] == "https://api.example.com/v1/embeddings"
+    assert call["payload"] == {
+        "model": "BAAI/bge-m3",
+        "input": ["first", "second"],
+    }
+    assert call["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_openai_compatible_query_and_interactive(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_success(1, dim=4),
+        _openai_compatible_success(1, dim=4),
+    )
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="http://localhost:8080/v1", transport=transport
+    )
+
+    assert provider.embed_query("question") == [1.0, 1.0, 1.0, 1.0]
+    assert provider.embed_query_interactive("q", timeout=5.0) == [1.0, 1.0, 1.0, 1.0]
+
+    assert [call["url"] for call in transport.calls] == [
+        "http://localhost:8080/v1/embeddings",
+        "http://localhost:8080/v1/embeddings",
+    ]
+
+
+def test_openai_compatible_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("LCM_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("SILICONFLOW_API_KEY", raising=False)
+    transport = FakeTransport(_openai_compatible_success(1))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="LCM_EMBEDDING_API_KEY"):
+        provider.embed_query("q")
+
+    assert transport.calls == []
+
+
+def test_openai_compatible_siliconflow_key_fallback(monkeypatch):
+    monkeypatch.delenv("LCM_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.setenv("SILICONFLOW_API_KEY", "fallback-key")
+    transport = FakeTransport(_openai_compatible_success(1))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    provider.embed_query("q")
+
+    assert transport.calls[0]["headers"]["Authorization"] == "Bearer fallback-key"
+
+
+def test_openai_compatible_empty_base_url_raises():
+    with pytest.raises(ValueError, match="LCM_EMBEDDING_BASE_URL"):
+        OpenAICompatibleProvider("bge-m3", base_url="   ")
+
+
+def test_openai_compatible_empty_model_raises():
+    with pytest.raises(ValueError, match="must not be empty"):
+        OpenAICompatibleProvider("  ", base_url="https://api.example.com/v1")
+
+
+def test_openai_compatible_network_error_is_not_retried(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(OSError("boom"))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="network error"):
+        provider.embed_documents(["doc"])
+
+    # The transport start makes an automatic identical resend unsafe.
+    assert len(transport.calls) == 1
+
+
+def test_openai_compatible_response_count_mismatch_raises(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(_openai_compatible_success(1))  # 1 vector for 2 texts
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="different number of embeddings"):
+        provider.embed_documents(["a", "b"])
+
+
+def test_resolve_provider_openai_compatible(monkeypatch):
+    config = LCMConfig(
+        embedding_provider="openai-compatible",
+        embedding_model="BAAI/bge-m3",
+        embedding_base_url="https://api.example.com/v1",
+    )
+    provider = resolve_provider(config)
+    assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider.model_id == "BAAI/bge-m3"
+    assert provider.base_url == "https://api.example.com/v1"
+
+    config.embedding_provider = "siliconflow"
+    assert isinstance(resolve_provider(config), OpenAICompatibleProvider)


### PR DESCRIPTION
## Summary

Adds an `OpenAICompatibleProvider` to the embedding stack, alongside the existing `voyage` / `ollama` / `fastembed` providers. It targets any OpenAI-format `/v1/embeddings` endpoint — llama.cpp server, vLLM, SiliconFlow, or a private gateway — so operators who already run an embedding service can point LCM at it instead of running a second embedding stack.

## Motivation

Issue #419 asks for exactly this: with the vector store and the Ollama provider in place, the HTTP embedding infrastructure already exists; a provider-neutral OpenAI-compatible option closes the gap for everyone with a local or cloud OpenAI-format embeddings endpoint.

## Implementation

- `embedding_provider.py`: new `OpenAICompatibleProvider(_ResilientProvider)` modeled on `OllamaProvider` — `_request` / `_embed` / `embed_documents` / `embed_document_batches` / `embed_query` / `embed_query_interactive`, dimension tracking, deadline budgets, and the same spend-guard / circuit-breaker semantics as the other remote providers.
- `resolve_provider()` accepts `openai-compatible` (aliases `openai`, `siliconflow`); unsupported-provider error text updated.
- `config.py`: two new env fields — `LCM_EMBEDDING_BASE_URL` (API root; trailing slash stripped, `/embeddings` appended) and `LCM_EMBEDDING_API_KEY` (falls back to `SILICONFLOW_API_KEY`).

## Env contract

```bash
LCM_EMBEDDING_PROVIDER=openai-compatible
LCM_EMBEDDING_MODEL=BAAI/bge-m3     # any model id your endpoint serves
LCM_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
LCM_EMBEDDING_API_KEY=sk-...        # falls back to SILICONFLOW_API_KEY
```

Request shape is the standard OpenAI one (`{"model": ..., "input": [...]}` with a `Bearer` header). Deadline and identity semantics match the other remote providers: `LCM_EMBEDDING_QUERY_TIMEOUT_S` bounds interactive queries, `LCM_EMBEDDING_BACKFILL_TIMEOUT_S` bounds backfill batches, and vectors are stored under the full `(provider, model, ...)` identity so switching back reactivates existing vectors without re-backfilling.

## Tests & docs

- 9 new unit tests in `tests/test_embedding_provider.py` (request shape, auth header, trailing-slash handling, query/interactive paths, missing-key and fallback behavior, base-url/model validation, network-error non-retry, response-count mismatch, `resolve_provider` wiring).
- `docs/embeddings-setup.md`: new "Option 4 — OpenAI-compatible API" section plus TL;DR row.

Closes #419
