### PR TITLE
fix: close finalized per-agent LCM clones

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -88,6 +88,33 @@ def _ensure_engine_bound_to_session(
         )
 
 
+def _make_session_finalize_handler(prototype_engine, resolve_active_lcm_engine):
+    """Close the exact per-agent LCM clone retired by a host session boundary."""
+
+    def _on_session_finalize(**payload) -> None:
+        session_id = str(payload.get("session_id") or "")
+        platform = str(payload.get("platform") or "").strip().lower()
+        if not session_id or platform == "cli":
+            # Interactive CLI /new finalizes the old session while reusing the
+            # same agent and context engine. Process exit closes its resources.
+            return
+
+        active_engine = resolve_active_lcm_engine(session_id=session_id)
+        if (
+            active_engine is None
+            or active_engine is prototype_engine
+            or _engine_bound_session_id(active_engine) != session_id
+        ):
+            return
+
+        try:
+            active_engine.shutdown()
+        except Exception as exc:
+            logger.debug("LCM finalized-clone shutdown failed: %s", exc)
+
+    return _on_session_finalize
+
+
 def _hook_question_date(payload: dict) -> object:
     """Return an explicit turn anchor without inventing event time."""
     explicit = payload.get("question_date") or payload.get("question_as_of")
@@ -386,6 +413,17 @@ def register(ctx):
             logger.info(
                 "LCM explicit subagent-lineage hooks unavailable on this Hermes "
                 "host; auxiliary detection uses the legacy frame-walk fallback: %s",
+                exc,
+            )
+
+        try:
+            register_hook(
+                "on_session_finalize",
+                _make_session_finalize_handler(engine, resolve_active_lcm_engine),
+            )
+        except Exception as exc:
+            logger.info(
+                "LCM finalized-clone cleanup hook unavailable on this Hermes host: %s",
                 exc,
             )
 

--- a/tests/test_plugin_lifecycle_cleanup.py
+++ b/tests/test_plugin_lifecycle_cleanup.py
@@ -1,0 +1,94 @@
+"""Plugin-owned cleanup for finalized per-agent LCM clones."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_plugin_module(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name,
+        str(REPO_ROOT / "__init__.py"),
+        submodule_search_locations=[str(REPO_ROOT)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _registered_plugin(tmp_path, monkeypatch, module_name: str):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    module = _load_plugin_module(module_name)
+    hooks = {}
+
+    class _Ctx:
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_hook(self, name, callback):
+            hooks[name] = callback
+
+    ctx = _Ctx()
+    module.register(ctx)
+    return ctx.engine, hooks
+
+
+def test_finalize_closes_only_the_clone_bound_to_that_session(tmp_path, monkeypatch):
+    prototype, hooks = _registered_plugin(
+        tmp_path,
+        monkeypatch,
+        "hermes_lcm_finalize_exact_clone",
+    )
+    clone_a = prototype.clone_for_agent()
+    clone_b = prototype.clone_for_agent()
+    clone_a.on_session_start("session-a", platform="desktop")
+    clone_b.on_session_start("session-b", platform="desktop")
+
+    try:
+        hooks["on_session_finalize"](
+            session_id="session-a",
+            platform="desktop",
+            reason="tui_close",
+        )
+
+        assert clone_a._store._conn is None
+        assert clone_a._dag._conn is None
+        assert clone_a._lifecycle._conn is None
+        assert clone_b._store._conn is not None
+        assert clone_b._dag._conn is not None
+        assert clone_b._lifecycle._conn is not None
+        assert prototype._store._conn is not None
+        assert prototype._dag._conn is not None
+        assert prototype._lifecycle._conn is not None
+    finally:
+        clone_a.shutdown()
+        clone_b.shutdown()
+        prototype.shutdown()
+
+
+def test_cli_finalize_keeps_the_reused_clone_open(tmp_path, monkeypatch):
+    prototype, hooks = _registered_plugin(
+        tmp_path,
+        monkeypatch,
+        "hermes_lcm_finalize_cli_reuse",
+    )
+    clone = prototype.clone_for_agent()
+    clone.on_session_start("cli-session", platform="cli")
+
+    try:
+        hooks["on_session_finalize"](
+            session_id="cli-session",
+            platform="cli",
+            reason="session_boundary",
+        )
+
+        assert clone._store._conn is not None
+        assert clone._dag._conn is not None
+        assert clone._lifecycle._conn is not None
+    finally:
+        clone.shutdown()
+        prototype.shutdown()

--- a/tests/test_plugin_lifecycle_cleanup.py
+++ b/tests/test_plugin_lifecycle_cleanup.py
@@ -3,6 +3,7 @@
 import importlib.util
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -14,6 +15,8 @@ def _load_plugin_module(name: str):
         str(REPO_ROOT / "__init__.py"),
         submodule_search_locations=[str(REPO_ROOT)],
     )
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)
@@ -47,6 +50,12 @@ def test_finalize_closes_only_the_clone_bound_to_that_session(tmp_path, monkeypa
     clone_b = prototype.clone_for_agent()
     clone_a.on_session_start("session-a", platform="desktop")
     clone_b.on_session_start("session-b", platform="desktop")
+    clone_a_shutdown = clone_a.shutdown
+    clone_b_shutdown = clone_b.shutdown
+    prototype_shutdown = prototype.shutdown
+    clone_a.shutdown = Mock(wraps=clone_a_shutdown)
+    clone_b.shutdown = Mock(wraps=clone_b_shutdown)
+    prototype.shutdown = Mock(wraps=prototype_shutdown)
 
     try:
         hooks["on_session_finalize"](
@@ -55,15 +64,9 @@ def test_finalize_closes_only_the_clone_bound_to_that_session(tmp_path, monkeypa
             reason="tui_close",
         )
 
-        assert clone_a._store._conn is None
-        assert clone_a._dag._conn is None
-        assert clone_a._lifecycle._conn is None
-        assert clone_b._store._conn is not None
-        assert clone_b._dag._conn is not None
-        assert clone_b._lifecycle._conn is not None
-        assert prototype._store._conn is not None
-        assert prototype._dag._conn is not None
-        assert prototype._lifecycle._conn is not None
+        clone_a.shutdown.assert_called_once_with()
+        clone_b.shutdown.assert_not_called()
+        prototype.shutdown.assert_not_called()
     finally:
         clone_a.shutdown()
         clone_b.shutdown()
@@ -78,6 +81,8 @@ def test_cli_finalize_keeps_the_reused_clone_open(tmp_path, monkeypatch):
     )
     clone = prototype.clone_for_agent()
     clone.on_session_start("cli-session", platform="cli")
+    clone_shutdown = clone.shutdown
+    clone.shutdown = Mock(wraps=clone_shutdown)
 
     try:
         hooks["on_session_finalize"](
@@ -86,9 +91,7 @@ def test_cli_finalize_keeps_the_reused_clone_open(tmp_path, monkeypatch):
             reason="session_boundary",
         )
 
-        assert clone._store._conn is not None
-        assert clone._dag._conn is not None
-        assert clone._lifecycle._conn is not None
+        clone.shutdown.assert_not_called()
     finally:
         clone.shutdown()
         prototype.shutdown()


### PR DESCRIPTION
## Summary

- register the supported `on_session_finalize` plugin hook on current `main`
- resolve the exact per-agent LCM clone by durable session ID
- shut down only that finalized clone, leaving other active clones and the plugin prototype untouched
- preserve interactive CLI `/new`, which reuses its agent and context engine

## Why

Hermes deep-copies the registered context-engine prototype for each `AIAgent`. In long-lived Desktop and gateway processes, retiring an agent does not guarantee that the clone's SQLite-backed LCM helpers are closed. Finalized sessions can therefore leave Store, DAG, and lifecycle descriptors open.

The plugin already owns an exact weak session-to-engine registry and an idempotent `shutdown()` boundary. This change connects those existing pieces through Hermes' supported hard session-boundary hook; it does not patch Hermes core or sweep unrelated engines.

This refreshes #470 on current `main`. It is complementary to #501: shared clone storage reduces per-clone SQLite ownership, while this hook closes the finalized clone's own lease/resources at the host lifecycle boundary.

## Validation

- [x] Focused lifecycle and packaging validation: `HERMES_HOME=<temp> pytest tests/test_plugin_lifecycle_cleanup.py tests/test_packaging_install.py -q` -> 40 passed
- [x] Compatibility validation with #501 applied: lifecycle cleanup + shared-storage class + packaging -> 53 passed
- [ ] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_plugin_lifecycle_cleanup.py -q` -> 1100 passed
  - [ ] `pytest -q`
  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-finalize-clones-v2`
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- [x] Ruff 0.15.13 on changed Python files
- [x] Python compilation on changed Python files

## Notes

- Scope is plugin-owned LCM clone cleanup only; it does not claim to close Hermes-owned `state.db` connections.
- The branch is intentionally opened as a draft while broader validation and review complete.

Refs #463
Replaces #470
