### PR TITLE
ci: run RC2 reconciliation candidate through CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,9 +766,12 @@ Hermes host discovery/status mismatch, not an LCM storage or compaction failure.
 
 ### `/lcm status` looks unbound after restart
 
-After a fresh Hermes restart, `/lcm status` may show `session_id: (unbound)` or
-`threshold_tokens: (uninitialized)`. Send one normal Hermes message first, then
-run `lcm_status` or `/lcm status` again for live per-session fields.
+Compatible Hermes gateway hosts expose task-local lane metadata while
+dispatching `/lcm`. Once that lane has constructed an agent, `/lcm status`
+resolves the same active LCM runtime as `lcm_status`, including its foreground
+view while an ignored or stateless side channel is bound. Before the first
+normal message constructs an agent, or in a genuinely sessionless process,
+`session_id: (unbound)` and `threshold_tokens: (uninitialized)` remain expected.
 
 ## Architecture
 

--- a/__init__.py
+++ b/__init__.py
@@ -340,6 +340,7 @@ def _command_engine_for_current_session(engine, resolve_active_lcm_engine):
         active_engine = resolve_active_lcm_engine(
             session_id=session_id,
             conversation_id=conversation_id,
+            allow_foreground=True,
         )
         if active_engine is not None:
             return active_engine

--- a/__init__.py
+++ b/__init__.py
@@ -310,6 +310,55 @@ def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
     return {"context": f"{recall_policy}\n\n" + "\n\n".join(augmentations)}
 
 
+def _session_context_value(name: str) -> str:
+    """Read task-local host session metadata with legacy env compatibility."""
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:
+        return str(os.environ.get(name, "") or "")
+    try:
+        return str(get_session_env(name, "") or "")
+    except Exception:
+        # Once a concurrent host exposes task-local session context, never fall
+        # back to process-global env after a read failure: it may name another
+        # lane. Unbound is safer than cross-session command dispatch.
+        logger.debug("LCM plugin command could not read %s", name, exc_info=True)
+        return ""
+
+
+def _command_engine_for_current_session(engine, resolve_active_lcm_engine):
+    """Resolve the runtime serving the current plugin-command invocation.
+
+    Gateway hosts bind task-local session/lane metadata before dispatching a
+    plugin slash command. Prefer the already-active AIAgent clone registered for
+    that lane. If no clone exists yet, keep the process-wide prototype's genuine
+    ``(unbound)`` cold-start status rather than mutating shared runtime state.
+    """
+    session_id = _session_context_value("HERMES_SESSION_ID")
+    conversation_id = _session_context_value("HERMES_SESSION_KEY")
+    if session_id or conversation_id:
+        active_engine = resolve_active_lcm_engine(
+            session_id=session_id,
+            conversation_id=conversation_id,
+        )
+        if active_engine is not None:
+            return active_engine
+    return engine
+
+
+def _make_command_handler(handle_lcm_command, engine, resolve_active_lcm_engine):
+    def _handler(raw_args: str):
+        return handle_lcm_command(
+            raw_args,
+            _command_engine_for_current_session(
+                engine,
+                resolve_active_lcm_engine,
+            ),
+        )
+
+    return _handler
+
+
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
@@ -484,7 +533,11 @@ def register(ctx):
 
         register_command(
             "lcm",
-            lambda raw_args: handle_lcm_command(raw_args, engine),
+            _make_command_handler(
+                handle_lcm_command,
+                engine,
+                resolve_active_lcm_engine,
+            ),
             description="LCM status and diagnostics",
         )
     elif callable(register_command):

--- a/command.py
+++ b/command.py
@@ -524,6 +524,8 @@ def _status_text(engine) -> str:
         f"database_exists: {_fmt_bool(db_exists)}",
         f"database_size: {_fmt_size(db_size) if db_exists else 'missing'}",
         f"compression_count: {engine.compression_count}",
+        f"total_compactions: {status.get('total_compactions', 0)}",
+        f"total_compactions_scope: {status.get('total_compactions_scope', 'current_conversation')}",
         f"last_compression_status: {status.get('last_compression_status', 'idle')}",
         f"last_compression_noop_reason: {status.get('last_compression_noop_reason', '') or '(none)'}",
         f"context_length: {engine.context_length if session_bound else '(uninitialized)'}",

--- a/compaction.py
+++ b/compaction.py
@@ -1037,5 +1037,12 @@ class CompactionMixin:
         self._write_generated_ignored_placeholder_hash_ordinals(
             self._generated_placeholder_digest_ordinals_for_active_replay(compressed)
         )
+        record_successful_compaction = getattr(
+            self,
+            "_record_successful_compaction_telemetry",
+            None,
+        )
+        if callable(record_successful_compaction):
+            record_successful_compaction()
 
         return compressed

--- a/engine.py
+++ b/engine.py
@@ -498,6 +498,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
         self.compression_count = 0
+        self._compaction_telemetry_counter_rebaseline_pending = True
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
         self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
@@ -1213,7 +1214,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
             prev_count = int(existing.get("compression_count_at_record", 0) or 0)
             counter_rebaseline_pending = bool(
-                getattr(self, "_compaction_telemetry_counter_rebaseline_pending", False)
+                existing
+                and getattr(
+                    self,
+                    "_compaction_telemetry_counter_rebaseline_pending",
+                    False,
+                )
             )
             compaction_delta = (
                 self.compression_count

--- a/engine.py
+++ b/engine.py
@@ -499,6 +499,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.cache_metrics_available = False
         self.compression_count = 0
         self._compaction_telemetry_counter_rebaseline_pending = True
+        self._compaction_telemetry_turn_reset_pending = False
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
         self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
@@ -1191,6 +1192,38 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         return prev_count, rebaseline_pending, delta
 
+    def _record_successful_compaction_telemetry(self) -> None:
+        """Durably count a completed leaf compaction before returning it."""
+        conversation_id = self._conversation_id
+        if not conversation_id:
+            return
+        try:
+            existing = self._store.read_compaction_telemetry(conversation_id) or {}
+            _, _, compaction_delta = self._compaction_telemetry_counter_delta(existing)
+            if compaction_delta <= 0:
+                return
+
+            record = dict(existing)
+            record.update({
+                "conversation_id": conversation_id,
+                "total_compactions": (
+                    _normalize_total_compactions(existing.get("total_compactions", 0))
+                    + compaction_delta
+                ),
+                "compression_count_at_record": self.compression_count,
+                "turns_since_leaf_compaction": 0,
+                "peak_prompt_tokens_since_leaf_compaction": 0,
+                "last_leaf_compaction_at": time.time(),
+                "last_compaction_duration_ms": round(self._last_compaction_duration_ms, 3),
+            })
+            self._store.write_compaction_telemetry(conversation_id, record)
+            self._compaction_telemetry_counter_rebaseline_pending = False
+            # The response hook still owns per-turn token/cache fields. Keep its
+            # first post-compaction snapshot at turn zero without recounting.
+            self._compaction_telemetry_turn_reset_pending = True
+        except Exception:
+            logger.debug("LCM successful compaction telemetry update failed", exc_info=True)
+
     def _record_turn_compaction_telemetry(self) -> None:
         """Persist a per-conversation compaction-telemetry snapshot for this turn.
 
@@ -1236,7 +1269,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             ) = self._compaction_telemetry_counter_delta(existing)
             compacted = compaction_delta > 0
             rebaselined = (
-                counter_rebaseline_pending or self.compression_count != prev_count
+                self._compaction_telemetry_turn_reset_pending
+                or counter_rebaseline_pending
+                or self.compression_count != prev_count
             )
             if rebaselined:
                 turns_since = 0
@@ -1282,6 +1317,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 record["last_cache_hit_at"] = time.time()
             self._store.write_compaction_telemetry(conversation_id, record)
             self._compaction_telemetry_counter_rebaseline_pending = False
+            self._compaction_telemetry_turn_reset_pending = False
         except Exception:
             logger.debug("LCM compaction telemetry update failed", exc_info=True)
 

--- a/engine.py
+++ b/engine.py
@@ -1174,6 +1174,23 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return 0.0
         return self.last_cache_read_tokens / self.last_prompt_tokens
 
+    def _compaction_telemetry_counter_delta(
+        self,
+        existing: Dict[str, Any],
+    ) -> tuple[int, bool, int]:
+        """Return persisted baseline, reset state, and unrecorded compactions."""
+        prev_count = int(existing.get("compression_count_at_record", 0) or 0)
+        rebaseline_pending = bool(
+            existing
+            and self._compaction_telemetry_counter_rebaseline_pending
+        )
+        delta = (
+            self.compression_count
+            if rebaseline_pending
+            else max(0, self.compression_count - prev_count)
+        )
+        return prev_count, rebaseline_pending, delta
+
     def _record_turn_compaction_telemetry(self) -> None:
         """Persist a per-conversation compaction-telemetry snapshot for this turn.
 
@@ -1212,20 +1229,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             elif cache_state == "cold":
                 cold_streak += 1
 
-            prev_count = int(existing.get("compression_count_at_record", 0) or 0)
-            counter_rebaseline_pending = bool(
-                existing
-                and getattr(
-                    self,
-                    "_compaction_telemetry_counter_rebaseline_pending",
-                    False,
-                )
-            )
-            compaction_delta = (
-                self.compression_count
-                if counter_rebaseline_pending
-                else max(0, self.compression_count - prev_count)
-            )
+            (
+                prev_count,
+                counter_rebaseline_pending,
+                compaction_delta,
+            ) = self._compaction_telemetry_counter_delta(existing)
             compacted = compaction_delta > 0
             rebaselined = (
                 counter_rebaseline_pending or self.compression_count != prev_count
@@ -3850,6 +3858,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         total_compactions = _normalize_total_compactions(
             telemetry.get("total_compactions", 0) if telemetry else 0
         )
+        if conversation_id and conversation_id == self._conversation_id:
+            try:
+                _, _, pending_compactions = self._compaction_telemetry_counter_delta(
+                    telemetry or {}
+                )
+            except (TypeError, ValueError):
+                pending_compactions = 0
+            total_compactions += pending_compactions
         status["total_compactions"] = total_compactions
         status["total_compactions_scope"] = _TOTAL_COMPACTIONS_SCOPE
         status["engine"] = "lcm"

--- a/engine.py
+++ b/engine.py
@@ -15,6 +15,7 @@ import sqlite3
 import threading
 import time
 from collections import deque
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -498,6 +499,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
         self.compression_count = 0
+        # Distinguishes this reset-scoped process counter from overlapping or
+        # previous runtimes that write the same conversation telemetry row.
+        self._compaction_telemetry_counter_epoch = uuid.uuid4().hex
         self._compaction_telemetry_counter_rebaseline_pending = True
         self._compaction_telemetry_turn_reset_pending = False
         # Wall-clock of the last leaf compaction (ms); surfaced via telemetry only.
@@ -1181,12 +1185,30 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     ) -> tuple[int, bool, int]:
         """Return persisted baseline, reset state, and unrecorded compactions."""
         prev_count = int(existing.get("compression_count_at_record", 0) or 0)
+        epoch_baseline = None
+        watermarks = existing.get("counter_epoch_watermarks", [])
+        if isinstance(watermarks, list):
+            for item in watermarks:
+                if (
+                    isinstance(item, list)
+                    and len(item) == 2
+                    and item[0] == self._compaction_telemetry_counter_epoch
+                    and isinstance(item[1], int)
+                    and not isinstance(item[1], bool)
+                    and item[1] >= 0
+                ):
+                    epoch_baseline = item[1]
+                    break
+        if epoch_baseline is not None:
+            prev_count = epoch_baseline
         rebaseline_pending = bool(
             existing
             and self._compaction_telemetry_counter_rebaseline_pending
         )
         delta = (
-            self.compression_count
+            max(0, self.compression_count - epoch_baseline)
+            if epoch_baseline is not None
+            else self.compression_count
             if rebaseline_pending
             else max(0, self.compression_count - prev_count)
         )
@@ -1203,20 +1225,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if compaction_delta <= 0:
                 return
 
-            record = dict(existing)
-            record.update({
+            updates = {
                 "conversation_id": conversation_id,
-                "total_compactions": (
-                    _normalize_total_compactions(existing.get("total_compactions", 0))
-                    + compaction_delta
-                ),
+                "counter_epoch": self._compaction_telemetry_counter_epoch,
                 "compression_count_at_record": self.compression_count,
                 "turns_since_leaf_compaction": 0,
                 "peak_prompt_tokens_since_leaf_compaction": 0,
                 "last_leaf_compaction_at": time.time(),
                 "last_compaction_duration_ms": round(self._last_compaction_duration_ms, 3),
-            })
-            self._store.write_compaction_telemetry(conversation_id, record)
+            }
+            self._store.increment_compaction_telemetry(
+                conversation_id,
+                compaction_delta,
+                updates,
+            )
             self._compaction_telemetry_counter_rebaseline_pending = False
             # The response hook still owns per-turn token/cache fields. Keep its
             # first post-compaction snapshot at turn zero without recounting.
@@ -1311,11 +1333,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 "last_leaf_compaction_at": last_leaf_compaction_at,
                 "last_compaction_duration_ms": last_compaction_duration_ms,
                 "total_compactions": total_compactions,
+                "counter_epoch": self._compaction_telemetry_counter_epoch,
                 "compression_count_at_record": self.compression_count,
             })
             if cache_state == "hot":
                 record["last_cache_hit_at"] = time.time()
-            self._store.write_compaction_telemetry(conversation_id, record)
+            # Even zero-delta snapshots use the transactional updater so an
+            # overlapping snapshot cannot overwrite a newly incremented total.
+            self._store.increment_compaction_telemetry(
+                conversation_id,
+                compaction_delta,
+                record,
+            )
             self._compaction_telemetry_counter_rebaseline_pending = False
             self._compaction_telemetry_turn_reset_pending = False
         except Exception:
@@ -2567,6 +2596,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")
         previous_session_id = self._session_id
+        previous_conversation_id = self._conversation_id
+        requested_conversation_id = str(kwargs.get("conversation_id") or session_id)
         self._lcm_current_start_allows_bypass_lineage = False
         requested_platform = str(kwargs.get("platform") or self._session_platform or "")
         pre_reset_preserve_ambiguous_no_frame_old_session = False
@@ -2817,6 +2848,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._finalize_pending_reset_boundary(previous_session_id)
             self._reset_session_scoped_runtime_state()
         else:
+            if (
+                previous_conversation_id
+                and requested_conversation_id != previous_conversation_id
+            ):
+                self._reset_session_counters()
             self._clear_pending_reset_boundary()
             self._ingest_cursor = 0
             self._last_compacted_store_id = 0

--- a/engine.py
+++ b/engine.py
@@ -1179,8 +1179,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         Best-effort and diagnostic only: any failure is logged at debug and never
         affects the turn. Turns with no token or cache signal are skipped so idle
         turns do not churn the record. The since-compaction accumulators reset off
-        the monotonic ``compression_count`` (which also drops to 0 on a session
-        reset) rather than instrumenting the compaction hot path.
+        the monotonic ``compression_count``. Session resets mark the next
+        telemetry write for an explicit zero-baseline comparison so compactions
+        that happen before that write are not mistaken for an old baseline.
         """
         conversation_id = self._conversation_id
         if not conversation_id:
@@ -1211,8 +1212,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 cold_streak += 1
 
             prev_count = int(existing.get("compression_count_at_record", 0) or 0)
-            compacted = self.compression_count > prev_count
-            rebaselined = self.compression_count != prev_count  # compaction or session reset
+            counter_rebaseline_pending = bool(
+                getattr(self, "_compaction_telemetry_counter_rebaseline_pending", False)
+            )
+            compaction_delta = (
+                self.compression_count
+                if counter_rebaseline_pending
+                else max(0, self.compression_count - prev_count)
+            )
+            compacted = compaction_delta > 0
+            rebaselined = (
+                counter_rebaseline_pending or self.compression_count != prev_count
+            )
             if rebaselined:
                 turns_since = 0
                 peak_tokens_since = prompt_tokens
@@ -1226,7 +1237,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 existing.get("total_compactions", 0)
             )
             if compacted:
-                total_compactions += self.compression_count - prev_count
+                total_compactions += compaction_delta
                 last_leaf_compaction_at = time.time()
                 last_compaction_duration_ms = round(self._last_compaction_duration_ms, 3)
             else:
@@ -1256,6 +1267,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             if cache_state == "hot":
                 record["last_cache_hit_at"] = time.time()
             self._store.write_compaction_telemetry(conversation_id, record)
+            self._compaction_telemetry_counter_rebaseline_pending = False
         except Exception:
             logger.debug("LCM compaction telemetry update failed", exc_info=True)
 

--- a/engine.py
+++ b/engine.py
@@ -348,6 +348,7 @@ _ROLLUP_MAINTENANCE_SCHEDULER = _RollupMaintenanceScheduler()
 
 _SESSION_END_BUSY_TIMEOUT_MS = 50
 _CODEX_GPT55_COMPACTION_THRESHOLD = 0.85
+_TOTAL_COMPACTIONS_SCOPE = "current_conversation"
 
 # Auto-focus topic derivation: infer a compact focus hint from the most recent
 # real user turns so that summarization can prioritise current user intent.
@@ -358,6 +359,13 @@ _AUTO_FOCUS_MAX_CHARS = 700
 
 _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
+
+
+def _normalize_total_compactions(value: Any) -> int:
+    """Return a persisted compaction total only when it is a valid counter."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value
 
 
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
@@ -1214,7 +1222,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     int(existing.get("peak_prompt_tokens_since_leaf_compaction", 0) or 0),
                     prompt_tokens,
                 )
-            total_compactions = int(existing.get("total_compactions", 0) or 0)
+            total_compactions = _normalize_total_compactions(
+                existing.get("total_compactions", 0)
+            )
             if compacted:
                 total_compactions += self.compression_count - prev_count
                 last_leaf_compaction_at = time.time()
@@ -3815,6 +3825,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         session_id = self.current_session_id
         conversation_id = self.current_conversation_id
         lifecycle_state = self._lifecycle.get_by_conversation(conversation_id) if conversation_id else None
+        try:
+            telemetry = self._store.read_compaction_telemetry(conversation_id)
+        except Exception:
+            telemetry = None
+        total_compactions = _normalize_total_compactions(
+            telemetry.get("total_compactions", 0) if telemetry else 0
+        )
+        status["total_compactions"] = total_compactions
+        status["total_compactions_scope"] = _TOTAL_COMPACTIONS_SCOPE
         status["engine"] = "lcm"
         status["runtime_identity"] = self.get_runtime_identity()
         status["ingest_protection"] = sensitive_pattern_status(self._config)
@@ -3883,10 +3902,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     "last_reset_at": lifecycle_state.last_reset_at,
                     "updated_at": lifecycle_state.updated_at,
                 }
-            try:
-                telemetry = self._store.read_compaction_telemetry(conversation_id)
-            except Exception:
-                telemetry = None
             if telemetry:
                 status["compaction_telemetry"] = {
                     "cache_state": telemetry.get("cache_state", "unknown"),
@@ -3905,7 +3920,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     "last_observed_cache_read": telemetry.get("last_observed_cache_read", 0),
                     "last_observed_cache_write": telemetry.get("last_observed_cache_write", 0),
                     "activity_band": telemetry.get("activity_band", "low"),
-                    "total_compactions": telemetry.get("total_compactions", 0),
+                    "total_compactions": total_compactions,
                     "last_leaf_compaction_at": telemetry.get("last_leaf_compaction_at"),
                     "last_compaction_duration_ms": telemetry.get("last_compaction_duration_ms"),
                     "provider": telemetry.get("provider"),

--- a/engine_registry.py
+++ b/engine_registry.py
@@ -93,7 +93,12 @@ def _remove_registry_entries_for_engine(
             _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(registered_conversation_id, None)
 
 
-def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -> Any:
+def resolve_active_lcm_engine(
+    session_id: str = "",
+    conversation_id: str = "",
+    *,
+    allow_foreground: bool = False,
+) -> Any:
     """Return the LCM runtime clone most recently bound to a session/lane.
 
     Newer Hermes Agent hosts pass the active per-agent context engine directly
@@ -125,11 +130,12 @@ def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -
                 return engine
             if engine is not None and not conversation_matches:
                 _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
-        # Direct lookups above follow the engine's actively-bound ingest lane.
-        # If that lane is a side channel, find the same engine by its stable
-        # operator-facing foreground view. Registry size is bounded by live
-        # AIAgent clones and values are weak, so this scan does not retain stale
-        # runtimes or grow with historical sessions.
+        if not allow_foreground:
+            return None
+        # Operator commands may target the stable foreground view while a side
+        # channel owns the bound ingest lane. Lifecycle callers must not take
+        # this fallback or they can rebind the side-channel clone mid-turn.
+        # Registry size is bounded by live AIAgent clones and values are weak.
         seen: set[int] = set()
         for engine in (
             list(_ACTIVE_ENGINES_BY_SESSION_ID.values())

--- a/engine_registry.py
+++ b/engine_registry.py
@@ -44,6 +44,39 @@ def _engine_matches_conversation_binding(engine: Any, conversation_id: str) -> b
     )
 
 
+def _engine_matches_foreground_binding(
+    engine: Any,
+    session_id: str,
+    conversation_id: str,
+) -> bool:
+    """Return whether an engine's operator-facing foreground matches the lane.
+
+    A stateless/ignored side channel can temporarily own the engine's bound
+    session while ``current_session_id`` and ``current_conversation_id`` keep
+    pointing at the foreground conversation. The direct registries intentionally
+    follow the bound session for ingest dispatch, so operator commands need this
+    bounded fallback scan to recover the same clone without rebinding it.
+    """
+    if not _is_usable_lcm_engine(engine) or not (session_id or conversation_id):
+        return False
+    try:
+        foreground_session_id = str(
+            getattr(engine, "current_session_id", "") or ""
+        )
+        foreground_conversation_id = str(
+            getattr(engine, "current_conversation_id", "") or ""
+        )
+    except Exception:
+        return False
+    return bool(
+        (not session_id or foreground_session_id == session_id)
+        and (
+            not conversation_id
+            or foreground_conversation_id == conversation_id
+        )
+    )
+
+
 def _remove_registry_entries_for_engine(
     engine: Any,
     *,
@@ -92,4 +125,24 @@ def resolve_active_lcm_engine(session_id: str = "", conversation_id: str = "") -
                 return engine
             if engine is not None and not conversation_matches:
                 _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
+        # Direct lookups above follow the engine's actively-bound ingest lane.
+        # If that lane is a side channel, find the same engine by its stable
+        # operator-facing foreground view. Registry size is bounded by live
+        # AIAgent clones and values are weak, so this scan does not retain stale
+        # runtimes or grow with historical sessions.
+        seen: set[int] = set()
+        for engine in (
+            list(_ACTIVE_ENGINES_BY_SESSION_ID.values())
+            + list(_ACTIVE_ENGINES_BY_CONVERSATION_ID.values())
+        ):
+            engine_id = id(engine)
+            if engine_id in seen:
+                continue
+            seen.add(engine_id)
+            if _engine_matches_foreground_binding(
+                engine,
+                session_id,
+                conversation_id,
+            ):
+                return engine
     return None

--- a/reset_state.py
+++ b/reset_state.py
@@ -31,6 +31,7 @@ class ResetStateMixin:
         self._last_compression_status = "idle"
         self._last_compression_noop_reason = ""
         self._last_boundary_skip_time = 0
+        self._compaction_telemetry_counter_rebaseline_pending = True
 
     def _reset_compaction_progress(self) -> None:
         """Reset process-local compaction markers for a fresh/unproven session."""

--- a/reset_state.py
+++ b/reset_state.py
@@ -7,6 +7,8 @@ reset or rolled over. State stays on the engine (accessed via ``self``);
 mixing this in leaves every call site and ``self._*`` reference unchanged.
 """
 
+import uuid
+
 
 class ResetStateMixin:
     def _reset_session_counters(self) -> None:
@@ -24,6 +26,7 @@ class ResetStateMixin:
         self.last_cache_write_tokens = 0
         self.last_reasoning_tokens = 0
         self.cache_metrics_available = False
+        self._compaction_telemetry_counter_epoch = uuid.uuid4().hex
         self._context_probed = False
         self._context_probe_persistable = False
         self._last_overflow_recovery_failed = False

--- a/reset_state.py
+++ b/reset_state.py
@@ -32,6 +32,7 @@ class ResetStateMixin:
         self._last_compression_noop_reason = ""
         self._last_boundary_skip_time = 0
         self._compaction_telemetry_counter_rebaseline_pending = True
+        self._compaction_telemetry_turn_reset_pending = False
 
     def _reset_compaction_progress(self) -> None:
         """Reset process-local compaction markers for a fresh/unproven session."""

--- a/store.py
+++ b/store.py
@@ -1081,6 +1081,105 @@ class MessageStore:
             return None
         return data if isinstance(data, dict) else None
 
+    def increment_compaction_telemetry(
+        self,
+        conversation_id: str,
+        increment: int,
+        updates: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Atomically increment and update one conversation's telemetry record."""
+        if not conversation_id:
+            return None
+        if isinstance(increment, bool) or not isinstance(increment, int) or increment < 0:
+            raise ValueError("compaction telemetry increment must be a non-negative integer")
+        conn = self._conn
+        if conn is None:
+            return None
+
+        key = self._compaction_telemetry_key(conversation_id)
+        with self._write_lock:
+            try:
+                # Separate MessageStore instances have separate Python locks.
+                # Acquire SQLite's write reservation before reading so this
+                # read-modify-write serializes across every connection.
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT value FROM metadata WHERE key = ?",
+                    (key,),
+                ).fetchone()
+                try:
+                    existing = json.loads(str(row[0])) if row and row[0] else {}
+                except (ValueError, TypeError):
+                    existing = {}
+                if not isinstance(existing, dict):
+                    existing = {}
+
+                # Per-runtime high-water marks make a committed increment
+                # idempotent when its caller observes an ambiguous exception.
+                # Retain enough recent epochs for overlapping runtimes without
+                # allowing this diagnostic metadata row to grow forever.
+                watermarks = []
+                raw_watermarks = existing.get("counter_epoch_watermarks", [])
+                if isinstance(raw_watermarks, list):
+                    watermarks = [
+                        item
+                        for item in raw_watermarks
+                        if (
+                            isinstance(item, list)
+                            and len(item) == 2
+                            and isinstance(item[0], str)
+                            and item[0]
+                            and isinstance(item[1], int)
+                            and not isinstance(item[1], bool)
+                            and item[1] >= 0
+                        )
+                    ]
+                effective_increment = increment
+                counter_epoch = updates.get("counter_epoch")
+                target_count = updates.get("compression_count_at_record")
+                if (
+                    isinstance(counter_epoch, str)
+                    and counter_epoch
+                    and isinstance(target_count, int)
+                    and not isinstance(target_count, bool)
+                    and target_count >= 0
+                ):
+                    prior_count = next(
+                        (item[1] for item in watermarks if item[0] == counter_epoch),
+                        0,
+                    )
+                    effective_increment = max(0, target_count - prior_count)
+                    watermarks = [item for item in watermarks if item[0] != counter_epoch]
+                    watermarks.append([counter_epoch, max(prior_count, target_count)])
+                    watermarks = watermarks[-64:]
+
+                current_total = existing.get("total_compactions", 0)
+                if (
+                    isinstance(current_total, bool)
+                    or not isinstance(current_total, int)
+                    or current_total < 0
+                ):
+                    current_total = 0
+                record = dict(existing)
+                record.update(updates)
+                record["conversation_id"] = conversation_id
+                record["counter_epoch_watermarks"] = watermarks
+                record["total_compactions"] = current_total + effective_increment
+                conn.execute(
+                    """
+                    INSERT INTO metadata(key, value)
+                    VALUES(?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (key, json.dumps(record, sort_keys=True)),
+                )
+                conn.commit()
+                return record
+            except Exception:
+                if conn.in_transaction:
+                    conn.rollback()
+                raise
+
     def write_compaction_telemetry(self, conversation_id: str, record: Dict[str, Any]) -> None:
         """Upsert the per-conversation compaction-telemetry record.
 

--- a/store.py
+++ b/store.py
@@ -49,6 +49,7 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .message_content import normalize_content_value as _normalize_content_value
+from .sqlite_util import _temporary_sqlite_busy_timeout
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -1101,18 +1102,22 @@ class MessageStore:
             try:
                 # Separate MessageStore instances have separate Python locks.
                 # Acquire SQLite's write reservation before reading so this
-                # read-modify-write serializes across every connection.
-                conn.execute("BEGIN IMMEDIATE")
-                row = conn.execute(
-                    "SELECT value FROM metadata WHERE key = ?",
-                    (key,),
-                ).fetchone()
-                try:
-                    existing = json.loads(str(row[0])) if row and row[0] else {}
-                except (ValueError, TypeError):
-                    existing = {}
-                if not isinstance(existing, dict):
-                    existing = {}
+                # read-modify-write serializes across every connection. This is
+                # best-effort telemetry on the completed-compaction hot path, so
+                # permit only a tightly bounded overlap before skipping instead
+                # of inheriting the connection's 30s wait.
+                with _temporary_sqlite_busy_timeout([conn], 100):
+                    conn.execute("BEGIN IMMEDIATE")
+                    row = conn.execute(
+                        "SELECT value FROM metadata WHERE key = ?",
+                        (key,),
+                    ).fetchone()
+                    try:
+                        existing = json.loads(str(row[0])) if row and row[0] else {}
+                    except (ValueError, TypeError):
+                        existing = {}
+                    if not isinstance(existing, dict):
+                        existing = {}
 
                 # Per-runtime high-water marks make a committed increment
                 # idempotent when its caller observes an ambiguous exception.
@@ -1160,8 +1165,31 @@ class MessageStore:
                     or current_total < 0
                 ):
                     current_total = 0
+                proposed_total = updates.get("total_compactions", current_total)
+                if (
+                    isinstance(proposed_total, bool)
+                    or not isinstance(proposed_total, int)
+                    or proposed_total < 0
+                ):
+                    proposed_total = current_total
+                stale_across_compaction = (
+                    effective_increment == 0 and proposed_total < current_total
+                )
                 record = dict(existing)
-                record.update(updates)
+                if stale_across_compaction:
+                    compaction_sensitive = {
+                        "turns_since_leaf_compaction",
+                        "peak_prompt_tokens_since_leaf_compaction",
+                        "last_leaf_compaction_at",
+                        "last_compaction_duration_ms",
+                    }
+                    record.update(
+                        (field, value)
+                        for field, value in updates.items()
+                        if field not in compaction_sensitive
+                    )
+                else:
+                    record.update(updates)
                 record["conversation_id"] = conversation_id
                 record["counter_epoch_watermarks"] = watermarks
                 record["total_compactions"] = current_total + effective_increment

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -139,6 +139,30 @@ def test_total_compactions_status_survives_session_rollover_for_conversation(eng
     _assert_total_compaction_surfaces(engine, 3)
 
 
+@pytest.mark.parametrize("previous_session_count", [1, 3])
+def test_total_compactions_includes_first_compaction_after_session_rollover(
+    engine,
+    previous_session_count,
+):
+    engine.compression_count = previous_session_count
+    engine.update_from_response(_hot_usage())
+
+    engine.on_session_start(
+        "test-session-next",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+    assert engine.compression_count == 0
+
+    # The first response telemetry can arrive after the new session has already
+    # compacted. Count it even when the new session's counter is equal to or
+    # below the persisted baseline from the previous session.
+    engine.compression_count = 1
+    engine.update_from_response(_hot_usage())
+
+    _assert_total_compaction_surfaces(engine, previous_session_count + 1)
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,6 +1,7 @@
 """Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
 
 import json
+import threading
 
 import pytest
 
@@ -204,6 +205,144 @@ def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_pa
         restarted.shutdown()
 
 
+def test_total_compactions_rebaseline_when_session_id_binds_new_conversation(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    engine.on_session_start(
+        "test-session",
+        platform="discord",
+        conversation_id="conv-2",
+    )
+
+    assert engine.compression_count == 0
+    _assert_total_compaction_surfaces(engine, 0)
+    assert engine._store.read_compaction_telemetry("conv-1")["total_compactions"] == 3
+
+    engine.compression_count = 1
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 1)
+
+
+@pytest.mark.parametrize("record_mode", ["successful_compaction", "response_hook"])
+def test_compactions_increment_total_atomically_across_engines(tmp_path, record_mode):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_test.db"))
+    engines = [
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_a")),
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_b")),
+    ]
+    barrier = threading.Barrier(2, timeout=5)
+    errors = []
+
+    try:
+        for index, current in enumerate(engines):
+            current.on_session_start(
+                f"test-session-{index}",
+                platform="cli",
+                conversation_id="conv-1",
+            )
+            current.compression_count = 1
+            original_increment = current._store.increment_compaction_telemetry
+
+            def paused_increment(
+                conversation_id,
+                increment,
+                updates,
+                *,
+                _increment=original_increment,
+            ):
+                barrier.wait()
+                return _increment(conversation_id, increment, updates)
+
+            current._store.increment_compaction_telemetry = paused_increment
+
+        def record(current):
+            try:
+                if record_mode == "successful_compaction":
+                    current._record_successful_compaction_telemetry()
+                else:
+                    current.update_from_response(_hot_usage())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=record, args=(current,)) for current in engines]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not [thread for thread in threads if thread.is_alive()]
+        assert errors == []
+        telemetry = engines[0]._store.read_compaction_telemetry("conv-1")
+        assert telemetry["total_compactions"] == 2
+    finally:
+        for current in engines:
+            current.shutdown()
+
+
+def test_zero_delta_snapshot_cannot_overwrite_concurrent_increment(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_test.db"))
+    engines = [
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_a")),
+        LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home_b")),
+    ]
+    barrier = threading.Barrier(2, timeout=5)
+    errors = []
+
+    try:
+        for index, current in enumerate(engines):
+            current.on_session_start(
+                f"test-session-{index}",
+                platform="cli",
+                conversation_id="conv-1",
+            )
+            original_increment = current._store.increment_compaction_telemetry
+
+            def paused_increment(
+                conversation_id,
+                increment,
+                updates,
+                *,
+                _increment=original_increment,
+            ):
+                barrier.wait()
+                return _increment(conversation_id, increment, updates)
+
+            current._store.increment_compaction_telemetry = paused_increment
+
+        engines[1].compression_count = 1
+
+        def record_snapshot():
+            try:
+                engines[0].update_from_response(_hot_usage())
+            except Exception as exc:
+                errors.append(exc)
+
+        def record_increment():
+            try:
+                engines[1]._record_successful_compaction_telemetry()
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=record_snapshot),
+            threading.Thread(target=record_increment),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not [thread for thread in threads if thread.is_alive()]
+        assert errors == []
+        telemetry = engines[0]._store.read_compaction_telemetry("conv-1")
+        assert telemetry["total_compactions"] == 1
+    finally:
+        for current in engines:
+            current.shutdown()
+
+
 def test_successful_compaction_is_durable_before_response_hook(tmp_path, monkeypatch):
     config = LCMConfig(
         database_path=str(tmp_path / "lcm_test.db"),
@@ -276,6 +415,35 @@ def test_response_hook_does_not_recount_durably_recorded_compaction(engine):
     assert telemetry["turns_since_leaf_compaction"] == 0
     assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
     assert telemetry["last_compaction_duration_ms"] == 12.5
+
+
+def test_response_hook_does_not_recount_ambiguous_committed_increment(engine, monkeypatch):
+    real_increment = engine._store.increment_compaction_telemetry
+
+    def commit_then_raise(conversation_id, increment, updates):
+        real_increment(conversation_id, increment, updates)
+        raise RuntimeError("simulated ambiguous commit outcome")
+
+    engine.compression_count = 1
+    engine._last_compaction_duration_ms = 12.5
+    monkeypatch.setattr(engine._store, "increment_compaction_telemetry", commit_then_raise)
+    engine._record_successful_compaction_telemetry()
+
+    committed = engine._store.read_compaction_telemetry("conv-1")
+    assert committed["total_compactions"] == 1
+    assert engine._compaction_telemetry_counter_rebaseline_pending is True
+
+    monkeypatch.setattr(engine._store, "increment_compaction_telemetry", real_increment)
+    engine.update_from_response(_hot_usage(prompt=400))
+
+    telemetry = engine._store.read_compaction_telemetry("conv-1")
+    assert telemetry["total_compactions"] == 1
+    assert telemetry["turns_since_leaf_compaction"] == 0
+    assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
+
+    engine.compression_count = 2
+    engine._record_successful_compaction_telemetry()
+    assert engine._store.read_compaction_telemetry("conv-1")["total_compactions"] == 2
 
 
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,7 +1,11 @@
 """Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
 
+import json
+
 import pytest
 
+from hermes_lcm import tools as lcm_tools
+from hermes_lcm.command import handle_lcm_command
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 from hermes_lcm.store import MessageStore
@@ -36,6 +40,28 @@ def _cold_usage(prompt=1000):
 
 def _telemetry(engine):
     return engine.get_status().get("compaction_telemetry")
+
+
+def _slash_status_fields(engine):
+    return {
+        key.strip(): value.strip()
+        for line in handle_lcm_command("status", engine).splitlines()
+        if ":" in line
+        for key, value in [line.split(":", 1)]
+    }
+
+
+def _assert_total_compaction_surfaces(engine, expected):
+    status = engine.get_status()
+    tool_status = json.loads(lcm_tools.lcm_status({}, engine=engine))
+    slash_status = _slash_status_fields(engine)
+
+    assert status["total_compactions"] == expected
+    assert status["total_compactions_scope"] == "current_conversation"
+    assert tool_status["total_compactions"] == expected
+    assert tool_status["total_compactions_scope"] == "current_conversation"
+    assert slash_status["total_compactions"] == str(expected)
+    assert slash_status["total_compactions_scope"] == "current_conversation"
 
 
 def test_records_per_turn_snapshot(engine):
@@ -96,6 +122,49 @@ def test_resets_on_compaction(engine):
     assert t["last_leaf_compaction_at"] is not None
     assert t["last_compaction_duration_ms"] == 12.5
     assert t["peak_prompt_tokens_since_leaf_compaction"] == 400  # reset to current
+
+
+def test_total_compactions_status_survives_session_rollover_for_conversation(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    engine.on_session_start(
+        "test-session-next",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+
+    assert engine.compression_count == 0
+    _assert_total_compaction_surfaces(engine, 3)
+
+
+def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
+    _assert_total_compaction_surfaces(engine, 0)
+
+
+def test_total_compactions_status_is_scoped_to_current_conversation(engine):
+    engine._store.write_compaction_telemetry(
+        "conv-1",
+        {"conversation_id": "conv-1", "total_compactions": 2},
+    )
+    engine._store.write_compaction_telemetry(
+        "other-conversation",
+        {"conversation_id": "other-conversation", "total_compactions": 99},
+    )
+
+    _assert_total_compaction_surfaces(engine, 2)
+
+
+@pytest.mark.parametrize("malformed", [-1, "7", 1.5, True, None, [], {}])
+def test_total_compactions_status_fails_closed_for_malformed_telemetry(engine, malformed):
+    engine._store.write_compaction_telemetry(
+        "conv-1",
+        {"conversation_id": "conv-1", "total_compactions": malformed},
+    )
+
+    _assert_total_compaction_surfaces(engine, 0)
+    assert _telemetry(engine)["total_compactions"] == 0
 
 
 def test_no_conversation_records_nothing(engine):

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -204,6 +204,80 @@ def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_pa
         restarted.shutdown()
 
 
+def test_successful_compaction_is_durable_before_response_hook(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "lcm_test.db"),
+        fresh_tail_count=2,
+        leaf_chunk_tokens=1,
+    )
+    conversation_id = "conv-1"
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old question one"},
+        {"role": "assistant", "content": "old answer one"},
+        {"role": "user", "content": "old question two"},
+        {"role": "assistant", "content": "old answer two"},
+        {"role": "user", "content": "fresh question"},
+        {"role": "assistant", "content": "fresh answer"},
+    ]
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    first.on_session_start(
+        "test-session",
+        platform="cli",
+        conversation_id=conversation_id,
+        context_length=200_000,
+    )
+
+    def summarize(initial_chunk, **_kwargs):
+        return (
+            list(initial_chunk),
+            100,
+            "Durable summary.\nExpand for details about: old turns",
+            1,
+            1,
+        )
+
+    monkeypatch.setattr(first, "_summarize_leaf_chunk_with_rescue", summarize)
+    first.compress(messages)
+    assert first.compression_count == 1
+    persisted = first._store.read_compaction_telemetry(conversation_id)
+    assert persisted is not None
+    assert persisted["total_compactions"] == 1
+    assert persisted["compression_count_at_record"] == 1
+
+    # Simulate process interruption before update_from_response() can persist
+    # the next per-turn telemetry snapshot.
+    first.shutdown()
+
+    restarted = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    try:
+        restarted.on_session_start(
+            "test-session-next",
+            platform="cli",
+            conversation_id=conversation_id,
+            context_length=200_000,
+        )
+
+        _assert_total_compaction_surfaces(restarted, 1)
+    finally:
+        restarted.shutdown()
+
+
+def test_response_hook_does_not_recount_durably_recorded_compaction(engine):
+    engine.compression_count = 1
+    engine._last_compaction_duration_ms = 12.5
+    engine._record_successful_compaction_telemetry()
+
+    engine.update_from_response(_hot_usage(prompt=400))
+
+    telemetry = _telemetry(engine)
+    assert telemetry["total_compactions"] == 1
+    assert telemetry["turns_since_leaf_compaction"] == 0
+    assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 400
+    assert telemetry["last_compaction_duration_ms"] == 12.5
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -1,7 +1,9 @@
 """Tests for B2 compaction telemetry (per-conversation snapshot in metadata)."""
 
 import json
+import sqlite3
 import threading
+import time
 
 import pytest
 
@@ -341,6 +343,123 @@ def test_zero_delta_snapshot_cannot_overwrite_concurrent_increment(tmp_path):
     finally:
         for current in engines:
             current.shutdown()
+
+
+def test_zero_delta_snapshot_preserves_concurrent_compaction_metadata(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm_test.db"))
+    snapshot_engine = LCMEngine(
+        config=config,
+        hermes_home=str(tmp_path / "hermes_home_snapshot"),
+    )
+    compaction_engine = LCMEngine(
+        config=config,
+        hermes_home=str(tmp_path / "hermes_home_compaction"),
+    )
+    snapshot_ready = threading.Event()
+    compaction_done = threading.Event()
+    errors = []
+
+    try:
+        snapshot_engine.on_session_start(
+            "snapshot-session",
+            platform="cli",
+            conversation_id="conv-1",
+        )
+        compaction_engine.on_session_start(
+            "compaction-session",
+            platform="cli",
+            conversation_id="conv-1",
+        )
+        original_increment = snapshot_engine._store.increment_compaction_telemetry
+
+        def paused_snapshot(conversation_id, increment, updates):
+            snapshot_ready.set()
+            assert compaction_done.wait(timeout=5)
+            return original_increment(conversation_id, increment, updates)
+
+        snapshot_engine._store.increment_compaction_telemetry = paused_snapshot
+
+        def record_snapshot():
+            try:
+                snapshot_engine.update_from_response(_hot_usage(prompt=1000))
+            except Exception as exc:
+                errors.append(exc)
+
+        snapshot_thread = threading.Thread(target=record_snapshot)
+        snapshot_thread.start()
+        assert snapshot_ready.wait(timeout=5)
+
+        compaction_engine.compression_count = 1
+        compaction_engine._last_compaction_duration_ms = 12.5
+        compaction_engine._record_successful_compaction_telemetry()
+        compaction_done.set()
+        snapshot_thread.join(timeout=10)
+
+        assert not snapshot_thread.is_alive()
+        assert errors == []
+        telemetry = snapshot_engine._store.read_compaction_telemetry("conv-1")
+        assert telemetry["total_compactions"] == 1
+        assert telemetry["turns_since_leaf_compaction"] == 0
+        assert telemetry["peak_prompt_tokens_since_leaf_compaction"] == 0
+        assert telemetry["last_leaf_compaction_at"] is not None
+        assert telemetry["last_compaction_duration_ms"] == 12.5
+    finally:
+        compaction_done.set()
+        snapshot_engine.shutdown()
+        compaction_engine.shutdown()
+
+
+def test_compaction_telemetry_lock_contention_is_nonblocking(tmp_path):
+    db_path = tmp_path / "lcm_test.db"
+    lock_owner = MessageStore(db_path)
+    telemetry_store = MessageStore(db_path)
+    lock_ready = threading.Event()
+    release_lock = threading.Event()
+    write_done = threading.Event()
+    write_errors = []
+
+    def hold_write_lock():
+        lock_owner._conn.execute("BEGIN IMMEDIATE")
+        lock_ready.set()
+        release_lock.wait(timeout=5)
+        lock_owner._conn.rollback()
+
+    def write_telemetry():
+        try:
+            telemetry_store.increment_compaction_telemetry(
+                "conv-1",
+                1,
+                {"compression_count_at_record": 1},
+            )
+        except Exception as exc:
+            write_errors.append(exc)
+        finally:
+            write_done.set()
+
+    holder = threading.Thread(target=hold_write_lock)
+    writer = threading.Thread(target=write_telemetry)
+    try:
+        holder.start()
+        assert lock_ready.wait(timeout=5)
+        assert telemetry_store._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+
+        started = time.monotonic()
+        writer.start()
+        assert write_done.wait(timeout=0.25)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 0.25
+        assert len(write_errors) == 1
+        assert isinstance(write_errors[0], sqlite3.OperationalError)
+        assert "locked" in str(write_errors[0]).lower()
+        assert telemetry_store._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+        assert telemetry_store.read_compaction_telemetry("conv-1") is None
+    finally:
+        release_lock.set()
+        writer.join(timeout=5)
+        holder.join(timeout=5)
+        lock_owner.close()
+        telemetry_store.close()
 
 
 def test_successful_compaction_is_durable_before_response_hook(tmp_path, monkeypatch):

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -163,6 +163,35 @@ def test_total_compactions_includes_first_compaction_after_session_rollover(
     _assert_total_compaction_surfaces(engine, previous_session_count + 1)
 
 
+def test_total_compactions_includes_first_compaction_after_engine_restart(tmp_path):
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_test.db")
+
+    first = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    first.on_session_start(
+        "test-session",
+        platform="discord",
+        conversation_id="conv-1",
+    )
+    first.compression_count = 3
+    first.update_from_response(_hot_usage())
+    first.shutdown()
+
+    restarted = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    try:
+        restarted.on_session_start(
+            "test-session-next",
+            platform="discord",
+            conversation_id="conv-1",
+        )
+        restarted.compression_count = 1
+        restarted.update_from_response(_hot_usage())
+
+        _assert_total_compaction_surfaces(restarted, 4)
+    finally:
+        restarted.shutdown()
+
+
 def test_total_compactions_status_defaults_to_zero_without_telemetry(engine):
     _assert_total_compaction_surfaces(engine, 0)
 

--- a/tests/test_compaction_telemetry.py
+++ b/tests/test_compaction_telemetry.py
@@ -124,6 +124,18 @@ def test_resets_on_compaction(engine):
     assert t["peak_prompt_tokens_since_leaf_compaction"] == 400  # reset to current
 
 
+def test_total_compactions_status_includes_pending_compaction(engine):
+    engine.compression_count = 3
+    engine.update_from_response(_hot_usage())
+    _assert_total_compaction_surfaces(engine, 3)
+
+    # Status can be requested after compaction increments the live counter but
+    # before the response hook persists the next telemetry snapshot.
+    engine.compression_count += 1
+
+    _assert_total_compaction_surfaces(engine, 4)
+
+
 def test_total_compactions_status_survives_session_rollover_for_conversation(engine):
     engine.compression_count = 3
     engine.update_from_response(_hot_usage())

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -1448,6 +1448,60 @@ def test_post_llm_hook_resolves_registered_active_clone_without_host_context_com
     ctx.engine.shutdown()
 
 
+def test_post_llm_hook_does_not_foreground_match_side_channel_clone(monkeypatch, tmp_path):
+    module = _load_plugin_entrypoint_module("hermes_lcm_post_hook_side_channel_clone")
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "side-channel")
+
+    class _CtxNoTool:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    ctx = _CtxNoTool()
+    module.register(ctx)
+    assert ctx.engine is not None
+    active_clone = ctx.engine.clone_for_agent()
+    active_clone.on_session_start(
+        "foreground-session",
+        platform="discord",
+        conversation_id="agent:main:discord:dm:42",
+    )
+    active_clone.on_session_start(
+        "side-channel",
+        platform="cron",
+        conversation_id="agent:main:cron:tick:1",
+    )
+    assert active_clone.bound_session_id == "side-channel"
+    assert active_clone.current_session_id == "foreground-session"
+
+    clone_ingests = []
+    singleton_ingests = []
+    monkeypatch.setattr(active_clone, "ingest", lambda messages: clone_ingests.append(list(messages)))
+    monkeypatch.setattr(ctx.engine, "ingest", lambda messages: singleton_ingests.append(list(messages)))
+    history = [{"role": "user", "content": "foreground turn"}]
+
+    manager._hooks["post_llm_call"][-1](
+        session_id="foreground-session",
+        conversation_id="agent:main:discord:dm:42",
+        platform="discord",
+        conversation_history=history,
+    )
+
+    assert active_clone.bound_session_id == "side-channel"
+    assert clone_ingests == []
+    assert singleton_ingests == [history]
+    active_clone.shutdown()
+    ctx.engine.shutdown()
+
+
 def test_post_llm_hook_ignores_stale_registered_clone_after_rebind(monkeypatch, tmp_path):
     for lookup_mode in ("session", "conversation", "mismatched_conversation"):
         module = _load_plugin_entrypoint_module(f"hermes_lcm_post_hook_stale_{lookup_mode}")

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -86,6 +86,54 @@ def _register_plugin_engine(module_name: str):
     return ctx.engine
 
 
+def _register_plugin_with_command(
+    monkeypatch,
+    tmp_path,
+    module_name: str,
+    session_values: dict[str, str],
+):
+    """Register the plugin against a host-shaped slash-command context."""
+    manager = types.SimpleNamespace(_hooks={})
+    fake_plugins = types.SimpleNamespace(get_plugin_manager=lambda: manager)
+    fake_hermes_cli = types.SimpleNamespace(plugins=fake_plugins)
+    fake_session_context = types.SimpleNamespace(
+        get_session_env=lambda name, default="": session_values.get(name, default)
+    )
+    fake_gateway = types.SimpleNamespace(session_context=fake_session_context)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+    monkeypatch.setitem(sys.modules, "gateway", fake_gateway)
+    monkeypatch.setitem(sys.modules, "gateway.session_context", fake_session_context)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / module_name))
+    monkeypatch.setenv("LCM_ENABLE_SLASH_COMMAND", "1")
+
+    module = _load_plugin_entrypoint_module(module_name)
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+            self.commands = {}
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_command(self, name, handler, description=""):
+            self.commands[name] = handler
+
+    ctx = _Ctx()
+    module.register(ctx)
+    return ctx
+
+
+def _slash_status_fields(text: str) -> dict[str, str]:
+    return {
+        key.strip(): value.strip()
+        for line in text.splitlines()
+        if ":" in line
+        for key, value in [line.split(":", 1)]
+    }
+
+
 def test_standalone_install_scripts_exist_and_are_shell_scripts():
     repo_root = Path(__file__).resolve().parent.parent
 
@@ -1252,6 +1300,95 @@ def test_registered_tool_handler_forwards_messages_to_engine_handle_tool_call(mo
         assert "messages" in kwargs, f"{name}: messages kwarg not forwarded"
         # Depending on whether engine passes it through, at minimum verify it arrived
         assert kwargs["messages"] == test_messages, f"{name}: messages content mismatch"
+
+
+def test_slash_status_matches_active_tool_clone_after_rebind_and_side_channel(
+    monkeypatch,
+    tmp_path,
+):
+    session_values = {
+        "HERMES_SESSION_KEY": "agent:main:discord:dm:42",
+    }
+    monkeypatch.setenv("LCM_STATELESS_SESSION_PATTERNS", "side-channel")
+    ctx = _register_plugin_with_command(
+        monkeypatch,
+        tmp_path,
+        "hermes_lcm_slash_active_clone",
+        session_values,
+    )
+    prototype = ctx.engine
+    clone = prototype.clone_for_agent()
+    try:
+        clone.update_model("gpt-active", 372000, provider="openai-codex")
+        clone.on_session_start(
+            "discord-session-a",
+            platform="discord",
+            conversation_id="agent:main:discord:dm:42",
+        )
+
+        tool_status = json.loads(clone.handle_tool_call("lcm_status", {}))
+        slash_status = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert slash_status["session_id"] == tool_status["session_id"]
+        assert (
+            slash_status["conversation_id"]
+            == tool_status["runtime_identity"]["conversation_id"]
+        )
+        assert slash_status["model"] == tool_status["model"]
+        assert slash_status["provider"] == tool_status["provider"]
+        assert int(slash_status["context_length"]) == tool_status["context_length"]
+        assert int(slash_status["threshold_tokens"]) == tool_status["threshold_tokens"]
+        assert prototype.current_session_id == ""
+
+        clone.on_session_start(
+            "discord-session-b",
+            platform="discord",
+            conversation_id="agent:main:discord:dm:84",
+        )
+        session_values.update({
+            "HERMES_SESSION_KEY": "agent:main:discord:dm:84",
+        })
+        rebound = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert rebound["session_id"] == "discord-session-b"
+        assert rebound["conversation_id"] == "agent:main:discord:dm:84"
+
+        clone.on_session_start(
+            "side-channel",
+            platform="cron",
+            conversation_id="agent:main:cron:tick:1",
+        )
+        assert clone.bound_session_id == "side-channel"
+        assert clone.current_session_id == "discord-session-b"
+        side_channel = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert side_channel["session_id"] == "discord-session-b"
+        assert side_channel["conversation_id"] == "agent:main:discord:dm:84"
+        assert side_channel["side_channel_active"] == "yes"
+    finally:
+        clone.shutdown()
+        prototype.shutdown()
+
+
+def test_slash_status_stays_unbound_until_lane_has_an_active_runtime(
+    monkeypatch,
+    tmp_path,
+):
+    session_values = {
+        "HERMES_SESSION_KEY": "agent:main:discord:dm:42",
+    }
+    ctx = _register_plugin_with_command(
+        monkeypatch,
+        tmp_path,
+        "hermes_lcm_slash_host_context",
+        session_values,
+    )
+    try:
+        cold = _slash_status_fields(ctx.commands["lcm"]("status"))
+        assert cold["session_id"] == "(unbound)"
+        assert cold["model"] == "(uninitialized)"
+        assert cold["context_length"] == "(uninitialized)"
+        assert cold["threshold_tokens"] == "(uninitialized)"
+        assert ctx.engine.current_session_id == ""
+    finally:
+        ctx.engine.shutdown()
 
 
 def test_post_llm_hook_resolves_registered_active_clone_without_host_context_compressor(monkeypatch, tmp_path):

--- a/tools.py
+++ b/tools.py
@@ -6441,6 +6441,10 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
     return json.dumps({
         "session_id": session_id,
         "compression_count": engine.compression_count,
+        "total_compactions": full_status.get("total_compactions", 0),
+        "total_compactions_scope": full_status.get(
+            "total_compactions_scope", "current_conversation"
+        ),
         "last_compression_status": full_status.get("last_compression_status", "idle"),
         "last_compression_noop_reason": full_status.get("last_compression_noop_reason", ""),
         "threshold_full_sweep": full_status.get("threshold_full_sweep"),


### PR DESCRIPTION
## Summary
- Submit the immutable CI-only RC2 reconciliation candidate for the repository's existing pull-request CI.
- Base RC2: `10cbb78347ec86f3004153b24767324ded9e37b4`.
- Candidate: `df4cde2918f0f19044d9b03a5d9a915425fa5184`.
- This candidate ports seven local-only runtime fixes.

## Why
- The exact reconciled candidate needs remote CI evidence without changing its immutable commit or activating it.

## Validation
- [x] Local test suite: 2,818 passed, 12 xfailed.
- [x] Python 3.11–3.14 parity validation.
- [x] Ruff and actionlint.
- [x] Copied-database validation and rollback rehearsal.
- [ ] GitHub pull-request CI on this exact candidate head.

## Notes
- CI-only: do not merge this pull request.
- No activation, plugin swap, database/configuration change, service restart, tag, or release is authorized by this pull request.
- Remote CI status is intentionally left pending until GitHub Actions reports terminal results.
