### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,10 +856,10 @@ for changelogs.
 
 ## Star history
 
-<a href="https://www.star-history.com/?repos=stephenschoettler%2Fhermes-lcm&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#stephenschoettler/hermes-lcm&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=stephenschoettler/hermes-lcm&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=stephenschoettler/hermes-lcm&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=stephenschoettler/hermes-lcm&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=stephenschoettler/hermes-lcm&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=stephenschoettler/hermes-lcm&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=stephenschoettler/hermes-lcm&type=timeline&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is broken. Due to GitHub stargazer API restrictions the current chart no longer loads, so I switched it to an alternative data source that requires no API token and serves the chart reliably. Updated the chart image and its link in README.md. This is a small documentation fix that restores a useful feature for visitors.