### PR TITLE
fix: stop compaction at cross-source lineage gaps

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -561,9 +561,13 @@ class CompactionMixin:
                     noop_reason = "selected leaf chunk lacks raw store lineage"
                     break
 
+            blocked_cross_source_message_ids: set[int] = set()
             if candidate_start < fresh_tail_start:
                 self._current_compress_store_ids_by_message_id = self._get_store_id_map_for_messages(
-                    working_messages[leading_anchor_count:]
+                    working_messages[leading_anchor_count:],
+                    stop_at_cross_source_gap=True,
+                    covered_prefix_messages=working_messages[:leading_anchor_count],
+                    blocked_message_ids=blocked_cross_source_message_ids,
                 )
                 compactable_pairs = list(
                     zip(
@@ -654,8 +658,19 @@ class CompactionMixin:
                 focus_topic = self._derive_auto_focus_topic(working_messages)
 
             candidate_raw = working_messages[leading_anchor_count:fresh_tail_start]
+            lineage_prefix_len = 0
+            for candidate_message in candidate_raw:
+                if id(candidate_message) in blocked_cross_source_message_ids:
+                    break
+                lineage_prefix_len += 1
+            if lineage_prefix_len < len(candidate_raw):
+                # Fail closed at the first cross-source store gap. Messages
+                # after that gap stay active and must not be summarized into a
+                # node whose source_ids omit the intervening history.
+                fresh_tail_start = leading_anchor_count + lineage_prefix_len
+                candidate_raw = candidate_raw[:lineage_prefix_len]
             if not candidate_raw:
-                noop_reason = "no eligible raw backlog outside fresh tail"
+                noop_reason = "selected leaf chunk crosses raw store source lineage"
                 if threshold_full_sweep_active:
                     sweep_raw_drained = True
                     sweep_stop_reason = "raw_prefix_drained"

--- a/reconcile.py
+++ b/reconcile.py
@@ -952,8 +952,24 @@ class ReconcileMixin:
             str(msg.get("tool_call_id") or ""),
         )
 
-    def _get_store_id_map_for_messages(self, messages: List[Dict[str, Any]]) -> dict[int, int]:
+    def _get_store_id_map_for_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        stop_at_cross_source_gap: bool = False,
+        covered_prefix_messages: Optional[List[Dict[str, Any]]] = None,
+        blocked_message_ids: Optional[set[int]] = None,
+    ) -> dict[int, int]:
         """Map current raw message objects back to store_ids in stable order.
+
+        ``stop_at_cross_source_gap`` is reserved for compaction, where mapping
+        a later active message across omitted history from another source could
+        advance the persisted frontier without lineage coverage. General
+        lookups retain suffix/partial-tail matching semantics.
+
+        ``covered_prefix_messages`` contains leading anchors intentionally
+        excluded from the returned mapping. Their replay identities may cover
+        matching stored rows before the first compactable message.
 
         Matching starts strictly after ``_last_compacted_store_id`` so repeated
         content from older already-compacted history cannot hijack the mapping.
@@ -978,6 +994,7 @@ class ReconcileMixin:
         for msg in messages:
             identity = self._message_replay_identity(msg)
             active_identity_counts[identity] = active_identity_counts.get(identity, 0) + 1
+
         stored_identity_counts: dict[tuple[Any, ...], int] = {}
         stored_cleanup_identity_counts: dict[tuple[Any, ...], int] = {}
         # Capture each candidate's identity (and its cleanup variant) here - both
@@ -1060,6 +1077,25 @@ class ReconcileMixin:
                 probe_idx += 1
             return None
 
+        def skipped_candidates_are_safe(start_idx: int, match_idx: int) -> bool:
+            ignore_matcher = getattr(self, "_matches_ignore_message_patterns", None)
+            scaffold_matcher = getattr(self, "_is_replayed_context_scaffold_message", None)
+            matched_source = str(candidates[match_idx].get("source") or "unknown")
+            for candidate_idx in range(start_idx, match_idx):
+                candidate = candidates[candidate_idx]
+                if (
+                    (callable(ignore_matcher) and ignore_matcher(candidate, stored_row=True))
+                    or (callable(scaffold_matcher) and scaffold_matcher(candidate))
+                ):
+                    continue
+                candidate_source = str(candidate.get("source") or "unknown")
+                # Same-source partial-tail replay is an existing reconciliation
+                # contract. A source change is the hard boundary: the active
+                # surface cannot prove coverage for another surface's row.
+                if candidate_source != matched_source:
+                    return False
+            return True
+
         def find_message_match_index(msg: Dict[str, Any], start_idx: int) -> int | None:
             msg_content = normalize_content_value(msg.get("content")) or ""
             if msg.get("store_id") is None and self._content_has_externalized_placeholder_ref(msg_content):
@@ -1119,6 +1155,11 @@ class ReconcileMixin:
 
         ids_by_message_id: dict[int, int] = {}
         store_idx = 0
+        for prefix_message in covered_prefix_messages or []:
+            prefix_match_idx = find_message_match_index(prefix_message, store_idx)
+            if prefix_match_idx != store_idx:
+                break
+            store_idx += 1
         for msg_idx, msg in enumerate(messages):
             msg_content = normalize_content_value(msg.get("content")) or ""
             if msg.get("store_id") is None and self._content_has_externalized_placeholder_ref(msg_content):
@@ -1126,6 +1167,14 @@ class ReconcileMixin:
                 if placeholder_identity_counts.get(raw_identity, 0) > 1:
                     match_idx = find_raw_placeholder_match_index(raw_identity, store_idx)
                     if match_idx is not None:
+                        if (
+                            stop_at_cross_source_gap
+                            and match_idx > store_idx
+                            and not skipped_candidates_are_safe(store_idx, match_idx)
+                        ):
+                            if blocked_message_ids is not None:
+                                blocked_message_ids.add(id(msg))
+                            break
                         ids_by_message_id[id(msg)] = candidates[match_idx]["store_id"]
                         store_idx = match_idx + 1
                 else:
@@ -1152,6 +1201,14 @@ class ReconcileMixin:
                             if not baseline_suffix_ids.issubset(candidate_suffix_ids):
                                 probe_idx -= 1
                                 continue
+                            if (
+                                stop_at_cross_source_gap
+                                and probe_idx > store_idx
+                                and not skipped_candidates_are_safe(store_idx, probe_idx)
+                            ):
+                                if blocked_message_ids is not None:
+                                    blocked_message_ids.add(id(msg))
+                                break
                             ids_by_message_id[id(msg)] = stored["store_id"]
                             store_idx = probe_idx + 1
                             break
@@ -1167,6 +1224,14 @@ class ReconcileMixin:
                 continue
             match_idx = find_message_match_index(msg, store_idx)
             if match_idx is not None:
+                if (
+                    stop_at_cross_source_gap
+                    and match_idx > store_idx
+                    and not skipped_candidates_are_safe(store_idx, match_idx)
+                ):
+                    if blocked_message_ids is not None:
+                        blocked_message_ids.add(id(msg))
+                    break
                 ids_by_message_id[id(msg)] = candidates[match_idx]["store_id"]
                 store_idx = match_idx + 1
 

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -123,6 +123,76 @@ def test_discord_short_turn_ingest_preserves_conversation_id(tmp_path):
         engine.shutdown()
 
 
+def test_compaction_stops_before_unmapped_cross_source_store_gap(tmp_path, monkeypatch):
+    config = LCMConfig(
+        database_path=str(tmp_path / "durable-frontier-gap.db"),
+        fresh_tail_count=1,
+        leaf_chunk_tokens=1,
+    )
+    engine = LCMEngine(config=config)
+    captured: dict[str, str] = {}
+
+    def capture_summary(**kwargs):
+        captured["text"] = kwargs["text"]
+        return "contiguous prefix summary\n[Expand for details: contiguous prefix]", 1
+
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", capture_summary)
+    try:
+        conversation_id = "agent:main:telegram:dm:durable-gap"
+        engine.on_session_start(
+            "durable-gap-session",
+            platform="desktop",
+            conversation_id=conversation_id,
+            context_length=200_000,
+        )
+        prefix = {"role": "user", "content": "PREFIX " + "a" * 200}
+        omitted = {"role": "assistant", "content": "OMITTED " + "b" * 200}
+        suffix = {"role": "user", "content": "SUFFIX " + "c" * 200}
+        fresh_tail = {"role": "assistant", "content": "FRESH_TAIL"}
+
+        prefix_id = engine._store.append(
+            "durable-gap-session",
+            prefix,
+            source="desktop",
+            conversation_id=conversation_id,
+        )
+        omitted_id = engine._store.append(
+            "durable-gap-session",
+            omitted,
+            source="telegram",
+            conversation_id=conversation_id,
+        )
+        suffix_id = engine._store.append(
+            "durable-gap-session",
+            suffix,
+            source="desktop",
+            conversation_id=conversation_id,
+        )
+        engine._store.append(
+            "durable-gap-session",
+            fresh_tail,
+            source="desktop",
+            conversation_id=conversation_id,
+        )
+
+        active_context = [prefix, suffix, fresh_tail]
+        engine._ingest_cursor = len(active_context)
+        engine._ingest_cursor_needs_reconcile = False
+
+        result = engine.compress(active_context, current_tokens=10_000, force=True)
+
+        nodes = engine._dag.get_session_nodes("durable-gap-session", depth=0)
+        assert len(nodes) == 1
+        assert nodes[0].source_ids == [prefix_id]
+        assert engine._last_compacted_store_id == prefix_id
+        assert omitted_id not in nodes[0].source_ids
+        assert suffix_id not in nodes[0].source_ids
+        assert "SUFFIX" not in captured["text"]
+        assert any(message.get("content", "").startswith("SUFFIX") for message in result)
+    finally:
+        engine.shutdown()
+
+
 def test_webui_like_local_short_turn_ingest_preserves_lane_metadata(tmp_path):
     config = LCMConfig(database_path=str(tmp_path / "webui-local.db"))
     engine = LCMEngine(config=config)


### PR DESCRIPTION
## Summary
- stop leaf compaction before an unmapped durable row from another source
- keep messages after that gap active instead of publishing incomplete lineage
- add a current-main regression for a Desktop replay that omits an intervening Telegram row

## Why
A session can retain durable rows from multiple sources while its active replay contains only one source. Current reconciliation may map a later active message across an omitted row, summarize the later message, and advance the frontier past history that the node does not cover.

This change enables gap-sensitive matching only for compaction. General replay reconciliation keeps its existing partial-tail behavior. Known ignored rows, replay scaffold rows, leading anchors, and ordinary same-source replay gaps retain their current treatment.

## Validation
- [x] Focused validation: `pytest tests/test_lcm_engine.py::test_compaction_stops_before_unmapped_cross_source_store_gap -q` -> `1 passed`
- [x] Default focused set: `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `1098 passed, 1 skipped`
- [ ] Full suite: `2792 passed, 2 skipped, 12 xfailed, 2 existing macOS path-alias failures`; command exits `1`
- [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-cross-source-v2`: all non-pytest gates passed; full and low-fd pytest each exit `1` only for the same two macOS path-alias failures
- [x] `ruff check compaction.py reconcile.py tests/test_lcm_engine.py`
- [x] `python -m compileall -q .`
- [x] `python -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check upstream/main...HEAD && git diff --check && git diff --cached --check`
- [x] Structured Codex autoreview on `HEAD`: clean, no accepted P0/P1 findings
- [ ] Workflow validation, if workflows changed: not applicable

## Notes
- The full macOS suite has two existing path-alias failures involving `/var` and `/private/var`; they reproduce on unmodified `main` and are unrelated to this patch.
- This PR covers the cross-source omitted-row trigger. It does not claim to resolve every duplicate-identity case described in #466.

Refs #466
