### PR TITLE
feat: add LCM_DISABLED_TOOLS env filter for context-engine tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ moved back to that assistant even when doing so exceeds a configured bound.
 | `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
 | `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires |
 | `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
+| `LCM_DISABLED_TOOLS` | empty | Comma-separated `lcm_*` tool names excluded from injected tool schemas, refused in `handle_tool_call` before message ingest, and filtered from plugin-registry registration — disabled tools cost zero tokens per turn. Unset to restore all tools. |
 
 ### Model and timeout settings
 

--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,14 @@ def _env_flag_enabled(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _disabled_tool_names() -> set[str]:
+    """Tools disabled via LCM_DISABLED_TOOLS (comma-separated lcm_* names)."""
+    raw = os.environ.get("LCM_DISABLED_TOOLS", "")
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
 def _make_wrapped_handler(tool_name: str, engine):
     """Route a registered lcm_* tool through the engine dispatch path."""
     def _wrapped(args: dict, **kwargs) -> str:
@@ -444,6 +452,12 @@ def register(ctx):
         ("lcm_inspect", LCM_INSPECT, "🧭"),
         ("lcm_doctor", LCM_DOCTOR, "🏥"),
     ]
+    # LCM_DISABLED_TOOLS (comma-separated lcm_* names) removes tools from the
+    # plugin-registry registration too, mirroring engine.get_tool_schemas() so
+    # disabled tools cost zero tokens on every host path.
+    _disabled = _disabled_tool_names()
+    if _disabled:
+        _TOOLS = [t for t in _TOOLS if t[0] not in _disabled]
     register_tool = getattr(ctx, "register_tool", None)
     if callable(register_tool) and _host_forwards_registered_tool_messages(ctx):
         for name, schema, emoji in _TOOLS:

--- a/engine.py
+++ b/engine.py
@@ -3633,7 +3633,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return self.carry_over_new_session_context(old_session_id, new_session_id)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [
+        disabled = self._disabled_tool_names()
+        schemas = [
             LCM_GREP,
             LCM_RECALL,
             LCM_QUERY_STATE,
@@ -3650,8 +3651,25 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             LCM_INSPECT,
             LCM_DOCTOR,
         ]
+        if disabled:
+            return [s for s in schemas if s.get("name") not in disabled]
+        return schemas
+
+    @staticmethod
+    def _disabled_tool_names() -> set[str]:
+        """Tools disabled via LCM_DISABLED_TOOLS (comma-separated lcm_* names).
+
+        Disabled tools are excluded from the injected context-engine schemas
+        AND refused in handle_tool_call, so they cost zero tokens per turn.
+        """
+        raw = os.environ.get("LCM_DISABLED_TOOLS", "")
+        if not raw:
+            return set()
+        return {part.strip() for part in raw.split(",") if part.strip()}
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        if name in self._disabled_tool_names():
+            return json.dumps({"error": f"LCM tool {name} is disabled via LCM_DISABLED_TOOLS"})
         # Ingest live messages if passed (enables current-turn search)
         messages = kwargs.get("messages")
 

--- a/tests/test_disabled_tools.py
+++ b/tests/test_disabled_tools.py
@@ -1,0 +1,76 @@
+"""Tests for the LCM_DISABLED_TOOLS env filter (local patch, Vocullum).
+
+Disabled tools are excluded from injected schemas AND refused in
+handle_tool_call, so they cost zero tokens per turn while remaining fully
+reversible (unset the env var to restore all 15 tools).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import hermes_lcm.embedding_provider  # noqa: F401  (module import side effects)
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+DISABLED = "lcm_compute,lcm_compile_evidence,lcm_evidence_pack,lcm_retrieve,lcm_query_state"
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "disabled_tools.db"))
+    e = LCMEngine(config=config)
+    e._session_id = "test-session"
+    try:
+        yield e
+    finally:
+        e.shutdown()
+
+
+def test_get_tool_schemas_full_without_env(engine, monkeypatch):
+    monkeypatch.delenv("LCM_DISABLED_TOOLS", raising=False)
+    names = {schema.get("name") for schema in engine.get_tool_schemas()}
+    assert len(names) == 15
+    assert "lcm_compute" in names
+    assert "lcm_grep" in names
+
+
+def test_get_tool_schemas_excludes_disabled(engine, monkeypatch):
+    monkeypatch.setenv("LCM_DISABLED_TOOLS", DISABLED)
+    names = {schema.get("name") for schema in engine.get_tool_schemas()}
+    assert len(names) == 10
+    assert "lcm_compute" not in names
+    assert "lcm_query_state" not in names
+    assert "lcm_grep" in names
+    assert "lcm_recall" in names
+    assert "lcm_status" in names
+
+
+def test_handle_tool_call_refuses_disabled_before_ingest(engine, monkeypatch):
+    monkeypatch.setenv("LCM_DISABLED_TOOLS", DISABLED)
+    result = engine.handle_tool_call(
+        "lcm_compute", {"expression": "1+1"}, messages=[{"role": "user", "content": "x"}]
+    )
+    payload = json.loads(result)
+    assert payload["error"].startswith("LCM tool lcm_compute is disabled")
+
+
+def test_handle_tool_call_allows_enabled_tools(engine, monkeypatch):
+    monkeypatch.setenv("LCM_DISABLED_TOOLS", DISABLED)
+    result = engine.handle_tool_call(
+        "lcm_status", {}, messages=[{"role": "user", "content": "x"}]
+    )
+    # Enabled tools are dispatched, not refused with the disabled error.
+    assert "disabled via LCM_DISABLED_TOOLS" not in result
+
+
+def test_disabled_tool_names_parsing(monkeypatch):
+    monkeypatch.setenv("LCM_DISABLED_TOOLS", " lcm_compute ,, lcm_retrieve ")
+    assert LCMEngine._disabled_tool_names() == {"lcm_compute", "lcm_retrieve"}
+
+    monkeypatch.setenv("LCM_DISABLED_TOOLS", "")
+    assert LCMEngine._disabled_tool_names() == set()
+
+    monkeypatch.delenv("LCM_DISABLED_TOOLS", raising=False)
+    assert LCMEngine._disabled_tool_names() == set()


### PR DESCRIPTION
## Summary

Adds an opt-in `LCM_DISABLED_TOOLS` environment variable that removes named `lcm_*` tools from the model-facing surface, so their full JSON schemas are not injected into every turn. This is a surgical, reversible alternative to disabling the whole context-engine toolset.

## Motivation

All 15 context-engine tool schemas are injected every turn, including heavy advanced tools (`lcm_compute`, `lcm_compile_evidence`, `lcm_evidence_pack`, `lcm_retrieve`, `lcm_query_state`) that many operators never call. On small-context routes those schemas are a meaningful fixed per-turn cost (~3-4k tokens for the advanced set). Operators who want the compression engine but not the evidence/assertion surface now have a per-tool switch instead of all-or-nothing.

## Implementation

One env var, three enforcement points, all reversible:

- `engine.get_tool_schemas()` — disabled tools are excluded from the injected schema list (zero tokens per turn).
- `engine.handle_tool_call()` — disabled tools are refused **before** message ingest, returning a clear error: `LCM tool <name> is disabled via LCM_DISABLED_TOOLS`.
- plugin `register()` — disabled tools are filtered from Path A plugin-registry registration, mirroring the engine so they cost nothing on every host path.

```bash
LCM_DISABLED_TOOLS=lcm_compute,lcm_compile_evidence,lcm_evidence_pack,lcm_retrieve,lcm_query_state
```

Unset the variable to restore all 15 tools. Unknown/whitespace entries are ignored; no tool names are hardcoded into the filter itself.

## Tests & docs

- New `tests/test_disabled_tools.py` (5 tests): full 15-tool baseline without env, 10-tool filtered set with env, refusal in `handle_tool_call` before ingest, enabled tools still dispatch, and env parsing (trimming, empties, unset).
- README environment-variable table row for `LCM_DISABLED_TOOLS`.
