### PR TITLE
fix(externalize): skip POSIX directory-fsync on Windows (#408)

### DIFF
--- a/externalize.py
+++ b/externalize.py
@@ -57,6 +57,14 @@ def _preview_sha256(preview_prefix: Any) -> str:
 
 
 def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        # Windows cannot use this POSIX directory-fsync path: opening a
+        # directory requires Windows-specific handle semantics
+        # (FILE_FLAG_BACKUP_SEMANTICS) not exposed by this os.open() call.
+        # The payload file itself has already been fsynced by the caller.
+        # Skip the parent-directory fsync on Windows; crash-durability
+        # semantics therefore differ from the POSIX path.
+        return
     flags = os.O_RDONLY
     if hasattr(os, "O_DIRECTORY"):
         flags |= os.O_DIRECTORY

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import os
 import re
 import sqlite3
 import stat
@@ -500,6 +501,42 @@ def test_externalized_payload_write_fsyncs_file_and_parent_directory(tmp_path, m
     assert result["path"].parent in fsynced_dirs
 
 
+def test_fsync_directory_noop_when_directory_handles_unsupported(tmp_path, monkeypatch):
+    """Windows regression for Issue #408.
+
+    os.open() on a directory raises PermissionError (Errno 13) on Windows
+    (no FILE_FLAG_BACKUP_SEMANTICS), so on Windows _fsync_directory must be
+    a safe no-op instead of breaking every externalized-payload write.
+    """
+    if os.name != "nt":
+        pytest.skip("Issue #408 is Windows-specific; directory handles work elsewhere")
+    real_open = os.open
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("os.open must not be called on Windows")
+
+    monkeypatch.setattr(os, "open", fail_open)
+    externalize_module._fsync_directory(tmp_path)  # must not raise
+
+
+def test_fsync_directory_still_fsyncs_on_posix(tmp_path, monkeypatch):
+    """POSIX behavior is preserved: the directory is opened read-only with
+    O_DIRECTORY and fsynced when the platform supports directory handles."""
+    if os.name == "nt":
+        pytest.skip("Windows: directory fsync is skipped (Issue #408)")
+    opened_flags = []
+    real_open = os.open
+
+    def recording_open(path, flags, *args):
+        opened_flags.append(flags)
+        return real_open(path, flags, *args)
+
+    monkeypatch.setattr(os, "open", recording_open)
+    externalize_module._fsync_directory(tmp_path)
+    assert opened_flags, "directory open should be attempted on POSIX"
+    assert all(flags & os.O_DIRECTORY for flags in opened_flags)
+
+
 def test_externalized_search_prefix_rejects_path_replaced_during_open(tmp_path, monkeypatch):
     engine = _engine(tmp_path)
     target = externalize_ingest_payload(
@@ -722,7 +759,12 @@ def test_externalized_payload_reassignment_fsyncs_replacement(tmp_path, monkeypa
     )
 
     assert moved == 1
-    assert len(fsync_calls) >= 3
+    # POSIX fsyncs: tmp-file write (file + parent dir) + replaced dir = 3.
+    # Windows (Issue #408): directory handles cannot be opened, so the
+    # durability story is the tmp-file fsync + atomic os.replace + NTFS
+    # journaling = 1 fsync call.
+    expected_min_fsyncs = 3 if os.name != "nt" else 1
+    assert len(fsync_calls) >= expected_min_fsyncs
     payload = json.loads(result["path"].read_text(encoding="utf-8"))
     assert payload["session_id"] == "new-session"
 
@@ -1264,6 +1306,10 @@ def test_ingest_preserves_inline_payload_when_externalization_fails(tmp_path, mo
 
 
 def test_externalized_payload_files_are_private(tmp_path):
+    if os.name == "nt":
+        # POSIX permission bits are not exposed by stat on Windows; access
+        # control is enforced by NTFS ACLs instead (Issue #408 context).
+        pytest.skip("POSIX permission bits are not available on Windows")
     engine = _engine(tmp_path)
 
     engine._store.append(engine.current_session_id, {"role": "user", "content": DATA_URI})


### PR DESCRIPTION
# Fix: Externalized-payload writes fail on Windows with Errno 13 (#408)

## Root cause

`externalize._fsync_directory()` used the POSIX directory-fsync pattern:

```python
flags = os.O_RDONLY
if hasattr(os, "O_DIRECTORY"):
    flags |= os.O_DIRECTORY
dir_fd = os.open(path, flags)   # <-- PermissionError on Windows
os.fsync(dir_fd)
```

On Windows, `os.open()` cannot obtain a directory handle: opening a
directory via the underlying `CreateFile` requires
`FILE_FLAG_BACKUP_SEMANTICS`, which this `os.open()` path does not set, so
every call raises
`PermissionError: [Errno 13] Permission denied: '...\lcm-large-outputs'`.
The `hasattr(os, "O_DIRECTORY")` guard only protected the flag, not the
`os.open()` call itself.

`_fsync_directory` is invoked on **every** externalized-payload write
(`_write_externalized_payload` / `_replace_externalized_payload`) and after
directory creation, so on Windows **every** large-payload externalization
failed, the payload was silently kept inline, and the `Errno 13` pointed at
the directory path — exactly the symptom in #408.

## Fix

Skip the parent-directory fsync explicitly on Windows (`os.name == "nt"`);
all other platforms keep the original behavior, including the original
capability check on the `O_DIRECTORY` flag. On Windows the payload file
itself has already been fsynced by the caller (`os.fsync` calls
`_commit()` there); the parent-directory fsync is skipped because the API
does not expose a directory handle. Crash-durability semantics therefore
differ from the POSIX path — the payload file is durable, the directory
entry is not fsynced. On POSIX the change is byte-for-byte behavior
preserving: same flags, same open → fsync → close sequence.

## Safety

Fail-open semantics are untouched: if any write step fails, the original
payload stays inline, a warning is logged, and no partial payload file is
left behind. The fix only removes the one operation Windows cannot perform.

## Tests

- New regression tests:
  - `test_fsync_directory_noop_when_directory_handles_unsupported`
    (Windows only: asserts `os.open` is never called and no exception is
    raised; fails on Windows before this fix, passes after)
  - `test_fsync_directory_still_fsyncs_on_posix` (guards the POSIX path)
- Platform-aware adjustments to two POSIX-semantics tests that assumed
  directory fsync / POSIX permission bits always exist:
  - `test_externalized_payload_reassignment_fsyncs_replacement`
  - `test_externalized_payload_files_are_private` (skips on Windows)
- Verified on Windows 11 / Python 3.11:
  - minimal repro of #408: FAIL before (exact Errno 13 on the directory
    path), PASS after
  - engine-level externalization: payload file created, exact SHA256
    recovery, recovery after engine restart, 6 consecutive writes, reused
    directory with pre-existing payloads, fail-open under simulated write
    failure, `lcm_expand` search-prefix reader recovery — all pass
  - Active Replay Stubbing layer: old tool results stubbed to durable
    recoverable refs, protected fresh tail stays inline, fail-open — all pass
  - `lcm_stress_check.py --tier release`: the
    `redaction_and_externalization_boundaries` scenario **fails on the
    unpatched code** (0 payloads externalized, oversized payload persisted
    raw to sqlite rows) and **passes after the fix**; all 6 release-tier
    scenarios pass

## Unrelated follow-up (separate issue)

During Windows validation, six additional pre-existing replay failures were
traced to an independent persisted-output CRLF translation issue (Windows
text-mode `\n` → `\r\n` inflation vs. the marker's character count). This
is unrelated to the directory-fsync failure fixed here and will be handled
separately in #XXX.
