### PR TITLE
fix(compaction): expose safe no-progress deferrals

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -145,7 +145,7 @@ class CompactionMixin:
             if self._compression_boundary_cooldown_active():
                 return False
             if pre_ingest_placeholder_ambiguous_noop:
-                self._last_compression_status = "noop"
+                self._last_compression_status = "deferred"
                 self._last_compression_noop_reason = pre_ingest_noop_reason
                 logger.info("LCM preflight compression no-op: %s", pre_ingest_noop_reason)
                 return False
@@ -164,7 +164,7 @@ class CompactionMixin:
             if self.threshold_tokens > 0 and replay_rough >= self.threshold_tokens:
                 if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
                     return self._mark_preflight_compression_requested()
-                self._last_compression_status = "noop"
+                self._last_compression_status = "deferred"
                 self._last_compression_noop_reason = reason
                 logger.info("LCM preflight compression no-op: %s", reason)
                 return False
@@ -178,7 +178,7 @@ class CompactionMixin:
             return self._mark_preflight_compression_requested()
         if self.threshold_tokens > 0 and rough >= self.threshold_tokens:
             if pre_ingest_placeholder_ambiguous_noop:
-                self._last_compression_status = "noop"
+                self._last_compression_status = "deferred"
                 self._last_compression_noop_reason = pre_ingest_noop_reason
                 logger.info("LCM preflight compression no-op: %s", pre_ingest_noop_reason)
                 return False
@@ -192,7 +192,7 @@ class CompactionMixin:
                 return self._mark_preflight_compression_requested()
             if self._should_run_deferred_maintenance(messages, observed_tokens=rough):
                 return self._mark_preflight_compression_requested()
-            self._last_compression_status = "noop"
+            self._last_compression_status = "deferred"
             self._last_compression_noop_reason = reason
             logger.info("LCM preflight compression no-op: %s", reason)
             return False
@@ -902,7 +902,22 @@ class CompactionMixin:
                     # written. Keep the cursor aligned with the returned context
                     # so the next appended turn is ingested instead of skipped.
                     self._ingest_cursor = len(sanitized_messages)
-                self._last_compression_status = "noop"
+                self._last_compression_status = (
+                    "deferred"
+                    if (
+                        (
+                            "no eligible raw backlog" in noop_reason
+                            and getattr(self, "threshold_tokens", 0) > 0
+                            and estimated_active_tokens >= getattr(self, "threshold_tokens", 0)
+                        )
+                        or (
+                            "below leaf chunk threshold" in noop_reason
+                            and getattr(self, "threshold_tokens", 0) > 0
+                            and estimated_active_tokens >= getattr(self, "threshold_tokens", 0)
+                        )
+                    )
+                    else "noop"
+                )
                 self._last_compression_noop_reason = noop_reason
                 logger.info("LCM compression no-op: %s", noop_reason)
             if threshold_full_sweep_active:

--- a/engine.py
+++ b/engine.py
@@ -997,7 +997,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     @property
     def last_compression_was_noop(self) -> bool:
         """Whether the most recent compression/preflight decision was a no-op."""
-        return self._last_compression_status == "noop"
+        return self._last_compression_status in {"noop", "deferred"}
 
     def _mark_preflight_compression_requested(self) -> bool:
         """Record that preflight found work and clear any stale no-op reason."""

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1672,7 +1672,7 @@ class TestEngineABC:
         try:
             assert count_messages_tokens(messages) >= instance.threshold_tokens
             assert not instance.should_compress_preflight(messages)
-            assert instance.last_compression_status == "noop"
+            assert instance.last_compression_status == "deferred"
             assert instance.last_compression_was_noop is True
             assert "below leaf chunk threshold" in instance.last_compression_noop_reason
         finally:


### PR DESCRIPTION
<!-- development-pr:managed:start -->
## Summary

LCM can be asked to compact after the host crosses its context threshold even when there is no eligible raw backlog outside the protected fresh tail (or the eligible backlog is below the configured leaf size). That is a safe deferral: the active conversation remains unchanged. This change exposes that outcome as `deferred` instead of the ambiguous `noop` status, while preserving `noop` for ordinary below-threshold pass-through and cleanup cases.

## Why

The Hermes host needs to distinguish a safe no-progress decision from an operational compression failure. Without an explicit status, an unchanged LCM result is reported as an aborted compression attempt and users see a false failure warning.

## Changes

- Mark threshold-triggered preflight no-progress decisions as `deferred`.
- Mark threshold-triggered compression no-progress decisions as `deferred` while retaining ordinary pass-through `noop` behavior.
- Keep `last_compression_was_noop` backward-compatible for both statuses.
- Update the focused regression expectation.

## Checks

- `/Users/brianle/.hermes/venvs/hermes-patched/bin/pytest tests/test_lcm_engine.py -q` — **751 passed, 1 skipped**.
- `git diff --check` — **passed**.

## Compatibility and scope

This is a narrow status-contract change. It does not discard messages, rewrite the fresh tail, change leaf sizing, or alter provider behavior. The Hermes host companion can map `deferred` to a benign terminal outcome and reserve failure reporting for actual faults.

Related context: #168. #188 is merged and tracks silent automatic compaction behavior; this change supplies the explicit engine outcome needed by host integrations.

## Reviewer focus

Please review the status classification at the preflight and no-leaf compaction boundaries, especially the distinction between threshold-triggered deferral and ordinary below-threshold pass-through.
<!-- development-pr:managed:end -->
