### PR TITLE
fix(fresh_tail): advance boundary past orphaned assistant tool_calls

### DIFF
--- a/fresh_tail.py
+++ b/fresh_tail.py
@@ -50,6 +50,69 @@ def _assistant_group_start(messages: Sequence[Dict[str, Any]], start: int) -> in
     return start
 
 
+def _assistant_tool_group_end(
+    messages: Sequence[Dict[str, Any]], start: int
+) -> int:
+    """Advance past a boundary that opens on an assistant with tool_calls.
+
+    ``_assistant_group_start`` only handles the case where the boundary falls
+    on a ``tool`` result and retreats to the assistant that opened the group.
+    The mirror case is equally broken: when the count/token boundary falls on
+    an assistant message whose ``tool_calls`` are followed by tool results,
+    the boundary already sits at a complete group (fine). But when the
+    boundary falls on an assistant message whose tool results were consumed
+    by the compacted prefix, keeping that assistant in the fresh tail emits
+    an orphaned ``tool_calls`` message into the active context. Downstream
+    OpenAI-compatible APIs reject this with:
+
+        "An assistant message with 'tool_calls' must be followed by tool
+         messages responding to each 'tool_call_id'."
+
+    To preserve tool-call integrity (the same guarantee the forward retreat
+    gives), walk forward from ``start`` while the tail opens with a sequence
+    of assistant/tool pairs and advance past any assistant whose tool results
+    are not fully present within the tail. Returns the new start index.
+    """
+    if start >= len(messages) or messages[start].get("role") != "assistant":
+        return start
+    opening_tool_calls = messages[start].get("tool_calls") or []
+    if not opening_tool_calls:
+        return start
+
+    pending_ids = {
+        _tool_call_id(tool_call)
+        for tool_call in opening_tool_calls
+    }
+    if not pending_ids:
+        return start
+
+    index = start + 1
+    resolved = set()
+    while index < len(messages):
+        message = messages[index]
+        role = str(message.get("role") or "")
+        if role == "tool":
+            resolved.add(str(message.get("tool_call_id") or "").strip())
+            index += 1
+            continue
+        if role == "assistant" and message.get("tool_calls"):
+            # Another tool-call group follows; the opening assistant's
+            # results were never resolved inside the tail, so advance the
+            # boundary to this next assistant (its own group is intact from
+            # here on).
+            if not pending_ids.issubset(resolved):
+                return index
+            return start
+        break
+
+    if not pending_ids.issubset(resolved):
+        # Opening assistant's tool results are missing/incomplete in the
+        # tail — advance the boundary to the end of what was resolved so the
+        # orphaned tool_calls do not enter the active context.
+        return index
+    return start
+
+
 def resolve_fresh_tail_boundary(
     messages: Sequence[Dict[str, Any]],
     *,
@@ -89,6 +152,11 @@ def resolve_fresh_tail_boundary(
     group_start = _assistant_group_start(messages, start)
     tool_group_extended = group_start < start
     start = group_start
+    # Mirror integrity check: if the boundary opens on an assistant with
+    # tool_calls whose results are missing from the tail, advance the
+    # boundary so the orphaned tool_calls message does not reach the
+    # active context (OpenAI-compatible APIs reject it with a 400).
+    start = _assistant_tool_group_end(messages, start)
     tail = list(messages[start:])
     return FreshTailBoundary(
         start=start,

--- a/tests/test_fresh_tail.py
+++ b/tests/test_fresh_tail.py
@@ -108,6 +108,91 @@ def test_orphan_tool_result_does_not_create_a_phantom_group():
     assert boundary.tool_group_extended is False
 
 
+def test_boundary_opens_on_orphaned_assistant_tool_calls_advances():
+    """A tail opening on an assistant whose tool results are missing must
+    advance past that assistant so the orphaned tool_calls never reach the
+    active context (mirror of _assistant_group_start's forward retreat).
+
+    The boundary falls on the assistant by the message-count limit; its
+    ``tool_calls`` reference a result that is absent from the sequence
+    (e.g. compacted/GC'd before assembly).
+    """
+    messages = [
+        _user("old"),
+        {
+            "role": "assistant",
+            "content": "calling tools",
+            "tool_calls": [
+                {"id": "call-a", "function": {"name": "a", "arguments": "{}"}},
+            ],
+        },
+        _user("newest"),
+    ]
+
+    boundary = resolve_fresh_tail_boundary(
+        messages,
+        fresh_tail_count=2,
+        fresh_tail_max_tokens=0,
+    )
+
+    assert boundary.start == 2
+    assert [message["role"] for message in messages[boundary.start:]] == ["user"]
+    assert "call-a" not in str(messages[boundary.start])
+
+
+def test_complete_assistant_tool_group_stays_in_tail():
+    """When the boundary opens on an assistant and its tool results are fully
+    present in the tail, the boundary must NOT advance."""
+    messages = [_user("old"), *_tool_group(payload_a="a", payload_b="b"), _user("newest")]
+
+    boundary = resolve_fresh_tail_boundary(
+        messages,
+        fresh_tail_count=4,
+        fresh_tail_max_tokens=0,
+    )
+
+    assert boundary.start == 1
+    assert boundary.count == 4
+    assert [message["role"] for message in messages[boundary.start:]] == [
+        "assistant", "tool", "tool", "user",
+    ]
+
+
+def test_multiple_tool_groups_advances_only_broken_opening_group():
+    """A tail opening on a broken assistant group should advance to the next
+    intact assistant group, preserving that group's own tool results."""
+    messages = [
+        _user("old"),
+        {
+            "role": "assistant",
+            "content": "calling tools",
+            "tool_calls": [
+                {"id": "call-a", "function": {"name": "a", "arguments": "{}"}},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "second group",
+            "tool_calls": [
+                {"id": "call-b", "function": {"name": "b", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-b", "content": "result-b"},
+        _user("newest"),
+    ]
+
+    boundary = resolve_fresh_tail_boundary(
+        messages,
+        fresh_tail_count=4,
+        fresh_tail_max_tokens=0,
+    )
+
+    assert boundary.start == 2
+    assert [message["role"] for message in messages[boundary.start:]] == [
+        "assistant", "tool", "user",
+    ]
+
+
 def test_stored_tail_expands_backward_until_tool_group_is_complete(tmp_path):
     config = LCMConfig(
         database_path=str(tmp_path / "fresh-tail.db"),


### PR DESCRIPTION
## Problem

When the fresh-tail boundary falls on an **assistant message carrying `tool_calls`**, and that assistant's tool results were consumed by the compacted prefix, the assistant stays in the fresh tail with **orphaned `tool_calls`**. Downstream OpenAI-compatible APIs reject the assembled context with:

```
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)
```

This is the mirror of the case already handled by `_assistant_group_start`: the existing code retreats the boundary *backward* when it lands on a `tool` result (to include the opening assistant), but does nothing when the boundary lands *on* an assistant whose results are missing — the orphaned `tool_calls` then reach the active context and break the request.

## Fix

Adds `_assistant_tool_group_end`, a forward integrity check run after `_assistant_group_start` in `resolve_fresh_tail_boundary`:

- If the boundary opens on an assistant with `tool_calls`, walk forward through the tail collecting resolved `tool_call_id`s.
- If the opening assistant's tool results are missing/incomplete, advance the boundary past it (to the end of what was resolved, or to the next intact assistant group) so the orphaned `tool_calls` never enter the active context.
- If the group is complete, the boundary is left unchanged.

Tool-call integrity is preserved in both directions: boundary on tool result → retreat to assistant; boundary on assistant → advance past incomplete group.

## Tests

Adds regression tests to `tests/test_fresh_tail.py`:

- `test_boundary_opens_on_orphaned_assistant_tool_calls_advances` — orphaned opening assistant is skipped
- `test_complete_assistant_tool_group_stays_in_tail` — complete group is preserved (no-op)
- `test_multiple_tool_groups_advances_only_broken_opening_group` — only the broken opening group is skipped; the next intact group is preserved

Related: #467, #466, #518