### PR TITLE
fix: ignore quoted placeholder source literals in doctor

### DIFF
--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -1665,6 +1665,22 @@ def _is_quoted_placeholder_example(text: str, start: int) -> bool:
     return False
 
 
+def _is_placeholder_code_literal(text: str, start: int, end: int) -> bool:
+    suffix = text[end:end + 80]
+    prefix = text[max(0, start - 2):start]
+    for quote_token in ('"', "'"):
+        for escaped in (False, True):
+            boundary = ("\\" if escaped else "") + quote_token
+            if not prefix.endswith(boundary):
+                continue
+            if re.match(
+                rf"^{re.escape(boundary)}\s*\.(?:startswith|endswith)(?:\s*\(|(?=\n|\\n|$))",
+                suffix,
+            ):
+                return True
+    return False
+
+
 def _looks_like_json_container_string(text: str) -> bool:
     stripped = text.lstrip()
     return stripped.startswith("{") or stripped.startswith("[")
@@ -1677,21 +1693,27 @@ def _looks_like_example_payload_ref(ref: str) -> bool:
 
 def _extract_unescaped_externalized_payload_refs(text: str, *, ignore_quoted_spans: bool = False) -> list[str]:
     refs: list[str] = []
-    for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
-        for match in pattern.finditer(text):
-            ref = match.group(1).strip()
-            if not _is_basename_ref(ref):
-                continue
-            if _looks_like_example_payload_ref(ref) and _is_escaped_placeholder_example(text, match.start()):
-                continue
-            if (
-                ignore_quoted_spans
-                and _looks_like_example_payload_ref(ref)
-                and _is_quoted_placeholder_example(text, match.start())
-            ):
-                continue
-            if ref not in refs:
-                refs.append(ref)
+    # A real placeholder is one line. Scan actual and serialized lines
+    # independently so an incomplete prefix cannot consume a later real ref.
+    segments = re.split(r"\n|\\n", text)
+    for segment in segments:
+        for pattern in (_INGEST_PLACEHOLDER_RE, _EXTERNALIZED_PAYLOAD_PLACEHOLDER_RE):
+            for match in pattern.finditer(segment):
+                ref = match.group(1).strip()
+                if not _is_basename_ref(ref):
+                    continue
+                if _is_placeholder_code_literal(segment, match.start(), match.end()):
+                    continue
+                if _looks_like_example_payload_ref(ref) and _is_escaped_placeholder_example(segment, match.start()):
+                    continue
+                if (
+                    ignore_quoted_spans
+                    and _looks_like_example_payload_ref(ref)
+                    and _is_quoted_placeholder_example(segment, match.start())
+                ):
+                    continue
+                if ref not in refs:
+                    refs.append(ref)
     return refs
 
 

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -2811,6 +2811,129 @@ def test_externalized_payload_integrity_scan_ignores_escaped_placeholder_example
     assert detail["missing_externalized_payload_refs"] == []
 
 
+def test_externalized_payload_integrity_scan_ignores_production_named_placeholder_in_quoted_source_literal(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized tool output: tool_call_id=call_gc; chars=12008; bytes=12008; "
+        "ref=20260809_161858_call_gc_71c66761c2bb_18ca2f6ae69a6d30.json]"
+    )
+    content = json.dumps(
+        {
+            "error": None,
+            "exit_code": 0,
+            "output": (
+                "terminal output preserves user's source text\n"
+                'assert stored_tool["content"].startswith("[GC\'d externalized tool output:")\n'
+                f"E <method startswith of str object> = '{placeholder}'.startswith\n"
+            ),
+        }
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "desktop",
+            "tool",
+            content,
+            "call_terminal",
+            None,
+            "terminal",
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 0
+    assert detail["externalized_payload_refs_missing"] == 0
+    assert detail["missing_externalized_payload_refs"] == []
+
+
+def test_externalized_payload_integrity_scan_counts_unquoted_ref_with_code_like_suffix(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized tool output: tool_call_id=call_real; chars=10; bytes=10; "
+        "ref=20260809_real_payload.json]"
+    )
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "desktop",
+            "tool",
+            placeholder + "'.startswith('suffix without an opening quote')",
+            "call_real",
+            None,
+            "terminal",
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"][0]["externalized_ref"] == "20260809_real_payload.json"
+
+
+def test_externalized_payload_integrity_scan_keeps_real_ref_after_incomplete_serialized_line(tmp_path):
+    engine = _engine(tmp_path)
+    (tmp_path / "externalized").mkdir()
+    placeholder = (
+        "[Externalized tool output: tool_call_id=call_real; chars=10; bytes=10; "
+        "ref=20260809_real_after_incomplete.json]"
+    )
+    content = "[Externalized tool output: incomplete\\n" + placeholder
+    engine._store._conn.execute(
+        """INSERT INTO messages
+           (session_id, source, role, content, tool_call_id, tool_calls, tool_name, timestamp, token_estimate, pinned)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            engine.current_session_id,
+            "desktop",
+            "tool",
+            content,
+            "call_real",
+            None,
+            "terminal",
+            1.0,
+            1,
+            0,
+        ),
+    )
+    engine._store._conn.commit()
+
+    detail = scan_externalized_payload_integrity(
+        engine._store._conn,
+        engine._config,
+        hermes_home=engine._hermes_home,
+    )
+
+    assert detail["externalized_payload_refs_total"] == 1
+    assert detail["externalized_payload_refs_missing"] == 1
+    assert detail["missing_externalized_payload_refs"][0]["externalized_ref"] == "20260809_real_after_incomplete.json"
+
+
 def test_lcm_doctor_warns_on_missing_externalized_payload_refs_when_inline_payloads_are_clean(tmp_path):
     engine = _engine(tmp_path)
     (tmp_path / "externalized").mkdir()


### PR DESCRIPTION
## Summary
- ignore externalized-payload placeholders used as quoted `.startswith()` or `.endswith()` source literals
- preserve real production-looking refs inside ordinary quoted tool/log data
- add a regression using the exact live false-positive shape

## Why
`lcm_doctor` should not tell operators to restore a payload file that never existed. Merged #278 filters escaped and clearly example-named placeholder text, but production-looking filenames inside captured source literals still pass the integrity scan.

This keeps the change inside the integrity scanner. Ingest, expansion, storage, and ordinary quoted log references are unchanged.

## Validation
- [x] RED on unmodified `main`: focused regression reported `1` missing ref instead of `0`
- [x] Focused regression and neighboring contracts: `4 passed`
- [x] `pytest tests/test_ingest_protection.py -q` -> `141 passed`
- [ ] Full suite: `2792 passed, 2 skipped, 12 xfailed, 2 existing macOS path-alias failures`; command exits `1`
- [x] `ruff check ingest_protection.py tests/test_ingest_protection.py`
- [x] `python -m compileall -q .`
- [x] `git diff --check upstream/main...HEAD && git diff --check && git diff --cached --check`
- [x] Structured Codex autoreview: clean, no accepted P0/P1 findings
- [ ] Workflow validation, if workflows changed: not applicable

## Notes
- This is a narrow follow-up to merged #278.
- Existing tests that count real production-looking refs inside quoted tool-call log data still pass.
- The two full-suite failures involve `/var` versus `/private/var` on macOS and reproduce on untouched `main`.

Refs #546
