### PR TITLE
fix: keep overflow recovery cap independent of host estimate

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -6139,15 +6139,19 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         observed_tokens: Optional[int] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[int]:
-        assembly_cap = self._effective_assembly_token_cap()
-        if assembly_cap is None:
-            return None
-        if messages is None or observed_tokens is None or observed_tokens <= 0:
-            return assembly_cap
+        """Return the cap used while rebuilding the provider-visible context.
 
-        message_tokens = count_messages_tokens(messages)
-        overhead_tokens = max(0, observed_tokens - message_tokens)
-        return max(1, assembly_cap - overhead_tokens)
+        ``observed_tokens`` is a pressure signal from the host.  It is not a
+        message-only count: Hermes may include system prompts, tool schemas,
+        and provider replay metadata that LCM's message estimator deliberately
+        does not model.  Subtracting ``observed_tokens - message_tokens``
+        therefore treats estimator skew as fixed assembly overhead and can
+        collapse a normal cap to one token.  Headroom for non-message payloads
+        belongs in ``reserve_tokens_floor`` (or an explicit cap), so recovery
+        must use the configured message-assembly cap unchanged.
+        """
+        assembly_cap = self._effective_assembly_token_cap()
+        return assembly_cap
 
     def _effective_assembly_token_cap(self) -> Optional[int]:
         """Return the active assembly cap, if any.

--- a/engine.py
+++ b/engine.py
@@ -5917,6 +5917,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """
         result = []
 
+        # An assembly_cap_override is the forced-overflow-recovery signature:
+        # every caller that passes one is rebuilding the context under
+        # recovery pressure. Project the inputs onto canonical message keys
+        # here so the recovery guarantee holds no matter which entry point
+        # (_assemble_overflow_recovery_context, the post-leaf-compaction
+        # assembly in compaction.py) reached this method — replay metadata
+        # that count_message_tokens does not model must not survive into a
+        # payload assembled against the cap. Normal (override-less) assembly
+        # never strips: replay fields are the host's business there.
+        if assembly_cap_override is not None:
+            system_msg = _strip_replay_metadata_for_recovery_message(system_msg)
+            tail_messages = [
+                _strip_replay_metadata_for_recovery_message(msg)
+                for msg in tail_messages
+            ]
+
         # Leading anchor with optional LCM annotation. Only a true system prompt
         # is a safe permanent anchor; gateway sessions can start directly with
         # user messages, and those user turns must remain compactable.

--- a/engine.py
+++ b/engine.py
@@ -359,6 +359,36 @@ _AUTO_FOCUS_MAX_CHARS = 700
 _PRESERVED_TODO_CONTEXT_PREFIX = "[Your active task list was preserved across context compression]"
 _LCM_MESSAGE_PREFIX_FINGERPRINT_LIMIT = 8
 
+# Canonical provider-visible message keys. Overflow recovery rebuilds the
+# active context from these only; every other key on an incoming message is
+# transport-replayed provider metadata (``reasoning``, ``codex_reasoning_items``,
+# ``codex_message_items``, ...) that count_message_tokens deliberately does
+# not model — keeping it would break the recovery cap in the provider-visible
+# payload (PR #533 review).
+_RECOVERY_CANONICAL_MESSAGE_KEYS = (
+    "role",
+    "name",
+    "content",
+    "tool_calls",
+    "tool_call_id",
+)
+
+
+def _strip_replay_metadata_for_recovery_message(
+    message: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Return a copy of *message* keeping only canonical provider keys.
+
+    Non-dict input passes through untouched (defensive, matches the
+    tolerance of the message estimator). Messages that already carry only
+    canonical keys are returned as-is — no copy, no mutation.
+    """
+    if not isinstance(message, dict):
+        return message
+    if not (set(message) - set(_RECOVERY_CANONICAL_MESSAGE_KEYS)):
+        return message
+    return {key: message[key] for key in _RECOVERY_CANONICAL_MESSAGE_KEYS if key in message}
+
 
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
     """Lossless Context Management engine.
@@ -6189,6 +6219,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         tail_messages: List[Dict[str, Any]],
         assembly_cap_override: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
+        # Recovery rebuilds the provider-visible payload from canonical
+        # message parts only. Transports replay provider metadata such as
+        # ``reasoning`` / ``codex_reasoning_items`` / ``codex_message_items``
+        # alongside each message; count_message_tokens does not count them,
+        # so retaining them would let a recovered context that measured at
+        # the cap ship a payload far past it and re-overflow on the next
+        # request. Copies, never mutates the caller's dicts.
+        system_msg = _strip_replay_metadata_for_recovery_message(system_msg)
+        tail_messages = [
+            _strip_replay_metadata_for_recovery_message(msg) for msg in tail_messages
+        ]
         if tail_messages:
             first = tail_messages[0]
             content = first.get("content") or ""

--- a/tests/test_active_tool_stubbing.py
+++ b/tests/test_active_tool_stubbing.py
@@ -500,6 +500,61 @@ def test_live_interceptor_survives_fresh_tail_overflow_recovery(make_engine):
     assert engine.last_compression_status in {"sanitized", "overflow_recovery"}
 
 
+def test_post_leaf_overflow_assembly_strips_replay_metadata(make_engine, monkeypatch):
+    """Forced overflow that also leaf-compacts must still project canonically.
+
+    The post-leaf Step-7 assembly calls _assemble_context directly with the
+    recovery cap override; replay metadata on the system anchor or the
+    retained fresh tail used to survive there while the estimator stayed
+    under the cap (Codex review P1 follow-up on PR #533).
+    """
+    engine = make_engine(
+        fresh_tail_count=2,
+        leaf_chunk_tokens=1,
+        max_assembly_tokens=400,
+    )
+    engine.threshold_tokens = 1
+    monkeypatch.setattr(
+        lcm_engine,
+        "summarize_with_escalation",
+        lambda **_kwargs: ("compact summary of the raw backlog", 1),
+    )
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "old request one", "reasoning": "replay envelope " * 50},
+        {
+            "role": "assistant",
+            "content": "old answer one",
+            "codex_reasoning_items": [{"type": "reasoning", "text": "x" * 400}],
+        },
+        {"role": "user", "content": "old request two"},
+        {"role": "assistant", "content": "old answer two"},
+        {
+            "role": "user",
+            "content": "fresh request",
+            "codex_message_items": [{"type": "message", "text": "y" * 400}],
+        },
+        {"role": "assistant", "content": "fresh answer"},
+    ]
+
+    assert engine._should_force_overflow_recovery(
+        observed_tokens=10_000, messages=messages
+    )
+    result = engine.compress(messages, current_tokens=10_000)
+
+    assert result
+    canonical = {"role", "name", "content", "tool_calls", "tool_call_id"}
+    for msg in result:
+        leaked = set(msg) - canonical
+        assert not leaked, f"recovery leaked replay metadata: {sorted(leaked)}"
+    assert any(m.get("content") == "fresh request" for m in result)
+    assert engine.last_compression_status in {"compacted", "overflow_recovery"}
+    # The caller's dicts are never mutated.
+    assert "reasoning" in messages[1]
+    assert "codex_reasoning_items" in messages[2]
+    assert "codex_message_items" in messages[5]
+
+
 def test_live_interceptor_is_preserved_after_normal_leaf_compaction(make_engine, monkeypatch):
     engine = make_engine(fresh_tail_count=2, leaf_chunk_tokens=1)
     engine.threshold_tokens = 1

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -20532,6 +20532,41 @@ class TestConfigCleanup:
 
 
 class TestAssemblyGuardrails:
+    def test_overflow_recovery_does_not_turn_estimator_skew_into_one_token_cap(self, tmp_path):
+        """The host pressure estimate is not an LCM message-overhead contract."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_overflow_estimator_skew.db"),
+            max_assembly_tokens=220_000,
+        )
+        instance = LCMEngine(config=config)
+        try:
+            messages = [
+                {
+                    "role": "user",
+                    "content": "continue the active task",
+                    # These fields are replayed by Codex transports but are
+                    # intentionally outside LCM's canonical message counter.
+                    "reasoning": "opaque provider replay envelope " * 1000,
+                    "codex_reasoning_items": [{"type": "reasoning", "text": "x" * 1000}],
+                    "codex_message_items": [{"type": "message", "text": "y" * 1000}],
+                }
+            ]
+            observed_tokens = 340_733
+
+            assert count_messages_tokens(messages) < 10_000
+            assert instance._overflow_recovery_assembly_cap(
+                observed_tokens=observed_tokens,
+                messages=messages,
+            ) == 220_000
+            recovered = instance._assemble_overflow_recovery_context(
+                None,
+                messages,
+                assembly_cap_override=220_000,
+            )
+            assert recovered and recovered[0]["role"] == "user"
+        finally:
+            instance.shutdown()
+
     def test_max_assembly_tokens_caps_recent_tail(self, tmp_path, monkeypatch):
         import importlib
 
@@ -20846,7 +20881,7 @@ class TestAssemblyGuardrails:
         assert instance._ingest_cursor == len(result)
         assert not instance.get_status()["overflow_recovery_failed"]
 
-    def test_forced_overflow_recovery_reserves_provider_overhead(self, tmp_path, monkeypatch):
+    def test_forced_overflow_recovery_uses_message_assembly_cap(self, tmp_path, monkeypatch):
         import importlib
 
         config = LCMConfig(
@@ -20878,8 +20913,8 @@ class TestAssemblyGuardrails:
 
         result = instance.compress(messages, current_tokens=100)
 
-        assert result == [messages[0], messages[-1]]
-        assert lcm_engine_module.count_messages_tokens(result) < 70
+        assert result == messages
+        assert lcm_engine_module.count_messages_tokens(result) <= 90
 
     def test_forced_overflow_recovery_does_not_duplicate_existing_summary_message(self, tmp_path, monkeypatch):
         import importlib

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -20567,6 +20567,99 @@ class TestAssemblyGuardrails:
         finally:
             instance.shutdown()
 
+    def test_overflow_recovery_strips_replay_metadata_from_recovered_payload(self, tmp_path):
+        """Recovery output must not retain transport-replayed provider metadata.
+
+        count_message_tokens only models canonical content/tool_calls, so a
+        recovered payload that keeps ``reasoning`` / ``codex_*`` fields can
+        measure at the cap while shipping a provider-visible payload far
+        past it — re-overflowing on the next request (PR #533 review P1).
+        """
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_overflow_replay_strip.db"),
+            max_assembly_tokens=220_000,
+        )
+        instance = LCMEngine(config=config)
+        try:
+            messages = [
+                {
+                    "role": "user",
+                    "content": "continue the active task",
+                    "reasoning": "opaque provider replay envelope " * 1000,
+                    "codex_reasoning_items": [{"type": "reasoning", "text": "x" * 1000}],
+                    "codex_message_items": [{"type": "message", "text": "y" * 1000}],
+                },
+                {
+                    "role": "assistant",
+                    "content": "working on it",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{\"path\": \"a\"}"},
+                        }
+                    ],
+                    "codex_reasoning_items": [{"type": "reasoning", "text": "z" * 500}],
+                },
+            ]
+
+            recovered = instance._assemble_overflow_recovery_context(
+                None,
+                messages,
+                assembly_cap_override=220_000,
+            )
+
+            assert recovered, "recovery returned an empty context"
+            canonical = {
+                "role",
+                "name",
+                "content",
+                "tool_calls",
+                "tool_call_id",
+            }
+            for msg in recovered:
+                assert not (set(msg) - canonical), (
+                    f"recovered message retained replay metadata: "
+                    f"{sorted(set(msg) - canonical)}"
+                )
+            # The required user turn survives with its content intact, and
+            # canonical tool calls survive alongside it.
+            user_rows = [m for m in recovered if m["role"] == "user"]
+            assert user_rows and user_rows[-1]["content"] == "continue the active task"
+            assistant_rows = [m for m in recovered if m["role"] == "assistant" and m.get("tool_calls")]
+            assert assistant_rows and assistant_rows[0]["tool_calls"][0]["id"] == "call-1"
+
+            # The caller's dicts are never mutated: the host owns the
+            # original message list and may replay it after recovery.
+            assert "reasoning" in messages[0]
+            assert "codex_reasoning_items" in messages[1]
+        finally:
+            instance.shutdown()
+
+    def test_overflow_recovery_strips_replay_metadata_from_system_anchor(self, tmp_path):
+        """The recovery system anchor gets the same canonical projection."""
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_overflow_replay_strip_system.db"),
+            max_assembly_tokens=220_000,
+        )
+        instance = LCMEngine(config=config)
+        try:
+            system_msg = {
+                "role": "system",
+                "content": "anchor prompt",
+                "codex_message_items": [{"type": "message", "text": "replayed" * 100}],
+            }
+            recovered = instance._assemble_overflow_recovery_context(
+                system_msg,
+                [{"role": "user", "content": "hi"}],
+                assembly_cap_override=220_000,
+            )
+            assert recovered and recovered[0]["role"] == "system"
+            assert set(recovered[0]) == {"role", "content"}
+            assert "codex_message_items" in system_msg
+        finally:
+            instance.shutdown()
+
     def test_max_assembly_tokens_caps_recent_tail(self, tmp_path, monkeypatch):
         import importlib
 


### PR DESCRIPTION
## Problem

Forced-overflow recovery derived its assembly cap as `assembly_cap - (observed_tokens - count_messages_tokens(messages))`. `observed_tokens` is the host rough full-request estimate; it may include system prompts, tool schemas, and provider replay metadata that LCM does not count. Treating that estimator difference as fixed overhead could collapse a valid cap to one token, after which sanitization returned an empty transcript and the host retried the same poisoned session.

## Fix

Use the configured LCM message-assembly cap unchanged during overflow recovery. The host estimate remains a pressure signal for the existing force-overflow gate; it no longer rewrites a cap whose accounting basis it does not share. Non-message headroom belongs in `reserve_tokens_floor` or an explicit cap.

The regression covers the production-shaped mismatch (`340,733` host estimate vs. `<10,000` LCM message estimate with Codex replay fields) and verifies a no-system recovery still returns a user message.

Fixes #530

## Verification

- `PYTHONPATH=$HOME/Dev/hermes-agent ~/the3asic-agentkit/.venv/bin/pytest -q tests/test_lcm_engine.py --disable-warnings`
- `752 passed, 1 skipped`
- `python -m compileall -q engine.py tests/test_lcm_engine.py`
- `git diff --check`