### PR TITLE
fix(lcm): stabilize foreground compaction

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -31,7 +31,40 @@ _THRESHOLD_FULL_SWEEP_MAX_PASSES = 12
 _THRESHOLD_FULL_SWEEP_MAX_SECONDS = 120.0
 
 
+class LCMCompressionCancelled(Exception):
+    """Raised when the host cancels a cooperative compression pass."""
+
+
 class CompactionMixin:
+    def _compression_cancelled(self) -> bool:
+        cancelled_check = getattr(self, "_compression_cancelled_check", None)
+        if not callable(cancelled_check):
+            return False
+        try:
+            return bool(cancelled_check())
+        except Exception:
+            logger.debug("LCM compression cancellation check failed", exc_info=True)
+            return False
+
+    def _raise_if_compression_cancelled(self) -> None:
+        if self._compression_cancelled():
+            raise LCMCompressionCancelled()
+
+    def _finalize_cancelled_compression(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        ingest_cleanup_changed_active_context: bool = False,
+    ) -> List[Dict[str, Any]]:
+        self._last_compression_status = "noop"
+        self._last_compression_noop_reason = "compression cancelled by host"
+        if ingest_cleanup_changed_active_context:
+            self._ingest_cursor = len(messages)
+        return self._sanitize_active_context_messages(
+            messages,
+            insert_missing_tool_stubs=False,
+        )
+
     def _maybe_reclassify_late_auxiliary_before_compaction_write(self) -> None:
         maybe_reclassify = getattr(
             self,
@@ -391,6 +424,9 @@ class CompactionMixin:
             + max(0.0, self._config.summary_timeout_ms / 1000)
         )
 
+        if self._compression_cancelled():
+            return self._finalize_cancelled_compression(messages)
+
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
             bypass_current_tokens = current_tokens
@@ -537,6 +573,11 @@ class CompactionMixin:
         preexisting_dependent_reply_records = self._load_generated_ignored_dependent_reply_records()
 
         while leaf_passes < max_leaf_passes:
+            if self._compression_cancelled():
+                return self._finalize_cancelled_compression(
+                    working_messages,
+                    ingest_cleanup_changed_active_context=ingest_cleanup_changed_active_context,
+                )
             if threshold_full_sweep_active and time.monotonic() >= sweep_deadline:
                 sweep_stop_reason = "time_budget_exhausted"
                 break
@@ -737,6 +778,7 @@ class CompactionMixin:
                 # Pre-compaction extraction: best-effort, never blocks compaction.
                 # Use the same dependency-filtered view as summarization so ignored
                 # turns cannot leak through derived assistant/tool replies.
+                self._raise_if_compression_cancelled()
                 if self._config.extraction_enabled:
                     effective_deadline = (
                         sweep_deadline
@@ -776,6 +818,12 @@ class CompactionMixin:
                     ) = self._summarize_leaf_chunk_with_rescue(
                         summary_input_chunk,
                         **summary_kwargs,
+                    )
+                    self._raise_if_compression_cancelled()
+                except LCMCompressionCancelled:
+                    return self._finalize_cancelled_compression(
+                        working_messages,
+                        ingest_cleanup_changed_active_context=ingest_cleanup_changed_active_context,
                     )
                 except Exception as exc:
                     if threshold_full_sweep_active and leaf_compacted_this_turn:
@@ -975,13 +1023,16 @@ class CompactionMixin:
                     )
                 )
         else:
-            self._maybe_condense(
-                focus_topic=focus_topic,
-                deadline=compaction_deadline,
-                leaf_compacted_this_turn=True,
-                force_overflow=force_overflow,
-                critical_budget_pressure=critical_budget_pressure,
-            )
+            try:
+                self._maybe_condense(
+                    focus_topic=focus_topic,
+                    deadline=compaction_deadline,
+                    leaf_compacted_this_turn=True,
+                    force_overflow=force_overflow,
+                    critical_budget_pressure=critical_budget_pressure,
+                )
+            except LCMCompressionCancelled:
+                pass
 
         # Step 7: Assemble new active context
         self._refresh_raw_backlog_debt(

--- a/compaction.py
+++ b/compaction.py
@@ -20,6 +20,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from .dag import SummaryNode
+from .escalation import _deterministic_truncate
 from .message_content import text_content_for_pattern_matching
 from .sanitize import _contains_sensitive_redaction
 from .tokens import count_message_tokens, count_messages_tokens, count_tokens
@@ -384,6 +385,11 @@ class CompactionMixin:
         self._last_compression_status = "running"
         self._last_compression_noop_reason = ""
         _compress_started = time.perf_counter()
+        _compress_started_monotonic = time.monotonic()
+        compaction_deadline = (
+            _compress_started_monotonic
+            + max(0.0, self._config.summary_timeout_ms / 1000)
+        )
 
         self._maybe_reclassify_late_auxiliary_before_compaction_write()
         if self._bypasses_lcm_context_management():
@@ -472,7 +478,10 @@ class CompactionMixin:
             and self.threshold_tokens > 0
             and estimated_active_tokens >= self.threshold_tokens
         )
-        sweep_deadline = time.monotonic() + _THRESHOLD_FULL_SWEEP_MAX_SECONDS
+        sweep_deadline = min(
+            compaction_deadline,
+            _compress_started_monotonic + _THRESHOLD_FULL_SWEEP_MAX_SECONDS,
+        )
         configured_sweep_target = int(self._config.summary_prefix_target_tokens)
         sweep_target_tokens = max(
             1,
@@ -684,6 +693,7 @@ class CompactionMixin:
                 else:
                     to_compact = self._select_oldest_leaf_chunk(candidate_raw, working_leaf_chunk_tokens)
             else:
+                working_leaf_chunk_tokens = max(1, self._config.leaf_chunk_tokens)
                 if raw_tokens_outside_tail < self._config.leaf_chunk_tokens and not force_overflow:
                     if not (deferred_maintenance_active and critical_budget_pressure):
                         noop_reason = (
@@ -700,6 +710,11 @@ class CompactionMixin:
             summary_input_chunk = [
                 message for message in selected_raw_chunk if id(message) not in dependent_reply_message_ids
             ]
+            oversized_singleton = (
+                len(selected_raw_chunk) == 1
+                and count_message_tokens(selected_raw_chunk[0])
+                > working_leaf_chunk_tokens
+            )
             if not summary_input_chunk:
                 compacted_chunk = selected_raw_chunk
                 source_tokens = count_messages_tokens(selected_raw_chunk)
@@ -709,18 +724,31 @@ class CompactionMixin:
                 )
                 _level = 0
                 _rescue_attempts = 0
+            elif oversized_singleton:
+                compacted_chunk = summary_input_chunk
+                source_tokens = count_messages_tokens(compacted_chunk)
+                summary_text = _deterministic_truncate(
+                    self._serialize_messages(compacted_chunk),
+                    self._config.l3_truncate_tokens,
+                )
+                _level = 3
+                _rescue_attempts = 0
             else:
                 # Pre-compaction extraction: best-effort, never blocks compaction.
                 # Use the same dependency-filtered view as summarization so ignored
                 # turns cannot leak through derived assistant/tool replies.
                 if self._config.extraction_enabled:
-                    extraction_timeout = None
-                    if threshold_full_sweep_active:
-                        extraction_timeout = max(0.001, sweep_deadline - time.monotonic())
-                    self._run_pre_compaction_extraction(
-                        summary_input_chunk,
-                        timeout_seconds=extraction_timeout,
+                    effective_deadline = (
+                        sweep_deadline
+                        if threshold_full_sweep_active
+                        else compaction_deadline
                     )
+                    remaining_seconds = effective_deadline - time.monotonic()
+                    if remaining_seconds > 0:
+                        self._run_pre_compaction_extraction(
+                            summary_input_chunk,
+                            timeout_seconds=max(0.001, remaining_seconds),
+                        )
                 if bool(
                     getattr(
                         self._config,
@@ -731,9 +759,14 @@ class CompactionMixin:
                     self._schedule_pre_compaction_assertions(summary_input_chunk)
 
                 try:
-                    summary_kwargs: dict[str, Any] = {"focus_topic": focus_topic}
-                    if threshold_full_sweep_active:
-                        summary_kwargs["deadline"] = sweep_deadline
+                    summary_kwargs: dict[str, Any] = {
+                        "focus_topic": focus_topic,
+                        "deadline": (
+                            sweep_deadline
+                            if threshold_full_sweep_active
+                            else compaction_deadline
+                        ),
+                    }
                     (
                         compacted_chunk,
                         source_tokens,
@@ -944,6 +977,7 @@ class CompactionMixin:
         else:
             self._maybe_condense(
                 focus_topic=focus_topic,
+                deadline=compaction_deadline,
                 leaf_compacted_this_turn=True,
                 force_overflow=force_overflow,
                 critical_budget_pressure=critical_budget_pressure,

--- a/compaction.py
+++ b/compaction.py
@@ -713,7 +713,7 @@ class CompactionMixin:
             oversized_singleton = (
                 len(selected_raw_chunk) == 1
                 and count_message_tokens(selected_raw_chunk[0])
-                > working_leaf_chunk_tokens
+                > max(working_leaf_chunk_tokens, self._config.l3_truncate_tokens)
             )
             if not summary_input_chunk:
                 compacted_chunk = selected_raw_chunk

--- a/compaction.py
+++ b/compaction.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _THRESHOLD_FULL_SWEEP_MAX_PASSES = 12
 _THRESHOLD_FULL_SWEEP_MAX_SECONDS = 120.0
+_PRE_COMPACTION_EXTRACTION_MAX_SECONDS = 5.0
 
 
 class LCMCompressionCancelled(Exception):
@@ -789,7 +790,13 @@ class CompactionMixin:
                     if remaining_seconds > 0:
                         self._run_pre_compaction_extraction(
                             summary_input_chunk,
-                            timeout_seconds=max(0.001, remaining_seconds),
+                            timeout_seconds=max(
+                                0.001,
+                                min(
+                                    remaining_seconds,
+                                    _PRE_COMPACTION_EXTRACTION_MAX_SECONDS,
+                                ),
+                            ),
                         )
                 if bool(
                     getattr(

--- a/engine.py
+++ b/engine.py
@@ -124,7 +124,7 @@ from .message_patterns import compile_message_patterns, matches_message_pattern
 from .aux_session import AuxiliarySessionMixin
 from .placeholder_ledger import PlaceholderLedgerMixin
 from .reconcile import ReconcileMixin, _PRESERVED_OBJECTIVE_CONTEXT_PREFIX
-from .compaction import CompactionMixin
+from .compaction import CompactionMixin, LCMCompressionCancelled
 from .reset_state import ResetStateMixin
 from .bypass import BypassMixin
 from .lifecycle_state import LifecycleStateStore
@@ -573,6 +573,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._last_active_replay_source_identities: list[tuple[Any, ...]] = []
         self._last_active_replay_messages: list[Dict[str, Any]] = []
         self._generated_ignored_active_replay_placeholder_message_ids: set[int] = set()
+        self._compression_cancelled_check: Callable[[], bool] | None = None
         self._logged_filter_config = False
         self._pending_reset_session_id: str = ""
         self._pending_reset_conversation_id: str = ""
@@ -1587,6 +1588,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         attempt_number = 0
 
         while attempt_chunk and attempt_number < max_attempts:
+            self._raise_if_compression_cancelled()
             attempt_number += 1
             source_tokens = count_messages_tokens(attempt_chunk)
             serialized = self._serialize_messages(attempt_chunk)
@@ -1614,6 +1616,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     focus_topic=focus_topic or "",
                     custom_instructions=self._config.custom_instructions,
                 )
+                self._raise_if_compression_cancelled()
                 return attempt_chunk, source_tokens, summary_text, level, attempt_number
             except Exception as exc:
                 if attempt_number >= max_attempts or not self._is_retry_worthy_leaf_summary_error(exc):
@@ -5459,6 +5462,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         fanin = max(1, self._config.condensation_fanin)
 
         for depth in range(upper):
+            self._raise_if_compression_cancelled()
             uncondensed = self._dag.get_uncondensed_at_depth(
                 self._session_id, depth
             )
@@ -5477,11 +5481,14 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
             # Take the first fanin nodes and condense
             to_condense = uncondensed[:fanin]
-            source_tokens, summary_tokens, level = self._condense_summary_nodes(
-                to_condense,
-                focus_topic=focus_topic,
-                deadline=deadline,
-            )
+            try:
+                source_tokens, summary_tokens, level = self._condense_summary_nodes(
+                    to_condense,
+                    focus_topic=focus_topic,
+                    deadline=deadline,
+                )
+            except LCMCompressionCancelled:
+                return
             condensed_any = True
 
             logger.info(
@@ -5504,6 +5511,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         deadline: Optional[float] = None,
     ) -> tuple[int, int, int]:
         """Persist one same-depth condensation and return source/output tokens and level."""
+        self._raise_if_compression_cancelled()
         if not nodes:
             raise ValueError("condensation requires at least one summary node")
         depth = nodes[0].depth
@@ -5532,6 +5540,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             focus_topic=focus_topic or "",
             custom_instructions=self._config.custom_instructions,
         )
+        self._raise_if_compression_cancelled()
         earliest_at, latest_at = self._dag.get_source_time_window(
             [node.node_id for node in nodes]
         )
@@ -5615,6 +5624,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     focus_topic=focus_topic,
                     deadline=deadline,
                 )
+            except LCMCompressionCancelled:
+                return passes, "compression_cancelled"
             except Exception as exc:
                 logger.warning(
                     "LCM threshold full sweep condensation stopped after %d pass(es): %s",

--- a/engine.py
+++ b/engine.py
@@ -498,10 +498,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # run_agent.py reads these for context probing
         self._context_probed = False
         self._context_probe_persistable = False
-        # Host compatibility: LCM treats successful automatic compaction as
-        # silent maintenance. Manual /lcm diagnostics and warning/error paths
-        # remain explicit.
-        self.emit_automatic_compaction_status = False
+        # Host compatibility: LCM used to treat successful automatic compaction
+        # as silent maintenance. Interactive surfaces (desktop/TUI) rely on the
+        # lifecycle status to show a "Summarizing…" indicator instead of a
+        # silent timer, so emit it by default; LCM_EMIT_AUTOMATIC_COMPACTION_STATUS=0
+        # restores the silent behavior. Manual /lcm diagnostics and warning/error
+        # paths remain explicit either way.
+        self.emit_automatic_compaction_status = os.environ.get(
+            "LCM_EMIT_AUTOMATIC_COMPACTION_STATUS", "1"
+        ).lower() not in ("0", "false", "no")
         self.quiet_mode = True
         self.summary_model = self._config.summary_model
         self._summary_circuit_breaker = SummaryCircuitBreaker(

--- a/engine.py
+++ b/engine.py
@@ -145,6 +145,13 @@ logger = logging.getLogger(__name__)
 
 _ASSERTION_EXTRACTION_PROCESS_SLOT = threading.BoundedSemaphore(1)
 
+_POST_COMPACTION_USER_GUIDANCE = (
+    "Post-compaction reminder: the verbatim text below is direct user guidance, "
+    "not a summary or inferred intent. Preserve its scope and meaning. Later "
+    "direct user messages override earlier ones. If exact wording or omitted "
+    "session guidance matters, use lcm_grep or lcm_expand before guessing."
+)
+
 class _RollupMaintenanceScheduler:
     """Run deduplicated rollup jobs on one process-wide worker.
 
@@ -5704,7 +5711,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             content,
             role=str(message.get("role") or "user"),
         )
-        return f"{_PRESERVED_OBJECTIVE_CONTEXT_PREFIX}\n{content}"
+        return (
+            f"{_PRESERVED_OBJECTIVE_CONTEXT_PREFIX}\n"
+            f"{_POST_COMPACTION_USER_GUIDANCE}\n\n"
+            f"{content}"
+        )
 
     def _latest_user_context_anchor(
         self,
@@ -5976,6 +5987,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             anchor_msg = {"role": summary_role, "content": anchor_part}
             if summary_budget is None or count_message_tokens(anchor_msg) <= summary_budget:
                 summary_parts.append(anchor_part)
+            else:
+                compact_anchor = anchor_part.replace(
+                    f"{_POST_COMPACTION_USER_GUIDANCE}\n\n",
+                    "",
+                    1,
+                )
+                compact_anchor_msg = {"role": summary_role, "content": compact_anchor}
+                if count_message_tokens(compact_anchor_msg) <= summary_budget:
+                    anchor_part = compact_anchor
+                    summary_parts.append(anchor_part)
 
         # Node ids placed in the summary prefix — used to dedupe proactive-recall
         # injection against summaries already visible in the active context.

--- a/engine.py
+++ b/engine.py
@@ -1591,9 +1591,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             try:
                 timeout_seconds = self._config.summary_timeout_ms / 1000
                 if deadline is not None:
-                    remaining_seconds = deadline - time.monotonic()
-                    if remaining_seconds <= 0:
-                        raise TimeoutError("threshold full sweep time budget exhausted")
+                    remaining_seconds = max(0.0, deadline - time.monotonic())
                     timeout_seconds = min(timeout_seconds, remaining_seconds)
                 summary_text, level = summarize_with_escalation(
                     text=serialized,
@@ -1605,6 +1603,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     circuit_breaker=self._summary_circuit_breaker,
                     spend_guard=self._summary_spend_guard,
                     timeout=timeout_seconds,
+                    deadline=deadline,
                     l2_budget_ratio=self._config.l2_budget_ratio,
                     l3_truncate_tokens=self._config.l3_truncate_tokens,
                     focus_topic=focus_topic or "",
@@ -5429,6 +5428,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self,
         focus_topic: Optional[str] = None,
         *,
+        deadline: Optional[float] = None,
         leaf_compacted_this_turn: bool = False,
         force_overflow: bool = False,
         critical_budget_pressure: bool = False,
@@ -5475,6 +5475,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             source_tokens, summary_tokens, level = self._condense_summary_nodes(
                 to_condense,
                 focus_topic=focus_topic,
+                deadline=deadline,
             )
             condensed_any = True
 
@@ -5508,9 +5509,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         token_budget = max(1000, int(source_tokens * 0.40))
         timeout_seconds = self._config.summary_timeout_ms / 1000
         if deadline is not None:
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                raise TimeoutError("threshold full sweep time budget exhausted")
+            remaining_seconds = max(0.0, deadline - time.monotonic())
             timeout_seconds = min(timeout_seconds, remaining_seconds)
         summary_text, level = summarize_with_escalation(
             text=combined_text,
@@ -5522,6 +5521,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             circuit_breaker=self._summary_circuit_breaker,
             spend_guard=self._summary_spend_guard,
             timeout=timeout_seconds,
+            deadline=deadline,
             l2_budget_ratio=self._config.l2_budget_ratio,
             l3_truncate_tokens=self._config.l3_truncate_tokens,
             focus_topic=focus_topic or "",

--- a/escalation.py
+++ b/escalation.py
@@ -371,6 +371,7 @@ def _invoke_summary_llm_chain(
     circuit_breaker: SummaryCircuitBreaker | None = None,
     spend_guard: "SummarySpendGuard | None" = None,
     accepts_result: Callable[[str], bool] | None = None,
+    deadline: float | None = None,
 ) -> Optional[str]:
     chain = _summary_model_chain(model, fallback_models)
     skipped = 0
@@ -382,6 +383,19 @@ def _invoke_summary_llm_chain(
                 candidate_model or _DEFAULT_ROUTE_KEY,
             )
             continue
+        call_timeout = timeout
+        if deadline is not None:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                logger.warning(
+                    "LCM summary deadline exhausted; deferring to deterministic fallback"
+                )
+                break
+            call_timeout = (
+                remaining_seconds
+                if timeout is None
+                else min(timeout, remaining_seconds)
+            )
         # Check the spend guard per-route so a mid-chain trip stops the
         # remaining fallbacks instead of over-spending by up to len(chain)-1.
         if spend_guard is not None and not spend_guard.try_record_call():
@@ -395,7 +409,7 @@ def _invoke_summary_llm_chain(
                 prompt,
                 max_tokens,
                 model=candidate_model,
-                timeout=timeout,
+                timeout=call_timeout,
             )
         except Exception as exc:
             logger.warning("LLM summarization failed: %s", exc)
@@ -556,6 +570,7 @@ def summarize_with_escalation(
     fallback_models: list[str] | tuple[str, ...] | None = None,
     circuit_breaker: SummaryCircuitBreaker | None = None,
     spend_guard: "SummarySpendGuard | None" = None,
+    deadline: float | None = None,
 ) -> tuple[str, int]:
     """Run 3-level escalation. Returns (summary, level_used).
 
@@ -575,6 +590,7 @@ def summarize_with_escalation(
         circuit_breaker=circuit_breaker,
         spend_guard=spend_guard,
         accepts_result=lambda result: count_tokens(result) < source_tokens,
+        deadline=deadline,
     )
 
     if l1_result:
@@ -595,6 +611,7 @@ def summarize_with_escalation(
         circuit_breaker=circuit_breaker,
         spend_guard=spend_guard,
         accepts_result=lambda result: count_tokens(result) < source_tokens,
+        deadline=deadline,
     )
 
     if l2_result:

--- a/escalation.py
+++ b/escalation.py
@@ -443,6 +443,8 @@ def _build_l1_prompt(text: str, token_budget: int, depth: int,
 
     return f"""Summarize this conversation segment for future turns.
 {guidance}
+Preserve user-authored directives, corrections, constraints, and approvals as direct user authority.
+Quote the user's exact wording when paraphrasing could change scope, meaning, or authority. Never turn assistant proposals into user decisions.
 Remove repetition and conversational filler.
 End with: "Expand for details about: <what was compressed>"
 {focus_guidance}{custom_block}
@@ -464,6 +466,8 @@ def _build_l2_prompt(text: str, token_budget: int,
 
     return f"""Compress this into bullet points. Maximum {token_budget} tokens.
 Keep only: decisions made, files changed, errors hit, current state.
+Preserve user-authored directives, corrections, constraints, and approvals as direct user authority.
+Quote the user's exact wording when paraphrasing could change scope, meaning, or authority. Never turn assistant proposals into user decisions.
 Drop all reasoning, alternatives considered, and process detail.
 {focus_guidance}{custom_block}
 

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -58,9 +58,19 @@ def _replace_with_header_only_sqlite_db(e: LCMEngine) -> Path:
     return db_path
 
 
-def test_lcm_engine_declares_automatic_compaction_silent(engine):
-    assert engine.emit_automatic_compaction_status is False
+def test_lcm_engine_emits_automatic_compaction_status_by_default(engine):
+    # Interactive surfaces (desktop/TUI) show a "Summarizing…" indicator from
+    # the lifecycle status, so automatic compaction emits it by default.
+    assert engine.emit_automatic_compaction_status is True
     assert engine.quiet_mode is True
+
+
+def test_lcm_engine_automatic_compaction_status_env_opt_out(tmp_path, monkeypatch):
+    monkeypatch.setenv("LCM_EMIT_AUTOMATIC_COMPACTION_STATUS", "0")
+    config = LCMConfig()
+    config.database_path = str(tmp_path / "lcm_test.db")
+    e = LCMEngine(config=config, hermes_home=str(tmp_path / "hermes_home"))
+    assert e.emit_automatic_compaction_status is False
 
 
 def test_lcm_status_default_reports_current_session(engine):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -4437,6 +4437,17 @@ class TestEscalation:
         assert "Additional instructions:" not in l1
         assert "Additional instructions:" not in l2
 
+    def test_summary_prompts_preserve_direct_user_authority(self):
+        from hermes_lcm.escalation import _build_l1_prompt, _build_l2_prompt
+
+        for prompt in (
+            _build_l1_prompt("test", 500, depth=0),
+            _build_l2_prompt("test", 500),
+        ):
+            assert "user-authored directives, corrections, constraints, and approvals" in prompt
+            assert "Quote the user's exact wording" in prompt
+            assert "Never turn assistant proposals into user decisions" in prompt
+
 
 class TestAssemblyBudgetSelection:
     def _engine(self, tmp_path: Path, monkeypatch, *, max_assembly_tokens: int = 120):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -401,6 +401,51 @@ class TestProviderPrefixedAuxiliaryCalls:
         assert level == 1
         assert calls == ["primary-model", "fallback-model"]
 
+    def test_summary_deadline_shrinks_across_routes_and_levels_then_uses_l3(self, monkeypatch):
+        from hermes_lcm import escalation
+        from hermes_lcm.escalation import _L3_TRUNCATION_MARKER
+
+        now = [0.0]
+        calls: list[tuple[str, float | None]] = []
+
+        def fake_summary_call(prompt, max_tokens, model="", timeout=None):
+            del prompt, max_tokens
+            calls.append((model, timeout))
+            if len(calls) == 1:
+                now[0] = 30.0
+            elif len(calls) == 2:
+                now[0] = 70.0
+            elif len(calls) == 3:
+                now[0] = 100.0
+            else:
+                pytest.fail("provider call started after the shared deadline")
+            return None
+
+        monkeypatch.setattr(escalation.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(escalation, "_call_llm_for_summary", fake_summary_call)
+
+        summary, level = escalation.summarize_with_escalation(
+            "source text " * 200,
+            source_tokens=400,
+            token_budget=100,
+            model="primary-model",
+            fallback_models=["fallback-model"],
+            timeout=100.0,
+            deadline=100.0,
+            l3_truncate_tokens=40,
+        )
+
+        assert level == 3
+        assert _L3_TRUNCATION_MARKER.strip() in summary
+        assert [model for model, _timeout in calls] == [
+            "primary-model",
+            "fallback-model",
+            "primary-model",
+        ]
+        assert [timeout for _model, timeout in calls] == pytest.approx(
+            [100.0, 70.0, 30.0]
+        )
+
 
     def test_summary_circuit_breaker_skips_temporarily_open_route(self, monkeypatch):
         from hermes_lcm import escalation

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11821,6 +11821,95 @@ class TestEngineCompress:
         finally:
             instance.shutdown()
 
+    def test_leaf_summary_cancelled_after_provider_return_does_not_publish_node(
+        self, tmp_path, monkeypatch
+    ):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1,
+            database_path=str(tmp_path / "lcm_cancelled_leaf_summary.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        cancelled = {"value": False}
+        calls = 0
+
+        def cancelled_check():
+            return cancelled["value"]
+
+        def mock_summary(**kwargs):
+            del kwargs
+            nonlocal calls
+            calls += 1
+            cancelled["value"] = True
+            return "late leaf summary", 1
+
+        monkeypatch.setattr(instance, "_compression_cancelled_check", cancelled_check)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        try:
+            messages = [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "old source " + ("detail " * 20)},
+                {"role": "user", "content": "fresh request"},
+                {"role": "assistant", "content": "fresh answer"},
+            ]
+
+            result = instance.compress(messages, current_tokens=count_messages_tokens(messages))
+
+            assert calls == 1
+            assert result == messages
+            assert instance._dag.get_session_nodes("test-session") == []
+            assert instance.last_compression_status == "noop"
+            assert instance.last_compression_noop_reason == "compression cancelled by host"
+        finally:
+            instance.shutdown()
+
+    def test_condensation_cancelled_after_provider_return_does_not_publish_parent(
+        self, tmp_path, monkeypatch
+    ):
+        config = LCMConfig(
+            condensation_fanin=2,
+            incremental_max_depth=1,
+            database_path=str(tmp_path / "lcm_cancelled_condensation.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        cancelled = {"value": False}
+        calls = 0
+        for index in range(2):
+            instance._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=0,
+                    summary=f"leaf {index}",
+                    token_count=100,
+                    source_token_count=200,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=float(index),
+                )
+            )
+
+        def cancelled_check():
+            return cancelled["value"]
+
+        def mock_summary(**kwargs):
+            del kwargs
+            nonlocal calls
+            calls += 1
+            cancelled["value"] = True
+            return "late parent summary", 1
+
+        monkeypatch.setattr(instance, "_compression_cancelled_check", cancelled_check)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", mock_summary)
+        try:
+            instance._maybe_condense()
+
+            assert calls == 1
+            assert instance._dag.get_session_nodes("test-session", depth=1) == []
+        finally:
+            instance.shutdown()
+
     def test_threshold_full_sweep_uses_earlier_compaction_deadline(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11331,7 +11331,8 @@ class TestEngineCompress:
             token_pairs.append((last_pressure_tokens, count_messages_tokens(candidate_raw)))
             return candidate_raw[:1]
 
-        def fake_summary(chunk, focus_topic=None):
+        def fake_summary(chunk, focus_topic=None, deadline=None):
+            del focus_topic, deadline
             return chunk, count_messages_tokens(chunk), "Window summary.\nExpand for details about: current window", 1, 0
 
         monkeypatch.setattr(engine, "_working_leaf_chunk_tokens", record_working_leaf_chunk_tokens)

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11443,7 +11443,7 @@ class TestEngineCompress:
         assert call_count == 1
         assert engine._dag.get_session_nodes("test-session") == []
 
-    def test_deferred_leaf_rescue_shares_compaction_deadline_with_extraction(self, engine, monkeypatch):
+    def test_deferred_leaf_rescue_caps_pre_compaction_extraction(self, engine, monkeypatch):
         engine._config.summary_timeout_ms = 100_000
         engine._config.fresh_tail_count = 1
         engine._config.leaf_chunk_tokens = 800
@@ -11495,7 +11495,7 @@ class TestEngineCompress:
         compressed = engine.compress(messages, current_tokens=90)
 
         assert compressed
-        assert extraction_timeouts == pytest.approx([100.0, 60.0])
+        assert extraction_timeouts == pytest.approx([5.0, 5.0])
         assert summary_deadlines == pytest.approx([100.0, 100.0, 100.0])
         assert summary_timeouts == pytest.approx([80.0, 60.0, 60.0])
         assert len(engine._dag.get_session_nodes("deadline-debt-session", depth=0)) == 2

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -5607,6 +5607,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "visible backlog objective " + "y" * 200},
             {"role": "assistant", "content": "fresh tail response"},
         ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(messages[1])
 
         engine.compress(messages, current_tokens=count_messages_tokens(messages))
 
@@ -5639,6 +5640,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "visible backlog objective " + "y" * 200},
             {"role": "assistant", "content": "fresh tail response"},
         ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(messages[2])
 
         engine.compress(messages, current_tokens=count_messages_tokens(messages))
 
@@ -5713,6 +5715,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "visible backlog objective " + "y" * 200},
             {"role": "assistant", "content": "fresh tail response"},
         ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(messages[1])
 
         engine.compress(messages, current_tokens=count_messages_tokens(messages))
 
@@ -5738,11 +5741,13 @@ class TestMessageFiltering:
             return "visible backlog summary\n[Expand for details: visible backlog]", 1
 
         monkeypatch.setattr(lcm_engine, "summarize_with_escalation", capture_summary)
+        first_messages = [
+            {"role": "user", "content": "visible backlog objective " + "y" * 200},
+            {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
+        ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(first_messages[0])
         first_result = engine.compress(
-            [
-                {"role": "user", "content": "visible backlog objective " + "y" * 200},
-                {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
-            ],
+            first_messages,
             current_tokens=10_000,
         )
         first_result_text = "\n".join(str(msg.get("content", "")) for msg in first_result)
@@ -5801,11 +5806,13 @@ class TestMessageFiltering:
             return "visible backlog summary\n[Expand for details: visible backlog]", 1
 
         monkeypatch.setattr(lcm_engine, "summarize_with_escalation", capture_summary)
+        first_messages = [
+            {"role": "user", "content": "first visible backlog " + "y" * 200},
+            {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
+        ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(first_messages[0])
         first_result = engine.compress(
-            [
-                {"role": "user", "content": "first visible backlog " + "y" * 200},
-                {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
-            ],
+            first_messages,
             current_tokens=10_000,
         )
         assert "LCM active replay placeholder: message ignored" in "\n".join(
@@ -5820,10 +5827,12 @@ class TestMessageFiltering:
             leaf_chunk_tokens=10,
         )
         captured.clear()
+        second_visible = {"role": "user", "content": "second visible backlog " + "z" * 200}
+        second._config.leaf_chunk_tokens = count_message_tokens(second_visible)
         second.compress(
             first_result
             + [
-                {"role": "user", "content": "second visible backlog " + "z" * 200},
+                second_visible,
                 {"role": "assistant", "content": "fresh tail response"},
             ],
             current_tokens=10_000,
@@ -6222,11 +6231,13 @@ class TestMessageFiltering:
             context_length=1000,
             conversation_id="conv-placeholder-rollover",
         )
+        first_messages = [
+            {"role": "user", "content": "visible backlog before rollover " + "v" * 200},
+            {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
+        ]
+        first._config.leaf_chunk_tokens = count_message_tokens(first_messages[0])
         first_result = first.compress(
-            [
-                {"role": "user", "content": "visible backlog before rollover " + "v" * 200},
-                {"role": "user", "content": "api_key=sk-ignore...cdef ignored fresh tail"},
-            ],
+            first_messages,
             current_tokens=10_000,
         )
         first.shutdown()
@@ -6258,10 +6269,12 @@ class TestMessageFiltering:
                 boundary_reason="compression",
                 old_session_id="old-session",
             )
+            second_visible = {"role": "user", "content": "visible new backlog " + "z" * 200}
+            second._config.leaf_chunk_tokens = count_message_tokens(second_visible)
             second.compress(
                 first_result
                 + [
-                    {"role": "user", "content": "visible new backlog " + "z" * 200},
+                    second_visible,
                     {"role": "assistant", "content": "fresh tail response"},
                 ],
                 current_tokens=10_000,
@@ -7314,6 +7327,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible historical backlog " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail"},
             ]
+            second._config.leaf_chunk_tokens = count_message_tokens(messages[1])
             second.compress(messages, current_tokens=count_messages_tokens(messages))
 
             assert "visible historical backlog" in captured["text"]
@@ -7432,6 +7446,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
+            second._config.leaf_chunk_tokens = count_message_tokens(messages[1])
             second.compress(messages, current_tokens=count_messages_tokens(messages))
 
             rows = second._store.get_session_messages("session")
@@ -7533,6 +7548,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
+            second._config.leaf_chunk_tokens = count_message_tokens(messages[2])
             second.compress(messages, current_tokens=count_messages_tokens(messages))
 
             stored_after = second._store.get_session_messages("session")
@@ -7614,6 +7630,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
+            second._config.leaf_chunk_tokens = count_message_tokens(messages[1])
             second.compress(messages, current_tokens=count_messages_tokens(messages))
 
             assert "visible backlog objective" in captured["text"]
@@ -7990,12 +8007,14 @@ class TestMessageFiltering:
             return "visible summary\n[Expand for details: visible]", 1
 
         monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary)
+        first_messages = [
+            {"role": "user", "content": "visible backlog before ignored turn " + "v" * 200},
+            {"role": "user", "content": "SECRET ignored turn"},
+            {"role": "assistant", "content": dependent_reply},
+        ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(first_messages[0])
         first_result = engine.compress(
-            [
-                {"role": "user", "content": "visible backlog before ignored turn " + "v" * 200},
-                {"role": "user", "content": "SECRET ignored turn"},
-                {"role": "assistant", "content": dependent_reply},
-            ],
+            first_messages,
             current_tokens=10_000,
         )
         assert dependent_reply in "\n".join(str(msg.get("content", "")) for msg in first_result)
@@ -8433,13 +8452,15 @@ class TestMessageFiltering:
             return "visible summary\n[Expand for details: visible]", 1
 
         monkeypatch.setattr(lcm_engine, "summarize_with_escalation", capture_summary)
+        messages = [
+            {"role": "assistant", "content": "SECRET ignored assistant output"},
+            {"role": "assistant", "content": "assistant continuation derived from SECRET"},
+            {"role": "user", "content": "visible backlog " + "v" * 200},
+            {"role": "assistant", "content": "fresh tail response"},
+        ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(messages[2])
         engine.compress(
-            [
-                {"role": "assistant", "content": "SECRET ignored assistant output"},
-                {"role": "assistant", "content": "assistant continuation derived from SECRET"},
-                {"role": "user", "content": "visible backlog " + "v" * 200},
-                {"role": "assistant", "content": "fresh tail response"},
-            ],
+            messages,
             current_tokens=10_000,
         )
 
@@ -8608,16 +8629,19 @@ class TestMessageFiltering:
             return "visible summary\n[Expand for details: visible summary]", 1
 
         monkeypatch.setattr(lcm_engine, "summarize_with_escalation", capture_summary)
+        first_messages = [
+            {"role": "user", "content": "visible backlog before secret " + "v" * 200},
+            {"role": "user", "content": "SECRET ignored turn before fresh tail"},
+            {"role": "assistant", "content": "dependent assistant reply that must not summarize later"},
+            {"role": "user", "content": "fresh tail request"},
+        ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(first_messages[0])
         first_result = engine.compress(
-            [
-                {"role": "user", "content": "visible backlog before secret " + "v" * 200},
-                {"role": "user", "content": "SECRET ignored turn before fresh tail"},
-                {"role": "assistant", "content": "dependent assistant reply that must not summarize later"},
-                {"role": "user", "content": "fresh tail request"},
-            ],
+            first_messages,
             current_tokens=10_000,
         )
 
+        engine._config.leaf_chunk_tokens = count_message_tokens(first_messages[2])
         engine.compress(
             first_result + [{"role": "assistant", "content": "new fresh assistant response"}],
             current_tokens=10_000,
@@ -9398,6 +9422,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "visible backlog objective " + "y" * 200},
             {"role": "user", "content": "SECRET ignored fresh tail must not become focus"},
         ]
+        engine._config.leaf_chunk_tokens = count_message_tokens(messages[0])
 
         engine.compress(messages, current_tokens=count_messages_tokens(messages))
 
@@ -11394,6 +11419,122 @@ class TestEngineCompress:
         assert call_count == 1
         assert engine._dag.get_session_nodes("test-session") == []
 
+    def test_deferred_leaf_rescue_shares_compaction_deadline_with_extraction(self, engine, monkeypatch):
+        engine._config.summary_timeout_ms = 100_000
+        engine._config.fresh_tail_count = 1
+        engine._config.leaf_chunk_tokens = 800
+        engine._config.dynamic_leaf_chunk_enabled = True
+        engine._config.dynamic_leaf_chunk_max = 800
+        engine._config.deferred_maintenance_enabled = True
+        engine._config.deferred_maintenance_max_passes = 2
+        engine._config.critical_budget_pressure_ratio = 0.90
+        engine._config.extraction_enabled = True
+        engine.on_session_start("deadline-debt-session", platform="cli", context_length=100)
+        engine._lifecycle.record_debt(
+            engine._conversation_id,
+            kind="raw_backlog",
+            size_estimate=1_000,
+        )
+
+        messages = [{"role": "system", "content": "system"}] + [
+            {"role": "user", "content": f"old-{index} " + ("chunk " * 250)}
+            for index in range(3)
+        ] + [{"role": "user", "content": "fresh tail"}]
+        candidate_raw = messages[1:-1]
+        initial_chunk = engine._select_oldest_leaf_chunk(candidate_raw, 800)
+        assert len(initial_chunk) == 2
+
+        now = [0.0]
+        extraction_timeouts: list[float | None] = []
+        summary_deadlines: list[float | None] = []
+        summary_timeouts: list[float] = []
+
+        def capture_extraction(_chunk, timeout_seconds=None):
+            extraction_timeouts.append(timeout_seconds)
+            if len(extraction_timeouts) == 1:
+                now[0] = 20.0
+
+        def flaky_summary(**kwargs):
+            summary_deadlines.append(kwargs.get("deadline"))
+            summary_timeouts.append(kwargs["timeout"])
+            if len(summary_timeouts) == 1:
+                now[0] = 40.0
+                raise RuntimeError("context length exceeded")
+            return "shared deadline summary", 1
+
+        import hermes_lcm.compaction as compaction_module
+
+        monkeypatch.setattr(compaction_module.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(engine, "_run_pre_compaction_extraction", capture_extraction)
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", flaky_summary)
+
+        compressed = engine.compress(messages, current_tokens=90)
+
+        assert compressed
+        assert extraction_timeouts == pytest.approx([100.0, 60.0])
+        assert summary_deadlines == pytest.approx([100.0, 100.0, 100.0])
+        assert summary_timeouts == pytest.approx([80.0, 60.0, 60.0])
+        assert len(engine._dag.get_session_nodes("deadline-debt-session", depth=0)) == 2
+
+    def test_non_threshold_follow_on_condensation_uses_compaction_deadline(
+        self, tmp_path, monkeypatch
+    ):
+        config = LCMConfig(
+            fresh_tail_count=1,
+            dynamic_leaf_chunk_enabled=False,
+            threshold_full_sweep_enabled=False,
+            condensation_fanin=2,
+            incremental_max_depth=1,
+            cache_friendly_condensation_enabled=False,
+            extraction_enabled=False,
+            summary_timeout_ms=100_000,
+            summary_model="primary-model",
+            summary_fallback_models=[],
+            database_path=str(tmp_path / "lcm_non_threshold_condensation_deadline.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        instance._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=0,
+                summary="earlier leaf summary",
+                token_count=40,
+                source_token_count=80,
+                source_ids=[],
+                source_type="messages",
+                created_at=1.0,
+            )
+        )
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "new leaf source " + ("detail " * 80)},
+            {"role": "assistant", "content": "fresh tail"},
+        ]
+        instance._config.leaf_chunk_tokens = count_message_tokens(messages[1])
+        now = [0.0]
+        provider_calls: list[str] = []
+
+        def provider(prompt, max_tokens, model="", timeout=None):
+            del prompt, max_tokens, timeout
+            provider_calls.append(model)
+            if len(provider_calls) == 1:
+                now[0] = 100.0
+            return "provider leaf summary"
+
+        import hermes_lcm.compaction as compaction_module
+        import hermes_lcm.escalation as escalation_module
+
+        monkeypatch.setattr(compaction_module.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(escalation_module, "_call_llm_for_summary", provider)
+        try:
+            instance.compress(messages)
+
+            assert provider_calls == ["primary-model"]
+            assert len(instance._dag.get_session_nodes("test-session", depth=1)) == 1
+        finally:
+            instance.shutdown()
+
     def test_threshold_full_sweep_drains_chunked_prefix_and_publishes_once(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
@@ -11611,7 +11752,7 @@ class TestEngineCompress:
     def test_threshold_full_sweep_publishes_persisted_progress_after_later_leaf_error(self, tmp_path, monkeypatch):
         config = LCMConfig(
             fresh_tail_count=2,
-            leaf_chunk_tokens=1,
+            leaf_chunk_tokens=80,
             threshold_full_sweep_enabled=True,
             database_path=str(tmp_path / "lcm_threshold_sweep_partial.db"),
         )
@@ -11657,12 +11798,14 @@ class TestEngineCompress:
         instance = LCMEngine(config=config)
         instance._session_id = "test-session"
         observed_timeout = None
+        observed_deadline = None
 
         import hermes_lcm.engine as engine_module
 
         def capture_timeout(**kwargs):
-            nonlocal observed_timeout
+            nonlocal observed_deadline, observed_timeout
             observed_timeout = kwargs["timeout"]
+            observed_deadline = kwargs.get("deadline")
             return "bounded summary", 1
 
         monkeypatch.setattr(engine_module.time, "monotonic", lambda: 10.0)
@@ -11673,6 +11816,99 @@ class TestEngineCompress:
                 deadline=110.0,
             )
             assert observed_timeout == 100.0
+            assert observed_deadline == 110.0
+        finally:
+            instance.shutdown()
+
+    def test_threshold_full_sweep_uses_earlier_compaction_deadline(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=2,
+            leaf_chunk_tokens=1_000,
+            threshold_full_sweep_enabled=True,
+            summary_prefix_target_tokens=10_000,
+            summary_timeout_ms=30_000,
+            database_path=str(tmp_path / "lcm_threshold_sweep_earlier_deadline.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        instance.threshold_tokens = 1
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old raw " + ("detail " * 40)},
+            {"role": "user", "content": "fresh request"},
+            {"role": "assistant", "content": "fresh answer"},
+        ]
+        observed_deadlines: list[float | None] = []
+
+        def fake_leaf(chunk, focus_topic=None, deadline=None):
+            del focus_topic
+            observed_deadlines.append(deadline)
+            return chunk, count_messages_tokens(chunk), "bounded leaf summary", 1, 0
+
+        import hermes_lcm.compaction as compaction_module
+
+        monkeypatch.setattr(compaction_module.time, "monotonic", lambda: 10.0)
+        monkeypatch.setattr(instance, "_summarize_leaf_chunk_with_rescue", fake_leaf)
+        try:
+            instance.compress(messages, current_tokens=count_messages_tokens(messages))
+            assert observed_deadlines == [40.0]
+        finally:
+            instance.shutdown()
+
+    def test_oversized_singleton_uses_lossless_l3_without_calling_llm(self, tmp_path, monkeypatch):
+        from hermes_lcm.escalation import _L3_TRUNCATION_MARKER
+
+        config = LCMConfig(
+            fresh_tail_count=1,
+            leaf_chunk_tokens=100,
+            dynamic_leaf_chunk_enabled=True,
+            dynamic_leaf_chunk_max=100,
+            l3_truncate_tokens=80,
+            database_path=str(tmp_path / "lcm_oversized_singleton.db"),
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "test-session"
+        instance.context_length = 200_000
+        instance.threshold_tokens = int(200_000 * config.context_threshold)
+        raw_content = "oversized singleton raw evidence " * 700
+        raw_message = {"role": "user", "content": raw_content}
+        messages = [
+            {"role": "system", "content": "system"},
+            raw_message,
+            {"role": "user", "content": "fresh tail"},
+        ]
+
+        instance._ingest_messages(messages)
+        raw_before = next(
+            row
+            for row in instance._store.get_session_messages("test-session")
+            if row["content"] == raw_content
+        )
+
+        def fail_if_summarized(**_kwargs):
+            pytest.fail("oversized singleton must skip summarize_with_escalation")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_if_summarized)
+        try:
+            compressed = instance.compress(messages)
+            nodes = instance._dag.get_session_nodes("test-session", depth=0)
+
+            assert compressed
+            assert len(nodes) == 1
+            node = nodes[0]
+            assert _L3_TRUNCATION_MARKER.strip() in node.summary
+            assert node.source_ids == [raw_before["store_id"]]
+            assert node.source_type == "messages"
+            assert node.source_token_count == count_message_tokens(raw_message)
+            assert instance._store.get(raw_before["store_id"]) == raw_before
+
+            expanded = json.loads(
+                lcm_tools.lcm_expand(
+                    {"node_id": node.node_id, "max_tokens": 100_000},
+                    engine=instance,
+                )
+            )
+            assert expanded["expanded"][0]["content"] == raw_content
         finally:
             instance.shutdown()
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3827,6 +3827,7 @@ class TestEngineABC:
         )
         combined_context = "\n".join(str(msg.get("content", "")) for msg in active_context)
         assert "Current user objective preserved" in combined_context
+        assert "direct user guidance, not a summary or inferred intent" in combined_context
         assert latest_request in combined_context
 
     def test_preserved_objective_anchor_externalizes_inline_payloads(self, tmp_path):
@@ -3852,6 +3853,28 @@ class TestEngineABC:
         assert expanded["kind"] == "ingest_payload"
         assert expanded["content"] == data_uri
         assert expanded["field_path"] == "preserved_objective.content"
+
+    def test_preserved_objective_anchor_marks_direct_user_words_as_authoritative(self, tmp_path):
+        engine = LCMEngine(
+            config=LCMConfig(database_path=str(tmp_path / "preserved-objective-guidance.db")),
+            hermes_home=str(tmp_path),
+        )
+        engine.on_session_start(
+            "preserved-objective-guidance-session",
+            platform="desktop",
+            conversation_id="preserved-objective-guidance-conversation",
+            context_length=200000,
+        )
+
+        exact_user_words = "متغيرش الـAPI وخلي التنفيذ على أصغر scope"
+        anchor = engine._build_preserved_objective_summary_part(
+            {"role": "user", "content": exact_user_words}
+        )
+
+        assert exact_user_words in anchor
+        assert "direct user guidance, not a summary or inferred intent" in anchor
+        assert "Later direct user messages override earlier ones" in anchor
+        assert "lcm_grep or lcm_expand" in anchor
 
     def test_existing_large_session_restart_reconciles_beyond_short_tail_window(self, tmp_path):
         db_path = tmp_path / "restart-large.db"

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -22,7 +22,7 @@ def test_path_containment_within_allowed_base(monkeypatch):
         # Should succeed without raising
         path = _state_db_path_for_engine(engine)
         assert path.is_absolute()
-        assert str(path).startswith(tmpdir)
+        assert str(path.resolve()).startswith(str(Path(tmpdir).resolve()))
 
 
 def test_path_containment_outside_allowed_base(monkeypatch):

--- a/tests/test_path_security.py
+++ b/tests/test_path_security.py
@@ -48,7 +48,7 @@ def test_configured_externalization_path_inside_allowed_base_accepted():
 
             path = get_large_output_storage_dir(FakeConfig(), "", create=False)
             assert path.is_absolute()
-            assert str(path).startswith(tmpdir)
+            assert str(path.resolve()).startswith(str(Path(tmpdir).resolve()))
         finally:
             del os.environ["LCM_HERMES_BASE_DIR"]
 


### PR DESCRIPTION
## Summary

- Bound foreground compaction latency and pre-compaction extraction time.
- Make automatic compaction status emission configurable.
- Support cooperative cancellation without committing partial compression writes.
- Preserve direct user authority through L1/L2 summaries and objective anchors.
- Add regression coverage for deadline, cancellation, oversized-input, and authority behavior.

## Why

Foreground compaction could spend too much of a turn's budget in extraction or continue after the host had cancelled the turn. Summaries could also blur the authority boundary between direct user instructions and assistant proposals.

This branch keeps the existing LCM architecture but makes the foreground path bounded, cancellation-aware, and explicit about user-authored directives.

## Validation

- [x] Focused affected tests.
- [x] Full Pytest: 2803 passed, 2 skipped, 12 xfailed.
- [x] Low-FD full Pytest under ulimit -n 1024.
- [x] Python compileall and script py_compile.
- [x] Shell syntax checks.
- [x] Diff checks against origin/main, working tree, and staged index.
- [x] Benchmark smoke, stress smoke, and release stress tier.
- [ ] Workflow validation is N/A; no workflow files changed.

Full release validation result: PASS.

## Notes

This PR intentionally includes the five existing local compaction-stability commits plus the two latest fixes. The authority and extraction changes build on the earlier deadline/cancellation groundwork, and the complete seven-commit tree passed the full release gate.

No matching open issue or PR was found for the compaction timeout/cancellation and user-authority symptoms.