### PR TITLE
feat: align LCM with Codex continuity and whitepaper control flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,40 @@ Based on the [LCM paper](https://papers.voltropy.com/LCM) by Ehrlich & Blackman
 OpenClaw. For an interactive visualization of the LCM idea, see
 [losslesscontext.ai](https://losslesscontext.ai/).
 
+## Codex, concurrency, and whitepaper extensions
+
+The engine includes changes exercised under large, concurrent Hermes gateway
+workloads:
+
+- **Fast restart reconciliation.** Durable tool-output recovery looks up files
+  by escaped tool-call ID instead of deserializing the entire externalized
+  output archive. Incoming replay identities are computed once per pass rather
+  than once for every candidate prefix. On the production archive that exposed
+  the defect (12,799 sidecars, about 540 MB), one lookup now takes about 23 ms
+  and a 590K-token session reconciles in about 2 seconds instead of timing out
+  after 30 seconds.
+- **Codex-native continuity.** OpenAI Codex reasoning and compaction capsules
+  are archived losslessly as opaque provider state. A valid provider-native
+  boundary remains authoritative, so LCM does not summarize the same history a
+  second time. Opaque capsules stay out of FTS, summaries, and public expansion.
+- **Whitepaper-conformant compaction.** Separate soft and hard pressure paths,
+  optional background preparation, oldest-first leaf compaction, a hierarchical
+  summary DAG, and deterministic level-3 truncation guarantee convergence while
+  keeping exact source pointers.
+- **Reliable concurrent storage.** Engines sharing the same database reuse one
+  reference-counted storage bundle. Closed bundles are detected and replaced
+  safely, WAL-backed writes use bounded lock waits, and lock-contended raw
+  ingests enter an fsync-backed queue that replays exactly once.
+- **Operator-level recursion.** Persistent `llm_map` and `agentic_map` process
+  JSONL datasets with atomic claims, bounded concurrency, retries, ordered
+  output, and dependency-free JSON Schema validation.
+- **Large-file awareness.** Stable path-only file IDs and type-aware exploration
+  summaries let file references survive repeated summary-DAG condensation.
+
 ## Table of contents
 
 - [What it does](#what-it-does)
+- [Codex, concurrency, and whitepaper extensions](#codex-concurrency-and-whitepaper-extensions)
 - [LCM vs built-in compression](#lcm-vs-built-in-compression)
 - [Quick start](#quick-start)
 - [Commands and tools](#commands-and-tools)
@@ -80,7 +111,7 @@ Core capabilities:
   payloads instead of dumping everything into the prompt
 - **Agent tools** - `lcm_grep`, `lcm_recall`, `lcm_query_state`, `lcm_compute`, `lcm_compile_evidence`, `lcm_evidence_pack`, `lcm_retrieve`, `lcm_recent`, `lcm_load_session`,
   `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, `lcm_inspect`,
-  and `lcm_doctor`
+  `lcm_doctor`, `llm_map`, and `agentic_map`
 - **Source-aware retrieval** - filters raw rows and summaries by descendant
   source lineage
 - **Session controls** - ignore noisy sessions or keep sessions read-only with
@@ -197,7 +228,7 @@ Expected signals:
 - selected context engine is `lcm`
 - tool list includes `lcm_grep`, `lcm_recall`, `lcm_recent`,
   `lcm_load_session`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`,
-  `lcm_status`, `lcm_inspect`, and `lcm_doctor`
+  `lcm_status`, `lcm_inspect`, `lcm_doctor`, `llm_map`, and `agentic_map`
 - the normal available-skills index includes `hermes-lcm`; current hosts can
   also resolve the explicit plugin-qualified skill `hermes-lcm:hermes-lcm`
 
@@ -205,7 +236,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc2 (17 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -280,6 +311,8 @@ outside the LCM database.
 | `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
 | `lcm_inspect` | Read-only operator inventory for current-session lineage, frontier/fresh-tail metadata, externalized refs/readability, compaction skip/no-op reasons, and matched ignore/stateless patterns. Returns metadata only; use retrieval tools for content. |
 | `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
+| `llm_map` | Apply one stateless model call to every item in an input JSONL file. LCM persists batch/item state, claims work atomically, runs with bounded concurrency (default 16), validates each result against the supplied JSON Schema, retries failures with validation feedback, and writes ordered JSONL output. |
+| `agentic_map` | Apply one isolated tool-capable sub-agent to every item in an input JSONL file. It uses the same durable claims, schema validation, retries, and JSONL output as `llm_map`; callers must explicitly choose the per-agent `read_only` capability boundary. |
 
 ## Recall skill and policy
 
@@ -826,6 +859,9 @@ config.py        env var defaults and overrides
 command.py       /lcm command handlers
 tools.py         lcm_grep, lcm_load_session, lcm_describe, lcm_expand, lcm_expand_query
 schemas.py       tool schemas shown to the model
+operators.py     persistent llm_map and agentic_map execution
+file_registry.py stable path-only file IDs and structural exploration summaries
+operator_schemas.py map tool schemas and dependency-free output validation
 tests/           standalone pytest coverage
 ```
 

--- a/__init__.py
+++ b/__init__.py
@@ -315,6 +315,7 @@ def register(ctx):
     from .config import LCMConfig
     from .engine import LCMEngine, resolve_active_lcm_engine
     from .schemas import (
+        AGENTIC_MAP,
         LCM_GREP,
         LCM_RECALL,
         LCM_QUERY_STATE,
@@ -330,6 +331,7 @@ def register(ctx):
         LCM_STATUS,
         LCM_INSPECT,
         LCM_DOCTOR,
+        LLM_MAP,
     )
 
     config = LCMConfig.from_env()
@@ -443,6 +445,8 @@ def register(ctx):
         ("lcm_status", LCM_STATUS, "💚"),
         ("lcm_inspect", LCM_INSPECT, "🧭"),
         ("lcm_doctor", LCM_DOCTOR, "🏥"),
+        ("llm_map", LLM_MAP, "🗺️"),
+        ("agentic_map", AGENTIC_MAP, "🧭"),
     ]
     register_tool = getattr(ctx, "register_tool", None)
     if callable(register_tool) and _host_forwards_registered_tool_messages(ctx):

--- a/async_compaction.py
+++ b/async_compaction.py
@@ -1,0 +1,530 @@
+"""Crash-safe background preparation and atomic summary publication.
+
+Prepared summaries deliberately live outside ``summary_nodes``.  They become
+visible only when promotion validates the live session, policy, route,
+frontier, source identities, and overlap constraints in one SQLite
+transaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from .db_bootstrap import configure_connection
+from .file_registry import union_file_ids
+from .tokens import count_messages_tokens, count_tokens
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedCompactionBatch:
+    batch_id: str
+    state: str
+    source_ids: tuple[int, ...] = ()
+    frontier_start_store_id: int = 0
+    frontier_end_store_id: int = 0
+    expected_leaf_count: int = 0
+    failure_reason: str = ""
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    promoted: bool
+    reason: str = ""
+    batch_id: str = ""
+    node_ids: tuple[int, ...] = ()
+
+
+def _stable_hash(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+class AsyncCompactionMixin:
+    """Engine mixin implementing the paper's soft/background publication path."""
+
+    def _initialize_async_compaction(self) -> None:
+        self._async_compaction_lock = threading.RLock()
+        self._async_compaction_worker: threading.Thread | None = None
+        self._async_compaction_closed = False
+        conn = self._store.connection
+        if conn is None:
+            return
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS compaction_batches (
+                batch_id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                state TEXT NOT NULL,
+                frontier_start_store_id INTEGER NOT NULL,
+                frontier_end_store_id INTEGER NOT NULL DEFAULT 0,
+                fresh_tail_start_store_id INTEGER NOT NULL DEFAULT 0,
+                policy_fingerprint TEXT NOT NULL,
+                route_fingerprint TEXT NOT NULL,
+                source_identity_hash TEXT NOT NULL DEFAULT '',
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                expected_leaf_count INTEGER NOT NULL DEFAULT 0,
+                prepared_leaf_count INTEGER NOT NULL DEFAULT 0,
+                failure_reason TEXT NOT NULL DEFAULT '',
+                retry_after REAL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_compaction_batches_scope_state
+                ON compaction_batches(conversation_id, session_id, state, created_at);
+            CREATE TABLE IF NOT EXISTS pending_summary_nodes (
+                pending_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                batch_id TEXT NOT NULL REFERENCES compaction_batches(batch_id) ON DELETE CASCADE,
+                ordinal INTEGER NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER NOT NULL,
+                source_token_count INTEGER NOT NULL,
+                source_ids TEXT NOT NULL,
+                source_identity_hash TEXT NOT NULL,
+                earliest_at REAL,
+                latest_at REAL,
+                expand_hint TEXT NOT NULL DEFAULT '',
+                file_ids TEXT NOT NULL DEFAULT '[]',
+                UNIQUE(batch_id, ordinal)
+            );
+            """
+        )
+        pending_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(pending_summary_nodes)").fetchall()
+        }
+        if "file_ids" not in pending_columns:
+            conn.execute(
+                "ALTER TABLE pending_summary_nodes ADD COLUMN file_ids TEXT NOT NULL DEFAULT '[]'"
+            )
+        conn.commit()
+        # A process that died while preparing cannot prove it finished writing
+        # every pending leaf.  Fail it closed; ready rows remain promotable.
+        now = time.time()
+        conn.execute(
+            """UPDATE compaction_batches
+               SET state='failed', failure_reason='interrupted_preparation',
+                   retry_after=?, updated_at=?
+               WHERE state='preparing'""",
+            (now + float(self._config.async_background_compaction_retry_backoff_seconds), now),
+        )
+        conn.commit()
+
+    def _async_policy_fingerprint(self) -> str:
+        c = self._config
+        return _stable_hash({
+            "fresh_tail_count": int(c.fresh_tail_count),
+            "fresh_tail_max_tokens": int(c.fresh_tail_max_tokens),
+            "leaf_chunk_tokens": int(c.leaf_chunk_tokens),
+            "context_threshold": float(c.context_threshold),
+            "hard_context_threshold": float(c.hard_context_threshold),
+            "l2_budget_ratio": float(c.l2_budget_ratio),
+            "l3_truncate_tokens": int(c.l3_truncate_tokens),
+            "custom_instructions": str(c.custom_instructions),
+        })
+
+    def _async_route_fingerprint(self) -> str:
+        return _stable_hash({
+            "summary_model": str(self._config.summary_model),
+            "fallback_models": list(self._config.summary_fallback_models),
+            "provider": str(self.provider),
+            "base_url": str(self.base_url),
+        })
+
+    @staticmethod
+    def _row_identity(row: sqlite3.Row) -> tuple[Any, ...]:
+        keys = (
+            "store_id", "session_id", "role", "content", "tool_call_id",
+            "tool_calls", "tool_name", "timestamp", "token_estimate",
+            "conversation_id", "observed_at", "observed_at_source",
+        )
+        if isinstance(row, sqlite3.Row):
+            return tuple(row[key] for key in keys)
+        return tuple(row)
+
+    def _source_identity_hash(self, conn: sqlite3.Connection, source_ids: Iterable[int]) -> str:
+        ids = tuple(int(value) for value in source_ids)
+        if not ids:
+            return _stable_hash([])
+        placeholders = ",".join("?" for _ in ids)
+        rows = conn.execute(
+            f"""SELECT store_id, session_id, role, content, tool_call_id, tool_calls,
+                       tool_name, timestamp, token_estimate, conversation_id,
+                       observed_at, observed_at_source
+                FROM messages WHERE store_id IN ({placeholders}) ORDER BY store_id""",
+            ids,
+        ).fetchall()
+        return _stable_hash([self._row_identity(row) for row in rows])
+
+    def _batch_from_row(self, row: sqlite3.Row) -> PreparedCompactionBatch:
+        if not isinstance(row, sqlite3.Row):
+            columns = (
+                "batch_id", "conversation_id", "session_id", "state",
+                "frontier_start_store_id", "frontier_end_store_id",
+                "fresh_tail_start_store_id", "policy_fingerprint",
+                "route_fingerprint", "source_identity_hash", "source_ids",
+                "expected_leaf_count", "prepared_leaf_count", "failure_reason",
+                "retry_after", "created_at", "updated_at",
+            )
+            row = dict(zip(columns, row))
+        return PreparedCompactionBatch(
+            batch_id=str(row["batch_id"]),
+            state=str(row["state"]),
+            source_ids=tuple(int(value) for value in json.loads(row["source_ids"] or "[]")),
+            frontier_start_store_id=int(row["frontier_start_store_id"] or 0),
+            frontier_end_store_id=int(row["frontier_end_store_id"] or 0),
+            expected_leaf_count=int(row["expected_leaf_count"] or 0),
+            failure_reason=str(row["failure_reason"] or ""),
+        )
+
+    def prepare_background_compaction_once(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        leave_state: str | None = None,
+    ) -> PreparedCompactionBatch | None:
+        if not bool(self._config.async_background_compaction_enabled):
+            return None
+        if not self._session_id or not self._conversation_id or not messages:
+            return PreparedCompactionBatch("", "failed", failure_reason="unbound_or_empty")
+        # The foreground compactor has additional dependency filtering for
+        # operator-configured ignore patterns.  Do not let the asynchronous
+        # path summarize data that policy intentionally excludes; hard
+        # pressure still falls back to that foreground path.
+        if self._compiled_ignore_message_patterns:
+            return PreparedCompactionBatch(
+                "",
+                "failed",
+                failure_reason="message_filter_requires_foreground_compaction",
+            )
+        conn = self._store.connection
+        assert conn is not None
+        with self._async_compaction_lock:
+            active = conn.execute(
+                """SELECT COUNT(*) FROM compaction_batches
+                   WHERE conversation_id=? AND session_id=? AND state IN ('preparing','ready')""",
+                (self._conversation_id, self._session_id),
+            ).fetchone()[0]
+            if int(active) >= max(1, int(self._config.async_background_compaction_max_batches)):
+                row = conn.execute(
+                    """SELECT * FROM compaction_batches
+                       WHERE conversation_id=? AND session_id=? AND state='ready'
+                       ORDER BY created_at LIMIT 1""",
+                    (self._conversation_id, self._session_id),
+                ).fetchone()
+                return self._batch_from_row(row) if row is not None else None
+
+            lifecycle = self._lifecycle.get_by_conversation(self._conversation_id)
+            frontier_start = int(lifecycle.current_frontier_store_id if lifecycle else 0)
+            tail_start = self._fresh_tail_start(messages)
+            leading = self._leading_anchor_count(messages)
+            candidates = list(messages[leading:tail_start])
+            source_ids = tuple(
+                sid for sid in self._get_store_ids_for_messages(candidates)
+                if int(sid) > frontier_start
+            )
+            if not source_ids:
+                return PreparedCompactionBatch("", "failed", failure_reason="no_eligible_sources")
+            rows = conn.execute(
+                f"SELECT store_id, timestamp FROM messages WHERE store_id IN ({','.join('?' for _ in source_ids)}) ORDER BY store_id",
+                source_ids,
+            ).fetchall()
+            if len(rows) != len(source_ids):
+                return PreparedCompactionBatch("", "failed", failure_reason="missing_sources")
+
+            batch_id = uuid.uuid4().hex
+            now = time.time()
+            identity_hash = self._source_identity_hash(conn, source_ids)
+            policy_hash = self._async_policy_fingerprint()
+            route_hash = self._async_route_fingerprint()
+            frontier_end = max(source_ids)
+            fresh_tail_ids = self._get_store_ids_for_messages(messages[tail_start:])
+            fresh_tail_start_id = min(fresh_tail_ids) if fresh_tail_ids else frontier_end + 1
+            conn.execute(
+                """INSERT INTO compaction_batches
+                   (batch_id,conversation_id,session_id,state,frontier_start_store_id,
+                    frontier_end_store_id,fresh_tail_start_store_id,policy_fingerprint,
+                    route_fingerprint,source_identity_hash,source_ids,created_at,updated_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (batch_id, self._conversation_id, self._session_id, "preparing",
+                 frontier_start, frontier_end, fresh_tail_start_id, policy_hash,
+                 route_hash, identity_hash, json.dumps(source_ids), now, now),
+            )
+            conn.commit()
+            if leave_state == "preparing":
+                row = conn.execute("SELECT * FROM compaction_batches WHERE batch_id=?", (batch_id,)).fetchone()
+                return self._batch_from_row(row)
+
+        try:
+            chosen, source_tokens, summary, _level, _attempts = self._summarize_leaf_chunk_with_rescue(candidates)
+            chosen_ids = tuple(self._get_store_ids_for_messages(chosen))
+            if not chosen_ids:
+                raise RuntimeError("background compaction resolved no durable source lineage")
+            identity_hash = self._source_identity_hash(conn, chosen_ids)
+            timestamps = [float(row[1]) for row in rows if row[1] is not None]
+            with self._async_compaction_lock:
+                conn.execute(
+                    """INSERT INTO pending_summary_nodes
+                       (batch_id,ordinal,depth,summary,token_count,source_token_count,
+                        source_ids,source_identity_hash,earliest_at,latest_at,expand_hint,file_ids)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (batch_id, 0, 0, summary, count_tokens(summary), source_tokens,
+                     json.dumps(chosen_ids), identity_hash,
+                     min(timestamps) if timestamps else None,
+                     max(timestamps) if timestamps else None,
+                     "Expand for the original messages in this summary.",
+                     json.dumps(union_file_ids(chosen))),
+                )
+                conn.execute(
+                    """UPDATE compaction_batches SET state='ready', source_ids=?,
+                       source_identity_hash=?, frontier_end_store_id=?,
+                       expected_leaf_count=1, prepared_leaf_count=1, updated_at=?
+                       WHERE batch_id=?""",
+                    (json.dumps(chosen_ids), identity_hash, max(chosen_ids), time.time(), batch_id),
+                )
+                conn.commit()
+                row = conn.execute("SELECT * FROM compaction_batches WHERE batch_id=?", (batch_id,)).fetchone()
+                return self._batch_from_row(row)
+        except Exception as exc:
+            with self._async_compaction_lock:
+                now = time.time()
+                conn.execute(
+                    """UPDATE compaction_batches SET state='failed', failure_reason=?,
+                       retry_after=?, updated_at=? WHERE batch_id=?""",
+                    (str(exc), now + float(self._config.async_background_compaction_retry_backoff_seconds), now, batch_id),
+                )
+                conn.commit()
+                row = conn.execute("SELECT * FROM compaction_batches WHERE batch_id=?", (batch_id,)).fetchone()
+                return self._batch_from_row(row)
+
+    def reject_prepared_compaction(self, batch_id: str, *, reason: str) -> None:
+        conn = self._store.connection
+        assert conn is not None
+        with self._async_compaction_lock:
+            conn.execute(
+                "UPDATE compaction_batches SET state='rejected', failure_reason=?, updated_at=? WHERE batch_id=? AND state IN ('preparing','ready')",
+                (reason, time.time(), batch_id),
+            )
+            conn.commit()
+
+    def _reject_promotion(self, conn: sqlite3.Connection, batch_id: str, reason: str) -> PromotionResult:
+        conn.execute(
+            "UPDATE compaction_batches SET state=?, failure_reason=?, updated_at=? WHERE batch_id=?",
+            ("superseded" if reason in {"frontier_mismatch", "canonical_source_overlap"} else "rejected", reason, time.time(), batch_id),
+        )
+        conn.commit()
+        return PromotionResult(False, reason, batch_id)
+
+    def promote_prepared_compaction(
+        self,
+        batch_id: str,
+        messages: list[dict[str, Any]],
+    ) -> PromotionResult:
+        # Use a dedicated connection: every canonical mutation below therefore
+        # shares one transaction even though normal stores own separate handles.
+        conn = sqlite3.connect(str(self._store.db_path), timeout=30.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        configure_connection(conn)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM compaction_batches WHERE batch_id=?", (batch_id,)).fetchone()
+            if row is None or row["state"] != "ready":
+                conn.rollback()
+                return PromotionResult(False, "batch_not_ready", batch_id)
+            if not bool(self._config.async_background_compaction_enabled):
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "feature_disabled")
+            if row["session_id"] != self._session_id or row["conversation_id"] != self._conversation_id:
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "session_mismatch")
+            if row["policy_fingerprint"] != self._async_policy_fingerprint():
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "policy_fingerprint_mismatch")
+            if row["route_fingerprint"] != self._async_route_fingerprint():
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "summary_route_fingerprint_mismatch")
+            lifecycle = conn.execute(
+                "SELECT * FROM lcm_lifecycle_state WHERE conversation_id=?",
+                (self._conversation_id,),
+            ).fetchone()
+            live_frontier = int(lifecycle["current_frontier_store_id"] if lifecycle else 0)
+            if live_frontier != int(row["frontier_start_store_id"]):
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "frontier_mismatch")
+            source_ids = tuple(int(value) for value in json.loads(row["source_ids"] or "[]"))
+            if not source_ids or self._source_identity_hash(conn, source_ids) != row["source_identity_hash"]:
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "source_identity_mismatch")
+            # Fresh-tail safety is recomputed from the live messages, not trusted
+            # from persisted preparation metadata.
+            live_tail_start = self._fresh_tail_start(messages)
+            live_tail_ids = set(self._get_store_ids_for_messages(messages[live_tail_start:]))
+            if live_tail_ids.intersection(source_ids):
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "fresh_tail_overlap")
+            canonical_rows = conn.execute(
+                "SELECT source_ids FROM summary_nodes WHERE session_id=? AND source_type='messages'",
+                (self._session_id,),
+            ).fetchall()
+            canonical_sources = {
+                int(value)
+                for canonical in canonical_rows
+                for value in json.loads(canonical[0] or "[]")
+            }
+            if canonical_sources.intersection(source_ids):
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "canonical_source_overlap")
+            pending = conn.execute(
+                "SELECT * FROM pending_summary_nodes WHERE batch_id=? ORDER BY ordinal",
+                (batch_id,),
+            ).fetchall()
+            if len(pending) != int(row["expected_leaf_count"] or 0) or not pending:
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "incomplete_preparation")
+            node_ids: list[int] = []
+            for node in pending:
+                cursor = conn.execute(
+                    """INSERT INTO summary_nodes
+                       (session_id,depth,summary,token_count,source_token_count,
+                        source_ids,source_type,created_at,earliest_at,latest_at,expand_hint,file_ids)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (self._session_id, int(node["depth"]), node["summary"],
+                     int(node["token_count"]), int(node["source_token_count"]),
+                     node["source_ids"], "messages", time.time(), node["earliest_at"],
+                     node["latest_at"], node["expand_hint"], node["file_ids"]),
+                )
+                node_id = int(cursor.lastrowid)
+                node_source_ids = [int(value) for value in json.loads(node["source_ids"] or "[]")]
+                conn.executemany(
+                    """INSERT INTO lcm_summary_message_sources
+                       (summary_node_id,message_store_id,source_ordinal)
+                       VALUES (?,?,?)""",
+                    ((node_id, source_id, ordinal) for ordinal, source_id in enumerate(node_source_ids)),
+                )
+                node_ids.append(node_id)
+            if getattr(self, "_async_compaction_publish_failure_hook", None) == "after_canonical_insert":
+                raise RuntimeError("injected async promotion failure")
+            cursor = conn.execute(
+                """UPDATE lcm_lifecycle_state
+                   SET current_frontier_store_id=?, updated_at=?
+                   WHERE conversation_id=? AND current_session_id=?
+                     AND current_frontier_store_id=?""",
+                (int(row["frontier_end_store_id"]), time.time(), self._conversation_id,
+                 self._session_id, int(row["frontier_start_store_id"])),
+            )
+            if cursor.rowcount != 1:
+                conn.rollback()
+                return self._reject_promotion(conn, batch_id, "frontier_mismatch")
+            conn.execute(
+                "UPDATE compaction_batches SET state='promoted', updated_at=? WHERE batch_id=?",
+                (time.time(), batch_id),
+            )
+            conn.execute(
+                """UPDATE compaction_batches SET state='superseded',
+                   failure_reason='newer_batch_promoted', updated_at=?
+                   WHERE conversation_id=? AND session_id=? AND state='ready' AND batch_id<>?""",
+                (time.time(), self._conversation_id, self._session_id, batch_id),
+            )
+            conn.commit()
+            self._last_compacted_store_id = max(self._last_compacted_store_id, int(row["frontier_end_store_id"]))
+            return PromotionResult(True, "", batch_id, tuple(node_ids))
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def get_async_compaction_status(self) -> dict[str, Any]:
+        enabled = bool(self._config.async_background_compaction_enabled)
+        status = {
+            "enabled": enabled,
+            "worker_enabled": bool(self._config.async_background_compaction_worker_enabled),
+            "pending_batches": 0,
+            "preparing_batches": 0,
+            "prepared_batches": 0,
+            "promoted_batches": 0,
+            "rejected_batches": 0,
+            "superseded_batches": 0,
+            "failed_batches": 0,
+        }
+        conn = self._store.connection
+        if conn is None:
+            return status
+        rows = conn.execute(
+            "SELECT state, COUNT(*) FROM compaction_batches WHERE conversation_id=? GROUP BY state",
+            (self.current_conversation_id or self._conversation_id or "",),
+        ).fetchall()
+        counts = {str(row[0]): int(row[1]) for row in rows}
+        status.update({
+            "pending_batches": counts.get("preparing", 0),
+            "preparing_batches": counts.get("preparing", 0),
+            "prepared_batches": counts.get("ready", 0),
+            "promoted_batches": counts.get("promoted", 0),
+            "rejected_batches": counts.get("rejected", 0),
+            "superseded_batches": counts.get("superseded", 0),
+            "failed_batches": counts.get("failed", 0),
+        })
+        return status
+
+    def _promote_oldest_ready_compaction(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> PromotionResult | None:
+        if not bool(self._config.async_background_compaction_enabled):
+            return None
+        conn = self._store.connection
+        if conn is None:
+            return None
+        row = conn.execute(
+            """SELECT batch_id FROM compaction_batches
+               WHERE conversation_id=? AND session_id=? AND state='ready'
+               ORDER BY created_at LIMIT 1""",
+            (self._conversation_id, self._session_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return self.promote_prepared_compaction(str(row[0]), messages)
+
+    def _schedule_background_compaction(self, messages: list[dict[str, Any]]) -> None:
+        if not (
+            self._config.async_background_compaction_enabled
+            and self._config.async_background_compaction_worker_enabled
+            and count_messages_tokens(messages) >= self.threshold_tokens > 0
+        ):
+            return
+        with self._async_compaction_lock:
+            if self._async_compaction_closed:
+                return
+            if self._async_compaction_worker is not None and self._async_compaction_worker.is_alive():
+                return
+            snapshot = [dict(message) for message in messages]
+
+            def run() -> None:
+                try:
+                    self.prepare_background_compaction_once(snapshot)
+                except Exception:
+                    logger.exception("LCM background compaction preparation failed")
+
+            self._async_compaction_worker = threading.Thread(
+                target=run,
+                name="lcm-background-compaction",
+                daemon=True,
+            )
+            self._async_compaction_worker.start()
+
+    def _close_async_compaction(self) -> None:
+        with self._async_compaction_lock:
+            self._async_compaction_closed = True
+            worker = self._async_compaction_worker
+        if worker is not None and worker.is_alive():
+            worker.join(timeout=2.0)

--- a/command.py
+++ b/command.py
@@ -1272,10 +1272,16 @@ def _doctor_source_apply_text(engine) -> str:
 
 
 def _doctor_text(engine) -> str:
-    db_path = Path(engine._store.db_path)
+    store = getattr(engine, "_store", None)
+    dag = getattr(engine, "_dag", None)
+    db_path = Path(
+        store.db_path
+        if store is not None
+        else engine._resolve_db_path(engine._hermes_home)
+    )
     runtime_identity = engine.get_runtime_identity()
-    store_conn = engine._store.connection
-    dag_conn = engine._dag.connection
+    store_conn = getattr(store, "connection", None)
+    dag_conn = getattr(dag, "connection", None)
 
     issues: list[str] = []
     recommended_actions: list[str] = []
@@ -1504,7 +1510,7 @@ def _doctor_text(engine) -> str:
         recommended_actions.append("inspect payload storage diagnostics before cleanup or deletion")
 
     try:
-        source_stats = engine._store.get_source_stats()
+        source_stats = store.get_source_stats()
     except Exception as exc:  # pragma: no cover - defensive
         issues.append("source_lineage")
         source_stats = {
@@ -1877,14 +1883,10 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
                 "WHERE scope.session_id = messages.session_id)"
             ).fetchall()
         ]
-        msg_cur = conn.execute(
-            f"DELETE FROM messages WHERE EXISTS ("
-            f"SELECT 1 FROM {scope_table} AS scope "
-            "WHERE scope.session_id = messages.session_id)"
-        )
-        archive_chunks = getattr(engine, "_archive_chunks_for_messages", None)
-        if callable(archive_chunks) and deleted_store_ids:
-            archive_chunks(deleted_store_ids, connection=conn)
+        # Delete summaries before their immutable raw sources.  Relational
+        # provenance intentionally uses ON DELETE RESTRICT on message sources;
+        # reversing this order would either fail or punch a hole in retained
+        # lineage.  Both deletes remain inside this one transaction.
         nodes_deleted = 0
         purge = getattr(engine, "_purge_embeddings_for_nodes", None)
         while True:
@@ -1898,6 +1900,15 @@ def _delete_clean_candidates_atomically(engine, session_ids: set[str]) -> dict[s
             nodes_deleted += len(deleted_ids)
             if callable(purge):
                 purge(deleted_ids, connection=conn)
+
+        msg_cur = conn.execute(
+            f"DELETE FROM messages WHERE EXISTS ("
+            f"SELECT 1 FROM {scope_table} AS scope "
+            "WHERE scope.session_id = messages.session_id)"
+        )
+        archive_chunks = getattr(engine, "_archive_chunks_for_messages", None)
+        if callable(archive_chunks) and deleted_store_ids:
+            archive_chunks(deleted_store_ids, connection=conn)
 
         lifecycle_scope = "temp_lcm_delete_lifecycle_scope"
         conn.execute(

--- a/compaction.py
+++ b/compaction.py
@@ -16,10 +16,16 @@ lifecycle) through normal attribute lookup. ``LCMEngine`` mixes this in ahead of
 from __future__ import annotations
 
 import logging
+import sqlite3
 import time
 from typing import Any, Dict, List, Optional
 
 from .dag import SummaryNode
+from .fresh_tail import (
+    fit_active_context_to_token_cap,
+    resolve_emergency_fresh_tail_boundary,
+)
+from .file_registry import union_file_ids
 from .message_content import text_content_for_pattern_matching
 from .sanitize import _contains_sensitive_redaction
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
@@ -31,6 +37,73 @@ _THRESHOLD_FULL_SWEEP_MAX_SECONDS = 120.0
 
 
 class CompactionMixin:
+    def _hard_context_token_cap(self) -> Optional[int]:
+        """Resolve the blocking compaction limit, including safe defaults.
+
+        Explicit assembly guardrails remain authoritative. When both optional
+        assembly knobs are disabled, the model's effective context length is
+        still a real hard limit; treating it as unbounded lets a protected fresh
+        tail grow past the provider window forever.
+        """
+        configured_cap = self._effective_assembly_token_cap()
+        if configured_cap is not None and configured_cap > 0:
+            return configured_cap
+        context_length = max(0, int(getattr(self, "context_length", 0) or 0))
+        if not context_length:
+            return None
+        hard_ratio = float(getattr(self._config, "hard_context_threshold", 0.85) or 0.85)
+        hard_ratio = min(1.0, max(float(self.context_threshold), hard_ratio))
+        return max(1, int(context_length * hard_ratio))
+
+    def _requires_hard_pressure_recovery(
+        self,
+        *,
+        observed_tokens: Optional[int] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        if self._should_force_overflow_recovery(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        ):
+            return True
+        cap = self._hard_context_token_cap()
+        if cap is None:
+            return False
+        if messages is not None:
+            # With no explicit assembly guardrail the derived cap constrains the
+            # active message view. Provider prompt totals may include a large or
+            # stale system/tool-schema overhead that this engine cannot compact.
+            return count_messages_tokens(messages) >= cap
+        return bool(observed_tokens is not None and observed_tokens >= cap)
+
+    def _hard_pressure_assembly_cap(
+        self,
+        *,
+        observed_tokens: Optional[int],
+        messages: List[Dict[str, Any]],
+    ) -> Optional[int]:
+        configured = self._overflow_recovery_assembly_cap(
+            observed_tokens=observed_tokens,
+            messages=messages,
+        )
+        if configured is not None:
+            return configured
+        cap = self._hard_context_token_cap()
+        if cap is None:
+            return None
+        return cap
+
+    @staticmethod
+    def _compaction_fresh_tail_start(
+        messages: List[Dict[str, Any]],
+        *,
+        shrink_protected_tail: bool,
+        normal_start: int,
+    ) -> int:
+        if not shrink_protected_tail:
+            return normal_start
+        return resolve_emergency_fresh_tail_boundary(messages).start
+
     def _maybe_reclassify_late_auxiliary_before_compaction_write(self) -> None:
         maybe_reclassify = getattr(
             self,
@@ -52,7 +125,7 @@ class CompactionMixin:
                     tokens = self._current_auxiliary_prompt_tokens(auxiliary_session_id)
                 else:
                     tokens = self.last_prompt_tokens
-            if self._should_force_overflow_recovery(observed_tokens=tokens):
+            if self._requires_hard_pressure_recovery(observed_tokens=tokens):
                 return True
             if self.threshold_tokens <= 0:
                 return False
@@ -60,10 +133,14 @@ class CompactionMixin:
         if self._compression_boundary_cooldown_active():
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        if self._should_force_overflow_recovery(observed_tokens=tokens):
+        if self._requires_hard_pressure_recovery(observed_tokens=tokens):
             return True
         if self.threshold_tokens <= 0:
             return False
+        if bool(getattr(self._config, "async_background_compaction_enabled", False)):
+            hard_cap = self._hard_context_token_cap()
+            if hard_cap is not None and tokens < hard_cap:
+                return False
         return tokens >= self.threshold_tokens
 
     def should_compress_preflight(self, messages):
@@ -75,10 +152,11 @@ class CompactionMixin:
             rough = count_messages_tokens(messages)
             if self._compression_boundary_cooldown_active():
                 return False
-            if self._should_force_overflow_recovery(observed_tokens=rough, messages=messages):
+            if self._requires_hard_pressure_recovery(observed_tokens=rough, messages=messages):
                 return True
             return self.threshold_tokens > 0 and rough >= self.threshold_tokens
-        rough = count_messages_tokens(messages)
+        native_boundary = self._native_compaction_boundary(messages)
+        rough = count_messages_tokens(self._provider_effective_messages(messages))
         pre_ingest_placeholder_ambiguous_noop = False
         pre_ingest_noop_reason = ""
         if (
@@ -102,7 +180,7 @@ class CompactionMixin:
         replay_messages = None
         if self._session_id and messages:
             try:
-                replay_messages = self._ingest_messages(messages)
+                replay_messages = self._ingest_messages(messages, durable_on_lock=True)
                 self._record_ingest_success()
             except Exception as e:
                 # Fail closed for NORMAL threshold compaction: the store did not
@@ -112,8 +190,28 @@ class CompactionMixin:
                 # job is to keep the prompt under the provider limit; it converges
                 # via deterministic L3 truncation without needing the store write.
                 self._record_ingest_failure("preflight", e)
-                if self._should_force_overflow_recovery(observed_tokens=rough):
+                if native_boundary is not None:
+                    return False
+                if self._requires_hard_pressure_recovery(
+                    observed_tokens=rough,
+                    messages=messages,
+                ):
                     return True
+                return False
+        if native_boundary is not None:
+            if replay_messages is not None and replay_messages != messages:
+                return self._mark_preflight_compression_requested()
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = "provider-native compaction boundary active"
+            return False
+        if bool(getattr(self._config, "async_background_compaction_enabled", False)):
+            promoted = self._promote_oldest_ready_compaction(messages)
+            if promoted is not None and promoted.promoted:
+                self._preflight_async_promotion_only = True
+                return self._mark_preflight_compression_requested()
+            self._schedule_background_compaction(replay_messages or messages)
+            hard_cap = self._hard_context_token_cap()
+            if hard_cap is not None and rough < hard_cap:
                 return False
         if replay_messages is not None and replay_messages != messages:
             replay_rough = count_messages_tokens(replay_messages)
@@ -121,10 +219,10 @@ class CompactionMixin:
                 messages,
                 replay_messages,
             )
-            force_overflow_requested = self._should_force_overflow_recovery(
+            force_overflow_requested = self._requires_hard_pressure_recovery(
                 observed_tokens=rough,
                 messages=messages,
-            ) or self._should_force_overflow_recovery(
+            ) or self._requires_hard_pressure_recovery(
                 observed_tokens=replay_rough,
                 messages=replay_messages,
             )
@@ -174,7 +272,10 @@ class CompactionMixin:
             return False
         if self._compression_boundary_cooldown_active():
             return False
-        if self._should_force_overflow_recovery(observed_tokens=rough):
+        if self._requires_hard_pressure_recovery(
+            observed_tokens=rough,
+            messages=messages,
+        ):
             return self._mark_preflight_compression_requested()
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
             if pre_ingest_placeholder_ambiguous_noop:
@@ -359,6 +460,22 @@ class CompactionMixin:
                 focus_topic=focus_topic,
                 force=force,
             )
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower():
+                self._last_compression_status = "error"
+                self._last_compression_noop_reason = ""
+                raise
+            # A transient writer collision must never abort the user turn.
+            # Spool any unpersisted suffix durably, preserve the full active
+            # context, and retry compaction on a later turn.
+            try:
+                replay = self._ingest_messages(messages, durable_on_lock=True)
+            except Exception:
+                replay = messages
+            self._record_ingest_failure("compression", exc)
+            self._last_compression_status = "noop"
+            self._last_compression_noop_reason = "sqlite writer busy; compaction deferred"
+            return self._remember_active_replay_messages(messages, replay)
         except BaseException:
             self._last_compression_status = "error"
             self._last_compression_noop_reason = ""
@@ -385,6 +502,31 @@ class CompactionMixin:
         self._last_compression_noop_reason = ""
         _compress_started = time.perf_counter()
 
+        if self._native_compaction_boundary(messages) is not None:
+            replay_messages = self._ingest_messages(messages, durable_on_lock=True)
+            changed = replay_messages != messages
+            self._last_compression_status = "compacted" if changed else "noop"
+            self._last_compression_noop_reason = (
+                "" if changed else "provider-native compaction boundary active"
+            )
+            return self._remember_active_replay_messages(messages, replay_messages)
+
+        if self._preflight_async_promotion_only:
+            self._preflight_async_promotion_only = False
+            working_messages = self._ingest_messages(messages, durable_on_lock=True)
+            leading = self._leading_anchor_count(working_messages)
+            tail_start = self._fresh_tail_start(working_messages)
+            compressed = self._assemble_context(
+                working_messages[0] if leading else None,
+                working_messages[max(leading, tail_start):],
+            )
+            self._ingest_cursor = len(compressed)
+            self.compression_count += 1
+            self._last_compression_status = "compacted"
+            self._last_compression_noop_reason = ""
+            self._last_compaction_duration_ms = (time.perf_counter() - _compress_started) * 1000.0
+            return self._remember_active_replay_messages(compressed, compressed)
+
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             bypass_current_tokens = current_tokens
@@ -404,9 +546,18 @@ class CompactionMixin:
             )
 
         observed_prompt_tokens = current_tokens if current_tokens is not None else None
-        force_overflow = self._should_force_overflow_recovery(
+        force_overflow = self._requires_hard_pressure_recovery(
             observed_tokens=observed_prompt_tokens,
             messages=messages,
+        )
+        # Existing explicit assembly caps already have a bounded active-tail
+        # selector. Override the normal protected suffix only for the previously
+        # unbounded default case where context_length supplies the hard cap.
+        shrink_protected_tail = bool(
+            force_overflow
+            and self._effective_assembly_token_cap() is None
+            and int(getattr(self, "context_length", 0) or 0) > 0
+            and count_messages_tokens(messages) >= int(self.context_length)
         )
         # NOTE: deliberately do NOT clear the spend guard on force_overflow.
         # force_overflow is automatic (set every turn the prompt exceeds the
@@ -415,7 +566,7 @@ class CompactionMixin:
         # in the case it exists for. A tripped guard still converges the
         # emergency via deterministic L3 truncation (no LLM spend).
         recovery_assembly_cap = (
-            self._overflow_recovery_assembly_cap(
+            self._hard_pressure_assembly_cap(
                 observed_tokens=observed_prompt_tokens,
                 messages=messages,
             )
@@ -426,8 +577,29 @@ class CompactionMixin:
         # Step 1: Ingest new messages into the immutable store. Work from a
         # replay-safe view so quarantined assistant loops do not enter summaries
         # or provider context after the durable row has been written.
-        working_messages = self._ingest_messages(messages)
+        working_messages = self._ingest_messages(messages, durable_on_lock=True)
         ingest_cleanup_changed_active_context = working_messages != messages
+        if self._effective_assembly_token_cap() is None:
+            # Ignore/redaction cleanup can remove the content that created the
+            # apparent pressure. Re-evaluate the derived context-length limit on
+            # the provider-visible replay before sacrificing fresh-tail history.
+            force_overflow = self._requires_hard_pressure_recovery(
+                observed_tokens=observed_prompt_tokens,
+                messages=working_messages,
+            )
+            shrink_protected_tail = bool(
+                force_overflow
+                and int(getattr(self, "context_length", 0) or 0) > 0
+                and count_messages_tokens(working_messages) >= int(self.context_length)
+            )
+            recovery_assembly_cap = (
+                self._hard_pressure_assembly_cap(
+                    observed_tokens=observed_prompt_tokens,
+                    messages=working_messages,
+                )
+                if force_overflow
+                else None
+            )
         cleanup_only_due_to_boundary_cooldown = bool(
             self._preflight_cleanup_only_due_to_boundary_cooldown
             and not force_overflow
@@ -531,7 +703,11 @@ class CompactionMixin:
             if threshold_full_sweep_active and time.monotonic() >= sweep_deadline:
                 sweep_stop_reason = "time_budget_exhausted"
                 break
-            fresh_tail_start = self._fresh_tail_start(pressure_messages)
+            fresh_tail_start = self._compaction_fresh_tail_start(
+                pressure_messages,
+                shrink_protected_tail=shrink_protected_tail,
+                normal_start=self._fresh_tail_start(pressure_messages),
+            )
 
             # Keep only a real system prompt anchored. Gateway sessions may
             # pass only conversation messages, so index 0 can be an old user
@@ -556,7 +732,11 @@ class CompactionMixin:
                 working_messages = working_messages[:leading_anchor_count] + working_messages[candidate_start:]
                 pressure_messages = pressure_messages[:leading_anchor_count] + pressure_messages[candidate_start:]
                 candidate_start = leading_anchor_count
-                fresh_tail_start = self._fresh_tail_start(pressure_messages)
+                fresh_tail_start = self._compaction_fresh_tail_start(
+                    pressure_messages,
+                    shrink_protected_tail=shrink_protected_tail,
+                    normal_start=self._fresh_tail_start(pressure_messages),
+                )
                 if fresh_tail_start <= leading_anchor_count:
                     noop_reason = "selected leaf chunk lacks raw store lineage"
                     break
@@ -623,7 +803,11 @@ class CompactionMixin:
                         + kept_pressure
                         + pressure_messages[fresh_tail_start:]
                     )
-                    fresh_tail_start = self._fresh_tail_start(pressure_messages)
+                    fresh_tail_start = self._compaction_fresh_tail_start(
+                        pressure_messages,
+                        shrink_protected_tail=shrink_protected_tail,
+                        normal_start=self._fresh_tail_start(pressure_messages),
+                    )
                 if drop_dependent_reply_into_tail:
                     tail_scan_start = max(fresh_tail_start, leading_anchor_count)
                     pending_tail_dependents: list[tuple[Dict[str, Any], str]] = []
@@ -679,10 +863,10 @@ class CompactionMixin:
                             "raw backlog outside fresh tail is below leaf chunk threshold"
                         )
                         break
-                if force_overflow:
-                    to_compact = candidate_raw
-                else:
-                    to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
+                to_compact = self._select_oldest_leaf_chunk(
+                    candidate_raw,
+                    working_leaf_chunk_tokens,
+                )
             else:
                 if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
                     if not (deferred_maintenance_active and critical_budget_pressure):
@@ -773,31 +957,81 @@ class CompactionMixin:
             source_lineage_chunk = [
                 message for message in source_lookup_chunk if id(message) not in dependent_reply_message_ids
             ]
-            source_store_ids = self._get_store_ids_for_messages(source_lineage_chunk)
-            source_store_ids = sorted(dict.fromkeys(source_store_ids))
-            consumed_store_ids = self._get_store_ids_for_messages(source_lookup_chunk)
-            consumed_store_ids = sorted(dict.fromkeys(consumed_store_ids))
-            earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
+            # Use the full active-replay map captured before selection. Rebuilding
+            # a map from only the selected subset changes duplicate-occurrence
+            # accounting and can falsely classify a valid persisted row as
+            # synthetic when older identical messages exist.
+            lineage_map = self._current_compress_store_ids_by_message_id or {}
+            raw_source_store_ids = [
+                lineage_map[id(message)]
+                for message in source_lineage_chunk
+                if id(message) in lineage_map
+            ]
+            raw_consumed_store_ids = [
+                lineage_map[id(message)]
+                for message in source_lookup_chunk
+                if id(message) in lineage_map
+            ]
+            filtered_only_marker = not summary_input_chunk
+            if filtered_only_marker and len(raw_consumed_store_ids) != len(source_lookup_chunk):
+                raise RuntimeError(
+                    "LCM refused leaf publication: selected compacted content "
+                    "lacks complete raw store lineage"
+                )
+            if not filtered_only_marker and len(raw_source_store_ids) != len(source_lineage_chunk):
+                raise RuntimeError(
+                    "LCM refused leaf publication: summarized content lacks "
+                    "complete raw store lineage"
+                )
+            source_store_ids = sorted(dict.fromkeys(raw_source_store_ids))
+            consumed_store_ids = sorted(dict.fromkeys(raw_consumed_store_ids))
+            if not filtered_only_marker and not source_store_ids:
+                raise RuntimeError(
+                    "LCM refused leaf publication: raw store lineage is empty"
+                )
             summary_tokens = count_tokens(summary_text)
+            conversation_id = self._conversation_id or self._session_id
+            lifecycle_state = self._lifecycle.get_by_conversation(conversation_id)
+            if lifecycle_state is None or lifecycle_state.current_session_id != self._session_id:
+                self._lifecycle.bind_session(
+                    self._session_id,
+                    conversation_id=conversation_id,
+                )
 
-            node = SummaryNode(
-                session_id=self._session_id,
-                depth=0,
-                summary=summary_text,
-                token_count=summary_tokens,
-                source_token_count=source_tokens,
-                source_ids=source_store_ids,
-                source_type="messages",
-                created_at=time.time(),
-                earliest_at=earliest_at,
-                latest_at=latest_at,
-                expand_hint=self._extract_expand_hint(summary_text),
-            )
-            self._dag.add_node(node)
-            self._invalidate_rollups_for_published_node(node)
-            self._maybe_gc_compacted_tool_results(compacted_chunk, source_store_ids)
+            if filtered_only_marker:
+                # Dependent replies intentionally excluded from summarization
+                # stay available as immutable raw rows.  Advance the consumed
+                # frontier without publishing a misleading summary edge to
+                # content the summarizer was forbidden to inspect.
+                self._lifecycle.advance_frontier(
+                    conversation_id,
+                    self._session_id,
+                    max(consumed_store_ids),
+                )
+            else:
+                earliest_at, latest_at = self._store.get_time_bounds(source_store_ids)
+                node = SummaryNode(
+                    session_id=self._session_id,
+                    depth=0,
+                    summary=summary_text,
+                    token_count=summary_tokens,
+                    source_token_count=source_tokens,
+                    source_ids=source_store_ids,
+                    source_type="messages",
+                    created_at=time.time(),
+                    earliest_at=earliest_at,
+                    latest_at=latest_at,
+                    expand_hint=self._extract_expand_hint(summary_text),
+                    file_ids=list(union_file_ids(source_lookup_chunk)),
+                )
+                self._dag.publish_node_and_advance_frontier(
+                    node,
+                    conversation_id=conversation_id,
+                    frontier_store_id=max(consumed_store_ids),
+                )
+                self._invalidate_rollups_for_published_node(node)
+                self._maybe_gc_compacted_tool_results(compacted_chunk, source_store_ids)
             self._last_compacted_store_id = max(consumed_store_ids) if consumed_store_ids else 0
-            self._persist_frontier_marker()
 
             pressure_remaining_messages = pressure_messages[leading_anchor_count + selected_raw_len:]
             working_messages = working_messages[:leading_anchor_count] + remaining_messages
@@ -808,7 +1042,11 @@ class CompactionMixin:
 
             if threshold_full_sweep_active:
                 leading_anchor_count = self._leading_anchor_count(working_messages)
-                remaining_fresh_tail_start = self._fresh_tail_start(pressure_messages)
+                remaining_fresh_tail_start = self._compaction_fresh_tail_start(
+                    pressure_messages,
+                    shrink_protected_tail=shrink_protected_tail,
+                    normal_start=self._fresh_tail_start(pressure_messages),
+                )
                 remaining_raw = working_messages[
                     leading_anchor_count:remaining_fresh_tail_start
                 ]
@@ -825,7 +1063,11 @@ class CompactionMixin:
                 if (not deferred_maintenance_active) and self.threshold_tokens > 0 and estimated_active_tokens < self.threshold_tokens:
                     break
                 leading_anchor_count = self._leading_anchor_count(working_messages)
-                remaining_fresh_tail_start = self._fresh_tail_start(pressure_messages)
+                remaining_fresh_tail_start = self._compaction_fresh_tail_start(
+                    pressure_messages,
+                    shrink_protected_tail=shrink_protected_tail,
+                    normal_start=self._fresh_tail_start(pressure_messages),
+                )
                 remaining_raw = working_messages[
                     leading_anchor_count:remaining_fresh_tail_start
                 ]
@@ -839,6 +1081,22 @@ class CompactionMixin:
                 if remaining_raw_tokens < remaining_threshold:
                     if not (deferred_maintenance_active and critical_budget_pressure):
                         break
+            else:
+                # Blocking recovery still compacts deterministic oldest blocks
+                # rather than collapsing the whole backlog into one node. Once
+                # the active estimate reaches the ordinary target, stop; if no
+                # soft target is configured, the hard cap is the target.
+                recovery_target = (
+                    self.threshold_tokens
+                    if self.threshold_tokens > 0
+                    else (self._hard_context_token_cap() or 0)
+                )
+                if (
+                    recovery_target > 0
+                    and estimated_active_tokens < recovery_target
+                    and not critical_budget_pressure
+                ):
+                    break
 
         if (
             threshold_full_sweep_active
@@ -860,6 +1118,14 @@ class CompactionMixin:
                     working_messages[leading_anchor_count:],
                     assembly_cap_override=recovery_assembly_cap,
                 )
+                if (
+                    recovery_assembly_cap is not None
+                    and count_messages_tokens(compressed) >= recovery_assembly_cap
+                ):
+                    compressed = fit_active_context_to_token_cap(
+                        compressed,
+                        recovery_assembly_cap,
+                    )
                 return self._finalize_forced_overflow_result(
                     working_messages,
                     compressed,
@@ -965,6 +1231,14 @@ class CompactionMixin:
             )
         finally:
             self._pending_context_anchor_messages = None
+        if (
+            recovery_assembly_cap is not None
+            and count_messages_tokens(compressed) >= recovery_assembly_cap
+        ):
+            compressed = fit_active_context_to_token_cap(
+                compressed,
+                recovery_assembly_cap,
+            )
         self.compression_count += 1
         self._last_compaction_duration_ms = (time.perf_counter() - _compress_started) * 1000.0
         logger.info(
@@ -1037,5 +1311,43 @@ class CompactionMixin:
         self._write_generated_ignored_placeholder_hash_ordinals(
             self._generated_placeholder_digest_ordinals_for_active_replay(compressed)
         )
+        # The host continues from the reassembled transcript, not from the raw
+        # input that _ingest_messages cached at the start of this call.  Keep
+        # the replay cache aligned with that returned transcript so the next
+        # appended turn can trust the numeric cursor.  Without this, the
+        # prefix-identity guard correctly notices a replacement but then has to
+        # reconstruct the boundary from storage; synthetic summary scaffolding
+        # can be mistaken for new immutable messages during that fallback.
+        return self._remember_active_replay_messages(compressed, compressed)
+    @staticmethod
+    def _native_compaction_boundary(messages: List[Dict[str, Any]]) -> int | None:
+        """Return the newest valid provider-native compaction turn index."""
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            items = message.get("codex_compaction_items")
+            if isinstance(items, list) and any(
+                isinstance(item, dict)
+                and item.get("type") == "compaction"
+                and isinstance(item.get("encrypted_content"), str)
+                and bool(item.get("encrypted_content"))
+                for item in items
+            ):
+                return index
+        return None
 
-        return compressed
+    @classmethod
+    def _provider_effective_messages(
+        cls, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Count only the canonical suffix after native server compaction."""
+        boundary = cls._native_compaction_boundary(messages)
+        if boundary is None:
+            return messages
+        leading_system = (
+            [messages[0]]
+            if boundary > 0 and messages and messages[0].get("role") == "system"
+            else []
+        )
+        return leading_system + messages[boundary:]

--- a/config.py
+++ b/config.py
@@ -313,6 +313,11 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("fresh_tail_max_tokens", "LCM_FRESH_TAIL_MAX_TOKENS", int),
     _EnvFieldSpec("leaf_chunk_tokens", "LCM_LEAF_CHUNK_TOKENS", int),
     _EnvFieldSpec("context_threshold", "LCM_CONTEXT_THRESHOLD", float),
+    _EnvFieldSpec("hard_context_threshold", "LCM_HARD_CONTEXT_THRESHOLD", float),
+    _EnvFieldSpec("async_background_compaction_enabled", "LCM_ASYNC_BACKGROUND_COMPACTION_ENABLED", bool),
+    _EnvFieldSpec("async_background_compaction_worker_enabled", "LCM_ASYNC_BACKGROUND_COMPACTION_WORKER_ENABLED", bool),
+    _EnvFieldSpec("async_background_compaction_max_batches", "LCM_ASYNC_BACKGROUND_COMPACTION_MAX_BATCHES", int),
+    _EnvFieldSpec("async_background_compaction_retry_backoff_seconds", "LCM_ASYNC_BACKGROUND_COMPACTION_RETRY_BACKOFF_SECONDS", float),
     _EnvFieldSpec("incremental_max_depth", "LCM_INCREMENTAL_MAX_DEPTH", int),
     _EnvFieldSpec("condensation_fanin", "LCM_CONDENSATION_FANIN", int),
     _EnvFieldSpec("dynamic_leaf_chunk_enabled", "LCM_DYNAMIC_LEAF_CHUNK_ENABLED", bool),
@@ -455,6 +460,14 @@ class LCMConfig:
     leaf_chunk_tokens: int = 20_000
     # Fraction of context window that triggers compaction (0.0–1.0)
     context_threshold: float = 0.35
+    # Hard pressure always blocks for a convergent foreground compaction.  The
+    # soft threshold above may instead prepare summaries in the background.
+    hard_context_threshold: float = 0.85
+    # Background compaction is opt-in until a host explicitly enables it.
+    async_background_compaction_enabled: bool = False
+    async_background_compaction_worker_enabled: bool = False
+    async_background_compaction_max_batches: int = 2
+    async_background_compaction_retry_backoff_seconds: float = 300.0
     # Mirror Hermes Agent's Codex gpt-5.5 route-specific threshold auto-raise
     # when LCM is inheriting the host compression threshold. Explicit LCM
     # threshold overrides remain authoritative.

--- a/dag.py
+++ b/dag.py
@@ -25,6 +25,7 @@ from .db_bootstrap import (
     add_column_if_missing,
     configure_connection,
     ensure_external_content_fts,
+    ensure_relational_summary_provenance,
     refuse_schema_version_too_new,
     run_versioned_migrations,
 )
@@ -152,6 +153,7 @@ class SummaryNode:
     earliest_at: float | None = None
     latest_at: float | None = None
     expand_hint: str = ""  # "Expand for details about: ..."
+    file_ids: List[str] = field(default_factory=list)
     search_rank: float | None = None
     search_directness: float = 0.0
 
@@ -196,7 +198,8 @@ class SummaryDAG:
                 created_at REAL NOT NULL,
                 earliest_at REAL,
                 latest_at REAL,
-                expand_hint TEXT DEFAULT ''
+                expand_hint TEXT DEFAULT '',
+                file_ids TEXT NOT NULL DEFAULT '[]'
             );
             CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
                 ON summary_nodes(session_id, depth, created_at);
@@ -216,6 +219,7 @@ class SummaryDAG:
         )
         run_versioned_migrations(self._conn)
         self._ensure_source_window_columns()
+        ensure_relational_summary_provenance(self._conn)
         self._conn.commit()
 
     def _ensure_source_window_columns(self) -> None:
@@ -229,6 +233,10 @@ class SummaryDAG:
         add_column_if_missing(
             self._conn, columns, "latest_at",
             "ALTER TABLE summary_nodes ADD COLUMN latest_at REAL",
+        )
+        add_column_if_missing(
+            self._conn, columns, "file_ids",
+            "ALTER TABLE summary_nodes ADD COLUMN file_ids TEXT NOT NULL DEFAULT '[]'",
         )
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_nodes_session_latest ON summary_nodes(session_id, latest_at, created_at)"
@@ -244,31 +252,203 @@ class SummaryDAG:
 
     # -- Write --------------------------------------------------------------
 
-    def add_node(self, node: SummaryNode) -> int:
-        """Insert a summary node and return its node_id."""
-        with self._db_lock:
-            cur = self._conn.execute(
+    @staticmethod
+    def _validated_source_ids(
+        conn: sqlite3.Connection,
+        node: SummaryNode,
+        *,
+        allow_empty_legacy_store: bool,
+    ) -> tuple[list[int], bool]:
+        """Validate a node's source set before any canonical row is inserted.
+
+        The boolean result says whether relational edges should be published.
+        A completely empty target table is tolerated only for old standalone
+        DAG clients/tests which historically used synthetic IDs without opening
+        the message store.  Real compaction always persists sources first.
+        """
+        if node.source_type not in {"messages", "nodes"}:
+            raise ValueError("source_type must be 'messages' or 'nodes'")
+        source_ids: list[int] = []
+        for raw_value in node.source_ids:
+            try:
+                source_id = int(raw_value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"invalid source id: {raw_value!r}") from exc
+            if source_id not in source_ids:
+                source_ids.append(source_id)
+        if not source_ids:
+            return source_ids, True
+
+        edge_table = (
+            "lcm_summary_message_sources"
+            if node.source_type == "messages"
+            else "lcm_summary_node_sources"
+        )
+        provenance_ready = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+            (edge_table,),
+        ).fetchone()
+        if not provenance_ready:
+            if allow_empty_legacy_store:
+                return source_ids, False
+            raise RuntimeError("relational summary provenance schema is unavailable")
+
+        if node.source_type == "messages":
+            rows = conn.execute(
+                f"SELECT store_id, session_id FROM messages WHERE store_id IN "
+                f"({','.join('?' for _ in source_ids)})",
+                source_ids,
+            ).fetchall()
+            by_id = {int(row[0]): str(row[1]) for row in rows}
+            missing = [value for value in source_ids if value not in by_id]
+            if missing:
+                target_count = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+                if allow_empty_legacy_store and target_count == 0:
+                    logger.debug(
+                        "LCM retaining JSON-only synthetic message lineage because the message store is empty: %s",
+                        missing,
+                    )
+                    return source_ids, False
+                raise ValueError(f"message source does not exist: {missing[0]}")
+            # Message lineage may intentionally aggregate immutable evidence
+            # across conversations. Node-to-node edges remain session-local so
+            # the per-session DAG itself stays acyclic and independently
+            # traversable.
+            return source_ids, True
+
+        rows = conn.execute(
+            f"SELECT node_id, session_id, depth FROM summary_nodes WHERE node_id IN "
+            f"({','.join('?' for _ in source_ids)})",
+            source_ids,
+        ).fetchall()
+        by_id = {int(row[0]): (str(row[1]), int(row[2])) for row in rows}
+        missing = [value for value in source_ids if value not in by_id]
+        if missing:
+            raise ValueError(f"node source does not exist: {missing[0]}")
+        cross_session = [value for value in source_ids if by_id[value][0] != node.session_id]
+        if cross_session:
+            raise ValueError(f"node source must belong to the same session: {cross_session[0]}")
+        invalid_depth = [value for value in source_ids if by_id[value][1] >= int(node.depth)]
+        if invalid_depth:
+            raise ValueError(
+                f"node source must have lower depth than its parent: {invalid_depth[0]}"
+            )
+        return source_ids, True
+
+    @classmethod
+    def _insert_node_on_connection(
+        cls,
+        conn: sqlite3.Connection,
+        node: SummaryNode,
+        *,
+        allow_empty_legacy_store: bool,
+    ) -> int:
+        source_ids, publish_edges = cls._validated_source_ids(
+            conn,
+            node,
+            allow_empty_legacy_store=allow_empty_legacy_store,
+        )
+        cur = conn.execute(
                 """INSERT INTO summary_nodes
                    (session_id, depth, summary, token_count, source_token_count,
-                    source_ids, source_type, created_at, earliest_at, latest_at, expand_hint)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    source_ids, source_type, created_at, earliest_at, latest_at, expand_hint,
+                    file_ids)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     node.session_id,
                     node.depth,
                     node.summary,
                     node.token_count,
                     node.source_token_count,
-                    json.dumps(node.source_ids),
+                    json.dumps(source_ids),
                     node.source_type,
                     node.created_at or time.time(),
                     node.earliest_at,
                     node.latest_at,
                     node.expand_hint,
+                    json.dumps(list(dict.fromkeys(str(value) for value in node.file_ids))),
                 ),
             )
-            self._conn.commit()
-            node.node_id = cur.lastrowid
-            return node.node_id
+        node_id = int(cur.lastrowid)
+        if publish_edges and source_ids:
+            if node.source_type == "messages":
+                conn.executemany(
+                    "INSERT INTO lcm_summary_message_sources"
+                    "(summary_node_id, message_store_id, source_ordinal) VALUES (?, ?, ?)",
+                    ((node_id, source_id, ordinal) for ordinal, source_id in enumerate(source_ids)),
+                )
+            else:
+                conn.executemany(
+                    "INSERT INTO lcm_summary_node_sources"
+                    "(summary_node_id, source_node_id, source_ordinal) VALUES (?, ?, ?)",
+                    ((node_id, source_id, ordinal) for ordinal, source_id in enumerate(source_ids)),
+                )
+        return node_id
+
+    def add_node(self, node: SummaryNode) -> int:
+        """Insert a summary node and its validated provenance atomically."""
+        with self._db_lock:
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                node_id = self._insert_node_on_connection(
+                    self._conn,
+                    node,
+                    allow_empty_legacy_store=True,
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            node.node_id = node_id
+            node.source_ids = list(dict.fromkeys(int(value) for value in node.source_ids))
+            return node_id
+
+    def publish_node_and_advance_frontier(
+        self,
+        node: SummaryNode,
+        *,
+        conversation_id: str,
+        frontier_store_id: int,
+    ) -> int:
+        """Atomically publish canonical summary lineage and its checkpoint.
+
+        A missing/mismatched lifecycle binding is an error: committing a node
+        without the matching frontier would make the same source range eligible
+        for compaction again after restart.
+        """
+        if not conversation_id:
+            raise ValueError("conversation_id is required for atomic publication")
+        with self._db_lock:
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                node_id = self._insert_node_on_connection(
+                    self._conn,
+                    node,
+                    allow_empty_legacy_store=False,
+                )
+                cursor = self._conn.execute(
+                    """UPDATE lcm_lifecycle_state
+                       SET current_frontier_store_id = MAX(current_frontier_store_id, ?),
+                           updated_at = ?
+                       WHERE conversation_id = ? AND current_session_id = ?""",
+                    (
+                        int(frontier_store_id or 0),
+                        time.time(),
+                        conversation_id,
+                        node.session_id,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise ValueError(
+                        "lifecycle session is not bound for atomic summary publication"
+                    )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            node.node_id = node_id
+            node.source_ids = list(dict.fromkeys(int(value) for value in node.source_ids))
+            return node_id
 
     @staticmethod
     def stage_delete_session_scope(
@@ -309,21 +489,73 @@ class SummaryDAG:
             return []
         where = "1 = 1"
         args: list[object] = []
-        order = "n.session_id, n.node_id"
+        # Delete parents before their sources so FK RESTRICT never observes a
+        # dangling retained parent.  Depth is a topological rank for all newly
+        # validated edges.
+        order = "n.session_id, n.depth DESC, n.node_id"
+        required_cte = ""
+        required_filter = ""
         if min_depth is not None:
             where += " AND n.depth < ?"
             args.append(int(min_depth))
-            order = "n.session_id, n.depth, n.node_id"
+            # Retained high-level nodes are useful only while every lower-level
+            # node in their transitive lineage remains expandable.  Traverse
+            # the compatibility JSON cache as well as relational provenance so
+            # databases created before the edge-table migration are safe too.
+            required_cte = f"""
+                WITH RECURSIVE required(node_id) AS (
+                    SELECT retained.node_id
+                    FROM summary_nodes AS retained
+                    JOIN {_DELETE_SESSION_SCOPE_TABLE} AS retained_scope
+                      ON retained_scope.session_id = retained.session_id
+                    WHERE retained.depth >= ?
+                    UNION
+                    SELECT CAST(j.value AS INTEGER)
+                    FROM required AS r
+                    JOIN summary_nodes AS parent ON parent.node_id = r.node_id
+                    JOIN json_each(
+                        CASE WHEN json_valid(parent.source_ids)
+                             THEN parent.source_ids ELSE '[]' END
+                    ) AS j
+                    JOIN summary_nodes AS child
+                      ON child.node_id = CAST(j.value AS INTEGER)
+                     AND child.session_id = parent.session_id
+                    WHERE parent.source_type = 'nodes'
+                )
+            """
+            args.insert(0, int(min_depth))
+            required_filter = " AND NOT EXISTS (SELECT 1 FROM required WHERE required.node_id = n.node_id)"
         rows = conn.execute(
-            f"SELECT n.node_id FROM summary_nodes AS n "
+            f"{required_cte} SELECT n.node_id FROM summary_nodes AS n "
             f"JOIN {_DELETE_SESSION_SCOPE_TABLE} AS scope "
-            f"ON scope.session_id = n.session_id WHERE {where} "
+            f"ON scope.session_id = n.session_id WHERE {where}{required_filter} "
             f"ORDER BY {order} LIMIT ?",
             (*args, limit),
         ).fetchall()
         node_ids = [int(row[0]) for row in rows]
         if node_ids:
             id_placeholders = ",".join("?" for _ in node_ids)
+            # Parent deletions cascade these rows too.  Deleting explicitly in
+            # the batch also handles an old SQLite build with FK enforcement
+            # disabled on the caller-owned connection.
+            available_tables = {
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'lcm_summary_%_sources'"
+                ).fetchall()
+            }
+            if "lcm_summary_node_sources" in available_tables:
+                conn.execute(
+                    f"DELETE FROM lcm_summary_node_sources "
+                    f"WHERE summary_node_id IN ({id_placeholders})",
+                    node_ids,
+                )
+            if "lcm_summary_message_sources" in available_tables:
+                conn.execute(
+                    f"DELETE FROM lcm_summary_message_sources "
+                    f"WHERE summary_node_id IN ({id_placeholders})",
+                    node_ids,
+                )
             conn.execute(
                 f"DELETE FROM summary_nodes WHERE node_id IN ({id_placeholders})",
                 node_ids,
@@ -849,6 +1081,7 @@ class SummaryDAG:
             "source_token_count": node.source_token_count,
             "source_type": node.source_type,
             "num_sources": len(node.source_ids),
+            "file_ids": node.file_ids,
             "earliest_at": node.earliest_at,
             "latest_at": node.latest_at,
             "expand_hint": node.expand_hint,
@@ -871,7 +1104,8 @@ class SummaryDAG:
             earliest_at=row[9],
             latest_at=row[10],
             expand_hint=row[11] or "",
-            search_rank=row[12] if len(row) > 12 else None,
+            file_ids=json.loads(row[12]) if len(row) > 12 and row[12] else [],
+            search_rank=row[13] if len(row) > 13 else None,
         )
 
     def close(self) -> None:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -101,11 +101,123 @@ def configure_connection(conn: sqlite3.Connection) -> None:
                                               readers cache WAL pages in RAM.
     """
     conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+    # Source-lineage sidecars use real foreign keys.  SQLite defaults FK
+    # enforcement off for every new connection, so setting it only during the
+    # migration would leave ordinary writes unprotected.
+    conn.execute("PRAGMA foreign_keys=ON")
     _execute_wal_conversion_with_lock_retry(conn)
     conn.execute("PRAGMA synchronous=FULL")
     conn.execute("PRAGMA wal_autocheckpoint=500")
     conn.execute("PRAGMA journal_size_limit=67108864")
     conn.execute("PRAGMA mmap_size=268435456")
+
+
+def ensure_relational_summary_provenance(conn: sqlite3.Connection) -> None:
+    """Install and backfill FK-enforced summary-source edge tables.
+
+    ``summary_nodes.source_ids`` remains as a compatibility/read cache for old
+    databases and older binaries.  New writes publish the JSON value and its
+    relational edges in one transaction.  Backfill is intentionally tolerant:
+    malformed legacy references remain readable through the JSON column but do
+    not become falsely validated relational edges.
+    """
+    tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "summary_nodes" not in tables or "messages" not in tables:
+        return
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS lcm_summary_message_sources (
+            summary_node_id INTEGER NOT NULL
+                REFERENCES summary_nodes(node_id) ON DELETE CASCADE,
+            message_store_id INTEGER NOT NULL
+                REFERENCES messages(store_id) ON DELETE RESTRICT,
+            source_ordinal INTEGER NOT NULL,
+            PRIMARY KEY(summary_node_id, source_ordinal),
+            UNIQUE(summary_node_id, message_store_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_lcm_summary_message_source
+            ON lcm_summary_message_sources(message_store_id, summary_node_id);
+
+        CREATE TABLE IF NOT EXISTS lcm_summary_node_sources (
+            summary_node_id INTEGER NOT NULL
+                REFERENCES summary_nodes(node_id) ON DELETE CASCADE,
+            source_node_id INTEGER NOT NULL
+                REFERENCES summary_nodes(node_id) ON DELETE RESTRICT,
+            source_ordinal INTEGER NOT NULL,
+            PRIMARY KEY(summary_node_id, source_ordinal),
+            UNIQUE(summary_node_id, source_node_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_lcm_summary_node_source
+            ON lcm_summary_node_sources(source_node_id, summary_node_id);
+
+        DROP TRIGGER IF EXISTS lcm_summary_message_source_validate;
+        CREATE TRIGGER lcm_summary_message_source_validate
+        BEFORE INSERT ON lcm_summary_message_sources BEGIN
+            SELECT CASE WHEN NOT EXISTS (
+                SELECT 1
+                FROM summary_nodes AS parent
+                JOIN messages AS source
+                  ON source.store_id = NEW.message_store_id
+                WHERE parent.node_id = NEW.summary_node_id
+                  AND parent.source_type = 'messages'
+            ) THEN RAISE(ABORT, 'invalid summary message source') END;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS lcm_summary_node_source_validate
+        BEFORE INSERT ON lcm_summary_node_sources BEGIN
+            SELECT CASE WHEN NOT EXISTS (
+                SELECT 1
+                FROM summary_nodes AS parent
+                JOIN summary_nodes AS source
+                  ON source.node_id = NEW.source_node_id
+                WHERE parent.node_id = NEW.summary_node_id
+                  AND parent.source_type = 'nodes'
+                  AND parent.session_id = source.session_id
+                  AND source.depth < parent.depth
+            ) THEN RAISE(ABORT, 'invalid summary node source') END;
+        END;
+        """
+    )
+
+    rows = conn.execute(
+        "SELECT node_id, session_id, depth, source_ids, source_type "
+        "FROM summary_nodes ORDER BY node_id"
+    ).fetchall()
+    for node_id, session_id, depth, raw_source_ids, source_type in rows:
+        try:
+            source_ids = list(dict.fromkeys(int(value) for value in json.loads(raw_source_ids or "[]")))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        for ordinal, source_id in enumerate(source_ids):
+            if source_type == "messages":
+                valid = conn.execute(
+                    "SELECT 1 FROM messages WHERE store_id = ?",
+                    (source_id,),
+                ).fetchone()
+                if valid:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO lcm_summary_message_sources"
+                        "(summary_node_id, message_store_id, source_ordinal) VALUES (?, ?, ?)",
+                        (node_id, source_id, ordinal),
+                    )
+            elif source_type == "nodes":
+                valid = conn.execute(
+                    "SELECT 1 FROM summary_nodes "
+                    "WHERE node_id = ? AND session_id = ? AND depth < ?",
+                    (source_id, session_id, depth),
+                ).fetchone()
+                if valid:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO lcm_summary_node_sources"
+                        "(summary_node_id, source_node_id, source_ordinal) VALUES (?, ?, ?)",
+                        (node_id, source_id, ordinal),
+                    )
 
 
 def _execute_wal_conversion_with_lock_retry(
@@ -272,7 +384,13 @@ _V5_CORE_TABLE_COLUMNS: dict[str, frozenset[str]] = {
 # have them until MessageStore opens it. Their presence is recognised, but an
 # unrelated extra core column still fails closed as a genuinely newer shape.
 _V5_CORE_OPTIONAL_COLUMNS: dict[str, frozenset[str]] = {
-    "messages": frozenset({"ingested_at", "observed_at", "observed_at_source"}),
+    "messages": frozenset({
+        "ingested_at", "observed_at", "observed_at_source", "provider_state",
+    }),
+    # Whitepaper file-awareness is a marker-gated, backward-compatible sidecar
+    # on the summary cache.  A v5 database opened by this build can gain it
+    # without changing the core numeric schema ladder.
+    "summary_nodes": frozenset({"file_ids"}),
 }
 
 # Core FTS5 virtual tables: presence is enough — their column layout is owned by
@@ -290,6 +408,12 @@ _KNOWN_FEATURE_TABLE_PREFIXES = (
     "lcm_assertion",
     "lcm_query",
     "lcm_trajectory",
+    "lcm_summary_",
+    "lcm_ingest_",
+    "lcm_files",
+    "lcm_operator_",
+    "compaction_batches",
+    "pending_summary_nodes",
 )
 
 # The known opt-in feature families whose derived tables an interim build may

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,13 +7,24 @@ This page keeps the implementation model and product-positioning nuance outside 
 - **SQLite message store** - preserves raw messages by default before compaction
 - **Summary DAG** - compacts older context into depth-aware summary nodes
 - **Bounded recovery** - pages raw messages, child summaries, and externalized payloads without flooding the main context
-- **Agent tools** - `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query`
+- **Agent tools** - retrieval/diagnostic tools plus persistent `llm_map` and `agentic_map` operators
 - **Source-aware retrieval** - filters raw rows and summaries by descendant source lineage
 - **Session controls** - ignore noisy sessions or keep sessions read-only with glob patterns
 - **Large payload controls** - optional ingest-time externalization for oversized tool/media/raw payloads, plus transcript GC for already-externalized tool results
 - **Sensitive-pattern controls** - optional named redaction of API keys, bearer tokens, passwords, and private keys before LCM stores or summarizes them
 - **Storage-boundary payload guard** - media-ish `data:*;base64` and long base64-looking strings are externalized before LCM writes them to SQLite
 - **Diagnostics** - `lcm_status`, `lcm_inspect`, `lcm_doctor`, and optional `/lcm` slash commands
+
+### Provider-native reasoning and compaction
+
+On the first-party GPT-5.6 Codex Responses route, Hermes requests encrypted
+all-turn reasoning continuity and server-side compaction at 175K tokens
+(`HERMES_CODEX_NATIVE_COMPACTION_THRESHOLD` overrides the threshold). The
+provider's compaction item remains the canonical active-context boundary. LCM
+still archives every raw message and the opaque provider capsule, but does not
+locally summarize pre-boundary history again. Opaque provider state is stored
+outside FTS and is excluded from summaries, retrieval results, and public
+message expansion.
 
 ## LCM vs built-in compression
 
@@ -39,6 +50,8 @@ claim that Hermes core has no persisted record of pre-compression history.
 4. **Escalate** - shrink oversize summaries from detailed to bullets to deterministic truncate
 5. **Assemble** - combine system prompt, highest-depth summaries, and fresh tail
 6. **Retrieve** - use LCM tools to drill into compacted history or synthesize from expanded context
+7. **Map** - process JSONL datasets outside the active prompt with persistent,
+   schema-validated `llm_map` or `agentic_map` batches
 
 ## Development
 
@@ -50,6 +63,9 @@ Plugin surface
   __init__.py            plugin registration and optional slash-command registration
   schemas.py             tool schemas shown to the model
   tools.py               lcm_grep, lcm_load_session, lcm_describe, lcm_expand, lcm_expand_query
+  operator_schemas.py    llm_map/agentic_map schemas and bounded JSON Schema validation
+  operators.py           persistent map batches, atomic claims, retries, JSONL output
+  file_registry.py       stable path-only file IDs and type-aware exploration summaries
   command.py             /lcm command handlers
   config.py              env var defaults and overrides
   presets.py             operator config presets

--- a/docs/async-background-compaction.md
+++ b/docs/async-background-compaction.md
@@ -1,6 +1,6 @@
 # Opt-in async/background compaction with atomic publish
 
-Design spike for preparing old stable chunks off the turn-critical path while keeping current LCM behavior unchanged unless explicitly enabled.
+Implementation notes for preparing old stable chunks off the turn-critical path while keeping current LCM behavior unchanged unless explicitly enabled.
 
 Refs:
 
@@ -10,7 +10,12 @@ Refs:
 
 ## Problem
 
-Today `LCMEngine.compress()` does the expensive work synchronously: ingest, select the oldest raw backlog outside the fresh tail, call the summarizer, write canonical DAG nodes, optionally condense, then assemble the active context. That preserves the important cache-friendly property: active context changes only at threshold/full-sweep boundaries. The downside is foreground latency, especially with slow local summarizers or serial leaf chains.
+The foreground fallback in `LCMEngine.compress()` performs ingest, leaf selection,
+summarization, canonical DAG publication, optional condensation, and active-context
+assembly synchronously. When the async feature and worker flags are enabled, stable
+leaf work is prepared ahead of that path and promoted during the foreground
+preflight. The synchronous path remains available whenever prepared work is absent,
+incomplete, stale, or invalid.
 
 The safe target is not “write summaries in another thread and flip a boolean.” The target is a two-phase lifecycle:
 
@@ -27,7 +32,7 @@ Until promotion, active context, search, recall, expansion, transcript GC, and d
 - No replacement for foreground compaction. If prepared work is absent, incomplete, stale, or invalid, foreground compaction falls back to today’s path.
 - No persisted threshold override that can win over live config. Persisted metadata is evidence to validate against live policy, not policy itself.
 
-## Proposed flags
+## Configuration
 
 Add config fields, all disabled by default:
 
@@ -267,19 +272,23 @@ Doctor should warn, not fail, for normal disabled state. It should warn on:
 - failed batches whose backoff has expired but no worker has retried;
 - pending rows whose batch is missing.
 
-## Implementation sequence
+## Implemented lifecycle
 
-1. **Acceptance tests first** for stale rejection, config change rejection, foreground/background race, summary failure/backoff, restart recovery, successful atomic promotion, pending invisibility, and status/doctor counts.
-2. Schema only: create the two tables and reader filters, with feature disabled and no behavior change.
-3. Manual one-shot preparer behind the flag, no automatic worker yet.
-4. Atomic promotion path in `compress()` before foreground summarization, with fallback on any reject.
-5. Status/doctor async counts.
-6. Optional worker loop with backpressure and retry policy.
-7. Later: pending condensed layers, if leaf-only promotion leaves too much foreground work.
+1. The store creates separate batch and pending-node tables; canonical readers never
+   see preparation state.
+2. Per-turn ingest schedules a bounded worker when both async flags are enabled.
+3. The worker claims a stable source range and prepares a complete leaf batch.
+4. Foreground preflight validates session, policy, route, source identities, fresh
+   tail, overlap, and coverage before one transactional promotion.
+5. Invalid or missing work is rejected/superseded and normal synchronous compaction
+   proceeds.
+6. Restart recovery, retry backoff, status counters, and doctor diagnostics expose
+   the durable lifecycle.
 
 ## Test matrix
 
-These are mirrored in `tests/test_async_background_compaction_design.py` as xfailed RED spike tests until the implementation exists.
+These regression tests are implemented in
+`tests/test_async_background_compaction_design.py`.
 
 | Test | Proves |
 | --- | --- |
@@ -296,9 +305,11 @@ These are mirrored in `tests/test_async_background_compaction_design.py` as xfai
 | `test_atomic_promotion_rolls_back_partial_publish_failure` | A mid-promotion failure leaves no canonical node/frontier/batch half-state. |
 | `test_status_and_doctor_report_async_compaction_counts` | Operators see pending/prepared/promoted/rejected/failed counts. |
 
-## Open questions
+## Deferred extensions
 
-- Should v1 reject a ready batch when only a prefix is still publishable, or support prefix promotion? Recommendation: reject in v1. Prefix promotion makes continuity and expected leaf counts more complex.
-- Should automatic workers live inside `LCMEngine`, a plugin lifecycle helper, or a host-managed scheduler? Recommendation: start with a manual one-shot preparer and make the automatic worker a later slice.
-- Should route fingerprint include fallback model order? Recommendation: yes. Different fallback order can change output after partial failures.
-- Should summary timeout changes reject prepared work? Recommendation: no unless timeout policy changes the output contract; include route/model/policy version, not operational timing knobs.
+- Ready batches are rejected when only a prefix remains publishable. Prefix
+  promotion would complicate continuity and expected-leaf accounting.
+- V1 prepares leaf nodes only; pending condensed layers remain a possible later
+  optimization.
+- Route fingerprints cover the selected summary route. Expanding that contract to
+  model fallback ordering can be considered if fallback execution is added.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -123,11 +123,11 @@ Expected signals:
 
 - plugin list includes `hermes-lcm`
 - selected context engine is `lcm`
-- tool list includes all 15 schemas: `lcm_grep`, `lcm_recall`,
+- tool list includes all 17 schemas: `lcm_grep`, `lcm_recall`,
   `lcm_query_state`, `lcm_compute`, `lcm_compile_evidence`,
   `lcm_evidence_pack`, `lcm_retrieve`, `lcm_recent`, `lcm_load_session`,
   `lcm_describe`, `lcm_expand`, `lcm_expand_query`, `lcm_status`, `lcm_inspect`,
-  and `lcm_doctor`
+  `lcm_doctor`, `llm_map`, and `agentic_map`
 - ordinary skill discovery includes `hermes-lcm`; plugin-qualified explicit
   loading is `hermes-lcm:hermes-lcm` on hosts that support plugin skills
 
@@ -135,7 +135,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
+  ✓ hermes-lcm v0.21.0-rc2 (17 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -169,8 +169,8 @@ LCM tools are still available through the context-engine schema/dispatch path
 registration (Path A) on those hosts because Path A would shadow Path B and lose
 current-turn ingest.
 
-Healthy signals are the same as above: selected context engine `lcm`, all 15
-`lcm_*` tools in the live tool list, and `lcm_status` / `lcm_inspect` / `lcm_doctor` responding
+Healthy signals are the same as above: selected context engine `lcm`, all 17
+LCM tools in the live tool list, and `lcm_status` / `lcm_inspect` / `lcm_doctor` responding
 after one normal message initializes the session.
 
 ### `/lcm status` looks unbound after restart
@@ -241,7 +241,7 @@ environment variables:
 
 ### Evidence and adaptive retrieval (0.21 RC)
 
-Hermes exposes all 15 LCM tool schemas whenever LCM is the active context
+Hermes exposes all 17 LCM tool schemas whenever LCM is the active context
 engine. Exposure is not activation. On a stock install:
 
 - `lcm_compute`, `lcm_compile_evidence`, and `lcm_evidence_pack` are bounded,

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -30,7 +30,7 @@ Make packaging a separate implementation lane only when one of these is true:
 2. Users need version-pinned installs without direct git checkouts.
 3. Release automation needs packaged artifacts beyond GitHub tags/releases.
 
-The narrow next step would be packaging metadata plus tests that prove a packaged install still exposes `hermes-lcm`, context engine `lcm`, and all 15 LCM tools through `hermes plugins`. Until then, clone/symlink remains the documented path.
+The narrow next step would be packaging metadata plus tests that prove a packaged install still exposes `hermes-lcm`, context engine `lcm`, and all 17 LCM tools through `hermes plugins`. Until then, clone/symlink remains the documented path.
 
 ## Current install and update references
 

--- a/docs/retrieval-tools.md
+++ b/docs/retrieval-tools.md
@@ -40,6 +40,13 @@ is the active context engine.
 | `lcm_status` | Show runtime health, context pressure, config, source lineage, and lifecycle stats. |
 | `lcm_inspect` | Read-only operator inventory for current-session lineage, message/frontier metadata, fresh tail, externalized refs/readability, compaction skip/no-op reasons, and matched ignore/stateless patterns. It returns metadata only; use `lcm_load_session`/`lcm_expand` when you need content. |
 | `lcm_doctor` | Run database, FTS, lifecycle, config, and context-pressure diagnostics. |
+| `llm_map` | Apply a prompt independently to every JSONL input item as a stateless model call. Persistent batch/item states, atomic claims, bounded concurrency, schema validation, retry feedback, and ordered JSONL output are engine-managed. |
+| `agentic_map` | Apply a prompt independently to every JSONL input item using an isolated tool-capable sub-agent. The caller must set `read_only`; execution otherwise uses the same persistent claims, schema validation, retries, and ordered output contract as `llm_map`. |
+
+The map operators keep datasets outside the active prompt. Their output files
+receive stable LCM file IDs containing only the canonical path, MIME/size/token
+metadata, and a bounded structural exploration summary; file bytes remain on
+the filesystem.
 
 ### Retrieval contract
 

--- a/engine.py
+++ b/engine.py
@@ -7,6 +7,7 @@ with a DAG-based summarization system that preserves every message.
 import asyncio
 import copy
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -89,6 +90,7 @@ from .assertion_store import AssertionStore, SourceSnapshot
 from .adaptive_retrieval import AdaptiveRetrievalRegistry
 from .query_view_store import QueryViewStore
 from .schemas import (
+    AGENTIC_MAP,
     LCM_DESCRIBE,
     LCM_DOCTOR,
     LCM_EXPAND,
@@ -104,6 +106,7 @@ from .schemas import (
     LCM_RECENT,
     LCM_RETRIEVE,
     LCM_STATUS,
+    LLM_MAP,
 )
 from .sanitize import (
     _clean_active_assistant_message,
@@ -127,6 +130,9 @@ from .reconcile import ReconcileMixin, _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
 from .compaction import CompactionMixin
 from .reset_state import ResetStateMixin
 from .bypass import BypassMixin
+from .async_compaction import AsyncCompactionMixin
+from .file_registry import FileRegistry, union_file_ids
+from .operators import LLMMap
 from .lifecycle_state import LifecycleStateStore
 from .message_content import (
     normalize_content_value,
@@ -360,7 +366,76 @@ _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across co
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
 
 
-class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
+class _SharedStorageBundle:
+    """Process-local SQLite helpers shared by session-isolated engine clones."""
+
+    def __init__(self, store, dag, lifecycle, assertions, query_views):
+        self.store = store
+        self.dag = dag
+        self.lifecycle = lifecycle
+        self.assertions = assertions
+        self.query_views = query_views
+        self.refs = 1
+
+    def is_open(self) -> bool:
+        """Return whether every SQLite helper still has a live connection."""
+        return all(
+            helper is None or getattr(helper, "_conn", None) is not None
+            for helper in (
+                self.store,
+                self.dag,
+                self.lifecycle,
+                self.assertions,
+                self.query_views,
+            )
+        )
+
+    def close(self) -> None:
+        for helper in (
+            self.query_views,
+            self.assertions,
+            self.lifecycle,
+            self.dag,
+            self.store,
+        ):
+            close = getattr(helper, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    logger.debug("LCM failed closing shared storage", exc_info=True)
+
+
+_SHARED_STORAGE_LOCK = threading.RLock()
+_StorageContract = tuple[object, ...]
+_StorageBundleKey = tuple[str, str, _StorageContract]
+_SHARED_STORAGE: dict[_StorageBundleKey, _SharedStorageBundle] = {}
+_EMPTY_LIFECYCLE_GC_LOCK = threading.Lock()
+_EMPTY_LIFECYCLE_GC_LAST_ATTEMPT: dict[str, float] = {}
+_EMPTY_LIFECYCLE_GC_INTERVAL_SECONDS = 300.0
+
+
+def _storage_contract(config: LCMConfig) -> _StorageContract:
+    """Return only configuration that changes shared SQLite helper behavior.
+
+    Per-agent runtime settings (summary routes/timeouts, context thresholds,
+    retrieval budgets, etc.) must not create another pool of connections for
+    the same database. MessageStore retains the first config object, so fields
+    it consults while serializing durable rows remain part of the key.
+    """
+    return (
+        bool(getattr(config, "assertions_enabled", False)),
+        bool(getattr(config, "query_views_enabled", False))
+        or bool(getattr(config, "adaptive_retrieval_enabled", False)),
+        bool(getattr(config, "sensitive_patterns_enabled", False)),
+        tuple(str(value) for value in (getattr(config, "sensitive_patterns", ()) or ())),
+        bool(getattr(config, "large_output_externalization_enabled", False)),
+        int(getattr(config, "large_output_externalization_threshold_chars", 0) or 0),
+        str(getattr(config, "large_output_externalization_path", "") or ""),
+    )
+
+
+class LCMEngine(AsyncCompactionMixin, CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
     """Lossless Context Management engine.
 
     Automatic LCM compaction is routine background maintenance. Hosts that
@@ -399,6 +474,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
         db_path = self._resolve_db_path(hermes_home)
         self._bind_storage(db_path, hermes_home)
+        self._initialize_async_compaction()
+        self._file_registry = FileRegistry(db_path)
+        self._llm_map_operator = LLMMap(db_path, executor=self._execute_llm_map_item, file_registry=self._file_registry)
 
         self._session_id: str = ""
         self._session_platform: str = ""
@@ -559,6 +637,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # One-shot handoff from preflight: adopt an already-durable replay
         # cleanup during boundary cooldown without running summary work.
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
+        self._preflight_async_promotion_only = False
         # Temporary source window used only while compress() assembles context.
         # _assemble_context also serves tests and recovery paths directly, so
         # keep anchoring opt-in rather than changing its public behavior.
@@ -632,6 +711,13 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         clone.api_key = self.api_key
         clone.provider = self.provider
         clone.api_mode = self.api_mode
+        # Provider health and spend are process-level properties, not session
+        # state. Sharing these guards across clones prevents concurrent gateway
+        # sessions from each retrying the same degraded summarizer route and
+        # multiplying compaction latency. Forced/manual compaction still calls
+        # clear() on the same guard, preserving the operator repair path.
+        clone._summary_circuit_breaker = self._summary_circuit_breaker
+        clone._summary_spend_guard = self._summary_spend_guard
         if self._context_length_source:
             clone._set_context_length(
                 self.raw_context_length,
@@ -661,8 +747,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         AIAgent instances. A default object deepcopy walks into MessageStore,
         SummaryDAG, and LifecycleStateStore sqlite3.Connection handles, which
         cannot be pickled. LCM already exposes clone_for_agent() as the safe
-        boundary: share durable configuration/database path, but allocate fresh
-        per-agent runtime/storage helper objects.
+        boundary: allocate isolated per-agent runtime state while sharing one
+        ref-counted set of SQLite helpers for an identical database/config.
         """
         clone = self.clone_for_agent()
         memo[id(self)] = clone
@@ -678,33 +764,88 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def _bind_storage(self, db_path: str | Path, hermes_home: str = "") -> None:
         """Bind store/DAG/lifecycle helpers to one SQLite database."""
+        resolved_db_path = str(Path(db_path).expanduser().resolve())
+        # MessageStore already treats an omitted home as the DB parent. Use
+        # that same canonical identity here so registration-time prototypes
+        # and profile-bound clones do not allocate duplicate helper bundles.
+        normalized_home = str(
+            Path(hermes_home).expanduser().resolve()
+            if hermes_home
+            else Path(resolved_db_path).parent
+        )
+        bundle_key: _StorageBundleKey = (
+            resolved_db_path,
+            normalized_home,
+            _storage_contract(self._config),
+        )
         self._assertions = None
         self._query_views = None
         self._adaptive_retrieval = None
         self._assertion_extractor = None
+        self._storage_bundle_key = None
+        self._storage_bundle = None
+        with _SHARED_STORAGE_LOCK:
+            bundle = _SHARED_STORAGE.get(bundle_key)
+            if bundle is not None and not bundle.is_open():
+                # A caller may explicitly close the exposed store/DAG helpers
+                # before constructing a replacement engine (the historical
+                # standalone-engine lifecycle).  Never hand those closed
+                # connections to the replacement or let the old engine's
+                # eventual shutdown decrement a newly-created bundle.
+                _SHARED_STORAGE.pop(bundle_key, None)
+                bundle.close()
+                bundle = None
+            if bundle is None:
+                store = dag = lifecycle = assertions = query_views = None
+                try:
+                    store = MessageStore(
+                        resolved_db_path,
+                        ingest_protection_config=self._config,
+                        hermes_home=hermes_home,
+                    )
+                    try:
+                        store.drain_pending_ingest(busy_timeout_ms=250)
+                    except Exception:
+                        logger.warning("LCM pending-ingest recovery deferred", exc_info=True)
+                    dag = SummaryDAG(resolved_db_path)
+                    if self._config.temporal_rollups_enabled:
+                        initialize_rollup_invalidation_outbox(dag)
+                    lifecycle = LifecycleStateStore(resolved_db_path)
+                    assertions = (
+                        AssertionStore(resolved_db_path)
+                        if bool(getattr(self._config, "assertions_enabled", False))
+                        else None
+                    )
+                    query_views = (
+                        QueryViewStore(resolved_db_path)
+                        if bool(getattr(self._config, "query_views_enabled", False))
+                        or bool(getattr(self._config, "adaptive_retrieval_enabled", False))
+                        else None
+                    )
+                    bundle = _SharedStorageBundle(
+                        store, dag, lifecycle, assertions, query_views
+                    )
+                    _SHARED_STORAGE[bundle_key] = bundle
+                except Exception:
+                    for helper in (query_views, assertions, lifecycle, dag, store):
+                        close = getattr(helper, "close", None)
+                        if callable(close):
+                            try:
+                                close()
+                            except Exception:
+                                pass
+                    raise
+            else:
+                bundle.refs += 1
+
+        self._storage_bundle_key = bundle_key
+        self._storage_bundle = bundle
+        self._store = bundle.store
+        self._dag = bundle.dag
+        self._lifecycle = bundle.lifecycle
+        self._assertions = bundle.assertions
+        self._query_views = bundle.query_views
         try:
-            self._store = MessageStore(
-                db_path,
-                ingest_protection_config=self._config,
-                hermes_home=hermes_home,
-            )
-            self._dag = SummaryDAG(db_path)
-            if self._config.temporal_rollups_enabled:
-                # Install the transaction-coupled summary mutation triggers before
-                # this engine can publish or delete a DAG node.
-                initialize_rollup_invalidation_outbox(self._dag)
-            self._lifecycle = LifecycleStateStore(db_path)
-            self._assertions = (
-                AssertionStore(db_path)
-                if bool(getattr(self._config, "assertions_enabled", False))
-                else None
-            )
-            self._query_views = (
-                QueryViewStore(db_path)
-                if bool(getattr(self._config, "query_views_enabled", False))
-                or bool(getattr(self._config, "adaptive_retrieval_enabled", False))
-                else None
-            )
             self._adaptive_retrieval = (
                 AdaptiveRetrievalRegistry(self._query_views)
                 if bool(
@@ -726,22 +867,33 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             raise
 
     def _close_storage(self) -> None:
-        """Best-effort close of currently bound SQLite helpers."""
-        for attr in (
-            "_adaptive_retrieval",
-            "_store",
-            "_dag",
-            "_lifecycle",
-            "_assertions",
-            "_query_views",
-        ):
-            helper = getattr(self, attr, None)
-            close = getattr(helper, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    logger.debug("LCM failed closing %s during profile rebind", attr, exc_info=True)
+        """Release this engine's reference and close the last shared bundle."""
+        adaptive = getattr(self, "_adaptive_retrieval", None)
+        close_adaptive = getattr(adaptive, "close", None)
+        if callable(close_adaptive):
+            try:
+                close_adaptive()
+            except Exception:
+                logger.debug("LCM failed closing adaptive retrieval", exc_info=True)
+        self._adaptive_retrieval = None
+
+        key = getattr(self, "_storage_bundle_key", None)
+        owned_bundle = getattr(self, "_storage_bundle", None)
+        self._storage_bundle_key = None
+        self._storage_bundle = None
+        bundle_to_close = None
+        if key is not None and owned_bundle is not None:
+            with _SHARED_STORAGE_LOCK:
+                current = _SHARED_STORAGE.get(key)
+                owned_bundle.refs -= 1
+                if current is owned_bundle and owned_bundle.refs <= 0:
+                    _SHARED_STORAGE.pop(key, None)
+                    bundle_to_close = owned_bundle
+        if bundle_to_close is not None:
+            bundle_to_close.close()
+
+        for attr in ("_store", "_dag", "_lifecycle", "_assertions", "_query_views"):
+            setattr(self, attr, None)
 
     def _assertion_extraction_model(self) -> str:
         return str(
@@ -1515,18 +1667,27 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return
         if self._session_id and messages:
             try:
+                try:
+                    self._store.drain_pending_ingest(
+                        busy_timeout_ms=_SESSION_END_BUSY_TIMEOUT_MS
+                    )
+                except sqlite3.OperationalError as exc:
+                    if "locked" not in str(exc).lower():
+                        raise
+                    logger.debug("LCM pending-ingest drain deferred by SQLite lock")
                 self._remember_lcm_normal_message_prefix(
                     self._session_id,
                     messages,
                     conversation_id=self._conversation_id,
                 )
-                self._ingest_messages(messages)
+                replay_messages = self._ingest_messages(messages, durable_on_lock=True)
                 self._record_ingest_success()
                 self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 logger.debug(
                     "Per-turn ingest OK: session=%s msgs=%d cursor=%d",
                     self._session_id, len(messages), self._ingest_cursor,
                 )
+                self._schedule_background_compaction(replay_messages)
             except Exception as e:
                 self._record_ingest_failure("per-turn ingest()", e)
 
@@ -1727,15 +1888,24 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._config.empty_lifecycle_gc_enabled
             and self._lifecycle.row_count() > self._config.empty_lifecycle_gc_threshold
         ):
-            protected = {str(self._session_id)} if self._session_id else None
-            max_age = self._config.empty_lifecycle_gc_max_age_hours
-            try:
-                deleted = self._lifecycle.prune_empty_sessions(
-                    protected_session_ids=protected,
-                    max_age_hours=max_age,
-                )
-            except Exception:
-                deleted = 0
+            db_key = str(Path(self._lifecycle.db_path).expanduser().resolve())
+            now = time.monotonic()
+            with _EMPTY_LIFECYCLE_GC_LOCK:
+                last_attempt = _EMPTY_LIFECYCLE_GC_LAST_ATTEMPT.get(db_key, 0.0)
+                run_gc = now - last_attempt >= _EMPTY_LIFECYCLE_GC_INTERVAL_SECONDS
+                if run_gc:
+                    _EMPTY_LIFECYCLE_GC_LAST_ATTEMPT[db_key] = now
+            deleted = 0
+            if run_gc:
+                protected = {str(self._session_id)} if self._session_id else None
+                max_age = self._config.empty_lifecycle_gc_max_age_hours
+                try:
+                    deleted = self._lifecycle.prune_empty_sessions(
+                        protected_session_ids=protected,
+                        max_age_hours=max_age,
+                    )
+                except Exception:
+                    deleted = 0
             if deleted:
                 logger.info(
                     "LCM pruned %d lifecycle rows with zero stored data "
@@ -3382,7 +3552,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     # Best-effort final flush. Keep this path bounded because
                     # host gateways call session-end hooks from lifecycle paths
                     # that must not wait through SQLite's normal busy timeout.
-                    self._ingest_messages(messages)
+                    ingest = self._ingest_messages
+                    try:
+                        ingest_parameters = inspect.signature(ingest).parameters.values()
+                    except (TypeError, ValueError):
+                        ingest_parameters = ()
+                    supports_durable_on_lock = any(
+                        parameter.name == "durable_on_lock"
+                        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                        for parameter in ingest_parameters
+                    )
+                    if supports_durable_on_lock:
+                        ingest(messages, durable_on_lock=True)
+                    else:
+                        # Preserve the long-standing one-argument seam used by
+                        # host adapters and tests which replace the ingest hook.
+                        ingest(messages)
                 except KeyboardInterrupt:
                     logger.warning(
                         "LCM session-end raw-message ingest interrupted; "
@@ -3632,8 +3817,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return 0
         return self.carry_over_new_session_context(old_session_id, new_session_id)
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [
+    def get_tool_schemas(self, *, is_subagent: bool = True) -> List[Dict[str, Any]]:
+        schemas = [
             LCM_GREP,
             LCM_RECALL,
             LCM_QUERY_STATE,
@@ -3649,9 +3834,24 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             LCM_STATUS,
             LCM_INSPECT,
             LCM_DOCTOR,
+            LLM_MAP,
+            AGENTIC_MAP,
         ]
+        if not is_subagent:
+            schemas = [
+                schema for schema in schemas
+                if schema.get("name") not in {"lcm_expand", "lcm_expand_query"}
+            ]
+        return schemas
 
     def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        if name in {"lcm_expand", "lcm_expand_query"} and kwargs.get("is_subagent") is False:
+            return json.dumps({
+                "error": (
+                    f"{name} is restricted to sub-agents so expanded history cannot flood "
+                    "the primary interaction context; delegate a bounded inspection task"
+                )
+            })
         # Ingest live messages if passed (enables current-turn search)
         messages = kwargs.get("messages")
 
@@ -3662,7 +3862,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 self._session_ignored or self._session_stateless or self._thread_context_stateless()
             ):
                 try:
-                    self._ingest_messages(messages)
+                    self._ingest_messages(messages, durable_on_lock=True)
                     self._record_ingest_success()
                     self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 except Exception as e:
@@ -3684,11 +3884,46 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             "lcm_status": lcm_tools.lcm_status,
             "lcm_inspect": lcm_tools.lcm_inspect,
             "lcm_doctor": lcm_tools.lcm_doctor,
+            "llm_map": lcm_tools.llm_map,
+            "agentic_map": lcm_tools.agentic_map,
         }
         handler = handlers.get(name)
         if handler:
-            return handler(args, engine=self)
+            return handler(args, engine=self, **kwargs)
         return json.dumps({"error": f"Unknown LCM tool: {name}"})
+
+    @staticmethod
+    def _parse_map_json_response(text: str) -> Any:
+        candidate = str(text or "").strip()
+        if candidate.startswith("```"):
+            candidate = re.sub(r"^```(?:json)?\s*", "", candidate, flags=re.IGNORECASE)
+            candidate = re.sub(r"\s*```$", "", candidate)
+        return json.loads(candidate)
+
+    def _execute_llm_map_item(
+        self,
+        *,
+        item: Any,
+        prompt: str,
+        attempt: int,
+        validation_error: str | None,
+    ) -> Any:
+        from agent.auxiliary_client import call_llm
+
+        correction = (
+            f"\nThe previous output failed validation: {validation_error}. Return a corrected value."
+            if validation_error else ""
+        )
+        response = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": (
+                f"{prompt}\n\nInput JSON:\n{json.dumps(item, ensure_ascii=False)}"
+                f"{correction}\nReturn only the requested JSON value."
+            )}],
+            temperature=0,
+            timeout=self._config.summary_timeout_ms / 1000,
+        )
+        return self._parse_map_json_response(response.choices[0].message.content)
 
     def _database_path_source(self) -> str:
         if self._config.database_path:
@@ -3710,11 +3945,19 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         conversation_id = self.current_conversation_id
         lifecycle_state = None
         lifecycle_error = ""
-        if conversation_id:
+        lifecycle = getattr(self, "_lifecycle", None)
+        if conversation_id and lifecycle is not None:
             try:
-                lifecycle_state = self._lifecycle.get_by_conversation(conversation_id)
+                lifecycle_state = lifecycle.get_by_conversation(conversation_id)
             except Exception as exc:  # pragma: no cover - defensive
                 lifecycle_error = str(exc)
+
+        store = getattr(self, "_store", None)
+        database_path = (
+            Path(store.db_path)
+            if store is not None
+            else self._resolve_db_path(self._hermes_home)
+        )
 
         identity: Dict[str, Any] = {
             "engine": self.name,
@@ -3723,7 +3966,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             "plugin_path": str(_PLUGIN_ROOT),
             "module_path": str(Path(__file__).resolve()),
             "hermes_home": str(self._hermes_home or ""),
-            "database_path": str(self._store.db_path),
+            "database_path": str(database_path),
             "database_path_source": self._database_path_source(),
             "session_id": session_id,
             "session_platform": self.current_session_platform,
@@ -3784,6 +4027,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             "config_sources": dict(getattr(self._config, "config_sources", {}) or {}),
             "config_source_warnings": list(getattr(self._config, "config_source_warnings", []) or []),
             "ignored_config_yaml_lcm_keys": list(getattr(self._config, "ignored_config_yaml_lcm_keys", []) or []),
+            "async_compaction": self.get_async_compaction_status(),
+            "pending_ingest_batches": self._store.pending_ingest_count(),
         })
         with self._assertion_extraction_metrics_lock:
             status["assertion_extraction"] = {
@@ -4357,7 +4602,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             redacted_replay_messages.append(redacted_message)
         return redacted_replay_messages
 
-    def _ingest_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _ingest_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        durable_on_lock: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Persist new messages to the store.
 
         Uses a cursor to track which portion of the current messages list
@@ -4384,6 +4634,25 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
         n = len(messages)
         cursor = min(max(self._ingest_cursor, 0), n)
+        # Hosts may replace the active transcript between calls (for example
+        # after an overflow recovery) instead of appending to the previous
+        # list.  A numeric cursor is only meaningful while that prefix is
+        # unchanged.  Reconcile against durable history before deciding that
+        # the replacement prefix has already been ingested; otherwise a later
+        # leaf can contain provider-visible messages with no store lineage.
+        if cursor > 0 and not self._ingest_cursor_needs_reconcile:
+            cached_source_identities = getattr(
+                self,
+                "_last_active_replay_source_identities",
+                None,
+            )
+            if cached_source_identities is not None:
+                current_prefix_identities = [
+                    self._message_replay_identity(message)
+                    for message in messages[:cursor]
+                ]
+                if current_prefix_identities != cached_source_identities[:cursor]:
+                    self._ingest_cursor_needs_reconcile = True
         scan_start = 0 if self._ingest_cursor_needs_reconcile else cursor
         ignored_original_messages = [False] * n
         if self._compiled_ignore_message_patterns:
@@ -4438,7 +4707,36 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 else replay_msg
                 for idx, (original_msg, replay_msg) in enumerate(zip(messages, replay_messages))
             ]
-            self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
+            reconciled_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
+            cached_active_replay_messages = getattr(self, "_last_active_replay_messages", None)
+            if (
+                cursor > 0
+                and len(messages) > cursor
+                and (
+                    any(
+                        self._is_replayed_context_scaffold_message(message)
+                        for message in messages[:cursor]
+                    )
+                    or (
+                        cached_active_replay_messages is not None
+                        and len(cached_active_replay_messages) >= cursor
+                        and [
+                            self._message_replay_identity(message)
+                            for message in messages[:cursor]
+                        ]
+                        == [
+                            self._message_replay_identity(message)
+                            for message in cached_active_replay_messages[:cursor]
+                        ]
+                    )
+                )
+            ):
+                # Reconciliation may classify a compacted scaffold plus its
+                # generated placeholders as a replay-only prefix. It must not
+                # extend that classification over newly appended, byte-equal
+                # user text beyond the cached active replay boundary.
+                reconciled_cursor = min(reconciled_cursor, cursor)
+            self._ingest_cursor = reconciled_cursor
             self._ingest_cursor_needs_reconcile = False
         cursor = min(max(self._ingest_cursor, 0), n)
         if cursor > 0:
@@ -4648,6 +4946,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     or metadata_replayed_active_placeholder
                 )
                 if (
+                    replayed_active_placeholder
+                    and cursor > 0
+                    and absolute_idx >= len(self._last_active_replay_messages)
+                    and not ignored_original_messages[absolute_idx]
+                ):
+                    # A literal user quote appended after the cached replay is
+                    # new immutable input, even when its text is byte-identical
+                    # to an engine-generated placeholder. Provenance applies to
+                    # cached occurrences, not to every future equal string.
+                    replayed_active_placeholder = False
+                if (
                     ignored_original_messages[absolute_idx]
                     or generated_volatile_placeholder
                     or replayed_active_placeholder
@@ -4744,13 +5053,29 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 active_replay_messages[absolute_idx] = stubbed_message
 
         estimates = [count_message_tokens(m) for m in protected_messages]
-        self._store._append_protected_batch(
-            self._session_id,
-            protected_messages,
-            estimates,
-            source=self._session_platform,
-            conversation_id=self._conversation_id,
-        )
+        if durable_on_lock:
+            durable_result = self._store.append_protected_batch_durable(
+                self._session_id,
+                protected_messages,
+                estimates,
+                source=self._session_platform,
+                conversation_id=self._conversation_id,
+                busy_timeout_ms=_SESSION_END_BUSY_TIMEOUT_MS,
+            )
+            if not durable_result.persisted:
+                logger.warning(
+                    "LCM session-end raw-message ingest skipped due to SQLite lock "
+                    "in the primary store and queued durably: batch=%s",
+                    durable_result.pending_batch_id,
+                )
+        else:
+            self._store._append_protected_batch(
+                self._session_id,
+                protected_messages,
+                estimates,
+                source=self._session_platform,
+                conversation_id=self._conversation_id,
+            )
         # Rollup staleness is driven by summary-node PUBLICATION
         # (_invalidate_rollups_for_published_node at every add_node site), not by
         # raw ingest: marking a period stale before its covering summary exists
@@ -5543,6 +5868,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             earliest_at=earliest_at,
             latest_at=latest_at,
             expand_hint=self._extract_expand_hint(summary_text),
+            file_ids=list(union_file_ids(*(node.file_ids for node in nodes))),
         )
         self._dag.add_node(condensed_node)
         self._invalidate_rollups_for_published_node(condensed_node)
@@ -6519,12 +6845,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def shutdown(self):
         self._unregister_active_engine_binding()
-        if self._adaptive_retrieval is not None:
-            self._adaptive_retrieval.close()
-        self._store.close()
-        self._dag.close()
-        self._lifecycle.close()
-        if self._assertions is not None:
-            self._assertions.close()
-        if self._query_views is not None:
-            self._query_views.close()
+        self._close_async_compaction()
+        self._close_storage()
+
+    def __del__(self) -> None:  # pragma: no cover - defensive refcount cleanup
+        try:
+            self.shutdown()
+        except Exception:
+            pass

--- a/escalation.py
+++ b/escalation.py
@@ -229,31 +229,27 @@ def _sanitize_reasoning_summary(text: str) -> str:
 def _call_llm_for_summary(prompt: str, max_tokens: int,
                            model: str = "", timeout: float | None = None) -> Optional[str]:
     """Call the Hermes auxiliary LLM for summarization."""
-    try:
-        from agent.auxiliary_client import call_llm
-        call_kwargs = {
-            "task": "compression",
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0.3,
-            "max_tokens": max_tokens,
-        }
-        apply_lcm_model_route(call_kwargs, model)
-        if timeout is not None:
-            call_kwargs["timeout"] = timeout
-        response = call_llm(**call_kwargs)
-        content = response.choices[0].message.content
-        if not isinstance(content, str):
-            content = str(content) if content else ""
-        sanitized = _sanitize_reasoning_summary(content)
-        if content.strip() and not sanitized:
-            logger.warning(
-                "LCM summary discarded reasoning-only output (model=%s); escalating",
-                model or "<default>",
-            )
-        return sanitized
-    except Exception as e:
-        logger.warning("LLM summarization failed: %s", e)
-        return None
+    from agent.auxiliary_client import call_llm
+    call_kwargs = {
+        "task": "compression",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.3,
+        "max_tokens": max_tokens,
+    }
+    apply_lcm_model_route(call_kwargs, model)
+    if timeout is not None:
+        call_kwargs["timeout"] = timeout
+    response = call_llm(**call_kwargs)
+    content = response.choices[0].message.content
+    if not isinstance(content, str):
+        content = str(content) if content else ""
+    sanitized = _sanitize_reasoning_summary(content)
+    if content.strip() and not sanitized:
+        logger.warning(
+            "LCM summary discarded reasoning-only output (model=%s); escalating",
+            model or "<default>",
+        )
+    return sanitized
 
 
 def _invoke_summary_llm(prompt: str, max_tokens: int, model: str = "", timeout: float | None = None) -> Optional[str]:
@@ -371,6 +367,7 @@ def _invoke_summary_llm_chain(
     circuit_breaker: SummaryCircuitBreaker | None = None,
     spend_guard: "SummarySpendGuard | None" = None,
     accepts_result: Callable[[str], bool] | None = None,
+    stats: dict[str, int] | None = None,
 ) -> Optional[str]:
     chain = _summary_model_chain(model, fallback_models)
     skipped = 0
@@ -390,6 +387,8 @@ def _invoke_summary_llm_chain(
                 "deferring to deterministic fallback"
             )
             break
+        if stats is not None:
+            stats["attempts"] = stats.get("attempts", 0) + 1
         try:
             result = _invoke_summary_llm(
                 prompt,
@@ -398,6 +397,8 @@ def _invoke_summary_llm_chain(
                 timeout=timeout,
             )
         except Exception as exc:
+            if stats is not None:
+                stats["exceptions"] = stats.get("exceptions", 0) + 1
             logger.warning("LLM summarization failed: %s", exc)
             result = None
         if result and (accepts_result is None or accepts_result(result)):
@@ -566,6 +567,7 @@ def summarize_with_escalation(
     l1_prompt = _build_l1_prompt(text, token_budget, depth,
                                  focus_topic=focus_topic,
                                  custom_instructions=custom_instructions)
+    l1_stats: dict[str, int] = {}
     l1_result = _invoke_summary_llm_chain(
         l1_prompt,
         token_budget * 2,
@@ -575,33 +577,61 @@ def summarize_with_escalation(
         circuit_breaker=circuit_breaker,
         spend_guard=spend_guard,
         accepts_result=lambda result: count_tokens(result) < source_tokens,
+        stats=l1_stats,
     )
 
     if l1_result:
         logger.debug("L1 summarization succeeded (%d tokens)", count_tokens(l1_result))
         return l1_result, 1
 
-    # Level 2: aggressive bullets at reduced budget
-    l2_budget = int(token_budget * l2_budget_ratio)
-    l2_prompt = _build_l2_prompt(text, l2_budget,
-                                 focus_topic=focus_topic,
-                                 custom_instructions=custom_instructions)
-    l2_result = _invoke_summary_llm_chain(
-        l2_prompt,
-        l2_budget * 2,
-        model=model,
-        fallback_models=fallback_models,
-        timeout=timeout,
-        circuit_breaker=circuit_breaker,
-        spend_guard=spend_guard,
-        accepts_result=lambda result: count_tokens(result) < source_tokens,
+    # Level 2 improves a successful-but-noncompressing model response. It
+    # cannot improve transport/auth/provider failures, and retrying the same
+    # dead route doubles user-facing latency before deterministic L3. When
+    # every route actually attempted at L1 raised, skip directly to L3.
+    l1_attempts = l1_stats.get("attempts", 0)
+    provider_chain_failed = (
+        l1_attempts > 0 and l1_stats.get("exceptions", 0) == l1_attempts
     )
+    l2_result = None
+    if provider_chain_failed:
+        logger.warning(
+            "LCM summary provider chain failed; skipping duplicate L2 network wait"
+        )
+    else:
+        l2_budget = int(token_budget * l2_budget_ratio)
+        l2_prompt = _build_l2_prompt(text, l2_budget,
+                                     focus_topic=focus_topic,
+                                     custom_instructions=custom_instructions)
+        l2_result = _invoke_summary_llm_chain(
+            l2_prompt,
+            l2_budget * 2,
+            model=model,
+            fallback_models=fallback_models,
+            timeout=timeout,
+            circuit_breaker=circuit_breaker,
+            spend_guard=spend_guard,
+            accepts_result=lambda result: count_tokens(result) < source_tokens,
+        )
 
     if l2_result:
         logger.debug("L2 summarization succeeded (%d tokens)", count_tokens(l2_result))
         return l2_result, 2
 
-    # Level 3: deterministic truncation — guaranteed convergence
-    l3_result = _deterministic_truncate(text, l3_truncate_tokens)
+    # Level 3: deterministic truncation — guaranteed convergence.  The
+    # configured cap is an upper bound, not a reason to return a short source
+    # unchanged: reserve at least one token of reduction even when the source is
+    # already below the usual 512-token fallback size. A one-token source can
+    # only converge to the empty string.
+    actual_source_tokens = count_tokens(text)
+    strict_cap = max(
+        0,
+        min(
+            max(0, int(l3_truncate_tokens or 0)),
+            max(0, actual_source_tokens - 1),
+        ),
+    )
+    l3_result = _deterministic_truncate(text, strict_cap)
+    if actual_source_tokens > 0 and count_tokens(l3_result) >= actual_source_tokens:
+        l3_result = _truncate_text_to_tokens(text, actual_source_tokens - 1)
     logger.debug("L3 deterministic truncation (%d tokens)", count_tokens(l3_result))
     return l3_result, 3

--- a/externalize.py
+++ b/externalize.py
@@ -9,6 +9,7 @@ recoverable through the LCM inspection and expansion tools.
 from __future__ import annotations
 
 import codecs
+import glob
 import hashlib
 import json
 import logging
@@ -1007,7 +1008,14 @@ def find_externalized_tool_result_content_for_call(
     storage_dir = get_large_output_storage_dir(config, hermes_home=hermes_home, create=False)
     if not storage_dir.exists() or not storage_dir.is_dir():
         return None
-    for path in sorted(storage_dir.glob("*.json")):
+    # Tool-result sidecars are written with the bounded tool-call stub in the
+    # filename.  Looking up that stub keeps restart reconciliation proportional
+    # to the number of retries for one call instead of the size of the entire
+    # externalized-output archive.  Escape the stub because provider-generated
+    # call IDs are opaque and may contain glob metacharacters.
+    tool_call_stub = glob.escape(_tool_call_stub(tool_call_id))
+    candidates = sorted(storage_dir.glob(f"*_{tool_call_stub}_*.json"))
+    for path in candidates:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):

--- a/externalize.py
+++ b/externalize.py
@@ -9,7 +9,6 @@ recoverable through the LCM inspection and expansion tools.
 from __future__ import annotations
 
 import codecs
-import glob
 import hashlib
 import json
 import logging
@@ -17,6 +16,7 @@ import math
 import os
 import re
 import stat
+import threading
 import time
 from pathlib import Path
 from typing import Any, BinaryIO, Dict
@@ -27,6 +27,15 @@ _EXTERNALIZED_REF_RE = re.compile(
 )
 _EXTERNALIZED_SEARCH_HEADER_BYTES = 64 * 1024
 _EXTERNALIZED_SEARCH_TAIL_BYTES = 64 * 1024
+_TOOL_RESULT_FILENAME_RE = re.compile(
+    r"^\d{8}_\d{6}_(?P<tool_call_stub>.+)_[0-9a-f]{12}_[0-9a-f]+\.json$"
+)
+_TOOL_RESULT_ARCHIVE_CACHE_LOCK = threading.RLock()
+_TOOL_RESULT_ARCHIVE_CACHE: dict[
+    str,
+    tuple[tuple[int, int, int], dict[str, tuple[Path, ...]], tuple[Path, ...]],
+] = {}
+_TOOL_RESULT_ARCHIVE_CACHE_MAX_DIRS = 32
 
 
 def _placeholder_metadata(value: Any) -> str:
@@ -49,6 +58,65 @@ def _safe_stub(value: str, fallback: str) -> str:
 
 def _content_digest_prefix(content: str) -> str:
     return hashlib.sha256((content or "").encode("utf-8")).hexdigest()[:12]
+
+
+def _directory_generation(path: Path) -> tuple[int, int, int]:
+    directory_stat = path.stat()
+    return (directory_stat.st_mtime_ns, directory_stat.st_ctime_ns, directory_stat.st_size)
+
+
+def _tool_result_archive_index(
+    storage_dir: Path,
+) -> tuple[dict[str, tuple[Path, ...]], tuple[Path, ...]]:
+    """Index stable sidecar filenames once per directory generation.
+
+    Restart reconciliation can recover thousands of persisted tool results in
+    one pass. Re-running ``Path.glob`` for every call turns that work into a
+    directory-size multiplied by message-count scan. The directory generation
+    tuple invalidates this bounded cache whenever entries are added or removed.
+    """
+    cache_key = str(storage_dir.resolve())
+    with _TOOL_RESULT_ARCHIVE_CACHE_LOCK:
+        generation = _directory_generation(storage_dir)
+        cached = _TOOL_RESULT_ARCHIVE_CACHE.get(cache_key)
+        if cached is not None and cached[0] == generation:
+            return cached[1], cached[2]
+
+        paths_by_stub: dict[str, list[Path]] = {}
+        unparsed_paths: list[Path] = []
+        for path in storage_dir.iterdir():
+            if not path.is_file() or path.suffix != ".json":
+                continue
+            match = _TOOL_RESULT_FILENAME_RE.fullmatch(path.name)
+            if match is None:
+                unparsed_paths.append(path)
+                continue
+            paths_by_stub.setdefault(match.group("tool_call_stub"), []).append(path)
+
+        frozen_index = {
+            stub: tuple(sorted(paths))
+            for stub, paths in paths_by_stub.items()
+        }
+        frozen_unparsed = tuple(sorted(unparsed_paths))
+        # Capture the post-scan generation. A concurrent writer will either be
+        # included by the iterator or invalidate this entry on the next lookup.
+        generation = _directory_generation(storage_dir)
+        _TOOL_RESULT_ARCHIVE_CACHE[cache_key] = (
+            generation,
+            frozen_index,
+            frozen_unparsed,
+        )
+        while len(_TOOL_RESULT_ARCHIVE_CACHE) > _TOOL_RESULT_ARCHIVE_CACHE_MAX_DIRS:
+            _TOOL_RESULT_ARCHIVE_CACHE.pop(next(iter(_TOOL_RESULT_ARCHIVE_CACHE)))
+        return frozen_index, frozen_unparsed
+
+
+def _tool_result_archive_candidates(storage_dir: Path, tool_call_id: str) -> tuple[Path, ...]:
+    tool_call_stub = _tool_call_stub(tool_call_id)
+    paths_by_stub, unparsed_paths = _tool_result_archive_index(storage_dir)
+    legacy_fragment = f"_{tool_call_stub}_"
+    legacy_matches = tuple(path for path in unparsed_paths if legacy_fragment in path.name)
+    return paths_by_stub.get(tool_call_stub, ()) + legacy_matches
 
 
 def _preview_sha256(preview_prefix: Any) -> str:
@@ -1009,12 +1077,9 @@ def find_externalized_tool_result_content_for_call(
     if not storage_dir.exists() or not storage_dir.is_dir():
         return None
     # Tool-result sidecars are written with the bounded tool-call stub in the
-    # filename.  Looking up that stub keeps restart reconciliation proportional
-    # to the number of retries for one call instead of the size of the entire
-    # externalized-output archive.  Escape the stub because provider-generated
-    # call IDs are opaque and may contain glob metacharacters.
-    tool_call_stub = glob.escape(_tool_call_stub(tool_call_id))
-    candidates = sorted(storage_dir.glob(f"*_{tool_call_stub}_*.json"))
+    # filename. Build one generation-aware archive index so a restart replay
+    # with thousands of tool results does not rescan the directory per call.
+    candidates = _tool_result_archive_candidates(storage_dir, tool_call_id)
     for path in candidates:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))

--- a/file_registry.py
+++ b/file_registry.py
@@ -1,0 +1,405 @@
+"""Filesystem-backed large-file awareness for LCM.
+
+The registry stores a stable opaque identifier, the canonical path, metadata,
+and a compact structural exploration summary.  File bytes remain exclusively
+on the filesystem; they are never copied into the LCM database.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+import json
+import mimetypes
+import re
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+from .db_bootstrap import configure_connection
+
+
+_CODE_SUFFIXES = {
+    ".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".js",
+    ".jsx", ".kt", ".php", ".rb", ".rs", ".swift", ".ts", ".tsx",
+}
+_SQLITE_SUFFIXES = {".db", ".sqlite", ".sqlite3"}
+_MAX_SUMMARY_CHARS = 8_000
+_MAX_TEXT_SCAN_BYTES = 4 * 1024 * 1024
+_MAX_JSON_PARSE_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    file_id: str
+    path: str
+    mime_type: str
+    size_bytes: int
+    token_count: int
+    exploration_summary: str
+    mtime_ns: int
+
+
+class FileRegistry:
+    """Persistent stable identifiers and structural summaries for large files."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        configure_connection(conn)
+        return conn
+
+    def _initialize(self) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS lcm_files (
+                    file_id TEXT PRIMARY KEY,
+                    path TEXT NOT NULL UNIQUE,
+                    mime_type TEXT NOT NULL,
+                    size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0),
+                    token_count INTEGER NOT NULL CHECK (token_count >= 0),
+                    exploration_summary TEXT NOT NULL,
+                    mtime_ns INTEGER NOT NULL,
+                    created_at REAL NOT NULL DEFAULT (unixepoch('subsec')),
+                    updated_at REAL NOT NULL DEFAULT (unixepoch('subsec'))
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_lcm_files_path ON lcm_files(path)"
+            )
+
+    def register(self, path: str | Path) -> FileRecord:
+        canonical = Path(path).expanduser().resolve(strict=True)
+        if not canonical.is_file():
+            raise ValueError(f"not a regular file: {canonical}")
+        stat = canonical.stat()
+        mime_type = _detect_mime(canonical)
+        summary = _explore(canonical, mime_type)
+        token_count = max(1, (stat.st_size + 3) // 4) if stat.st_size else 0
+
+        with closing(self._connect()) as conn, conn:
+            existing = conn.execute(
+                "SELECT file_id FROM lcm_files WHERE path = ?", (str(canonical),)
+            ).fetchone()
+            file_id = str(existing["file_id"]) if existing else _new_file_id()
+            conn.execute(
+                """
+                INSERT INTO lcm_files (
+                    file_id, path, mime_type, size_bytes, token_count,
+                    exploration_summary, mtime_ns
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(path) DO UPDATE SET
+                    mime_type = excluded.mime_type,
+                    size_bytes = excluded.size_bytes,
+                    token_count = excluded.token_count,
+                    exploration_summary = excluded.exploration_summary,
+                    mtime_ns = excluded.mtime_ns,
+                    updated_at = unixepoch('subsec')
+                """,
+                (
+                    file_id,
+                    str(canonical),
+                    mime_type,
+                    stat.st_size,
+                    token_count,
+                    summary[:_MAX_SUMMARY_CHARS],
+                    stat.st_mtime_ns,
+                ),
+            )
+        record = self.get(file_id)
+        if record is None:  # pragma: no cover - defensive against disk failure
+            raise RuntimeError(f"file registry write did not persist {file_id}")
+        return record
+
+    def get(self, file_id: str) -> FileRecord | None:
+        with closing(self._connect()) as conn, conn:
+            row = conn.execute(
+                """
+                SELECT file_id, path, mime_type, size_bytes, token_count,
+                       exploration_summary, mtime_ns
+                FROM lcm_files WHERE file_id = ?
+                """,
+                (file_id,),
+            ).fetchone()
+        return _row_to_record(row) if row else None
+
+    def get_by_path(self, path: str | Path) -> FileRecord | None:
+        canonical = str(Path(path).expanduser().resolve())
+        with closing(self._connect()) as conn, conn:
+            row = conn.execute(
+                """
+                SELECT file_id, path, mime_type, size_bytes, token_count,
+                       exploration_summary, mtime_ns
+                FROM lcm_files WHERE path = ?
+                """,
+                (canonical,),
+            ).fetchone()
+        return _row_to_record(row) if row else None
+
+
+def union_file_ids(*lineage: Any) -> tuple[str, ...]:
+    """Return a stable union of file IDs referenced anywhere in lineage data.
+
+    Only explicit ``file_id`` and ``file_ids`` fields are considered; generic
+    node/message ``id`` and ``source_ids`` fields are intentionally ignored.
+    """
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    def add(value: Any) -> None:
+        if isinstance(value, str):
+            candidates = (
+                [value]
+                if value.startswith("file_") and not any(char.isspace() for char in value)
+                else re.findall(r"\bfile_[A-Za-z0-9_-]{8,}\b", value)
+            )
+            for candidate in candidates:
+                if candidate not in seen:
+                    seen.add(candidate)
+                    ordered.append(candidate)
+            return
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key == "file_id":
+                    add(nested)
+                elif key == "file_ids":
+                    if isinstance(nested, (list, tuple, set, frozenset)):
+                        for item in nested:
+                            add(item)
+                    else:
+                        add(nested)
+                elif isinstance(nested, (dict, list, tuple, str)):
+                    add(nested)
+            return
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                add(item)
+
+    for value in lineage:
+        add(value)
+    return tuple(ordered)
+
+
+def _new_file_id() -> str:
+    return "file_" + secrets.token_urlsafe(18)
+
+
+def _row_to_record(row: sqlite3.Row) -> FileRecord:
+    return FileRecord(
+        file_id=str(row["file_id"]),
+        path=str(row["path"]),
+        mime_type=str(row["mime_type"]),
+        size_bytes=int(row["size_bytes"]),
+        token_count=int(row["token_count"]),
+        exploration_summary=str(row["exploration_summary"]),
+        mtime_ns=int(row["mtime_ns"]),
+    )
+
+
+def _detect_mime(path: Path) -> str:
+    suffix = path.suffix.lower()
+    overrides = {
+        ".json": "application/json",
+        ".jsonl": "application/x-ndjson",
+        ".ndjson": "application/x-ndjson",
+        ".csv": "text/csv",
+        ".sql": "application/sql",
+        ".sqlite": "application/vnd.sqlite3",
+        ".sqlite3": "application/vnd.sqlite3",
+        ".db": "application/vnd.sqlite3",
+        ".py": "text/x-python",
+    }
+    return overrides.get(suffix) or mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+
+def _explore(path: Path, mime_type: str) -> str:
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".json":
+            return _summarize_json(path)
+        if suffix in {".jsonl", ".ndjson"}:
+            return _summarize_jsonl(path)
+        if suffix == ".csv":
+            return _summarize_csv(path)
+        if suffix in _SQLITE_SUFFIXES:
+            return _summarize_sqlite(path)
+        if suffix == ".sql":
+            return _summarize_sql(path)
+        if suffix == ".py":
+            return _summarize_python(path)
+        if suffix in _CODE_SUFFIXES:
+            return _summarize_code(path)
+        if mime_type.startswith("text/"):
+            return _summarize_text(path)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError, csv.Error, sqlite3.Error, SyntaxError) as exc:
+        return f"{path.name}: {path.stat().st_size} bytes; structural exploration failed ({type(exc).__name__})"
+    return f"{path.name}: binary file, {path.stat().st_size} bytes"
+
+
+def _shape(value: Any, *, depth: int = 0) -> str:
+    if depth >= 4:
+        return type(value).__name__
+    if isinstance(value, dict):
+        entries = [f"{key}: {_shape(nested, depth=depth + 1)}" for key, nested in list(value.items())[:50]]
+        suffix = ", ..." if len(value) > 50 else ""
+        return "{" + ", ".join(entries) + suffix + "}"
+    if isinstance(value, list):
+        samples = {_shape(item, depth=depth + 1) for item in value[:50]}
+        return f"array[{len(value)}]<{' | '.join(sorted(samples)) or 'empty'}>"
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
+
+def _summarize_json(path: Path) -> str:
+    if path.stat().st_size > _MAX_JSON_PARSE_BYTES:
+        sample = _read_bounded_text(path)
+        stripped = sample.lstrip()
+        if stripped.startswith("{"):
+            keys = re.findall(r'"((?:[^"\\]|\\.)*)"\s*:', sample)
+            unique_keys = list(dict.fromkeys(keys))[:100]
+            return (
+                f"JSON {path.name}: large object ({path.stat().st_size} bytes); "
+                f"sampled keys [{', '.join(unique_keys)}]"
+            )
+        if stripped.startswith("["):
+            return f"JSON {path.name}: large array ({path.stat().st_size} bytes); prefix sampled"
+        return f"JSON {path.name}: large JSON value ({path.stat().st_size} bytes); prefix sampled"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return f"JSON {path.name}: {_shape(value)}"
+
+
+def _summarize_jsonl(path: Path) -> str:
+    shapes: set[str] = set()
+    count = 0
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            count += 1
+            if len(shapes) < 10:
+                try:
+                    shapes.add(_shape(json.loads(line)))
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"invalid JSONL line {line_number}") from exc
+    return f"JSONL {path.name}: {count} records; shapes: {' | '.join(sorted(shapes)) or 'empty'}"
+
+
+def _summarize_csv(path: Path) -> str:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, [])
+        rows = sum(1 for _ in reader)
+    columns = ", ".join(header[:100])
+    if len(header) > 100:
+        columns += ", ..."
+    return f"CSV {path.name}: {rows} data rows, {len(header)} columns [{columns}]"
+
+
+def _summarize_sqlite(path: Path) -> str:
+    uri = path.resolve().as_uri() + "?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+        descriptions: list[str] = []
+        for (table_name,) in tables[:100]:
+            escaped = str(table_name).replace('"', '""')
+            columns = conn.execute(f'PRAGMA table_info("{escaped}")').fetchall()
+            column_text = ", ".join(
+                f"{column[1]} {column[2] or 'ANY'}" + (" NOT NULL" if column[3] else "")
+                for column in columns
+            )
+            descriptions.append(f"{table_name}({column_text})")
+    return f"SQLite {path.name}: " + ("; ".join(descriptions) if descriptions else "no user tables")
+
+
+def _summarize_sql(path: Path) -> str:
+    text = _read_bounded_text(path)
+    tables = re.findall(r"(?is)\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w.\"`\[\]-]+)", text)
+    views = re.findall(r"(?is)\bCREATE\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w.\"`\[\]-]+)", text)
+    return f"SQL {path.name}: tables [{', '.join(tables[:100])}]; views [{', '.join(views[:100])}]"
+
+
+def _format_python_args(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    args = [argument.arg for argument in node.args.posonlyargs + node.args.args]
+    if node.args.vararg:
+        args.append("*" + node.args.vararg.arg)
+    args.extend(argument.arg for argument in node.args.kwonlyargs)
+    if node.args.kwarg:
+        args.append("**" + node.args.kwarg.arg)
+    # ast.unparse preserves useful annotations while the fallback above remains
+    # available on the oldest supported Python if an unusual node fails.
+    rendered: list[str] = []
+    all_nodes = node.args.posonlyargs + node.args.args
+    annotation_by_name = {
+        argument.arg: ast.unparse(argument.annotation)
+        for argument in all_nodes + node.args.kwonlyargs
+        if argument.annotation is not None
+    }
+    for arg in args:
+        prefix = ""
+        name = arg
+        if arg.startswith("**"):
+            prefix, name = "**", arg[2:]
+        elif arg.startswith("*"):
+            prefix, name = "*", arg[1:]
+        annotation = annotation_by_name.get(name)
+        rendered.append(prefix + name + (f": {annotation}" if annotation else ""))
+    return ", ".join(rendered)
+
+
+def _summarize_python(path: Path) -> str:
+    tree = ast.parse(_read_bounded_text(path))
+    structures: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            structures.append(f"class {node.name}")
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            prefix = "async " if isinstance(node, ast.AsyncFunctionDef) else ""
+            structures.append(f"{prefix}{node.name}({_format_python_args(node)})")
+    return f"Python {path.name}: " + ("; ".join(structures[:200]) if structures else "no classes or functions")
+
+
+def _summarize_code(path: Path) -> str:
+    text = _read_bounded_text(path)
+    declarations = re.findall(
+        r"(?m)^\s*(?:export\s+)?(?:public\s+|private\s+|protected\s+)?(?:async\s+)?"
+        r"(?:class|interface|struct|enum|function|fn|func)\s+[A-Za-z_$][\w$]*(?:\s*\([^\n{;]*\))?",
+        text,
+    )
+    return f"Code {path.name}: " + ("; ".join(item.strip() for item in declarations[:200]) if declarations else "no recognized declarations")
+
+
+def _summarize_text(path: Path) -> str:
+    text = _read_bounded_text(path)
+    lines = text.count("\n") + (1 if text and not text.endswith("\n") else 0)
+    words = len(re.findall(r"\S+", text))
+    truncated = path.stat().st_size > _MAX_TEXT_SCAN_BYTES
+    suffix = f" (first {_MAX_TEXT_SCAN_BYTES} bytes scanned)" if truncated else ""
+    return f"Text {path.name}: {lines} lines, {words} words{suffix}"
+
+
+def _read_bounded_text(path: Path) -> str:
+    with path.open("rb") as handle:
+        data = handle.read(_MAX_TEXT_SCAN_BYTES)
+    return data.decode("utf-8")

--- a/fresh_tail.py
+++ b/fresh_tail.py
@@ -10,8 +10,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
+from .escalation import _truncate_text_to_tokens
 from .message_analysis import _tool_call_id
+from .message_content import text_content_for_pattern_matching
 from .tokens import count_message_tokens, count_messages_tokens
+
+
+_ACTIVE_TRUNCATION_MARKER = (
+    "\n\n[...active-context truncation; full content retained in LCM storage...]"
+)
 
 
 @dataclass(frozen=True)
@@ -99,3 +106,110 @@ def resolve_fresh_tail_boundary(
         token_limited=token_limited,
         tool_group_extended=tool_group_extended,
     )
+
+
+def resolve_emergency_fresh_tail_boundary(
+    messages: Sequence[Dict[str, Any]],
+) -> FreshTailBoundary:
+    """Protect only the newest indivisible conversation unit under hard pressure.
+
+    Normal compaction protects a generously sized recent suffix. Once the
+    provider's hard context limit is reached that policy must yield or a
+    conversation shorter than ``fresh_tail_count`` can never converge. The
+    newest message remains protected, and a trailing tool result retreats to
+    the assistant that opened its tool-call group so active replay stays valid.
+    """
+    if not messages:
+        return FreshTailBoundary(0, 0, 0, 0, 0, False, False)
+
+    start = len(messages) - 1
+    group_start = _assistant_group_start(messages, start)
+    tool_group_extended = group_start < start
+    start = group_start
+    tail = list(messages[start:])
+    return FreshTailBoundary(
+        start=start,
+        count=len(tail),
+        tokens=count_messages_tokens(tail),
+        count_limit=len(tail),
+        token_limit=0,
+        token_limited=True,
+        tool_group_extended=tool_group_extended,
+    )
+
+
+def fit_active_context_to_token_cap(
+    messages: Sequence[Dict[str, Any]],
+    token_cap: int,
+) -> list[Dict[str, Any]]:
+    """Return a best-effort provider replay strictly below ``token_cap``.
+
+    Raw messages are already durable before this active-view operation runs.
+    Prefer the newest complete assistant/tool group (or newest single message),
+    retain a leading system message only when it fits, and as a final resort
+    deterministically shorten provider-visible content. Tool metadata and IDs
+    are never rewritten.
+    """
+    cap = max(0, int(token_cap or 0))
+    copied = [dict(message) for message in messages]
+    if not copied or cap <= 0 or count_messages_tokens(copied) < cap:
+        return copied
+
+    boundary = resolve_emergency_fresh_tail_boundary(copied)
+    newest_group = copied[boundary.start:]
+    leading_system = copied[0] if copied[0].get("role") == "system" else None
+    candidate = list(newest_group)
+    if leading_system is not None and leading_system not in candidate:
+        with_system = [leading_system, *candidate]
+        if count_messages_tokens(with_system) < cap:
+            candidate = with_system
+
+    if count_messages_tokens(candidate) < cap:
+        return candidate
+
+    # Preserve envelopes and tool-call identities, assigning the remaining
+    # content budget newest-first. ``cap - 1`` makes the hard-limit comparison
+    # unambiguous and leaves one token of safety for approximate counters.
+    target = max(0, cap - 1)
+    fitted = []
+    original_texts: list[str] = []
+    for message in candidate:
+        clone = dict(message)
+        original_texts.append(
+            text_content_for_pattern_matching(message.get("content")) or ""
+        )
+        clone["content"] = ""
+        fitted.append(clone)
+
+    for index in range(len(fitted) - 1, -1, -1):
+        original = original_texts[index]
+        if not original:
+            continue
+        used = count_messages_tokens(fitted)
+        available = target - used
+        if available <= 0:
+            continue
+        if count_message_tokens({**fitted[index], "content": original}) - count_message_tokens(
+            fitted[index]
+        ) <= available:
+            fitted[index]["content"] = original
+            continue
+
+        marker_tokens = count_message_tokens(
+            {**fitted[index], "content": _ACTIVE_TRUNCATION_MARKER}
+        ) - count_message_tokens(fitted[index])
+        body_budget = max(0, available - marker_tokens)
+        body = _truncate_text_to_tokens(original, body_budget)
+        fitted[index]["content"] = body + _ACTIVE_TRUNCATION_MARKER
+
+        # Token estimates can be non-additive. Tighten the body until the final
+        # message list is definitely under the cap.
+        while body and count_messages_tokens(fitted) > target:
+            body_tokens = count_message_tokens({**fitted[index], "content": body})
+            body = _truncate_text_to_tokens(body, max(0, body_tokens - 2))
+            fitted[index]["content"] = body + _ACTIVE_TRUNCATION_MARKER
+
+    # Extremely large tool metadata can itself exceed the limit. Preserve the
+    # newest message rather than corrupting its tool schema; callers surface
+    # this exceptional best-effort failure through existing overflow telemetry.
+    return fitted

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -720,83 +720,93 @@ class LifecycleStateStore:
         assert conn is not None
         protected = {str(s) for s in (protected_session_ids or ()) if s}
 
+        sessions_with_data: set[str] = set()
+        tables = {
+            row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+        def _session_has_data(session_id: str) -> bool:
+            if not session_id:
+                return False
+            if "messages" in tables and conn.execute(
+                "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone():
+                return True
+            if "summary_nodes" in tables and conn.execute(
+                "SELECT 1 FROM summary_nodes WHERE session_id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone():
+                return True
+            return False
+
+        if "messages" in tables:
+            for row in conn.execute(
+                "SELECT DISTINCT session_id FROM messages"
+            ).fetchall():
+                sessions_with_data.add(str(row[0]))
+        if "summary_nodes" in tables:
+            for row in conn.execute(
+                "SELECT DISTINCT session_id FROM summary_nodes"
+            ).fetchall():
+                sessions_with_data.add(str(row[0]))
+
+        now = time.time()
+        max_age_seconds = (
+            float(max_age_hours) * 3600.0
+            if max_age_hours is not None
+            else None
+        )
+        rows = conn.execute("SELECT * FROM lcm_lifecycle_state").fetchall()
+        candidates: list[str] = []
+        for row in rows:
+            cur = str(row["current_session_id"] or "")
+            fin = str(row["last_finalized_session_id"] or "")
+
+            if ((cur and cur in sessions_with_data)
+                    or (fin and fin in sessions_with_data)):
+                continue
+
+            refs = {r for r in (cur, fin) if r}
+            if refs & protected:
+                continue
+
+            if max_age_seconds is not None:
+                row_age = (
+                    row["current_bound_at"]
+                    or row["last_finalized_at"]
+                    or row["updated_at"]
+                )
+                if row_age is not None and (now - float(row_age)) < max_age_seconds:
+                    continue
+
+            candidates.append(str(row["conversation_id"]))
+
+        # The common healthy path has no candidates. Do not acquire SQLite's
+        # sole writer slot merely to roll back an empty maintenance pass.
+        if not candidates:
+            return 0
+
         conn.execute("BEGIN IMMEDIATE")
         try:
-            sessions_with_data: set[str] = set()
-            tables = {
-                row[0] for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                ).fetchall()
-            }
-
-            def _session_has_data(session_id: str) -> bool:
-                if not session_id:
-                    return False
-                if "messages" in tables and conn.execute(
-                    "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
-                    (session_id,),
-                ).fetchone():
-                    return True
-                if "summary_nodes" in tables and conn.execute(
-                    "SELECT 1 FROM summary_nodes WHERE session_id = ? LIMIT 1",
-                    (session_id,),
-                ).fetchone():
-                    return True
-                return False
-
-            if "messages" in tables:
-                for row in conn.execute(
-                    "SELECT DISTINCT session_id FROM messages"
-                ).fetchall():
-                    sessions_with_data.add(str(row[0]))
-            if "summary_nodes" in tables:
-                for row in conn.execute(
-                    "SELECT DISTINCT session_id FROM summary_nodes"
-                ).fetchall():
-                    sessions_with_data.add(str(row[0]))
-
-            now = time.time()
-            max_age_seconds = (
-                float(max_age_hours) * 3600.0
-                if max_age_hours is not None
-                else None
-            )
             deleted = 0
-
-            rows = conn.execute(
-                "SELECT * FROM lcm_lifecycle_state"
-            ).fetchall()
-            for row in rows:
+            for conversation_id in candidates:
+                row = conn.execute(
+                    "SELECT * FROM lcm_lifecycle_state WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+                if row is None:
+                    continue
                 cur = str(row["current_session_id"] or "")
                 fin = str(row["last_finalized_session_id"] or "")
-
-                if ((cur and cur in sessions_with_data)
-                        or (fin and fin in sessions_with_data)):
-                    continue
-
-                refs = {r for r in (cur, fin) if r}
-                if refs & protected:
-                    continue
-
-                if max_age_seconds is not None:
-                    row_age = (
-                        row["current_bound_at"]
-                        or row["last_finalized_at"]
-                        or row["updated_at"]
-                    )
-                    if row_age is not None and (now - float(row_age)) < max_age_seconds:
-                        continue
-
-                # Recheck against the tables right before deletion. BEGIN
-                # IMMEDIATE blocks concurrent writers while this transaction is
-                # open; this fresh query also keeps the safety check honest if
-                # the broad snapshot logic above changes later.
                 if _session_has_data(cur) or _session_has_data(fin):
                     continue
 
                 conn.execute(
                     "DELETE FROM lcm_lifecycle_state WHERE conversation_id = ?",
-                    (row["conversation_id"],),
+                    (conversation_id,),
                 )
                 deleted += 1
 

--- a/operator_schemas.py
+++ b/operator_schemas.py
@@ -1,0 +1,287 @@
+"""Tool schemas for the engine-managed LCM map operators."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from typing import Any
+
+
+_JSON_TYPES = {"object", "array", "string", "number", "integer", "boolean", "null"}
+_SCHEMA_KEYWORDS = {
+    "$id", "$schema", "title", "description", "default", "examples",
+    "type", "properties", "required", "additionalProperties", "items",
+    "enum", "minimum", "maximum", "anyOf",
+}
+
+
+class JSONSchemaError(ValueError):
+    """The caller supplied a schema outside the supported bounded subset."""
+
+
+class JSONSchemaValidationError(ValueError):
+    """An operator result did not satisfy its declared output schema."""
+
+    def __init__(self, message: str, path: tuple[str | int, ...] = ()):
+        super().__init__(message)
+        self.message = message
+        self.path = path
+
+
+class JSONSchemaValidator:
+    """Dependency-free validator for the operator output-schema subset."""
+
+    def __init__(self, schema: dict[str, Any]):
+        _check_schema(schema, path=("schema",))
+        self.schema = deepcopy(schema)
+
+    def validate(self, instance: Any) -> None:
+        _validate_instance(instance, self.schema, path=())
+
+
+def compile_json_schema(schema: dict[str, Any]) -> JSONSchemaValidator:
+    if not isinstance(schema, dict):
+        raise JSONSchemaError("output_schema must be a JSON Schema object")
+    return JSONSchemaValidator(schema)
+
+
+def _check_schema(schema: Any, *, path: tuple[str | int, ...]) -> None:
+    if not isinstance(schema, dict):
+        raise JSONSchemaError(f"{_path(path)} must be an object")
+    unsupported = sorted(set(schema) - _SCHEMA_KEYWORDS)
+    if unsupported:
+        raise JSONSchemaError(
+            f"{_path(path)} uses unsupported keyword(s): {', '.join(unsupported)}"
+        )
+    expected_type = schema.get("type")
+    if expected_type is not None and expected_type not in _JSON_TYPES:
+        raise JSONSchemaError(f"{_path(path + ('type',))} is not a supported JSON type")
+    enum = schema.get("enum")
+    if enum is not None:
+        if not isinstance(enum, list) or not enum:
+            raise JSONSchemaError(f"{_path(path + ('enum',))} must be a non-empty array")
+        try:
+            for value in enum:
+                _canonical_json(value)
+        except (TypeError, ValueError) as exc:
+            raise JSONSchemaError(f"{_path(path + ('enum',))} must contain JSON values") from exc
+    for keyword in ("minimum", "maximum"):
+        value = schema.get(keyword)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, (int, float))):
+            raise JSONSchemaError(f"{_path(path + (keyword,))} must be a number")
+    if "minimum" in schema and "maximum" in schema and schema["minimum"] > schema["maximum"]:
+        raise JSONSchemaError(f"{_path(path)} minimum cannot exceed maximum")
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict) or not all(isinstance(key, str) for key in properties):
+            raise JSONSchemaError(f"{_path(path + ('properties',))} must be an object")
+        for key, child in properties.items():
+            _check_schema(child, path=path + ("properties", key))
+    required = schema.get("required")
+    if required is not None:
+        if (
+            not isinstance(required, list)
+            or not all(isinstance(key, str) for key in required)
+            or len(set(required)) != len(required)
+        ):
+            raise JSONSchemaError(f"{_path(path + ('required',))} must be unique strings")
+    additional = schema.get("additionalProperties")
+    if additional is not None and not isinstance(additional, (bool, dict)):
+        raise JSONSchemaError(
+            f"{_path(path + ('additionalProperties',))} must be boolean or a schema"
+        )
+    if isinstance(additional, dict):
+        _check_schema(additional, path=path + ("additionalProperties",))
+    if "items" in schema:
+        _check_schema(schema["items"], path=path + ("items",))
+    any_of = schema.get("anyOf")
+    if any_of is not None:
+        if not isinstance(any_of, list) or not any_of:
+            raise JSONSchemaError(f"{_path(path + ('anyOf',))} must be a non-empty array")
+        for index, child in enumerate(any_of):
+            _check_schema(child, path=path + ("anyOf", index))
+
+
+def _validate_instance(
+    instance: Any,
+    schema: dict[str, Any],
+    *,
+    path: tuple[str | int, ...],
+) -> None:
+    any_of = schema.get("anyOf")
+    if any_of is not None:
+        failures: list[str] = []
+        for child in any_of:
+            try:
+                _validate_instance(instance, child, path=path)
+            except JSONSchemaValidationError as exc:
+                failures.append(exc.message)
+            else:
+                break
+        else:
+            detail = "; ".join(failures[:3])
+            raise JSONSchemaValidationError(
+                "does not satisfy anyOf" + (f" ({detail})" if detail else ""), path
+            )
+
+    expected_type = schema.get("type")
+    if expected_type is not None and not _is_json_type(instance, expected_type):
+        raise JSONSchemaValidationError(f"must be of type {expected_type}", path)
+
+    enum = schema.get("enum")
+    if enum is not None and all(not _json_equal(instance, allowed) for allowed in enum):
+        raise JSONSchemaValidationError(f"must be one of {enum!r}", path)
+
+    if _is_json_type(instance, "number"):
+        if "minimum" in schema and instance < schema["minimum"]:
+            raise JSONSchemaValidationError(f"must be >= {schema['minimum']}", path)
+        if "maximum" in schema and instance > schema["maximum"]:
+            raise JSONSchemaValidationError(f"must be <= {schema['maximum']}", path)
+
+    if isinstance(instance, dict):
+        properties = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in instance:
+                raise JSONSchemaValidationError(f"missing required property {key!r}", path)
+        for key, value in instance.items():
+            if key in properties:
+                _validate_instance(value, properties[key], path=path + (key,))
+                continue
+            additional = schema.get("additionalProperties", True)
+            if additional is False:
+                raise JSONSchemaValidationError(
+                    f"additional property {key!r} is not allowed", path + (key,)
+                )
+            if isinstance(additional, dict):
+                _validate_instance(value, additional, path=path + (key,))
+
+    if isinstance(instance, list) and "items" in schema:
+        for index, value in enumerate(instance):
+            _validate_instance(value, schema["items"], path=path + (index,))
+
+
+def _is_json_type(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    return False
+
+
+def _json_equal(left: Any, right: Any) -> bool:
+    try:
+        return _canonical_json(left) == _canonical_json(right)
+    except (TypeError, ValueError):
+        return False
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _path(parts: tuple[str | int, ...]) -> str:
+    result = ""
+    for part in parts:
+        if isinstance(part, int):
+            result += f"[{part}]"
+        else:
+            result += ("." if result else "") + part
+    return result or "output"
+
+
+_COMMON_PROPERTIES: dict[str, Any] = {
+    "input_path": {
+        "type": "string",
+        "description": "Path to a JSONL file containing one input item per line.",
+    },
+    "output_path": {
+        "type": "string",
+        "description": "Optional destination JSONL path for ordered item results.",
+    },
+    "prompt": {
+        "type": "string",
+        "description": "Instruction applied independently to every input item.",
+    },
+    "output_schema": {
+        "type": "object",
+        "description": "JSON Schema that every successful output must satisfy.",
+    },
+    "concurrency": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 256,
+        "default": 16,
+    },
+    "max_retries": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 20,
+        "default": 2,
+    },
+    "batch_id": {
+        "type": "string",
+        "description": "Existing batch ID to resume instead of creating a new batch.",
+    },
+}
+
+
+LLM_MAP_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "llm_map",
+        "description": (
+            "Apply a stateless LLM call to every JSONL item. The engine handles "
+            "persistent claims, bounded concurrency, schema validation, and retries."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": deepcopy(_COMMON_PROPERTIES),
+            "required": [],
+            "anyOf": [
+                {"required": ["batch_id"]},
+                {"required": ["input_path", "prompt", "output_schema"]},
+            ],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+_agentic_properties = deepcopy(_COMMON_PROPERTIES)
+_agentic_properties["read_only"] = {
+    "type": "boolean",
+    "description": "Capability boundary enforced for every spawned sub-agent.",
+}
+AGENTIC_MAP_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "agentic_map",
+        "description": (
+            "Apply an isolated tool-capable sub-agent to every JSONL item. The "
+            "engine handles persistent claims, schema validation, and retries."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": _agentic_properties,
+            "required": [],
+            "anyOf": [
+                {"required": ["batch_id"]},
+                {"required": ["input_path", "prompt", "output_schema", "read_only"]},
+            ],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+OPERATOR_TOOL_SCHEMAS = (LLM_MAP_SCHEMA, AGENTIC_MAP_SCHEMA)

--- a/operators.py
+++ b/operators.py
@@ -1,0 +1,681 @@
+"""Persistent engine-managed JSONL map operators.
+
+``LLMMap`` and ``AgenticMap`` move iteration, bounded concurrency, item claims,
+schema validation, and retry state out of model-written control flow.  The
+execution callable is injected by the host so this module remains provider and
+network independent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import secrets
+import sqlite3
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .db_bootstrap import configure_connection
+from .file_registry import FileRegistry
+from .operator_schemas import (
+    JSONSchemaError,
+    JSONSchemaValidationError,
+    compile_json_schema,
+)
+
+
+DEFAULT_CONCURRENCY = 16
+DEFAULT_MAX_RETRIES = 2
+MAX_CONCURRENCY = 256
+
+
+@dataclass(frozen=True)
+class ClaimedItem:
+    batch_id: str
+    item_index: int
+    item: Any
+    attempt: int
+    validation_error: str | None
+
+
+@dataclass(frozen=True)
+class BatchResult:
+    batch_id: str
+    kind: str
+    status: str
+    total: int
+    completed: int
+    failed: int
+    pending: int
+    running: int
+    concurrency: int
+    output_path: str
+    output_file_id: str | None
+
+
+class OperatorStore:
+    """Transactional persistent state for map batches and their items."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        configure_connection(conn)
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _initialize(self) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS lcm_operator_batches (
+                    batch_id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL CHECK (kind IN ('llm_map', 'agentic_map')),
+                    input_path TEXT NOT NULL,
+                    output_path TEXT NOT NULL,
+                    output_file_id TEXT,
+                    prompt TEXT NOT NULL,
+                    output_schema TEXT NOT NULL,
+                    concurrency INTEGER NOT NULL CHECK (concurrency BETWEEN 1 AND 256),
+                    max_retries INTEGER NOT NULL CHECK (max_retries >= 0),
+                    read_only INTEGER,
+                    status TEXT NOT NULL CHECK (
+                        status IN ('pending', 'running', 'completed', 'completed_with_errors')
+                    ),
+                    total INTEGER NOT NULL CHECK (total >= 0),
+                    created_at REAL NOT NULL DEFAULT (unixepoch('subsec')),
+                    updated_at REAL NOT NULL DEFAULT (unixepoch('subsec')),
+                    completed_at REAL
+                );
+
+                CREATE TABLE IF NOT EXISTS lcm_operator_items (
+                    batch_id TEXT NOT NULL,
+                    item_index INTEGER NOT NULL,
+                    input_json TEXT NOT NULL,
+                    status TEXT NOT NULL CHECK (
+                        status IN ('pending', 'running', 'completed', 'failed')
+                    ),
+                    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+                    output_json TEXT,
+                    error TEXT,
+                    claimed_by TEXT,
+                    claim_started_at REAL,
+                    completed_at REAL,
+                    PRIMARY KEY (batch_id, item_index),
+                    FOREIGN KEY (batch_id) REFERENCES lcm_operator_batches(batch_id)
+                        ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_lcm_operator_claims
+                ON lcm_operator_items(batch_id, status, item_index);
+                """
+            )
+
+    def create_batch(
+        self,
+        *,
+        kind: str,
+        input_path: str | Path,
+        output_path: str | Path,
+        prompt: str,
+        output_schema: dict[str, Any],
+        concurrency: int = DEFAULT_CONCURRENCY,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        read_only: bool | None = None,
+    ) -> str:
+        if kind not in {"llm_map", "agentic_map"}:
+            raise ValueError(f"unsupported operator kind: {kind}")
+        concurrency = _validate_concurrency(concurrency)
+        max_retries = _validate_max_retries(max_retries)
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        if kind == "agentic_map" and not isinstance(read_only, bool):
+            raise ValueError("agentic_map requires an explicit read_only boolean")
+        _compile_validator(output_schema)
+
+        source = Path(input_path).expanduser().resolve(strict=True)
+        destination = Path(output_path).expanduser().resolve()
+        if source == destination:
+            raise ValueError("output_path must differ from input_path")
+        items = _read_jsonl(source)
+        batch_id = "map_" + secrets.token_urlsafe(18)
+        schema_json = json.dumps(output_schema, ensure_ascii=False, sort_keys=True)
+
+        with closing(self._connect()) as conn, conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO lcm_operator_batches (
+                    batch_id, kind, input_path, output_path, prompt,
+                    output_schema, concurrency, max_retries, read_only,
+                    status, total
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+                """,
+                (
+                    batch_id,
+                    kind,
+                    str(source),
+                    str(destination),
+                    prompt,
+                    schema_json,
+                    concurrency,
+                    max_retries,
+                    int(read_only) if read_only is not None else None,
+                    len(items),
+                ),
+            )
+            conn.executemany(
+                """
+                INSERT INTO lcm_operator_items (
+                    batch_id, item_index, input_json, status
+                ) VALUES (?, ?, ?, 'pending')
+                """,
+                [
+                    (
+                        batch_id,
+                        index,
+                        json.dumps(item, ensure_ascii=False, sort_keys=True),
+                    )
+                    for index, item in enumerate(items)
+                ],
+            )
+        return batch_id
+
+    def batch_config(self, batch_id: str) -> dict[str, Any]:
+        with closing(self._connect()) as conn, conn:
+            row = conn.execute(
+                "SELECT * FROM lcm_operator_batches WHERE batch_id = ?", (batch_id,)
+            ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown operator batch: {batch_id}")
+        result = dict(row)
+        result["output_schema"] = json.loads(result["output_schema"])
+        if result["read_only"] is not None:
+            result["read_only"] = bool(result["read_only"])
+        return result
+
+    def mark_running(self, batch_id: str) -> None:
+        with closing(self._connect()) as conn, conn:
+            cursor = conn.execute(
+                """
+                UPDATE lcm_operator_batches
+                SET status = 'running', updated_at = unixepoch('subsec'), completed_at = NULL
+                WHERE batch_id = ?
+                  AND status IN ('pending', 'running', 'completed_with_errors')
+                """,
+                (batch_id,),
+            )
+            if cursor.rowcount != 1:
+                row = conn.execute(
+                    "SELECT status FROM lcm_operator_batches WHERE batch_id = ?",
+                    (batch_id,),
+                ).fetchone()
+                if row is None:
+                    raise KeyError(f"unknown operator batch: {batch_id}")
+                if row["status"] == "completed":
+                    return
+                raise RuntimeError(f"batch {batch_id} cannot run from {row['status']}")
+
+    def claim_next(self, batch_id: str, worker_id: str) -> ClaimedItem | None:
+        """Atomically claim one pending item and increment its attempt count."""
+
+        with closing(self._connect()) as conn, conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT item_index, input_json, attempts, error
+                FROM lcm_operator_items
+                WHERE batch_id = ? AND status = 'pending'
+                ORDER BY item_index
+                LIMIT 1
+                """,
+                (batch_id,),
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return None
+            attempt = int(row["attempts"]) + 1
+            updated = conn.execute(
+                """
+                UPDATE lcm_operator_items
+                SET status = 'running', attempts = ?, claimed_by = ?,
+                    claim_started_at = unixepoch('subsec')
+                WHERE batch_id = ? AND item_index = ? AND status = 'pending'
+                """,
+                (attempt, worker_id, batch_id, int(row["item_index"])),
+            )
+            if updated.rowcount != 1:  # pragma: no cover - BEGIN IMMEDIATE serializes this
+                conn.rollback()
+                return None
+            conn.commit()
+        return ClaimedItem(
+            batch_id=batch_id,
+            item_index=int(row["item_index"]),
+            item=json.loads(row["input_json"]),
+            attempt=attempt,
+            validation_error=str(row["error"]) if row["error"] else None,
+        )
+
+    def complete_item(self, item: ClaimedItem, output: Any) -> None:
+        output_json = json.dumps(output, ensure_ascii=False, sort_keys=True)
+        with closing(self._connect()) as conn, conn:
+            cursor = conn.execute(
+                """
+                UPDATE lcm_operator_items
+                SET status = 'completed', output_json = ?, error = NULL,
+                    claimed_by = NULL, claim_started_at = NULL,
+                    completed_at = unixepoch('subsec')
+                WHERE batch_id = ? AND item_index = ? AND status = 'running'
+                """,
+                (output_json, item.batch_id, item.item_index),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"item {item.batch_id}/{item.item_index} lost its running claim"
+                )
+
+    def fail_item(self, item: ClaimedItem, error: str, max_retries: int) -> None:
+        terminal = item.attempt > max_retries
+        status = "failed" if terminal else "pending"
+        with closing(self._connect()) as conn, conn:
+            cursor = conn.execute(
+                """
+                UPDATE lcm_operator_items
+                SET status = ?, error = ?, claimed_by = NULL,
+                    claim_started_at = NULL,
+                    completed_at = CASE WHEN ? THEN unixepoch('subsec') ELSE NULL END
+                WHERE batch_id = ? AND item_index = ? AND status = 'running'
+                """,
+                (
+                    status,
+                    error[:8_000],
+                    int(terminal),
+                    item.batch_id,
+                    item.item_index,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"item {item.batch_id}/{item.item_index} lost its running claim"
+                )
+
+    def requeue_running(self, batch_id: str) -> int:
+        """Recover items whose process exited after claiming them."""
+
+        with closing(self._connect()) as conn, conn:
+            cursor = conn.execute(
+                """
+                UPDATE lcm_operator_items
+                SET status = 'pending', claimed_by = NULL, claim_started_at = NULL,
+                    error = COALESCE(error, 'recovered abandoned running claim')
+                WHERE batch_id = ? AND status = 'running'
+                """,
+                (batch_id,),
+            )
+            return int(cursor.rowcount)
+
+    def finish_batch(self, batch_id: str) -> BatchResult:
+        with closing(self._connect()) as conn, conn:
+            counts = _item_counts(conn, batch_id)
+            if counts["pending"] or counts["running"]:
+                raise RuntimeError(f"batch {batch_id} still has unfinished items")
+            status = "completed_with_errors" if counts["failed"] else "completed"
+            conn.execute(
+                """
+                UPDATE lcm_operator_batches
+                SET status = ?, updated_at = unixepoch('subsec'),
+                    completed_at = unixepoch('subsec')
+                WHERE batch_id = ?
+                """,
+                (status, batch_id),
+            )
+        return self.status(batch_id)
+
+    def set_output_file_id(self, batch_id: str, file_id: str) -> None:
+        with closing(self._connect()) as conn, conn:
+            conn.execute(
+                """
+                UPDATE lcm_operator_batches
+                SET output_file_id = ?, updated_at = unixepoch('subsec')
+                WHERE batch_id = ?
+                """,
+                (file_id, batch_id),
+            )
+
+    def write_output(self, batch_id: str) -> Path:
+        config = self.batch_config(batch_id)
+        destination = Path(config["output_path"])
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(destination.name + f".{batch_id}.tmp")
+        with closing(self._connect()) as conn, conn, temporary.open("w", encoding="utf-8") as handle:
+            rows = conn.execute(
+                """
+                SELECT item_index, status, attempts, output_json, error
+                FROM lcm_operator_items
+                WHERE batch_id = ?
+                ORDER BY item_index
+                """,
+                (batch_id,),
+            )
+            for row in rows:
+                output_row = {
+                    "index": int(row["item_index"]),
+                    "status": str(row["status"]),
+                    "attempts": int(row["attempts"]),
+                }
+                if row["output_json"] is not None:
+                    output_row["output"] = json.loads(row["output_json"])
+                if row["error"] is not None:
+                    output_row["error"] = str(row["error"])
+                handle.write(json.dumps(output_row, ensure_ascii=False, sort_keys=True) + "\n")
+        temporary.replace(destination)
+        return destination
+
+    def status(self, batch_id: str) -> BatchResult:
+        with closing(self._connect()) as conn, conn:
+            batch = conn.execute(
+                "SELECT * FROM lcm_operator_batches WHERE batch_id = ?", (batch_id,)
+            ).fetchone()
+            if batch is None:
+                raise KeyError(f"unknown operator batch: {batch_id}")
+            counts = _item_counts(conn, batch_id)
+        return BatchResult(
+            batch_id=batch_id,
+            kind=str(batch["kind"]),
+            status=str(batch["status"]),
+            total=int(batch["total"]),
+            completed=counts["completed"],
+            failed=counts["failed"],
+            pending=counts["pending"],
+            running=counts["running"],
+            concurrency=int(batch["concurrency"]),
+            output_path=str(batch["output_path"]),
+            output_file_id=str(batch["output_file_id"]) if batch["output_file_id"] else None,
+        )
+
+
+class _MapOperator:
+    kind: str
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        executor: Callable[..., Any],
+        file_registry: FileRegistry | None = None,
+    ):
+        if not callable(executor):
+            raise TypeError("executor must be callable")
+        # A bound engine method otherwise creates
+        # engine -> operator -> bound method -> engine.  That cycle delays the
+        # engine's SQLite-backed children until cyclic GC, violating the host's
+        # refcount-time deallocation contract.  WeakMethod keeps normal call
+        # semantics without retaining the owner.
+        self._executor_ref: weakref.WeakMethod | Callable[..., Any]
+        self.executor = executor
+        self.store = OperatorStore(db_path)
+        self.file_registry = file_registry or FileRegistry(db_path)
+
+    @property
+    def executor(self) -> Callable[..., Any]:
+        """Current injected execution callable (replaceable by hosts/tests)."""
+
+        return self._executor()
+
+    @executor.setter
+    def executor(self, executor: Callable[..., Any]) -> None:
+        if not callable(executor):
+            raise TypeError("executor must be callable")
+        if inspect.ismethod(executor) and executor.__self__ is not None:
+            self._executor_ref = weakref.WeakMethod(executor)
+        else:
+            self._executor_ref = executor
+
+    def _executor(self) -> Callable[..., Any]:
+        if isinstance(self._executor_ref, weakref.WeakMethod):
+            executor = self._executor_ref()
+            if executor is None:
+                raise RuntimeError("map operator owner has been released")
+            return executor
+        return self._executor_ref
+
+    def _create_and_run(
+        self,
+        *,
+        input_path: str | Path,
+        output_path: str | Path | None,
+        prompt: str,
+        output_schema: dict[str, Any],
+        concurrency: int,
+        max_retries: int,
+        read_only: bool | None,
+    ) -> BatchResult:
+        source = Path(input_path).expanduser().resolve(strict=True)
+        if output_path is None:
+            output_path = source.with_name(source.name + ".lcm-output.jsonl")
+        batch_id = self.store.create_batch(
+            kind=self.kind,
+            input_path=source,
+            output_path=output_path,
+            prompt=prompt,
+            output_schema=output_schema,
+            concurrency=concurrency,
+            max_retries=max_retries,
+            read_only=read_only,
+        )
+        return self._execute(batch_id, recover=False)
+
+    def resume(self, batch_id: str) -> BatchResult:
+        config = self.store.batch_config(batch_id)
+        if config["kind"] != self.kind:
+            raise ValueError(
+                f"batch {batch_id} belongs to {config['kind']}, not {self.kind}"
+            )
+        if config["status"] == "completed":
+            return self._materialize_output(batch_id)
+        return self._execute(batch_id, recover=True)
+
+    def status(self, batch_id: str) -> BatchResult:
+        return self.store.status(batch_id)
+
+    def _execute(self, batch_id: str, *, recover: bool) -> BatchResult:
+        config = self.store.batch_config(batch_id)
+        validator = _compile_validator(config["output_schema"])
+        if recover:
+            self.store.requeue_running(batch_id)
+        self.store.mark_running(batch_id)
+
+        def worker(worker_number: int) -> None:
+            worker_id = f"{batch_id}:{worker_number}:{secrets.token_hex(4)}"
+            while True:
+                item = self.store.claim_next(batch_id, worker_id)
+                if item is None:
+                    return
+                try:
+                    output = self._invoke(
+                        item=item.item,
+                        prompt=config["prompt"],
+                        attempt=item.attempt,
+                        validation_error=item.validation_error,
+                        read_only=config["read_only"],
+                    )
+                    validator.validate(output)
+                    # JSON serialization is part of the output contract, not a
+                    # best-effort logging concern.
+                    json.dumps(output, ensure_ascii=False, sort_keys=True)
+                except JSONSchemaValidationError as exc:
+                    self.store.fail_item(
+                        item,
+                        _format_validation_error(exc),
+                        int(config["max_retries"]),
+                    )
+                except Exception as exc:
+                    self.store.fail_item(
+                        item,
+                        f"{type(exc).__name__}: {exc}",
+                        int(config["max_retries"]),
+                    )
+                else:
+                    self.store.complete_item(item, output)
+
+        worker_count = int(config["concurrency"])
+        with ThreadPoolExecutor(
+            max_workers=worker_count,
+            thread_name_prefix=f"lcm-{self.kind}",
+        ) as pool:
+            futures = [pool.submit(worker, index) for index in range(worker_count)]
+            for future in futures:
+                future.result()
+
+        self.store.finish_batch(batch_id)
+        return self._materialize_output(batch_id)
+
+    def _materialize_output(self, batch_id: str) -> BatchResult:
+        output_path = self.store.write_output(batch_id)
+        output_record = self.file_registry.register(output_path)
+        self.store.set_output_file_id(batch_id, output_record.file_id)
+        return self.store.status(batch_id)
+
+    def _invoke(
+        self,
+        *,
+        item: Any,
+        prompt: str,
+        attempt: int,
+        validation_error: str | None,
+        read_only: bool | None,
+    ) -> Any:
+        kwargs = {
+            "item": item,
+            "prompt": prompt,
+            "attempt": attempt,
+            "validation_error": validation_error,
+        }
+        if self.kind == "agentic_map":
+            kwargs["read_only"] = read_only
+        result = self._executor()(**kwargs)
+        if inspect.isawaitable(result):
+            return asyncio.run(result)
+        return result
+
+
+class LLMMap(_MapOperator):
+    """Stateless, side-effect-free per-item map execution."""
+
+    kind = "llm_map"
+
+    def run(
+        self,
+        *,
+        input_path: str | Path,
+        prompt: str,
+        output_schema: dict[str, Any],
+        output_path: str | Path | None = None,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> BatchResult:
+        return self._create_and_run(
+            input_path=input_path,
+            output_path=output_path,
+            prompt=prompt,
+            output_schema=output_schema,
+            concurrency=concurrency,
+            max_retries=max_retries,
+            read_only=None,
+        )
+
+
+class AgenticMap(_MapOperator):
+    """Tool-capable per-item sub-agent map with an explicit capability mode."""
+
+    kind = "agentic_map"
+
+    def run(
+        self,
+        *,
+        input_path: str | Path,
+        prompt: str,
+        output_schema: dict[str, Any],
+        read_only: bool,
+        output_path: str | Path | None = None,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> BatchResult:
+        if not isinstance(read_only, bool):
+            raise TypeError("read_only must be an explicit boolean")
+        return self._create_and_run(
+            input_path=input_path,
+            output_path=output_path,
+            prompt=prompt,
+            output_schema=output_schema,
+            concurrency=concurrency,
+            max_retries=max_retries,
+            read_only=read_only,
+        )
+
+
+def _validate_concurrency(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("concurrency must be an integer")
+    if not 1 <= value <= MAX_CONCURRENCY:
+        raise ValueError(f"concurrency must be between 1 and {MAX_CONCURRENCY}")
+    return value
+
+
+def _validate_max_retries(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("max_retries must be an integer")
+    if value < 0:
+        raise ValueError("max_retries cannot be negative")
+    return value
+
+
+def _read_jsonl(path: Path) -> list[Any]:
+    items: list[Any] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                items.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSONL at line {line_number}: {exc.msg}") from exc
+    return items
+
+
+def _compile_validator(schema: dict[str, Any]):
+    try:
+        return compile_json_schema(schema)
+    except JSONSchemaError as exc:
+        raise ValueError(f"invalid output_schema: {exc}") from exc
+
+
+def _format_validation_error(error: JSONSchemaValidationError) -> str:
+    location = ".".join(str(part) for part in error.path)
+    prefix = f"output.{location}: " if location else "output: "
+    return prefix + error.message
+
+
+def _item_counts(conn: sqlite3.Connection, batch_id: str) -> dict[str, int]:
+    counts = {"pending": 0, "running": 0, "completed": 0, "failed": 0}
+    rows = conn.execute(
+        """
+        SELECT status, COUNT(*) AS count
+        FROM lcm_operator_items
+        WHERE batch_id = ?
+        GROUP BY status
+        """,
+        (batch_id,),
+    ).fetchall()
+    for row in rows:
+        counts[str(row["status"])] = int(row["count"])
+    return counts

--- a/placeholder_ledger.py
+++ b/placeholder_ledger.py
@@ -260,7 +260,12 @@ class PlaceholderLedgerMixin:
             serialized = json.dumps(payload, sort_keys=True)
             # skip_unchanged avoids the fsync commit (under synchronous=FULL) when
             # the stored value already matches; this runs on every ingest.
-            self._store.write_metadata_json(count_keys, serialized, skip_unchanged=True)
+            self._store.write_metadata_json(
+                count_keys,
+                serialized,
+                skip_unchanged=True,
+                busy_timeout_ms=50,
+            )
         except Exception:
             logger.debug("LCM ignored placeholder count metadata write failed", exc_info=True)
 
@@ -321,7 +326,12 @@ class PlaceholderLedgerMixin:
             serialized = json.dumps(payload, sort_keys=True)
             # Skip the write (and its fsync commit) when unchanged; see the counts
             # writer above for rationale.
-            self._store.write_metadata_json(ordinal_keys, serialized, skip_unchanged=True)
+            self._store.write_metadata_json(
+                ordinal_keys,
+                serialized,
+                skip_unchanged=True,
+                busy_timeout_ms=50,
+            )
         except Exception:
             logger.debug("LCM ignored placeholder ordinal metadata write failed", exc_info=True)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -18,3 +18,5 @@ provides_tools:
   - lcm_status
   - lcm_inspect
   - lcm_doctor
+  - llm_map
+  - agentic_map

--- a/reconcile.py
+++ b/reconcile.py
@@ -446,6 +446,17 @@ class ReconcileMixin:
                 })
         effective_fresh_tail_count = self._fresh_tail_boundary(boundary_messages).count
         empty_prefix_cursor: int | None = None
+        identity_cache: dict[int, tuple[str, str, str, str]] = {}
+
+        def replay_identity(msg: Dict[str, Any]) -> tuple[str, str, str, str]:
+            """Compute each incoming message identity at most once per pass."""
+            key = id(msg)
+            identity = identity_cache.get(key)
+            if identity is None:
+                identity = self._message_replay_identity(msg)
+                identity_cache[key] = identity
+            return identity
+
         for cursor in range(len(messages), -1, -1):
             candidate_messages = messages[:cursor]
             candidate_visible_messages = [
@@ -468,7 +479,7 @@ class ReconcileMixin:
                 and not (
                     self._compiled_ignore_message_patterns
                     and self._is_quarantined_assistant_replay_identity(
-                        self._message_replay_identity(msg)
+                        replay_identity(msg)
                     )
                     and self._matches_ignore_message_patterns(msg, stored_row=True)
                 )
@@ -478,7 +489,7 @@ class ReconcileMixin:
                 self._is_replayed_context_scaffold_message(msg) for msg in candidate_messages
             )
             candidate_has_quarantined_replay_evidence = any(
-                self._is_quarantined_assistant_replay_identity(self._message_replay_identity(msg))
+                self._is_quarantined_assistant_replay_identity(replay_identity(msg))
                 for msg in candidate_messages
             )
             candidate_identity_messages = (
@@ -487,11 +498,11 @@ class ReconcileMixin:
                 else candidate_visible_messages
             )
             candidate_visible_prefix = [
-                self._message_replay_identity(msg)
+                replay_identity(msg)
                 for msg in candidate_visible_messages
             ]
             candidate_prefix = [
-                self._message_replay_identity(msg)
+                replay_identity(msg)
                 for msg in candidate_identity_messages
             ]
             if not candidate_prefix:
@@ -601,7 +612,7 @@ class ReconcileMixin:
                 or (
                     self._compiled_ignore_message_patterns
                     and self._is_quarantined_assistant_replay_identity(
-                        self._message_replay_identity(msg)
+                        replay_identity(msg)
                     )
                     and self._matches_ignore_message_patterns(msg, stored_row=True)
                 )
@@ -966,10 +977,17 @@ class ReconcileMixin:
         candidates: list[Dict[str, Any]] = []
         next_candidate_after = self._last_compacted_store_id
         while True:
-            page = self._store.get_session_messages_after(
-                self._session_id,
-                after_store_id=next_candidate_after,
-            )
+            if self._conversation_id:
+                page = self._store.get_conversation_messages_after(
+                    self._conversation_id,
+                    after_store_id=next_candidate_after,
+                    current_session_id=self._session_id,
+                )
+            else:
+                page = self._store.get_session_messages_after(
+                    self._session_id,
+                    after_store_id=next_candidate_after,
+                )
             if not page:
                 break
             candidates.extend(page)

--- a/reconcile.py
+++ b/reconcile.py
@@ -50,9 +50,121 @@ import logging
 logger = logging.getLogger(__name__)
 
 _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+_TRIGGERING_MESSAGE_HEADER_RE = re.compile(
+    r"(?m)^\[Triggering message id: `(?P<message_id>[^`]+)`[^\n]*\](?:\r?\n)?"
+)
+_LARGE_REPLAY_MIN_ITEMS = 4_096
+_LARGE_REPLAY_DURABLE_SUFFIX_ITEMS = 1_024
+
+
+def _prefix_lengths_matching_tail_suffix(
+    prefix_items: list[tuple[str, str, str, str]],
+    tail_items: list[tuple[str, str, str, str]],
+) -> set[int]:
+    """Return prefix lengths whose values equal a suffix of ``tail_items``.
+
+    The prefix-function construction finds every viable replay boundary in
+    linear time. Following failure links from the final match yields shorter
+    matching boundaries without retrying every progressively shorter message
+    prefix.
+    """
+    if not prefix_items or not tail_items:
+        return set()
+    separator = object()
+    combined: list[Any] = [*prefix_items, separator, *tail_items]
+    prefix_function = [0] * len(combined)
+    for index in range(1, len(combined)):
+        match_length = prefix_function[index - 1]
+        while match_length and combined[index] != combined[match_length]:
+            match_length = prefix_function[match_length - 1]
+        if combined[index] == combined[match_length]:
+            match_length += 1
+        prefix_function[index] = match_length
+
+    matches: set[int] = set()
+    match_length = prefix_function[-1]
+    while match_length:
+        if match_length <= len(prefix_items):
+            matches.add(match_length)
+        match_length = prefix_function[match_length - 1]
+    return matches
+
+
+def _matching_suffix_length(
+    left: list[tuple[str, str, str, str]],
+    right: list[tuple[str, str, str, str]],
+) -> int:
+    match_length = 0
+    limit = min(len(left), len(right))
+    while match_length < limit and left[-1 - match_length] == right[-1 - match_length]:
+        match_length += 1
+    return match_length
 
 
 class ReconcileMixin:
+    @staticmethod
+    def _triggering_message_id(msg: Dict[str, Any]) -> str:
+        if str(msg.get("role") or "") != "user":
+            return ""
+        content = normalize_content_value(msg.get("content")) or ""
+        match = _TRIGGERING_MESSAGE_HEADER_RE.match(content)
+        return match.group("message_id") if match is not None else ""
+
+    @classmethod
+    def _collapse_superseded_triggering_user_messages(
+        cls,
+        messages: list[Dict[str, Any]],
+    ) -> list[Dict[str, Any]]:
+        """Keep the latest row in an adjacent run for one Discord message id."""
+        collapsed: list[Dict[str, Any]] = []
+        for msg in messages:
+            message_id = cls._triggering_message_id(msg)
+            if (
+                message_id
+                and collapsed
+                and cls._triggering_message_id(collapsed[-1]) == message_id
+            ):
+                collapsed[-1] = msg
+            else:
+                collapsed.append(msg)
+        return collapsed
+
+    @staticmethod
+    def _is_host_transient_empty_replay_message(msg: Dict[str, Any]) -> bool:
+        """Identify host lifecycle placeholders that are not durable turns.
+
+        Hermes can leave empty user rows in active SessionDB history while
+        restoring an interrupted gateway run. They carry no user content or
+        tool identity and are not consistently presented to context engines at
+        creation time, so treating them as replay identities prevents an
+        otherwise exact durable transcript from reconciling after restart.
+        """
+        return bool(
+            str(msg.get("role") or "") == "user"
+            and not (normalize_content_value(msg.get("content")) or "").strip()
+            and not msg.get("tool_call_id")
+            and not msg.get("tool_calls")
+            and not msg.get("tool_name")
+        )
+
+    @staticmethod
+    def _canonical_user_replay_content(content: str) -> str:
+        """Collapse cumulative Discord runtime injections to their latest view.
+
+        Background-process completions can rewrite one active user row by
+        appending another copy of its stable triggering-message envelope. LCM
+        may have persisted the cumulative view while SessionDB later exposes
+        only the newest suffix. The repeated platform message id is durable
+        evidence that both representations refer to the same host row.
+        """
+        matches = list(_TRIGGERING_MESSAGE_HEADER_RE.finditer(content))
+        if len(matches) < 2 or matches[0].start() != 0:
+            return content
+        message_id = matches[0].group("message_id")
+        if any(match.group("message_id") != message_id for match in matches[1:]):
+            return content
+        return content[matches[-1].start():]
+
     @staticmethod
     def _canonicalize_tool_call_identity_value(value: Any) -> Any:
         if isinstance(value, dict):
@@ -234,6 +346,8 @@ class ReconcileMixin:
             )
             if payload is not None and isinstance(payload.get("content"), str):
                 content = payload["content"]
+        if role == "user":
+            content = self._canonical_user_replay_content(content)
         tool_calls_identity = self._stable_tool_calls_identity(tool_calls)
         return (
             role,
@@ -457,13 +571,124 @@ class ReconcileMixin:
                 identity_cache[key] = identity
             return identity
 
-        for cursor in range(len(messages), -1, -1):
+        # Classify and identify the incoming replay once. Candidate prefixes are
+        # prefixes of these two sequences, so KMP can identify every boundary
+        # capable of matching a durable tail without an O(n^2) descending scan.
+        incoming_visible_identities: list[tuple[str, str, str, str]] = []
+        incoming_candidate_identities: list[tuple[str, str, str, str]] = []
+        visible_count_by_cursor = [0]
+        candidate_count_by_cursor = [0]
+        base_visible_messages = [
+            msg
+            for msg in messages
+            if not self._is_replayed_context_scaffold_message(msg)
+            and not self._is_host_transient_empty_replay_message(msg)
+            and not self._matches_ignore_message_patterns(msg)
+        ]
+        collapsed_visible_messages = self._collapse_superseded_triggering_user_messages(
+            base_visible_messages
+        )
+        superseded_visible_message_ids = {
+            id(msg) for msg in base_visible_messages
+        } - {
+            id(msg) for msg in collapsed_visible_messages
+        }
+        for msg in messages:
+            is_visible = (
+                not self._is_replayed_context_scaffold_message(msg)
+                and not self._is_host_transient_empty_replay_message(msg)
+                and not self._matches_ignore_message_patterns(msg)
+                and id(msg) not in superseded_visible_message_ids
+            )
+            if is_visible:
+                identity = replay_identity(msg)
+                incoming_visible_identities.append(identity)
+                content = text_content_for_pattern_matching(msg.get("content")) or ""
+                is_filtered_placeholder = (
+                    self._is_volatile_ignored_quarantine_placeholder(msg, content)
+                    or self._is_ignored_active_replay_placeholder(msg, content)
+                    or (
+                        self._compiled_ignore_message_patterns
+                        and self._is_quarantined_assistant_replay_identity(identity)
+                        and self._matches_ignore_message_patterns(msg, stored_row=True)
+                    )
+                )
+                if not is_filtered_placeholder:
+                    incoming_candidate_identities.append(identity)
+            visible_count_by_cursor.append(len(incoming_visible_identities))
+            candidate_count_by_cursor.append(len(incoming_candidate_identities))
+
+        candidate_match_lengths: set[int] = set()
+        visible_match_lengths: set[int] = set()
+        for tail in (stored_tail, sanitized_replay_tail):
+            candidate_match_lengths.update(
+                _prefix_lengths_matching_tail_suffix(incoming_candidate_identities, tail)
+            )
+            visible_match_lengths.update(
+                _prefix_lengths_matching_tail_suffix(incoming_visible_identities, tail)
+            )
+        generationless_candidate_identities = [
+            self._strip_inline_persisted_output_generation_identity(identity)
+            for identity in incoming_candidate_identities
+        ]
+        generationless_sanitized_tail = [
+            self._strip_inline_persisted_output_generation_identity(identity)
+            for identity in sanitized_replay_tail
+        ]
+        candidate_match_lengths.update(
+            _prefix_lengths_matching_tail_suffix(
+                generationless_candidate_identities,
+                generationless_sanitized_tail,
+            )
+        )
+
+        # Hermes may rewrite old SessionDB rows in place while preserving a
+        # long, already-durable newest tail (for example cumulative background
+        # process notifications). In a chronological transcript, new messages
+        # cannot precede an exact durable suffix. A deliberately high anchor
+        # lets large restart snapshots reconcile without weakening the
+        # ambiguity safeguards used for ordinary deltas and repeated turns.
+        if len(incoming_candidate_identities) >= _LARGE_REPLAY_MIN_ITEMS:
+            durable_suffix_length = max(
+                _matching_suffix_length(incoming_candidate_identities, stored_tail),
+                _matching_suffix_length(incoming_candidate_identities, sanitized_replay_tail),
+            )
+            if durable_suffix_length >= _LARGE_REPLAY_DURABLE_SUFFIX_ITEMS:
+                return len(messages)
+
+        plausible_cursors: set[int] = set()
+        for cursor in range(len(messages) + 1):
+            candidate_count = candidate_count_by_cursor[cursor]
+            visible_count = visible_count_by_cursor[cursor]
+            if (
+                candidate_count in candidate_match_lengths
+                or (bool(stored_tail) and candidate_count == len(stored_tail))
+                or (
+                    candidate_count < visible_count
+                    and visible_count in visible_match_lengths
+                )
+            ):
+                plausible_cursors.add(cursor)
+        if allow_empty_prefix:
+            plausible_cursors.add(0)
+            # The original descending scan returns the longest leading run of
+            # synthetic/ignored context whose effective replay prefix is empty.
+            # Keep that exact boundary so scaffolds are skipped while the first
+            # real delta remains eligible for ingestion.
+            for cursor in range(len(messages), -1, -1):
+                if candidate_count_by_cursor[cursor] == 0:
+                    plausible_cursors.add(cursor)
+                    break
+
+        for cursor in sorted(plausible_cursors, reverse=True):
             candidate_messages = messages[:cursor]
             candidate_visible_messages = [
                 msg
                 for msg in candidate_messages
                 if not self._is_replayed_context_scaffold_message(msg)
+                and not self._is_host_transient_empty_replay_message(msg)
                 and not self._matches_ignore_message_patterns(msg)
+                and id(msg) not in superseded_visible_message_ids
             ]
             candidate_non_placeholder_messages = [
                 msg
@@ -778,11 +1003,16 @@ class ReconcileMixin:
         self,
         messages: List[Dict[str, Any]],
     ) -> list[tuple[str, str, str, str]]:
-        return [
-            self._message_replay_identity(msg)
+        visible_messages = [
+            msg
             for msg in messages
             if not self._is_replayed_context_scaffold_message(msg)
+            and not self._is_host_transient_empty_replay_message(msg)
             and not self._matches_ignore_message_patterns(msg)
+        ]
+        return [
+            self._message_replay_identity(msg)
+            for msg in self._collapse_superseded_triggering_user_messages(visible_messages)
         ]
 
     def _is_suspicious_stale_no_overlap_snapshot(
@@ -856,11 +1086,12 @@ class ReconcileMixin:
         stored_rows = self._store.get_session_tail(self._session_id, limit=tail_limit)
         if not stored_rows:
             return 0
-        stored_tail_rows = [
+        stored_tail_rows = self._collapse_superseded_triggering_user_messages([
             row
             for row in stored_rows
+            if not self._is_host_transient_empty_replay_message(row)
             if not self._matches_ignore_message_patterns(row, stored_row=True)
-        ]
+        ])
         stored_tail = [
             self._message_replay_identity(row, stored_row=True)
             for row in stored_tail_rows

--- a/schemas.py
+++ b/schemas.py
@@ -1,5 +1,12 @@
 """Tool schemas for LCM — what the LLM sees."""
 
+from .operator_schemas import AGENTIC_MAP_SCHEMA, LLM_MAP_SCHEMA
+
+# The public contract uses one flat schema object per tool.  The operator
+# module also exports OpenAI-style wrappers for hosts that need them directly.
+LLM_MAP = LLM_MAP_SCHEMA["function"]
+AGENTIC_MAP = AGENTIC_MAP_SCHEMA["function"]
+
 LCM_GREP = {
     "name": "lcm_grep",
     "description": (
@@ -18,13 +25,17 @@ LCM_GREP = {
         "properties": {
             "mode": {
                 "type": "string",
-                "enum": ["full_text", "semantic", "hybrid"],
+                "enum": ["full_text", "regex", "semantic", "hybrid"],
                 "description": (
                     "Retrieval mode. 'full_text' preserves the historical FTS behavior byte-for-byte. "
                     "'semantic' searches embedded summaries and degrades to full-text on provider timeout or transient unavailability. "
                     "'hybrid' fuses full-text and semantic ranks with reciprocal-rank fusion (RRF)."
                 ),
                 "default": "full_text",
+            },
+            "summary_id": {
+                "type": "integer",
+                "description": "Optional summary node whose recursive raw-message lineage bounds a regex search.",
             },
             "query": {
                 "type": "string",
@@ -1007,6 +1018,10 @@ LCM_DESCRIBE = {
             "externalized_ref": {
                 "type": "string",
                 "description": "Optional externalized payload ref filename to inspect instead of a summary node.",
+            },
+            "file_id": {
+                "type": "string",
+                "description": "Optional opaque LCM file ID to inspect instead of a summary node.",
             },
         },
         "required": [],

--- a/store.py
+++ b/store.py
@@ -12,9 +12,13 @@ row identity (`store_id`) for DAG/source lookup.
 import json
 import logging
 import math
+import os
 import sqlite3
 import threading
 import time
+import uuid
+from contextlib import nullcontext
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -49,6 +53,7 @@ from .search_query import (
     should_apply_directness_rank_adjustment,
 )
 from .message_content import normalize_content_value as _normalize_content_value
+from .sqlite_util import _is_sqlite_locked_error, _temporary_sqlite_busy_timeout
 from .tokens import count_message_tokens
 
 logger = logging.getLogger(__name__)
@@ -62,6 +67,40 @@ _MESSAGE_SELECT_COLUMNS = (
 )
 _MESSAGE_SELECT_COLUMN_COUNT = len(_MESSAGE_SELECT_COLUMNS.split(","))
 _UNKNOWN_SOURCE = "unknown"
+_PROVIDER_STATE_KEYS = (
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+    "codex_message_items",
+    "codex_compaction_items",
+    "finish_reason",
+)
+
+
+def _encode_provider_state(message: Dict[str, Any]) -> str | None:
+    """Serialize provider continuity state without making it searchable.
+
+    The values are opaque replay capsules/signatures.  They are intentionally
+    excluded from FTS, summaries, and ``to_openai_msg``; this column is only a
+    lossless durable archive for provider-aware recovery code.
+    """
+    state = {
+        key: message[key]
+        for key in _PROVIDER_STATE_KEYS
+        if message.get(key) is not None
+    }
+    if not state:
+        return None
+    return json.dumps(state, ensure_ascii=False, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class DurableAppendResult:
+    """Outcome of an append that may have fallen back to the disk queue."""
+
+    persisted: bool
+    store_ids: tuple[int, ...] = ()
+    pending_batch_id: str = ""
 
 
 def _legacy_blank_source_clause(column: str) -> str:
@@ -306,7 +345,8 @@ class MessageStore:
                 pinned INTEGER DEFAULT 0,
                 ingested_at REAL,
                 observed_at REAL,
-                observed_at_source TEXT
+                observed_at_source TEXT,
+                provider_state TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_msg_session
                 ON messages(session_id, store_id);
@@ -317,6 +357,11 @@ class MessageStore:
                 key TEXT PRIMARY KEY,
                 value TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS lcm_ingest_receipts (
+                batch_id TEXT PRIMARY KEY,
+                persisted_at REAL NOT NULL
+            );
         """)
         ensure_external_content_fts(
             self._conn,
@@ -326,6 +371,7 @@ class MessageStore:
         self._ensure_source_column()
         self._ensure_conversation_id_column()
         self._ensure_time_contract_columns()
+        self._ensure_provider_state_column()
         self._conn.commit()
 
     def _ensure_source_column(self) -> None:
@@ -384,6 +430,17 @@ class MessageStore:
             "UPDATE messages SET ingested_at = timestamp WHERE ingested_at IS NULL"
         )
 
+    def _ensure_provider_state_column(self) -> None:
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        add_column_if_missing(
+            self._conn,
+            columns,
+            "provider_state",
+            "ALTER TABLE messages ADD COLUMN provider_state TEXT",
+        )
+
     # -- Write operations ---------------------------------------------------
 
     def append(self, session_id: str, msg: Dict[str, Any],
@@ -406,8 +463,8 @@ class MessageStore:
                 """INSERT INTO messages
                    (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,
                     tool_name, timestamp, token_estimate, pinned, ingested_at,
-                    observed_at, observed_at_source)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    observed_at, observed_at_source, provider_state)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     _normalize_source_value(source),
@@ -423,6 +480,7 @@ class MessageStore:
                     ingested_at,
                     observed_at,
                     "host_message_timestamp" if observed_at is not None else None,
+                    _encode_provider_state(msg),
                 ),
             )
             self._conn.commit()
@@ -452,7 +510,9 @@ class MessageStore:
                                 messages: List[Dict[str, Any]],
                                 token_estimates: List[int] | None = None,
                                 source: str = "",
-                                conversation_id: str = "") -> List[int]:
+                                conversation_id: str = "",
+                                *,
+                                batch_id: str = "") -> List[int]:
         """Persist messages that already passed ingest protection.
 
         This is an internal fast path for callers that need the protected form
@@ -465,6 +525,11 @@ class MessageStore:
 
         ids = []
         with self._write_lock, self._conn:
+            if batch_id and self._conn.execute(
+                "SELECT 1 FROM lcm_ingest_receipts WHERE batch_id = ?",
+                (batch_id,),
+            ).fetchone():
+                return []
             for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
@@ -474,8 +539,8 @@ class MessageStore:
                     """INSERT INTO messages
                        (session_id, source, conversation_id, role, content, tool_call_id, tool_calls,
                         tool_name, timestamp, token_estimate, pinned, ingested_at,
-                        observed_at, observed_at_source)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        observed_at, observed_at_source, provider_state)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         _normalize_source_value(source),
@@ -491,10 +556,168 @@ class MessageStore:
                         ts,
                         observed_at,
                         "host_message_timestamp" if observed_at is not None else None,
+                        _encode_provider_state(msg),
                     ),
                 )
                 ids.append(cur.lastrowid)
+            if batch_id:
+                self._conn.execute(
+                    "INSERT INTO lcm_ingest_receipts(batch_id, persisted_at) VALUES (?, ?)",
+                    (batch_id, time.time()),
+                )
         return ids
+
+    @property
+    def _pending_ingest_dir(self) -> Path:
+        return self.db_path.parent / f".{self.db_path.name}.pending-ingest"
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        try:
+            descriptor = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _write_pending_ingest_file(self, batch_id: str, payload: Dict[str, Any]) -> Path:
+        """Durably publish one immutable pending-ingest sidecar."""
+        queue_dir = self._pending_ingest_dir
+        queue_dir.mkdir(parents=True, exist_ok=True)
+        final_path = queue_dir / f"{batch_id}.json"
+        temp_path = queue_dir / f".{batch_id}.{uuid.uuid4().hex}.tmp"
+        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        descriptor = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            offset = 0
+            while offset < len(encoded):
+                offset += os.write(descriptor, encoded[offset:])
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temp_path, final_path)
+        self._fsync_directory(queue_dir)
+        return final_path
+
+    def append_batch_durable(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        token_estimates: List[int] | None = None,
+        source: str = "",
+        conversation_id: str = "",
+        *,
+        busy_timeout_ms: int = 250,
+    ) -> DurableAppendResult:
+        """Append once or durably spool the batch when SQLite is locked.
+
+        The receipt is committed in the same transaction as the messages.  If
+        the process crashes after that commit but before deleting a replay
+        sidecar, the next drain sees the receipt and does not duplicate rows.
+        """
+        protected_messages = protect_messages_for_ingest(
+            messages,
+            config=self._ingest_protection_config,
+            hermes_home=self._hermes_home,
+            session_id=session_id,
+        )
+        return self.append_protected_batch_durable(
+            session_id,
+            protected_messages,
+            token_estimates,
+            source=source,
+            conversation_id=conversation_id,
+            busy_timeout_ms=busy_timeout_ms,
+        )
+
+    def append_protected_batch_durable(
+        self,
+        session_id: str,
+        protected_messages: List[Dict[str, Any]],
+        token_estimates: List[int] | None = None,
+        source: str = "",
+        conversation_id: str = "",
+        *,
+        busy_timeout_ms: int = 250,
+    ) -> DurableAppendResult:
+        """Durably append messages already transformed by ingest protection."""
+        estimates = list(token_estimates or [0] * len(protected_messages))
+        batch_id = uuid.uuid4().hex
+        payload: Dict[str, Any] = {
+            "batch_id": batch_id,
+            "session_id": session_id,
+            "messages": protected_messages,
+            "token_estimates": estimates,
+            "source": source,
+            "conversation_id": conversation_id,
+        }
+        try:
+            # The busy-timeout PRAGMA is connection-scoped. Keep it under the
+            # same process-wide store lock as the write so a sibling engine
+            # cannot observe the temporary 50/250ms value mid-transaction.
+            with self._write_lock:
+                with _temporary_sqlite_busy_timeout([self._conn], busy_timeout_ms):
+                    ids = self._append_protected_batch(
+                        session_id,
+                        protected_messages,
+                        estimates,
+                        source=source,
+                        conversation_id=conversation_id,
+                        batch_id=batch_id,
+                    )
+            return DurableAppendResult(True, tuple(ids), "")
+        except Exception as exc:
+            if not _is_sqlite_locked_error(exc):
+                raise
+            self._write_pending_ingest_file(batch_id, payload)
+            return DurableAppendResult(False, (), batch_id)
+
+    def pending_ingest_count(self) -> int:
+        queue_dir = self._pending_ingest_dir
+        if not queue_dir.exists():
+            return 0
+        return sum(1 for path in queue_dir.glob("*.json") if path.is_file())
+
+    def drain_pending_ingest(
+        self,
+        *,
+        limit: int = 100,
+        busy_timeout_ms: int | None = None,
+    ) -> int:
+        """Replay durable pending batches, leaving the first failed file intact."""
+        queue_dir = self._pending_ingest_dir
+        if not queue_dir.exists():
+            return 0
+        processed = 0
+        for path in sorted(queue_dir.glob("*.json"))[:max(0, int(limit))]:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            batch_id = str(payload["batch_id"])
+            with self._write_lock:
+                if busy_timeout_ms is None:
+                    self._append_protected_batch(
+                        str(payload["session_id"]),
+                        list(payload["messages"]),
+                        [int(value) for value in payload.get("token_estimates", [])],
+                        source=str(payload.get("source") or ""),
+                        conversation_id=str(payload.get("conversation_id") or ""),
+                        batch_id=batch_id,
+                    )
+                else:
+                    with _temporary_sqlite_busy_timeout([self._conn], busy_timeout_ms):
+                        self._append_protected_batch(
+                            str(payload["session_id"]),
+                            list(payload["messages"]),
+                            [int(value) for value in payload.get("token_estimates", [])],
+                            source=str(payload.get("source") or ""),
+                            conversation_id=str(payload.get("conversation_id") or ""),
+                            batch_id=batch_id,
+                        )
+            path.unlink()
+            self._fsync_directory(queue_dir)
+            processed += 1
+        return processed
 
     def reassign_session_messages(self, old_session_id: str, new_session_id: str) -> int:
         """Move all persisted messages from one session_id to another."""
@@ -798,6 +1021,38 @@ class MessageStore:
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    def get_conversation_messages_after(
+        self,
+        conversation_id: str,
+        after_store_id: int = 0,
+        limit: int = 10000,
+        *,
+        current_session_id: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Get ordered messages across every segment of one conversation.
+
+        Compression rollover intentionally leaves immutable rows owned by the
+        session segment that produced them.  Context rebuilt in the next
+        segment can therefore contain an un-compacted tail from the previous
+        segment, and provenance reconciliation must be able to see those rows.
+        """
+        if current_session_id:
+            rows = self._conn.execute(
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+                   WHERE (conversation_id = ? OR session_id = ?)
+                     AND store_id > ?
+                   ORDER BY store_id LIMIT ?""",
+                (conversation_id, current_session_id, after_store_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                f"""SELECT {_MESSAGE_SELECT_COLUMNS} FROM messages
+                   WHERE conversation_id = ? AND store_id > ?
+                   ORDER BY store_id LIMIT ?""",
+                (conversation_id, after_store_id, limit),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def get_session_tail(self, session_id: str, limit: int = 1000) -> List[Dict[str, Any]]:
         """Get the latest messages for a session, returned in store order."""
         if limit <= 0:
@@ -1025,6 +1280,7 @@ class MessageStore:
         serialized: str,
         *,
         skip_unchanged: bool = False,
+        busy_timeout_ms: int | None = None,
     ) -> bool:
         """Write the pre-serialized JSON string ``serialized`` to every key in ``keys``.
 
@@ -1033,31 +1289,39 @@ class MessageStore:
         commit. With ``skip_unchanged=True`` a key already holding ``serialized``
         is left untouched and the commit is skipped entirely when nothing changed
         -- the ingest-hot-path optimization used by the placeholder count/ordinal
-        writers. Returns ``True`` if any key was written.
+        writers. ``busy_timeout_ms`` lets best-effort hot-path metadata avoid
+        inheriting the connection's normal 30-second writer wait. Returns
+        ``True`` if any key was written.
         """
         conn = self._conn
         if conn is None:
             return False
         wrote = False
         with self._write_lock:
-            for key in keys:
-                if skip_unchanged:
-                    existing = conn.execute(
-                        "SELECT value FROM metadata WHERE key = ?", (key,)
-                    ).fetchone()
-                    if existing is not None and existing[0] == serialized:
-                        continue
-                conn.execute(
-                    """
-                    INSERT INTO metadata(key, value)
-                    VALUES(?, ?)
-                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                    """,
-                    (key, serialized),
-                )
-                wrote = True
-            if wrote:
-                conn.commit()
+            timeout_scope = (
+                _temporary_sqlite_busy_timeout([conn], busy_timeout_ms)
+                if busy_timeout_ms is not None
+                else nullcontext()
+            )
+            with timeout_scope:
+                for key in keys:
+                    if skip_unchanged:
+                        existing = conn.execute(
+                            "SELECT value FROM metadata WHERE key = ?", (key,)
+                        ).fetchone()
+                        if existing is not None and existing[0] == serialized:
+                            continue
+                    conn.execute(
+                        """
+                        INSERT INTO metadata(key, value)
+                        VALUES(?, ?)
+                        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                        """,
+                        (key, serialized),
+                    )
+                    wrote = True
+                if wrote:
+                    conn.commit()
         return wrote
 
     # -- Compaction telemetry ------------------------------------------------
@@ -1508,6 +1772,21 @@ class MessageStore:
         if stored.get("tool_name"):
             msg["name"] = stored["tool_name"]
         return msg
+
+    def get_provider_state(self, store_id: int) -> Dict[str, Any] | None:
+        """Return opaque archived provider state for trusted internal recovery."""
+        row = self._conn.execute(
+            "SELECT provider_state FROM messages WHERE store_id = ?",
+            (store_id,),
+        ).fetchone()
+        if row is None or not row[0]:
+            return None
+        try:
+            state = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Ignoring invalid provider_state for store_id=%s", store_id)
+            return None
+        return state if isinstance(state, dict) else None
 
     # -- Connection access --------------------------------------------------
 

--- a/tests/test_active_tool_stubbing.py
+++ b/tests/test_active_tool_stubbing.py
@@ -387,7 +387,11 @@ def test_flag_off_replay_cleanup_preflight_outranks_boundary_cooldown(
     engine.threshold_tokens = 100_000
     engine._last_boundary_skip_time = time.time()
     messages, cleanup_messages = externalized_raw_cleanup_messages()
-    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: cleanup_messages)
+    monkeypatch.setattr(
+        engine,
+        "_ingest_messages",
+        lambda _messages, **_kwargs: cleanup_messages,
+    )
 
     assert engine.should_compress_preflight(messages) is True
     assert engine._preflight_cleanup_only_due_to_boundary_cooldown is True
@@ -401,7 +405,11 @@ def test_flag_off_replay_cleanup_cooldown_publishes_without_summary_llm(
     engine.threshold_tokens = 100_000
     engine._last_boundary_skip_time = time.time()
     messages, cleanup_messages = externalized_raw_cleanup_messages()
-    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: cleanup_messages)
+    monkeypatch.setattr(
+        engine,
+        "_ingest_messages",
+        lambda _messages, **_kwargs: cleanup_messages,
+    )
     summary_spy = Mock(
         side_effect=AssertionError("cooldown-limited replay cleanup must not summarize")
     )
@@ -425,7 +433,11 @@ def test_flag_off_noncleanup_replay_diff_remains_blocked_during_cooldown(
     engine._last_boundary_skip_time = time.time()
     messages = [{"role": "user", "content": "original visible payload"}]
     replay_messages = [{"role": "user", "content": "normalized visible payload"}]
-    monkeypatch.setattr(engine, "_ingest_messages", lambda _messages: replay_messages)
+    monkeypatch.setattr(
+        engine,
+        "_ingest_messages",
+        lambda _messages, **_kwargs: replay_messages,
+    )
 
     assert engine._replay_diff_requests_ingest_cleanup(messages, replay_messages) is False
     assert engine._should_force_overflow_recovery(messages=replay_messages) is False

--- a/tests/test_async_background_compaction_design.py
+++ b/tests/test_async_background_compaction_design.py
@@ -1,10 +1,4 @@
-"""RED spike tests for opt-in async/background compaction.
-
-These tests intentionally describe the desired public/private contract before
-implementation exists. They stay xfailed on the design branch so the normal
-suite remains green, but strict xfail means each scenario becomes a real gate as
-soon as the feature starts landing.
-"""
+"""Regression tests for opt-in asynchronous compaction and atomic promotion."""
 
 from __future__ import annotations
 
@@ -15,12 +9,6 @@ import pytest
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.engine import LCMEngine
 
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="async/background compaction with atomic publish is design-only; implementation not landed",
-)
-
-
 def _engine(tmp_path, *, session_id="async-session", conversation_id="async-conversation"):
     config = LCMConfig(
         database_path=str(tmp_path / f"{session_id}.db"),
@@ -28,8 +16,6 @@ def _engine(tmp_path, *, session_id="async-session", conversation_id="async-conv
         leaf_chunk_tokens=20,
         context_threshold=0.10,
     )
-    # Future config fields. They are dynamic here so these RED tests can be
-    # written before the dataclass grows the real fields.
     config.async_background_compaction_enabled = True
     config.async_background_compaction_worker_enabled = False
     engine = LCMEngine(config=config)
@@ -102,6 +88,22 @@ def test_pending_summaries_are_invisible_until_atomic_promotion(tmp_path):
         assert status["dag"]["total_nodes"] == 0
         grep = json.loads(engine.handle_tool_call("lcm_grep", {"query": "message"}))
         assert all(result.get("kind") != "pending_summary" for result in grep.get("results", []))
+    finally:
+        engine.shutdown()
+
+
+def test_atomic_promotion_carries_file_ids_into_canonical_dag(tmp_path):
+    engine = _engine(tmp_path)
+    try:
+        messages = _messages(prefix="file_0123456789abcdef")
+        engine.ingest(messages)
+        batch = engine.prepare_background_compaction_once(messages)
+
+        result = engine.promote_prepared_compaction(batch.batch_id, messages)
+
+        assert result.promoted is True
+        nodes = engine._dag.get_session_nodes(engine.current_session_id)
+        assert nodes[0].file_ids == ["file_0123456789abcdef"]
     finally:
         engine.shutdown()
 

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 EXPECTED_LCM_TOOLS = {
+    "agentic_map",
     "lcm_grep",
     "lcm_recall",
     "lcm_query_state",
@@ -21,6 +22,7 @@ EXPECTED_LCM_TOOLS = {
     "lcm_status",
     "lcm_inspect",
     "lcm_doctor",
+    "llm_map",
 }
 
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -40,7 +40,10 @@ def engine(tmp_path):
 def _replace_with_header_only_sqlite_db(e: LCMEngine) -> Path:
     """Replace the active DB file with a valid SQLite header and no tables."""
     db_path = Path(e._store.db_path)
-    e.shutdown()
+    # Close the shared helpers without clearing the engine's references: the
+    # doctor call below intentionally inspects replacement connections on the
+    # same engine instance.
+    e._storage_bundle.close()
     for path in (db_path, Path(str(db_path) + "-wal"), Path(str(db_path) + "-shm")):
         path.unlink(missing_ok=True)
     with sqlite3.connect(str(db_path)) as conn:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -7775,6 +7775,54 @@ def test_externalized_tool_replay_lookup_reads_only_matching_call_files(tmp_path
     assert read_paths == [wanted["path"]]
 
 
+def test_externalized_tool_replay_lookup_indexes_stable_archive_once(tmp_path, monkeypatch):
+    from hermes_lcm.externalize import (
+        find_externalized_tool_result_content_for_call,
+        maybe_externalize_tool_output,
+    )
+
+    output_dir = tmp_path / "externalized"
+    config = LCMConfig(
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=1,
+        large_output_externalization_path=str(output_dir),
+    )
+    expected = {}
+    for index in range(20):
+        call_id = f"call-{index}"
+        content = f"durable content {index}"
+        created = maybe_externalize_tool_output(
+            content,
+            tool_call_id=call_id,
+            session_id="session-1",
+            force=True,
+            config=config,
+            hermes_home=str(tmp_path),
+        )
+        assert created is not None
+        expected[call_id] = content
+
+    original_iterdir = Path.iterdir
+    archive_scans = 0
+
+    def tracked_iterdir(path):
+        nonlocal archive_scans
+        if path == output_dir:
+            archive_scans += 1
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", tracked_iterdir)
+    for call_id, content in expected.items():
+        assert find_externalized_tool_result_content_for_call(
+            tool_call_id=call_id,
+            session_id="session-1",
+            config=config,
+            hermes_home=str(tmp_path),
+        ) == content
+
+    assert archive_scans == 1
+
+
 def test_reconciliation_computes_each_incoming_identity_once(tmp_path, monkeypatch):
     if "agent.context_engine" not in sys.modules:
         agent_mod = ModuleType("agent")
@@ -7833,3 +7881,189 @@ def test_reconciliation_computes_each_incoming_identity_once(tmp_path, monkeypat
         assert max(identity_calls.values()) == 1
     finally:
         engine.shutdown()
+
+
+def test_reconciliation_large_mismatch_classifies_messages_linearly(tmp_path, monkeypatch):
+    if "agent.context_engine" not in sys.modules:
+        agent_mod = ModuleType("agent")
+        agent_mod.__path__ = []
+        context_engine_mod = ModuleType("agent.context_engine")
+
+        class ContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        context_engine_mod.ContextEngine = ContextEngine
+        monkeypatch.setitem(sys.modules, "agent", agent_mod)
+        monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
+    existing_engine_module = sys.modules.get("hermes_lcm.engine")
+    if existing_engine_module is not None and not hasattr(existing_engine_module, "LCMEngine"):
+        monkeypatch.delitem(sys.modules, "hermes_lcm.engine")
+
+    from hermes_lcm.engine import LCMEngine
+
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(tmp_path / "lcm.db")),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    try:
+        message_count = 2_000
+        messages = [
+            {"role": "assistant", "content": f"incoming-{index}"}
+            for index in range(message_count)
+        ]
+        stored_tail = [
+            ("assistant", f"stored-{index}", "", "")
+            for index in range(message_count)
+        ]
+        original_scaffold_check = engine._is_replayed_context_scaffold_message
+        scaffold_checks = 0
+
+        def counted_scaffold_check(message):
+            nonlocal scaffold_checks
+            scaffold_checks += 1
+            return original_scaffold_check(message)
+
+        monkeypatch.setattr(engine, "_is_replayed_context_scaffold_message", counted_scaffold_check)
+        cursor = engine._find_reconciled_cursor_for_store_tail(
+            messages,
+            stored_tail,
+            allow_empty_prefix=False,
+            session_count=len(stored_tail),
+            raw_session_count=len(stored_tail),
+        )
+
+        assert cursor is None
+        assert scaffold_checks <= message_count * 4
+    finally:
+        engine.shutdown()
+
+
+def test_reconciliation_large_replay_accepts_long_durable_suffix(tmp_path, monkeypatch):
+    if "agent.context_engine" not in sys.modules:
+        agent_mod = ModuleType("agent")
+        agent_mod.__path__ = []
+        context_engine_mod = ModuleType("agent.context_engine")
+
+        class ContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        context_engine_mod.ContextEngine = ContextEngine
+        monkeypatch.setitem(sys.modules, "agent", agent_mod)
+        monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
+    existing_engine_module = sys.modules.get("hermes_lcm.engine")
+    if existing_engine_module is not None and not hasattr(existing_engine_module, "LCMEngine"):
+        monkeypatch.delitem(sys.modules, "hermes_lcm.engine")
+
+    from hermes_lcm.engine import LCMEngine
+
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(tmp_path / "lcm.db")),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    try:
+        message_count = 4_096
+        durable_suffix_count = 1_024
+        messages = [
+            {"role": "assistant", "content": f"rewritten-active-{index}"}
+            for index in range(message_count - durable_suffix_count)
+        ] + [
+            {"role": "assistant", "content": f"durable-tail-{index}"}
+            for index in range(durable_suffix_count)
+        ]
+        stored_tail = [
+            ("assistant", f"older-durable-{index}", "", "")
+            for index in range(message_count - durable_suffix_count)
+        ] + [
+            ("assistant", f"durable-tail-{index}", "", "")
+            for index in range(durable_suffix_count)
+        ]
+
+        cursor = engine._find_reconciled_cursor_for_store_tail(
+            messages,
+            stored_tail,
+            allow_empty_prefix=True,
+            session_count=len(stored_tail),
+            raw_session_count=len(stored_tail) * 2,
+        )
+
+        assert cursor == len(messages)
+    finally:
+        engine.shutdown()
+
+
+def test_reconciliation_ignores_host_transient_empty_user_rows(tmp_path, monkeypatch):
+    if "agent.context_engine" not in sys.modules:
+        agent_mod = ModuleType("agent")
+        agent_mod.__path__ = []
+        context_engine_mod = ModuleType("agent.context_engine")
+
+        class ContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        context_engine_mod.ContextEngine = ContextEngine
+        monkeypatch.setitem(sys.modules, "agent", agent_mod)
+        monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
+    existing_engine_module = sys.modules.get("hermes_lcm.engine")
+    if existing_engine_module is not None and not hasattr(existing_engine_module, "LCMEngine"):
+        monkeypatch.delitem(sys.modules, "hermes_lcm.engine")
+
+    from hermes_lcm.engine import LCMEngine
+
+    config = LCMConfig(database_path=str(tmp_path / "lcm.db"))
+    before_restart = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+    before_restart.on_session_start("session", platform="discord")
+    trigger_header = (
+        "[Triggering message id: `1234` — use as `message_id` for "
+        "reply/react/pin via the discord tools.]"
+    )
+    current_notice = f"{trigger_header}\n\n[IMPORTANT: Background process current exited.]"
+    old_notice = f"{trigger_header}\n\n[IMPORTANT: Background process old exited.]"
+    cumulative_notice = (
+        f"{old_notice}\n\n"
+        f"{current_notice}"
+    )
+    durable_messages = [
+        {"role": "user", "content": cumulative_notice},
+        {"role": "assistant", "content": "initial response"},
+        {"role": "assistant", "content": "first restore marker"},
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": "second restore marker"},
+    ]
+    before_restart._ingest_messages(durable_messages)
+    before_restart.shutdown()
+
+    after_restart = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+    try:
+        after_restart.on_session_start("session", platform="discord")
+        after_restart._ingest_messages([
+            {"role": "user", "content": old_notice},
+            {"role": "user", "content": current_notice},
+            durable_messages[1],
+            durable_messages[2],
+            {"role": "user", "content": ""},
+            durable_messages[4],
+            {"role": "user", "content": "new request"},
+        ])
+
+        rows = after_restart._store.get_session_messages("session")
+        assert [row["content"] for row in rows] == [
+            *(message["content"] for message in durable_messages),
+            "new request",
+        ]
+    finally:
+        after_restart.shutdown()

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -3317,8 +3317,11 @@ class TestLifecycleStateStore:
         store.append("s1", {"role": "user", "content": "hi"}, source="cli")
         state.bind_session("s1")
 
+        statements = []
+        state.connection.set_trace_callback(statements.append)
         deleted = state.prune_empty_sessions()
         assert deleted == 0
+        assert not any(statement == "BEGIN IMMEDIATE" for statement in statements)
         state.close()
 
     def test_prune_empty_sessions_handles_empty_table(self, tmp_path):
@@ -7149,6 +7152,64 @@ class TestExtraction:
 
 
 class TestLCMEngineCloning:
+    def test_storage_bundle_ignores_runtime_only_config_differences(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        db_path = tmp_path / "lcm-storage-contract.db"
+        first_config = LCMConfig(
+            database_path=str(db_path),
+            summary_timeout_ms=20_000,
+        )
+        second_config = LCMConfig(
+            database_path=str(db_path),
+            summary_timeout_ms=45_000,
+        )
+        first = LCMEngine(config=first_config, hermes_home=str(tmp_path))
+        second = LCMEngine(config=second_config, hermes_home=str(tmp_path))
+        try:
+            assert second._store is first._store
+            assert second._dag is first._dag
+            assert second._lifecycle is first._lifecycle
+        finally:
+            first.shutdown()
+            second.shutdown()
+
+    def test_storage_bundle_normalizes_default_home_to_database_parent(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        db_path = tmp_path / "lcm-default-home.db"
+        config = LCMConfig(database_path=str(db_path))
+        implicit_home = LCMEngine(config=copy.deepcopy(config))
+        explicit_home = LCMEngine(
+            config=copy.deepcopy(config),
+            hermes_home=str(tmp_path),
+        )
+        try:
+            assert explicit_home._store is implicit_home._store
+        finally:
+            implicit_home.shutdown()
+            explicit_home.shutdown()
+
+    def test_storage_bundle_separates_storage_affecting_config(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        db_path = tmp_path / "lcm-storage-feature.db"
+        disabled = LCMEngine(
+            config=LCMConfig(database_path=str(db_path), assertions_enabled=False),
+            hermes_home=str(tmp_path),
+        )
+        enabled = LCMEngine(
+            config=LCMConfig(database_path=str(db_path), assertions_enabled=True),
+            hermes_home=str(tmp_path),
+        )
+        try:
+            assert enabled._store is not disabled._store
+            assert disabled._assertions is None
+            assert enabled._assertions is not None
+        finally:
+            disabled.shutdown()
+            enabled.shutdown()
+
     def test_clone_for_agent_isolates_session_binding_while_sharing_store(self, tmp_path):
         from hermes_lcm.engine import LCMEngine
 
@@ -7254,15 +7315,64 @@ class TestLCMEngineCloning:
 
             assert clone is not prototype
             assert isinstance(clone, LCMEngine)
-            assert clone._store is not prototype._store
-            assert clone._dag is not prototype._dag
-            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._store is prototype._store
+            assert clone._dag is prototype._dag
+            assert clone._lifecycle is prototype._lifecycle
             assert clone._config.database_path == prototype._config.database_path
             assert clone._hermes_home == prototype._hermes_home
+            assert clone._summary_circuit_breaker is prototype._summary_circuit_breaker
+            assert clone._summary_spend_guard is prototype._summary_spend_guard
         finally:
             prototype.shutdown()
             if clone is not None:
                 clone.shutdown()
+
+    def test_clone_shutdown_keeps_shared_store_alive_until_last_owner(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-refcount.db"))
+        prototype = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes"))
+        clone = prototype.clone_for_agent()
+        shared_store = prototype._store
+
+        clone.shutdown()
+        assert shared_store.connection is not None
+        prototype.on_session_start("still-live", platform="cli")
+        prototype.ingest([{"role": "user", "content": "survives sibling close"}])
+        assert shared_store.get_session_count("still-live") == 1
+
+        prototype.shutdown()
+        assert shared_store.connection is None
+
+    def test_closed_shared_bundle_is_replaced_without_old_owner_closing_replacement(
+        self, tmp_path
+    ):
+        from hermes_lcm.engine import LCMEngine
+
+        config = LCMConfig(database_path=str(tmp_path / "lcm-stale-bundle.db"))
+        old_owner = LCMEngine(config=config, hermes_home=str(tmp_path))
+        old_bundle = old_owner._storage_bundle
+
+        # Preserve the historical standalone lifecycle: callers sometimes
+        # close the exposed helpers directly before constructing a restart.
+        old_owner._store.close()
+        old_owner._dag.close()
+        old_owner._lifecycle.close()
+
+        replacement = LCMEngine(config=config, hermes_home=str(tmp_path))
+        try:
+            assert replacement._storage_bundle is not old_bundle
+            assert replacement._store.connection is not None
+
+            # The stale owner's later finalizer must not decrement or close the
+            # newly installed bundle at the same pool key.
+            old_owner.shutdown()
+            replacement.on_session_start("replacement-session", platform="cli")
+            replacement.ingest([{"role": "user", "content": "still writable"}])
+            assert replacement._store.get_session_count("replacement-session") == 1
+        finally:
+            old_owner.shutdown()
+            replacement.shutdown()
 
     def test_deepcopy_matches_hermes_host_copy_contract_without_fallback(self, tmp_path):
         from hermes_lcm.engine import LCMEngine
@@ -7297,9 +7407,9 @@ class TestLCMEngineCloning:
             assert isinstance(clone, LCMEngine)
             assert clone.name == "lcm"
             assert clone is not prototype
-            assert clone._store is not prototype._store
-            assert clone._dag is not prototype._dag
-            assert clone._lifecycle is not prototype._lifecycle
+            assert clone._store is prototype._store
+            assert clone._dag is prototype._dag
+            assert clone._lifecycle is prototype._lifecycle
             assert clone._session_id == ""
             assert clone._conversation_id == ""
             assert clone.model == prototype.model
@@ -7611,3 +7721,115 @@ class TestSummaryDagLikeSanitization:
             assert emoji_only in {node.node_id for node in results}
         finally:
             dag.close()
+
+
+def test_externalized_tool_replay_lookup_reads_only_matching_call_files(tmp_path, monkeypatch):
+    from hermes_lcm.externalize import (
+        find_externalized_tool_result_content_for_call,
+        maybe_externalize_tool_output,
+    )
+
+    output_dir = tmp_path / "externalized"
+    config = LCMConfig(
+        large_output_externalization_enabled=True,
+        large_output_externalization_threshold_chars=1,
+        large_output_externalization_path=str(output_dir),
+    )
+    wanted_call_id = "call[target]*"
+    wanted = maybe_externalize_tool_output(
+        "wanted durable content",
+        tool_call_id=wanted_call_id,
+        session_id="session-1",
+        force=True,
+        config=config,
+        hermes_home=str(tmp_path),
+    )
+    assert wanted is not None
+    for index in range(25):
+        created = maybe_externalize_tool_output(
+            f"unrelated durable content {index}",
+            tool_call_id=f"other-call-{index}",
+            session_id="session-1",
+            force=True,
+            config=config,
+            hermes_home=str(tmp_path),
+        )
+        assert created is not None
+
+    original_read_text = Path.read_text
+    read_paths = []
+
+    def tracked_read_text(path, *args, **kwargs):
+        read_paths.append(path)
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+    recovered = find_externalized_tool_result_content_for_call(
+        tool_call_id=wanted_call_id,
+        session_id="session-1",
+        config=config,
+        hermes_home=str(tmp_path),
+    )
+
+    assert recovered == "wanted durable content"
+    assert read_paths == [wanted["path"]]
+
+
+def test_reconciliation_computes_each_incoming_identity_once(tmp_path, monkeypatch):
+    if "agent.context_engine" not in sys.modules:
+        agent_mod = ModuleType("agent")
+        agent_mod.__path__ = []
+        context_engine_mod = ModuleType("agent.context_engine")
+
+        class ContextEngine:
+            def __init__(self, **kwargs):
+                self.compression_count = 0
+                self.last_prompt_tokens = 0
+
+            def get_status(self):
+                return {}
+
+        context_engine_mod.ContextEngine = ContextEngine
+        monkeypatch.setitem(sys.modules, "agent", agent_mod)
+        monkeypatch.setitem(sys.modules, "agent.context_engine", context_engine_mod)
+    existing_engine_module = sys.modules.get("hermes_lcm.engine")
+    if existing_engine_module is not None and not hasattr(existing_engine_module, "LCMEngine"):
+        monkeypatch.delitem(sys.modules, "hermes_lcm.engine")
+
+    from hermes_lcm.engine import LCMEngine
+
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(tmp_path / "lcm.db")),
+        hermes_home=str(tmp_path / "hermes"),
+    )
+    try:
+        messages = [
+            {"role": "assistant", "content": f"incoming-{index}"}
+            for index in range(40)
+        ]
+        stored_tail = [
+            ("assistant", f"stored-{index}", "", "")
+            for index in range(40)
+        ]
+        original_identity = engine._message_replay_identity
+        identity_calls = {}
+
+        def counted_identity(message, *, stored_row=False):
+            key = id(message)
+            identity_calls[key] = identity_calls.get(key, 0) + 1
+            return original_identity(message, stored_row=stored_row)
+
+        monkeypatch.setattr(engine, "_message_replay_identity", counted_identity)
+        cursor = engine._find_reconciled_cursor_for_store_tail(
+            messages,
+            stored_tail,
+            allow_empty_prefix=False,
+            session_count=len(stored_tail),
+            raw_session_count=len(stored_tail),
+        )
+
+        assert cursor is None
+        assert identity_calls
+        assert max(identity_calls.values()) == 1
+    finally:
+        engine.shutdown()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -60,10 +60,12 @@ def externalized_search_engine(tmp_path):
 def test_shutdown_closes_lifecycle_store(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "shutdown-lifecycle.db"))
     engine = LCMEngine(config=config)
+    lifecycle = engine._lifecycle
 
     engine.shutdown()
 
-    assert engine._lifecycle._conn is None
+    assert engine._lifecycle is None
+    assert lifecycle._conn is None
 
 
 def test_assertion_store_is_default_off_and_closes_when_enabled(tmp_path):
@@ -376,7 +378,7 @@ def test_compress_exception_sets_terminal_error_status_and_reraises_same_excepti
     engine._last_compression_status = "noop"
     engine._last_compression_noop_reason = "stale no-op reason"
 
-    def fail_ingest(_messages):
+    def fail_ingest(_messages, **_kwargs):
         raise original
 
     monkeypatch.setattr(engine, "_ingest_messages", fail_ingest)
@@ -4926,7 +4928,7 @@ class TestEngineABC:
         assert "dag_nodes" in status
 
     def test_ingest_failure_is_surfaced_in_status_and_not_swallowed(self, engine):
-        def boom(_messages):
+        def boom(_messages, **_kwargs):
             raise sqlite3.OperationalError("disk I/O error")
 
         engine._ingest_messages = boom
@@ -4954,7 +4956,7 @@ class TestEngineABC:
         # Fail-closed defers NORMAL compaction on ingest failure, but emergency
         # overflow recovery (which keeps the prompt under the provider limit and
         # converges via deterministic L3) must still be requested.
-        def boom(_messages):
+        def boom(_messages, **_kwargs):
             raise sqlite3.OperationalError("disk I/O error")
 
         engine._ingest_messages = boom
@@ -4967,7 +4969,7 @@ class TestEngineABC:
     def test_tool_call_ingest_failure_is_surfaced_in_status(self, engine):
         engine.on_session_start("live-search-failure", platform="telegram", context_length=200000)
 
-        def boom(_messages):
+        def boom(_messages, **_kwargs):
             raise sqlite3.OperationalError("disk I/O error")
 
         engine._ingest_messages = boom
@@ -12256,7 +12258,7 @@ class TestSessionRollover:
     def test_on_session_end_fails_open_when_ingest_store_is_locked(self, engine, monkeypatch, caplog):
         engine.on_session_start("test-session", platform="discord")
 
-        def locked_ingest(messages):
+        def locked_ingest(messages, **_kwargs):
             raise sqlite3.OperationalError("database is locked")
 
         monkeypatch.setattr(engine, "_ingest_messages", locked_ingest)
@@ -12269,7 +12271,7 @@ class TestSessionRollover:
     def test_on_session_end_fails_open_when_ingest_is_interrupted(self, engine, monkeypatch, caplog):
         engine.on_session_start("test-session", platform="discord")
 
-        def interrupted_ingest(messages):
+        def interrupted_ingest(messages, **_kwargs):
             raise KeyboardInterrupt()
 
         monkeypatch.setattr(engine, "_ingest_messages", interrupted_ingest)
@@ -12330,7 +12332,7 @@ class TestSessionRollover:
     def test_on_session_end_reraises_non_lock_errors(self, engine, monkeypatch):
         engine.on_session_start("test-session", platform="discord")
 
-        def broken_ingest(messages):
+        def broken_ingest(messages, **_kwargs):
             raise RuntimeError("not a lock")
 
         monkeypatch.setattr(engine, "_ingest_messages", broken_ingest)
@@ -12731,7 +12733,7 @@ class TestSessionRollover:
         )
         messages = [{"role": "assistant", "content": "raw assistant output"}]
 
-        def replay_diff(_messages):
+        def replay_diff(_messages, **_kwargs):
             return [{"role": "assistant", "content": "sanitized assistant output"}]
 
         monkeypatch.setattr(engine, "_ingest_messages", replay_diff)

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -12,6 +12,7 @@ import types
 
 
 EXPECTED_LCM_TOOLS = {
+    "agentic_map",
     "lcm_grep",
     "lcm_recall",
     "lcm_query_state",
@@ -27,6 +28,7 @@ EXPECTED_LCM_TOOLS = {
     "lcm_status",
     "lcm_inspect",
     "lcm_doctor",
+    "llm_map",
 }
 
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -36,8 +36,8 @@ def test_release_candidate_identity_surfaces_are_synchronized():
     ).read_text(encoding="utf-8")
 
     assert f"version: {RELEASE_VERSION}" in manifest
-    assert f"hermes-lcm v{RELEASE_VERSION} (15 tools)" in readme
-    assert f"hermes-lcm v{RELEASE_VERSION} (15 tools)" in operator_guide
+    assert f"hermes-lcm v{RELEASE_VERSION} (17 tools)" in readme
+    assert f"hermes-lcm v{RELEASE_VERSION} (17 tools)" in operator_guide
     assert f"## v{RELEASE_VERSION} - " in changelog
     assert f"v{RELEASE_VERSION}, main, or commit SHA" in bug_report
 

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -72,12 +72,12 @@ def _manifest_tool_names() -> list[str]:
 def _schema_by_tool_name() -> dict[str, dict]:
     public_schemas = {}
     for symbol, value in vars(schemas).items():
-        if not symbol.startswith("LCM_"):
+        if not (symbol.startswith("LCM_") or symbol in {"LLM_MAP", "AGENTIC_MAP"}):
             continue
         if not isinstance(value, dict) or not isinstance(value.get("name"), str):
             continue
         name = value["name"]
-        if not name.startswith("lcm_"):
+        if not (name.startswith("lcm_") or name in {"llm_map", "agentic_map"}):
             continue
         expected_symbol = name.upper()
         assert symbol == expected_symbol, f"{symbol} should be exported as {expected_symbol}"

--- a/tests/test_whitepaper_compaction.py
+++ b/tests/test_whitepaper_compaction.py
@@ -1,0 +1,290 @@
+"""Regression tests for the whitepaper's compaction invariants."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+import hermes_lcm.escalation as escalation
+from agent.context_engine import ContextEngine  # noqa: F401 - primes plugin host imports
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+from hermes_lcm.tokens import count_messages_tokens, count_tokens
+
+
+@pytest.fixture
+def make_engine(tmp_path):
+    engines: list[LCMEngine] = []
+
+    def factory(**overrides) -> LCMEngine:
+        config = LCMConfig(database_path=str(tmp_path / f"lcm-{len(engines)}.db"))
+        for name, value in overrides.items():
+            setattr(config, name, value)
+        engine = LCMEngine(config=config)
+        engine.on_session_start(
+            f"whitepaper-session-{len(engines)}",
+            context_length=220,
+        )
+        engines.append(engine)
+        return engine
+
+    yield factory
+
+    for engine in engines:
+        engine.shutdown()
+
+
+def _cheap_summary(engine: LCMEngine) -> None:
+    def summarize(chunk, **_kwargs):
+        return chunk, count_messages_tokens(chunk), "Persisted compact summary.", 1, 0
+
+    engine._summarize_leaf_chunk_with_rescue = summarize
+
+
+def test_compression_sqlite_lock_preserves_active_context(monkeypatch, make_engine):
+    engine = make_engine()
+    messages = [{"role": "user", "content": "keep this exact turn"}]
+
+    def locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(engine, "_compress_impl", locked)
+    monkeypatch.setattr(
+        engine,
+        "_ingest_messages",
+        lambda value, **_kwargs: value,
+    )
+
+    assert engine.compress(messages, force=True) == messages
+    assert engine._last_compression_status == "noop"
+    assert "sqlite writer busy" in engine._last_compression_noop_reason
+
+
+def test_per_turn_ingest_spools_when_another_connection_holds_writer(tmp_path):
+    db_path = tmp_path / "durable-lock.db"
+    engine = LCMEngine(
+        config=LCMConfig(database_path=str(db_path)),
+        hermes_home=str(tmp_path),
+    )
+    blocker = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        engine.on_session_start("durable-session", platform="cli")
+        blocker.execute("BEGIN IMMEDIATE")
+
+        started_at = time.monotonic()
+        engine.ingest([{"role": "user", "content": "must survive contention"}])
+        elapsed = time.monotonic() - started_at
+
+        assert engine._store.pending_ingest_count() == 1
+        assert engine._consecutive_ingest_failures == 0
+        assert elapsed < 2.0
+
+        blocker.rollback()
+        assert engine._store.drain_pending_ingest() == 1
+        assert engine._store.pending_ingest_count() == 0
+        assert engine._store.get_session_count("durable-session") == 1
+    finally:
+        blocker.rollback()
+        blocker.close()
+        engine.shutdown()
+
+
+def test_native_compaction_boundary_archives_without_local_resummarization(make_engine):
+    engine = make_engine(fresh_tail_count=1)
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old context " * 80},
+        {
+            "role": "assistant",
+            "content": "continued",
+            "codex_compaction_items": [{
+                "type": "compaction",
+                "encrypted_content": "opaque-native-capsule",
+                "_issuer_kind": "codex_backend",
+            }],
+        },
+        {"role": "user", "content": "new turn"},
+    ]
+    engine.threshold_tokens = 10
+
+    assert engine.should_compress_preflight(messages) is False
+    assert engine.last_compression_noop_reason == "provider-native compaction boundary active"
+    assert engine._store.get_session_count(engine._session_id) == len(messages)
+    assert engine._dag.get_session_nodes(engine._session_id) == []
+
+
+def test_default_context_length_is_a_hard_cap_inside_fresh_tail(make_engine):
+    engine = make_engine(fresh_tail_count=32)
+    _cheap_summary(engine)
+    messages = [
+        {"role": "user", "content": f"turn-{index} " + ("detail " * 45)}
+        for index in range(4)
+    ]
+    assert len(messages) < engine._config.fresh_tail_count
+    assert count_messages_tokens(messages) > engine.context_length
+    assert engine._effective_assembly_token_cap() is None
+
+    assert engine.should_compress_preflight(messages) is True
+    compacted = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    assert count_messages_tokens(compacted) < engine.context_length
+    assert compacted[-1] == messages[-1]
+    assert engine._dag.get_session_nodes(engine._session_id)
+
+
+def test_hard_pressure_preserves_the_newest_tool_call_group(make_engine):
+    engine = make_engine(fresh_tail_count=32)
+    _cheap_summary(engine)
+    messages = [
+        {"role": "user", "content": "old context " * 55},
+        {"role": "assistant", "content": "older answer " * 30},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-latest",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-latest", "content": "ok"},
+    ]
+    assert count_messages_tokens(messages) > engine.context_length
+
+    compacted = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    latest_assistant = next(
+        message
+        for message in compacted
+        if message.get("tool_calls")
+        and message["tool_calls"][0].get("id") == "call-latest"
+    )
+    assert latest_assistant["role"] == "assistant"
+    assert any(message.get("tool_call_id") == "call-latest" for message in compacted)
+    assert count_messages_tokens(compacted) < engine.context_length
+
+
+def test_single_oversized_latest_message_is_losslessly_stored_but_fitted(make_engine):
+    engine = make_engine(fresh_tail_count=32)
+    message = {"role": "user", "content": "oversized-current-turn " * 500}
+    messages = [message]
+    assert count_messages_tokens(messages) > engine.context_length
+
+    compacted = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    assert count_messages_tokens(compacted) < engine.context_length
+    assert compacted[0]["role"] == "user"
+    assert "active-context truncation" in compacted[0]["content"]
+    stored = engine._store.get_session_messages(engine._session_id)
+    assert len(stored) == 1
+    assert stored[0]["content"] == message["content"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "x",
+        "short source " * 80,
+    ],
+)
+def test_l3_is_strictly_smaller_even_below_configured_truncation_cap(monkeypatch, text):
+    monkeypatch.setattr(escalation, "_invoke_summary_llm_chain", lambda *_a, **_k: None)
+    source_tokens = count_tokens(text)
+    assert 0 < source_tokens <= 512
+
+    result, level = escalation.summarize_with_escalation(
+        text,
+        source_tokens=source_tokens,
+        token_budget=256,
+        l3_truncate_tokens=512,
+    )
+
+    assert level == 3
+    assert count_tokens(result) < source_tokens
+
+
+def test_provider_exception_skips_duplicate_l2_wait_and_uses_l3(monkeypatch):
+    attempts = []
+
+    def unavailable(*_args, **_kwargs):
+        attempts.append(1)
+        raise TimeoutError("auxiliary provider unavailable")
+
+    monkeypatch.setattr(escalation, "_invoke_summary_llm", unavailable)
+    text = "provider outage must converge without another network wait " * 200
+    source_tokens = count_tokens(text)
+
+    result, level = escalation.summarize_with_escalation(
+        text,
+        source_tokens=source_tokens,
+        token_budget=256,
+    )
+
+    assert level == 3
+    assert count_tokens(result) < source_tokens
+    assert len(attempts) == 1
+
+
+def test_leaf_publication_fails_closed_when_raw_lineage_is_missing(make_engine):
+    engine = make_engine(fresh_tail_count=1, leaf_chunk_tokens=1)
+    _cheap_summary(engine)
+    messages = [
+        {"role": "user", "content": "first persisted turn " * 20},
+        {"role": "assistant", "content": "first persisted reply " * 20},
+        {"role": "user", "content": "newest protected turn"},
+    ]
+    engine._get_store_id_map_for_messages = lambda _messages: {}
+
+    with pytest.raises(RuntimeError, match="raw store lineage"):
+        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    assert engine._dag.get_session_nodes(engine._session_id) == []
+    assert engine._last_compacted_store_id == 0
+    assert messages[-1]["content"] == "newest protected turn"
+
+
+def test_filtered_only_marker_advances_without_false_summary_lineage(make_engine):
+    engine = make_engine(fresh_tail_count=1, leaf_chunk_tokens=1)
+    messages = [
+        {"role": "assistant", "content": "derived ignored reply"},
+        {"role": "user", "content": "newest protected turn"},
+    ]
+    engine._is_generated_ignored_dependent_reply = lambda _message, text: (
+        text == "derived ignored reply"
+    )
+    engine._remember_generated_ignored_dependent_reply = lambda *_a, **_k: None
+
+    engine.compress(messages, current_tokens=count_messages_tokens(messages))
+
+    assert engine._dag.get_session_nodes(engine._session_id) == []
+    assert engine._store.get_session_messages(engine._session_id)[0]["content"] == (
+        "derived ignored reply"
+    )
+    state = engine._lifecycle.get_by_conversation(engine._conversation_id)
+    assert state.current_frontier_store_id > 0
+
+
+def test_file_ids_propagate_from_raw_messages_through_condensation(make_engine, monkeypatch):
+    engine = make_engine(fresh_tail_count=1, leaf_chunk_tokens=1)
+    _cheap_summary(engine)
+    file_id = "file_0123456789abcdef"
+    messages = [
+        {"role": "user", "content": '{"output_file_id":"%s"}' % file_id},
+        {"role": "user", "content": "newest protected turn"},
+    ]
+
+    engine.compress(messages, current_tokens=count_messages_tokens(messages))
+    leaf = engine._dag.get_session_nodes(engine._session_id)[0]
+    assert leaf.file_ids == [file_id]
+
+    monkeypatch.setattr(
+        "hermes_lcm.engine.summarize_with_escalation",
+        lambda **_kwargs: ("condensed summary", 1),
+    )
+    engine._condense_summary_nodes([leaf])
+    condensed = engine._dag.get_session_nodes(engine._session_id, depth=1)[0]
+    assert condensed.file_ids == [file_id]

--- a/tests/test_whitepaper_operators.py
+++ b/tests/test_whitepaper_operators.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+from hermes_lcm.file_registry import FileRegistry, union_file_ids
+from hermes_lcm.operators import AgenticMap, LLMMap, OperatorStore
+
+
+OBJECT_SCHEMA = {
+    "type": "object",
+    "required": ["value"],
+    "additionalProperties": False,
+    "properties": {"value": {"type": "integer"}},
+}
+
+
+def _jsonl(path: Path, values: list[object]) -> None:
+    path.write_text(
+        "".join(json.dumps(value) + "\n" for value in values),
+        encoding="utf-8",
+    )
+
+
+def test_file_registry_keeps_only_path_and_type_aware_json_summary(tmp_path: Path):
+    source = tmp_path / "large.json"
+    marker = "payload-that-must-not-be-copied-into-sqlite"
+    source.write_text(
+        json.dumps({"users": [{"id": 1, "secret": marker}], "active": True}),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "lcm.db"
+    registry = FileRegistry(db_path)
+
+    first = registry.register(source)
+    second = registry.register(source)
+
+    assert first.file_id == second.file_id
+    assert first.file_id.startswith("file_")
+    assert first.path == str(source.resolve())
+    assert first.mime_type == "application/json"
+    assert first.size_bytes == source.stat().st_size
+    assert first.token_count > 0
+    assert "users" in first.exploration_summary
+    assert "active" in first.exploration_summary
+    assert marker not in first.exploration_summary
+    assert marker.encode() not in db_path.read_bytes()
+
+
+def test_file_registry_summarizes_csv_sqlite_python_and_text(tmp_path: Path):
+    registry = FileRegistry(tmp_path / "lcm.db")
+
+    csv_path = tmp_path / "rows.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["name", "score"])
+        writer.writerow(["Ada", 10])
+        writer.writerow(["Lin", 20])
+
+    sqlite_path = tmp_path / "catalog.sqlite"
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
+
+    python_path = tmp_path / "service.py"
+    python_path.write_text(
+        "class Service:\n"
+        "    def run(self, count: int) -> str:\n"
+        "        return str(count)\n\n"
+        "def helper(value):\n"
+        "    return value\n",
+        encoding="utf-8",
+    )
+
+    text_path = tmp_path / "notes.txt"
+    text_path.write_text("first line\nsecond line\nthird line\n", encoding="utf-8")
+
+    csv_record = registry.register(csv_path)
+    sqlite_record = registry.register(sqlite_path)
+    python_record = registry.register(python_path)
+    text_record = registry.register(text_path)
+
+    assert "name" in csv_record.exploration_summary
+    assert "2 data rows" in csv_record.exploration_summary
+    assert "books" in sqlite_record.exploration_summary
+    assert "title TEXT" in sqlite_record.exploration_summary
+    assert "class Service" in python_record.exploration_summary
+    assert "run(self, count: int)" in python_record.exploration_summary
+    assert "3 lines" in text_record.exploration_summary
+    assert "6 words" in text_record.exploration_summary
+
+
+def test_file_registry_summarizes_jsonl_sql_and_generic_code(tmp_path: Path):
+    registry = FileRegistry(tmp_path / "lcm.db")
+    jsonl_path = tmp_path / "events.jsonl"
+    _jsonl(jsonl_path, [{"kind": "open", "count": 1}, {"kind": "close", "count": 2}])
+    sql_path = tmp_path / "schema.sql"
+    sql_path.write_text(
+        "CREATE TABLE accounts (id INTEGER);\nCREATE VIEW account_ids AS SELECT id FROM accounts;\n",
+        encoding="utf-8",
+    )
+    code_path = tmp_path / "worker.js"
+    code_path.write_text(
+        "export class Worker {}\nexport function execute(item) { return item; }\n",
+        encoding="utf-8",
+    )
+
+    jsonl_record = registry.register(jsonl_path)
+    sql_record = registry.register(sql_path)
+    code_record = registry.register(code_path)
+
+    assert "2 records" in jsonl_record.exploration_summary
+    assert "count: integer" in jsonl_record.exploration_summary
+    assert "accounts" in sql_record.exploration_summary
+    assert "account_ids" in sql_record.exploration_summary
+    assert "class Worker" in code_record.exploration_summary
+    assert "function execute(item)" in code_record.exploration_summary
+
+
+def test_file_id_union_propagates_lineage_without_collecting_unrelated_ids():
+    values = [
+        {"file_id": "file_a", "source_ids": [10, 11]},
+        {"file_ids": ["file_b", "file_a"]},
+        {"metadata": {"file_ids": ["file_c"]}, "id": "not-a-file"},
+    ]
+
+    assert union_file_ids(*values) == ("file_a", "file_b", "file_c")
+
+
+def test_file_id_union_finds_ids_in_serialized_tool_results():
+    assert union_file_ids(
+        '{"output_file_id":"file_0123456789abcdef"}'
+    ) == ("file_0123456789abcdef",)
+
+
+def test_llm_map_runs_jsonl_concurrently_and_persists_completed_state(tmp_path: Path):
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "output.jsonl"
+    _jsonl(input_path, [{"n": value} for value in range(12)])
+    lock = threading.Lock()
+    calls: dict[int, int] = {}
+
+    def executor(*, item, prompt, attempt, validation_error):
+        assert prompt == "double"
+        assert validation_error is None
+        with lock:
+            calls[item["n"]] = calls.get(item["n"], 0) + 1
+        return {"value": item["n"] * 2}
+
+    operator = LLMMap(tmp_path / "lcm.db", executor=executor)
+    result = operator.run(
+        input_path=input_path,
+        output_path=output_path,
+        prompt="double",
+        output_schema=OBJECT_SCHEMA,
+    )
+
+    assert result.status == "completed"
+    assert result.total == 12
+    assert result.completed == 12
+    assert result.failed == 0
+    assert result.concurrency == 16
+    assert result.output_file_id is not None
+    assert operator.file_registry.get(result.output_file_id).path == str(output_path)
+    assert calls == {value: 1 for value in range(12)}
+    rows = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert [row["output"]["value"] for row in rows] == [value * 2 for value in range(12)]
+    assert all(row["status"] == "completed" for row in rows)
+
+    stored = operator.status(result.batch_id)
+    assert stored == result
+
+
+def test_llm_map_retries_schema_failures_with_validation_feedback(tmp_path: Path):
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "output.jsonl"
+    _jsonl(input_path, [{"n": 4}])
+    feedback: list[str | None] = []
+
+    def executor(*, item, prompt, attempt, validation_error):
+        feedback.append(validation_error)
+        if attempt == 1:
+            return {"value": "wrong type"}
+        return {"value": item["n"]}
+
+    result = LLMMap(tmp_path / "lcm.db", executor=executor).run(
+        input_path=input_path,
+        output_path=output_path,
+        prompt="extract",
+        output_schema=OBJECT_SCHEMA,
+        max_retries=2,
+        concurrency=1,
+    )
+
+    assert result.status == "completed"
+    assert result.completed == 1
+    assert feedback[0] is None
+    assert "integer" in feedback[1]
+    row = json.loads(output_path.read_text())
+    assert row["attempts"] == 2
+    assert row["output"] == {"value": 4}
+
+
+def test_operator_store_claim_is_atomic_and_resume_requeues_abandoned_work(tmp_path: Path):
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "output.jsonl"
+    _jsonl(input_path, [{"n": 1}, {"n": 2}])
+    db_path = tmp_path / "lcm.db"
+    store = OperatorStore(db_path)
+    batch_id = store.create_batch(
+        kind="llm_map",
+        input_path=input_path,
+        output_path=output_path,
+        prompt="copy",
+        output_schema=OBJECT_SCHEMA,
+        concurrency=2,
+        max_retries=0,
+    )
+
+    claimed: list[int] = []
+    barrier = threading.Barrier(3)
+
+    def claim(worker: str) -> None:
+        barrier.wait()
+        item = store.claim_next(batch_id, worker)
+        assert item is not None
+        claimed.append(item.item_index)
+
+    threads = [threading.Thread(target=claim, args=(f"w{i}",)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(claimed) == [0, 1]
+    assert store.requeue_running(batch_id) == 2
+
+    calls: list[int] = []
+
+    def executor(*, item, prompt, attempt, validation_error):
+        calls.append(item["n"])
+        return {"value": item["n"]}
+
+    result = LLMMap(db_path, executor=executor).resume(batch_id)
+    assert result.status == "completed"
+    assert sorted(calls) == [1, 2]
+
+
+def test_agentic_map_passes_enforced_read_only_capability(tmp_path: Path):
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "output.jsonl"
+    _jsonl(input_path, [{"path": "one"}])
+    observed: list[bool] = []
+
+    def subagent(*, item, prompt, attempt, validation_error, read_only):
+        observed.append(read_only)
+        return {"value": 1}
+
+    operator = AgenticMap(tmp_path / "lcm.db", executor=subagent)
+    result = operator.run(
+        input_path=input_path,
+        output_path=output_path,
+        prompt="inspect",
+        output_schema=OBJECT_SCHEMA,
+        read_only=True,
+    )
+
+    assert result.status == "completed"
+    assert observed == [True]
+
+
+def test_malformed_input_and_permanent_failure_are_durable(tmp_path: Path):
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text('{"ok": 1}\nnot json\n', encoding="utf-8")
+    operator = LLMMap(tmp_path / "lcm.db", executor=lambda **_: {"value": 1})
+
+    try:
+        operator.run(
+            input_path=malformed,
+            output_path=tmp_path / "out.jsonl",
+            prompt="x",
+            output_schema=OBJECT_SCHEMA,
+        )
+    except ValueError as exc:
+        assert "line 2" in str(exc)
+    else:
+        raise AssertionError("malformed JSONL was accepted")
+
+    valid = tmp_path / "valid.jsonl"
+    _jsonl(valid, [{"n": 1}])
+    failed = LLMMap(
+        tmp_path / "failed.db",
+        executor=lambda **_: {"value": "invalid"},
+    ).run(
+        input_path=valid,
+        output_path=tmp_path / "failed-output.jsonl",
+        prompt="x",
+        output_schema=OBJECT_SCHEMA,
+        max_retries=1,
+    )
+    assert failed.status == "completed_with_errors"
+    assert failed.failed == 1
+    row = json.loads((tmp_path / "failed-output.jsonl").read_text())
+    assert row["status"] == "failed"
+    assert row["attempts"] == 2
+    assert "integer" in row["error"]

--- a/tests/test_whitepaper_storage.py
+++ b/tests/test_whitepaper_storage.py
@@ -1,0 +1,263 @@
+"""Storage invariants required by the LCM whitepaper.
+
+These tests intentionally exercise the persistence primitives directly.  The
+engine wires them into compaction and session shutdown separately.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from hermes_lcm.dag import SummaryDAG, SummaryNode
+from hermes_lcm.lifecycle_state import LifecycleStateStore
+from hermes_lcm.store import MessageStore
+
+
+def _message(store: MessageStore, session_id: str, content: str = "source") -> int:
+    return store.append(
+        session_id,
+        {"role": "user", "content": content},
+        token_estimate=3,
+        conversation_id=session_id,
+    )
+
+
+def test_provider_state_is_archived_but_not_exposed_or_indexed(tmp_path):
+    store = MessageStore(tmp_path / "lcm-provider-state.db")
+    capsule = [{
+        "type": "compaction",
+        "encrypted_content": "opaque-native-capsule",
+        "_issuer_kind": "codex_backend",
+    }]
+
+    store_id = store.append(
+        "session-a",
+        {
+            "role": "assistant",
+            "content": "visible answer",
+            "codex_compaction_items": capsule,
+        },
+    )
+
+    stored = store.get(store_id)
+    assert "provider_state" not in stored
+    assert store.to_openai_msg(stored) == {
+        "role": "assistant",
+        "content": "visible answer",
+    }
+    assert store.get_provider_state(store_id) == {
+        "codex_compaction_items": capsule,
+    }
+    assert store.search("opaque-native-capsule", session_id="session-a") == []
+
+
+def test_relational_provenance_enforces_sources_depth_and_session(tmp_path):
+    db_path = tmp_path / "lcm.db"
+    store = MessageStore(db_path)
+    source_id = _message(store, "session-a")
+    dag = SummaryDAG(db_path)
+
+    leaf = SummaryNode(
+        session_id="session-a",
+        depth=0,
+        summary="leaf",
+        source_ids=[source_id],
+        source_type="messages",
+    )
+    leaf_id = dag.add_node(leaf)
+    assert dag.connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    assert dag.connection.execute(
+        "SELECT message_store_id FROM lcm_summary_message_sources "
+        "WHERE summary_node_id = ?",
+        (leaf_id,),
+    ).fetchall() == [(source_id,)]
+
+    parent_id = dag.add_node(SummaryNode(
+        session_id="session-a",
+        depth=1,
+        summary="parent",
+        source_ids=[leaf_id],
+        source_type="nodes",
+    ))
+    assert dag.connection.execute(
+        "SELECT source_node_id FROM lcm_summary_node_sources "
+        "WHERE summary_node_id = ?",
+        (parent_id,),
+    ).fetchall() == [(leaf_id,)]
+
+    with pytest.raises(ValueError, match="does not exist"):
+        dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="missing message",
+            source_ids=[source_id + 999],
+            source_type="messages",
+        ))
+    with pytest.raises(ValueError, match="same session"):
+        dag.add_node(SummaryNode(
+            session_id="session-b",
+            depth=1,
+            summary="cross-session parent",
+            source_ids=[leaf_id],
+            source_type="nodes",
+        ))
+    with pytest.raises(ValueError, match="lower depth"):
+        dag.add_node(SummaryNode(
+            session_id="session-a",
+            depth=0,
+            summary="cycle-shaped parent",
+            source_ids=[leaf_id],
+            source_type="nodes",
+        ))
+
+    dag.close()
+    store.close()
+
+
+def test_relational_provenance_migrates_valid_legacy_json_edges(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    store = MessageStore(db_path)
+    source_id = _message(store, "legacy")
+    dag = SummaryDAG(db_path)
+    dag.close()
+    store.connection.execute(
+        """INSERT INTO summary_nodes(
+               session_id, depth, summary, token_count, source_token_count,
+               source_ids, source_type, created_at, earliest_at, latest_at,
+               expand_hint
+           ) VALUES (?, 0, 'legacy leaf', 1, 3, ?, 'messages', ?, NULL, NULL, '')""",
+        ("legacy", json.dumps([source_id]), time.time()),
+    )
+    node_id = store.connection.execute("SELECT last_insert_rowid()").fetchone()[0]
+    store.connection.commit()
+    store.close()
+
+    dag = SummaryDAG(db_path)
+    assert dag.connection.execute(
+        "SELECT message_store_id FROM lcm_summary_message_sources "
+        "WHERE summary_node_id = ?",
+        (node_id,),
+    ).fetchall() == [(source_id,)]
+    dag.close()
+
+
+def test_retention_preserves_transitive_node_dependencies(tmp_path):
+    db_path = tmp_path / "retention.db"
+    store = MessageStore(db_path)
+    source_id = _message(store, "retain")
+    other_source_id = _message(store, "retain", "unrelated")
+    dag = SummaryDAG(db_path)
+
+    leaf = dag.add_node(SummaryNode(
+        session_id="retain", depth=0, summary="leaf",
+        source_ids=[source_id], source_type="messages",
+    ))
+    middle = dag.add_node(SummaryNode(
+        session_id="retain", depth=1, summary="middle",
+        source_ids=[leaf], source_type="nodes",
+    ))
+    top = dag.add_node(SummaryNode(
+        session_id="retain", depth=2, summary="top",
+        source_ids=[middle], source_type="nodes",
+    ))
+    unrelated = dag.add_node(SummaryNode(
+        session_id="retain", depth=0, summary="unrelated",
+        source_ids=[other_source_id], source_type="messages",
+    ))
+
+    assert dag.delete_below_depth("retain", 2) == 1
+    assert dag.get_node(unrelated) is None
+    assert [dag.get_node(node_id).node_id for node_id in (leaf, middle, top)] == [
+        leaf, middle, top,
+    ]
+    dag.close()
+    store.close()
+
+
+def test_publish_node_and_frontier_is_one_transaction(tmp_path):
+    db_path = tmp_path / "atomic.db"
+    store = MessageStore(db_path)
+    source_id = _message(store, "atomic")
+    lifecycle = LifecycleStateStore(db_path)
+    lifecycle.bind_session("atomic", conversation_id="conversation")
+    dag = SummaryDAG(db_path)
+
+    node = SummaryNode(
+        session_id="atomic", depth=0, summary="atomic leaf",
+        source_ids=[source_id], source_type="messages",
+    )
+    node_id = dag.publish_node_and_advance_frontier(
+        node,
+        conversation_id="conversation",
+        frontier_store_id=source_id,
+    )
+    assert node_id == node.node_id
+    assert lifecycle.get_by_conversation("conversation").current_frontier_store_id == source_id
+
+    dag.connection.execute(
+        """CREATE TRIGGER reject_frontier_advance
+           BEFORE UPDATE OF current_frontier_store_id ON lcm_lifecycle_state
+           BEGIN SELECT RAISE(ABORT, 'frontier rejected'); END"""
+    )
+    before = dag.connection.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0]
+    with pytest.raises(sqlite3.IntegrityError, match="frontier rejected"):
+        dag.publish_node_and_advance_frontier(
+            SummaryNode(
+                session_id="atomic", depth=0, summary="must roll back",
+                source_ids=[source_id], source_type="messages",
+            ),
+            conversation_id="conversation",
+            frontier_store_id=source_id + 1,
+        )
+    assert dag.connection.execute("SELECT COUNT(*) FROM summary_nodes").fetchone()[0] == before
+
+    dag.close()
+    lifecycle.close()
+    store.close()
+
+
+def test_durable_pending_ingest_replays_exactly_once_after_lock(tmp_path):
+    db_path = tmp_path / "pending.db"
+    store = MessageStore(db_path)
+    blocker = sqlite3.connect(db_path, timeout=0.1)
+    blocker.execute("BEGIN IMMEDIATE")
+    try:
+        result = store.append_batch_durable(
+            "pending-session",
+            [{"role": "assistant", "content": "final response"}],
+            [4],
+            source="cli",
+            conversation_id="pending-session",
+            busy_timeout_ms=1,
+        )
+        assert result.persisted is False
+        assert result.pending_batch_id
+        assert store.pending_ingest_count() == 1
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert store.drain_pending_ingest() == 1
+    assert store.pending_ingest_count() == 0
+    assert store.get_session_count("pending-session") == 1
+
+    # A receipt makes replay idempotent across a crash after DB commit but
+    # before removal of the durable sidecar file.
+    store._write_pending_ingest_file(
+        result.pending_batch_id,
+        {
+            "batch_id": result.pending_batch_id,
+            "session_id": "pending-session",
+            "messages": [{"role": "assistant", "content": "final response"}],
+            "token_estimates": [4],
+            "source": "cli",
+            "conversation_id": "pending-session",
+        },
+    )
+    assert store.drain_pending_ingest() == 1
+    assert store.get_session_count("pending-session") == 1
+    store.close()

--- a/tests/test_whitepaper_tools.py
+++ b/tests/test_whitepaper_tools.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.dag import SummaryNode
+from hermes_lcm.engine import LCMEngine
+
+
+def _engine(tmp_path):
+    engine = LCMEngine(LCMConfig(database_path=str(tmp_path / "lcm.db")))
+    engine.on_session_start(
+        "session", conversation_id="conversation", context_length=1_000
+    )
+    return engine
+
+
+def test_regex_grep_and_summary_scope(tmp_path):
+    engine = _engine(tmp_path)
+    try:
+        messages = [
+            {"role": "user", "content": "ticket ABC-123 is open"},
+            {"role": "assistant", "content": "unrelated"},
+        ]
+        engine.ingest(messages)
+        ids = engine._get_store_ids_for_messages(messages)
+        node = SummaryNode(
+            session_id="session",
+            depth=0,
+            summary="ticket summary",
+            source_ids=[ids[0]],
+            source_type="messages",
+        )
+        engine._dag.add_node(node)
+
+        payload = json.loads(engine.handle_tool_call(
+            "lcm_grep",
+            {"mode": "regex", "query": r"ABC-\d+", "summary_id": node.node_id},
+        ))
+        assert [hit["store_id"] for hit in payload["results"]] == [ids[0]]
+    finally:
+        engine.shutdown()
+
+
+def test_expand_is_not_exposed_to_root_and_is_defensively_denied(tmp_path):
+    engine = _engine(tmp_path)
+    try:
+        root_names = {schema["name"] for schema in engine.get_tool_schemas(is_subagent=False)}
+        child_names = {schema["name"] for schema in engine.get_tool_schemas(is_subagent=True)}
+        assert "lcm_expand" not in root_names
+        assert "lcm_expand_query" not in root_names
+        assert {"lcm_expand", "lcm_expand_query"} <= child_names
+        denied = json.loads(engine.handle_tool_call(
+            "lcm_expand", {"store_id": 1}, is_subagent=False
+        ))
+        assert "restricted to sub-agents" in denied["error"]
+    finally:
+        engine.shutdown()
+
+
+def test_llm_map_is_wired_to_engine_tool_surface(tmp_path):
+    engine = _engine(tmp_path)
+    input_path = tmp_path / "input.jsonl"
+    input_path.write_text('{"value": 2}\n{"value": 4}\n', encoding="utf-8")
+    engine._llm_map_operator.executor = lambda **kwargs: {
+        "doubled": kwargs["item"]["value"] * 2
+    }
+    try:
+        names = {schema["name"] for schema in engine.get_tool_schemas()}
+        assert {"llm_map", "agentic_map"} <= names
+        payload = json.loads(engine.handle_tool_call("llm_map", {
+            "input_path": str(input_path),
+            "prompt": "double value",
+            "output_schema": {
+                "type": "object",
+                "properties": {"doubled": {"type": "integer"}},
+                "required": ["doubled"],
+                "additionalProperties": False,
+            },
+        }))
+        assert payload["status"] == "completed"
+        assert payload["completed"] == 2
+        assert payload["output_file_id"].startswith("file_")
+    finally:
+        engine.shutdown()
+
+
+def test_describe_accepts_opaque_file_ids(tmp_path):
+    engine = _engine(tmp_path)
+    source = tmp_path / "large.json"
+    source.write_text('{"records":[{"id":1}]}', encoding="utf-8")
+    try:
+        record = engine._file_registry.register(source)
+        payload = json.loads(engine.handle_tool_call(
+            "lcm_describe", {"file_id": record.file_id}
+        ))
+        assert payload["file_id"] == record.file_id
+        assert payload["path"] == str(source.resolve())
+        assert "records" in payload["exploration_summary"]
+    finally:
+        engine.shutdown()

--- a/tools.py
+++ b/tools.py
@@ -9,6 +9,7 @@ import re
 import sqlite3
 import threading
 import time
+from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
@@ -82,6 +83,7 @@ from .search_query import AGE_DECAY_RATE, normalize_search_sort
 from .session_patterns import build_session_match_keys, compile_session_pattern
 from .sqlite_util import _sqlite_savepoint
 from .store import build_message_fts_spec
+from .operators import AgenticMap
 from .vector_store import VectorStore
 
 if TYPE_CHECKING:
@@ -3452,6 +3454,155 @@ def _lcm_grep_hybrid(
     return response
 
 
+def _regex_summary_message_ids(engine: "LCMEngine", summary_id: int) -> set[int]:
+    """Resolve a summary's recursive raw lineage without exposing pending rows."""
+    root = engine._dag.get_node(summary_id)
+    if root is None or root.session_id != engine.current_session_id:
+        return set()
+    raw_ids: set[int] = set()
+    pending = [root]
+    seen: set[int] = set()
+    while pending:
+        node = pending.pop()
+        if node.node_id in seen:
+            continue
+        seen.add(node.node_id)
+        if node.source_type == "messages":
+            raw_ids.update(int(value) for value in node.source_ids)
+            continue
+        for child_id in node.source_ids:
+            child = engine._dag.get_node(int(child_id))
+            if child is not None and child.session_id == root.session_id:
+                pending.append(child)
+    return raw_ids
+
+
+def _lcm_grep_regex(args: Dict[str, Any], *, engine: "LCMEngine") -> str:
+    pattern = str(args.get("query") or "")
+    if not pattern:
+        return json.dumps({"error": "No query provided"})
+    try:
+        expression = re.compile(pattern)
+    except re.error as exc:
+        return json.dumps({"error": f"Invalid regular expression: {exc}"})
+    requested_limit = _parse_int_value(args.get("limit", 10), 10)
+    if requested_limit <= 0:
+        return json.dumps({"error": "limit must be a positive integer"})
+    limit = min(requested_limit, _LCM_GREP_HARD_LIMIT_CAP)
+    scope = str(args.get("session_scope") or "current").lower()
+    explicit_session = str(args.get("session_id") or "").strip()
+    if scope == "current":
+        if explicit_session:
+            return json.dumps({"error": "session_id is only valid with session_scope=session"})
+        session_id = engine.current_session_id
+    elif scope == "session":
+        if not explicit_session:
+            return json.dumps({"error": "session_scope=session requires session_id"})
+        session_id = explicit_session
+    elif scope == "all":
+        if explicit_session:
+            return json.dumps({"error": "session_id is not used with session_scope=all"})
+        session_id = None
+    else:
+        return json.dumps({"error": "session_scope must be one of: current, all, session"})
+    summary_id = args.get("summary_id")
+    allowed_ids: set[int] | None = None
+    if summary_id is not None:
+        try:
+            summary_id = int(summary_id)
+        except (TypeError, ValueError):
+            return json.dumps({"error": "summary_id must be an integer"})
+        if scope != "current":
+            return json.dumps({"error": "summary_id requires session_scope=current"})
+        allowed_ids = _regex_summary_message_ids(engine, summary_id)
+        if not allowed_ids:
+            return json.dumps({"error": "Summary not found or has no raw-message lineage"})
+    role, role_error = _parse_grep_role(args.get("role"))
+    if role_error:
+        return json.dumps({"error": role_error})
+    source = str(args.get("source") or "").strip() or None
+    conversation_id = str(args.get("conversation_id") or "").strip() or None
+    time_from, error = _parse_optional_timestamp(args.get("time_from"), "time_from")
+    if error:
+        return json.dumps({"error": error})
+    time_to, error = _parse_optional_timestamp(args.get("time_to"), "time_to")
+    if error:
+        return json.dumps({"error": error})
+    if time_from is not None and time_to is not None and time_to < time_from:
+        return json.dumps({"error": "time_to must be greater than or equal to time_from"})
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if session_id is not None:
+        clauses.append("session_id=?")
+        params.append(session_id)
+    if role is not None:
+        clauses.append("role=?")
+        params.append(role)
+    if source is not None:
+        clauses.append("source=?")
+        params.append(source)
+    if conversation_id is not None:
+        clauses.append("conversation_id=?")
+        params.append(conversation_id)
+    if time_from is not None:
+        clauses.append("timestamp>=?")
+        params.append(time_from)
+    if time_to is not None:
+        clauses.append("timestamp<=?")
+        params.append(time_to)
+    if allowed_ids is not None:
+        placeholders = ",".join("?" for _ in allowed_ids)
+        clauses.append(f"store_id IN ({placeholders})")
+        params.extend(sorted(allowed_ids))
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    conn = engine._store.connection
+    assert conn is not None
+    rows = conn.execute(
+        "SELECT store_id,session_id,source,role,content,timestamp,token_estimate,conversation_id "
+        f"FROM messages{where} ORDER BY timestamp DESC, store_id DESC LIMIT 100000",
+        params,
+    ).fetchall()
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        store_id, row_session, row_source, row_role, content, timestamp, token_estimate, row_conversation = row
+        match = expression.search(str(content or ""))
+        if match is None:
+            continue
+        start = max(0, match.start() - 120)
+        end = min(len(str(content or "")), match.end() + 180)
+        results.append({
+            "type": "message",
+            "depth": "raw",
+            "store_id": int(store_id),
+            "session_id": row_session,
+            "source": row_source,
+            "role": row_role,
+            "snippet": str(content or "")[start:end],
+            "match_start": match.start(),
+            "match_end": match.end(),
+            "timestamp": timestamp,
+            "token_count": int(token_estimate or 0),
+            "conversation_id": row_conversation,
+            "from_current_session": bool(engine.current_session_id and row_session == engine.current_session_id),
+        })
+        if len(results) >= limit:
+            break
+    response: dict[str, Any] = {
+        "query": pattern,
+        "mode": "regex",
+        "session_scope": scope,
+        "limit": limit,
+        "total_results": len(results),
+        "results": results,
+    }
+    if summary_id is not None:
+        response["summary_id"] = summary_id
+    if requested_limit > _LCM_GREP_HARD_LIMIT_CAP:
+        response["limit_clamped_from"] = requested_limit
+    return json.dumps(response)
+
+
 def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     """Search LCM history using full-text, semantic, or RRF hybrid retrieval."""
     request_started = time.monotonic()
@@ -3462,6 +3613,8 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     engine = _require_engine(kwargs)
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
+    if mode == "regex":
+        return _lcm_grep_regex(args, engine=engine)
     timeout_s = max(
         0.001,
         float(getattr(engine._config, "embedding_query_timeout_s", 3.0)),
@@ -3474,8 +3627,94 @@ def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
     if mode == "hybrid":
         return json.dumps(_lcm_grep_hybrid(args, engine=engine, deadline=deadline))
     return json.dumps({
-        "error": "mode must be one of: full_text, semantic, hybrid",
+        "error": "mode must be one of: full_text, regex, semantic, hybrid",
     })
+
+
+def _map_result_json(result: Any) -> str:
+    return json.dumps(asdict(result), ensure_ascii=False)
+
+
+def llm_map(args: Dict[str, Any], **kwargs) -> str:
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+    try:
+        batch_id = str(args.get("batch_id") or "").strip()
+        if batch_id:
+            return _map_result_json(engine._llm_map_operator.resume(batch_id))
+        result = engine._llm_map_operator.run(
+            input_path=args["input_path"],
+            output_path=args.get("output_path"),
+            prompt=args["prompt"],
+            output_schema=args["output_schema"],
+            concurrency=int(args.get("concurrency", 16)),
+            max_retries=int(args.get("max_retries", 2)),
+        )
+        return _map_result_json(result)
+    except Exception as exc:
+        return json.dumps({"error": f"llm_map failed: {exc}"})
+
+
+def agentic_map(args: Dict[str, Any], **kwargs) -> str:
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+    parent_agent = kwargs.get("agent")
+    if parent_agent is None:
+        return json.dumps({"error": "agentic_map requires a Hermes agent execution context"})
+
+    def execute_item(*, item, prompt, attempt, validation_error, read_only):
+        from tools.delegate_tool import delegate_task
+
+        correction = (
+            f"\nPrior output validation error: {validation_error}. Correct it."
+            if validation_error else ""
+        )
+        raw = delegate_task(
+            goal=(
+                f"{prompt}\n\nInput JSON:\n{json.dumps(item, ensure_ascii=False)}"
+                f"{correction}\nReturn only the requested JSON value."
+            ),
+            context="This is one isolated agentic_map item.",
+            role="leaf",
+            background=False,
+            read_only=bool(read_only),
+            parent_agent=parent_agent,
+        )
+        payload = json.loads(raw)
+        if payload.get("error"):
+            raise RuntimeError(str(payload["error"]))
+        results = payload.get("results") or []
+        if not results:
+            raise RuntimeError("sub-agent returned no result")
+        item_result = results[0]
+        value = item_result.get("result", item_result.get("output", item_result))
+        if isinstance(value, str):
+            return engine._parse_map_json_response(value)
+        return value
+
+    operator = AgenticMap(
+        engine._store.db_path,
+        executor=execute_item,
+        file_registry=engine._file_registry,
+    )
+    try:
+        batch_id = str(args.get("batch_id") or "").strip()
+        if batch_id:
+            return _map_result_json(operator.resume(batch_id))
+        result = operator.run(
+            input_path=args["input_path"],
+            output_path=args.get("output_path"),
+            prompt=args["prompt"],
+            output_schema=args["output_schema"],
+            read_only=args["read_only"],
+            concurrency=int(args.get("concurrency", 16)),
+            max_retries=int(args.get("max_retries", 2)),
+        )
+        return _map_result_json(result)
+    except Exception as exc:
+        return json.dumps({"error": f"agentic_map failed: {exc}"})
 
 
 def _lcm_recall_recency_boost(timestamp: Any, *, now: float) -> float:
@@ -5238,6 +5477,24 @@ def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
     if engine is None:
         return json.dumps({"error": "LCM engine not initialized"})
 
+    file_id = str(args.get("file_id") or "").strip()
+    if file_id:
+        record = engine._file_registry.get(file_id)
+        if record is None:
+            return json.dumps({"error": f"File {file_id} not found"})
+        return json.dumps(
+            {
+                "file_id": record.file_id,
+                "path": record.path,
+                "mime_type": record.mime_type,
+                "size_bytes": record.size_bytes,
+                "token_count": record.token_count,
+                "mtime_ns": record.mtime_ns,
+                "exploration_summary": record.exploration_summary,
+            },
+            ensure_ascii=False,
+        )
+
     externalized_ref = str(args.get("externalized_ref") or "").strip()
     if externalized_ref:
         payload = _get_externalized_payload(engine, externalized_ref)
@@ -6456,6 +6713,8 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
         "context_threshold_source": full_status.get("context_threshold_source", ""),
         "context_threshold_autoraised": full_status.get("context_threshold_autoraised"),
         "threshold_tokens": engine.threshold_tokens,
+        "async_compaction": full_status.get("async_compaction", engine.get_async_compaction_status()),
+        "pending_ingest_batches": full_status.get("pending_ingest_batches", 0),
         "last_prompt_tokens": engine.last_prompt_tokens,
         "last_input_tokens": engine.last_input_tokens,
         "last_output_tokens": engine.last_output_tokens,
@@ -6492,6 +6751,7 @@ def lcm_status(args: Dict[str, Any], **kwargs) -> str:
             "threshold_full_sweep_max_passes": 12,
             "threshold_full_sweep_max_seconds": 120,
             "context_threshold": engine._config.context_threshold,
+            "hard_context_threshold": engine._config.hard_context_threshold,
             "max_depth": engine._config.incremental_max_depth,
             "condensation_fanin": engine._config.condensation_fanin,
             "summary_model": engine._config.summary_model or "(auxiliary)",
@@ -6587,6 +6847,15 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
             "last_error": getattr(engine, "_last_ingest_error", "") or "",
             "last_error_time": getattr(engine, "_last_ingest_error_time", 0) or 0,
         } if ingest_failures else "no ingest failures recorded",
+    })
+    pending_ingest = engine._store.pending_ingest_count()
+    checks.append({
+        "check": "pending_ingest_recovery",
+        "status": "warn" if pending_ingest else "pass",
+        "detail": {
+            "pending_batches": pending_ingest,
+            "guarantee": "fsynced sidecar with receipt-based exactly-once replay",
+        },
     })
 
     # ignore_message_patterns drops discard raw content that is never persisted.
@@ -6825,6 +7094,21 @@ def lcm_doctor(args: Dict[str, Any], **kwargs) -> str:
         "status": "pass" if not config_warnings else "warn",
         "detail": config_warnings if config_warnings else "all settings within normal ranges",
     })
+
+    try:
+        async_status = engine.get_async_compaction_status()
+        async_unhealthy = int(async_status.get("failed_batches", 0)) > 0
+        checks.append({
+            "check": "async_compaction_state",
+            "status": "warn" if async_unhealthy else "pass",
+            "detail": async_status,
+        })
+    except Exception as e:
+        checks.append({
+            "check": "async_compaction_state",
+            "status": "fail",
+            "detail": str(e),
+        })
 
     # 5. Source-lineage hygiene
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- add lossless opaque Codex reasoning and native-compaction continuity without exposing capsules through FTS, summaries, inspection, or expansion
- add explicit soft/hard compaction, deterministic convergence, file lineage, and persistent llm_map / agentic_map operators
- make concurrent SQLite ownership and lock recovery durable, and bound restart reconciliation over large externalized-output archives

## Why
Long-running concurrent gateway sessions exposed two production failures: restart reconciliation repeatedly scanned a 12,799-file, roughly 540 MB archive, and cloned engines could contend over independently owned SQLite helpers. The first failure pushed a 590K-token resume beyond the 30-second host timeout. The bounded lookup and per-pass identity cache reduce that reconciliation to roughly 2 seconds while preserving every source row and externalized payload.

## Validation
- [x] Focused validation: 483 passed
- [x] Default validation:
  - [x] pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q
  - [x] pytest -q: 2,846 passed, 1 skipped
  - [x] low-FD pytest at ulimit -n 1024: 2,846 passed, 1 skipped
  - [x] scripts/validate_release.sh --full --keep-going: all gates passed
  - [x] benchmark smoke, stress smoke, and release stress tier: zero failures
  - [x] git diff checks for origin/main...HEAD, working tree, and staged tree
  - [x] Python compileall, script py_compile, and shell syntax checks
- [x] Workflow validation not applicable: workflow files are unchanged

## Notes
- Scope is broad because the storage, compaction, provider-state, and operator invariants share one schema and lifecycle boundary; the commit keeps the existing plugin name, engine name, and database path compatible.
- Background compaction remains opt-in.
- The separate Hermes gateway-core teardown patch is intentionally excluded from this plugin PR.
- Validation started and ended with a clean git status.