### PR TITLE
fix: harden read-only Hermes state probes

### DIFF
--- a/aux_session.py
+++ b/aux_session.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import inspect
 import logging
-import sqlite3
 import threading
 import weakref
 from pathlib import Path
 from typing import Any, Dict
+
+from .db_bootstrap import open_readonly_connection
 
 logger = logging.getLogger(__name__)
 
@@ -696,8 +697,7 @@ class AuxiliarySessionMixin:
         if not path.exists():
             return False
         try:
-            uri = path.resolve().as_uri() + "?mode=ro"
-            conn = sqlite3.connect(uri, uri=True)
+            conn = open_readonly_connection(path)
             try:
                 row = conn.execute(
                     """
@@ -759,8 +759,7 @@ class AuxiliarySessionMixin:
         visited: set[str] = set()
         current = session_id
         try:
-            uri = state_db_path.resolve().as_uri() + "?mode=ro"
-            conn = sqlite3.connect(uri, uri=True)
+            conn = open_readonly_connection(state_db_path)
             try:
                 for _ in range(32):
                     if not current or current in visited:

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 import logging
 import math
 import os
+from pathlib import Path
 import re
 import shutil
 import sqlite3
@@ -49,6 +50,32 @@ REQUIRED_CORE_TABLES = (
     "messages_fts",
     "nodes_fts",
 )
+
+
+READONLY_STATE_DB_TIMEOUT_SECONDS = 120.0
+READONLY_STATE_DB_BUSY_TIMEOUT_MS = 120_000
+
+
+def open_readonly_connection(
+    db_path: str | os.PathLike[str],
+    *,
+    timeout: float = READONLY_STATE_DB_TIMEOUT_SECONDS,
+    busy_timeout_ms: int = READONLY_STATE_DB_BUSY_TIMEOUT_MS,
+) -> sqlite3.Connection:
+    """Open a state database without becoming a hidden writer.
+
+    Auxiliary LCM probes read Hermes' live ``state.db`` while the gateway owns
+    its write path. A normal ``sqlite3.connect(path)`` can create journals or
+    other side effects, and changing ``journal_mode`` from a reader adds lock
+    contention. Read-only URI mode plus explicit wait/query-only settings keeps
+    these probes from mutating the source database.
+    """
+    path = Path(db_path).expanduser().resolve()
+    uri = path.as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=timeout)
+    conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")
+    conn.execute("PRAGMA query_only=ON")
+    return conn
 
 
 class ExternalContentFtsSpec:

--- a/engine.py
+++ b/engine.py
@@ -25,6 +25,7 @@ from .codex_routing import (
     _is_codex_gpt55_route,
 )
 from .config import LCMConfig
+from .db_bootstrap import open_readonly_connection
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
 from .engine_registry import (
@@ -1321,8 +1322,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         if not path.exists():
             return False
         try:
-            uri = path.resolve().as_uri() + "?mode=ro"
-            conn = sqlite3.connect(uri, uri=True)
+            conn = open_readonly_connection(path)
             try:
                 row = conn.execute(
                     """

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -18,7 +18,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-from .db_bootstrap import configure_connection, refuse_schema_version_too_new, run_versioned_migrations
+from .db_bootstrap import (
+    configure_connection,
+    open_readonly_connection,
+    refuse_schema_version_too_new,
+    run_versioned_migrations,
+)
 
 
 def _synchronized(method):
@@ -455,8 +460,7 @@ class LifecycleStateStore:
             if path.exists():
                 stats["state_db_checked"] = True
                 try:
-                    state_uri = path.resolve().as_uri() + "?mode=ro"
-                    state_conn = sqlite3.connect(state_uri, uri=True)
+                    state_conn = open_readonly_connection(path)
                     try:
                         state_rows = state_conn.execute("SELECT id FROM sessions WHERE id IS NOT NULL").fetchall()
                     finally:

--- a/tests/test_readonly_state_db.py
+++ b/tests/test_readonly_state_db.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hermes_lcm.db_bootstrap import open_readonly_connection
+
+
+def test_open_readonly_connection_is_read_only_and_waits_for_wal(tmp_path):
+    db_path = tmp_path / "state.db"
+    writer = sqlite3.connect(db_path)
+    writer.execute("PRAGMA journal_mode=WAL")
+    writer.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+    writer.execute("INSERT INTO sessions VALUES ('session-1')")
+    writer.commit()
+    writer.close()
+
+    conn = open_readonly_connection(db_path)
+    try:
+        assert conn.execute("SELECT id FROM sessions").fetchone()[0] == "session-1"
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 120_000
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("INSERT INTO sessions VALUES ('must-not-write')")
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
-

## Why
-

## Validation
- [ ] Focused validation: `<command>` -> `<result>`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`## Summary- Add a shared `open_readonly_connection()` helper for auxiliary Hermes `state.db` probes.- Use SQLite URI `mode=ro`, a 120-second connection timeout, `busy_timeout=120000`, and `query_only=ON`.- Replace the bare read-only connections in `engine.py`, `aux_session.py`, and `lifecycle_state.py`.- Prevent auxiliary readers from becoming hidden writers or changing journal state while the Hermes gateway is writing.## Tests- `python -m pytest tests/test_readonly_state_db.py tests/test_auxiliary_## Summary- Add a shared `open_readonly_connection()` helper for auxiliary Hermes `state.db` probes.- Use SQLite URI `mode=ro`, a 120-second connection timeout, `busy_timeout=120000`, and `query_only=ON`.- Replace the bare read-only connections in `engine.py`, `aux_session.py`, and `lifecycle_state.py`.- Prevent auxiliary readers from becoming hidden writers or changing journal state while the Hermes gateway is writing.## Tests- `python -m pytest tests/test_readonly_state_db.py tests/test_auxiliary_first_ingest.py tests/test_crash_safe_wal.py -q` — **33 passed**- Two targeted lifecycle/auxiliary engine tests — **2 passed**- `python -m compileall` on all touched Python files — passed- `git diff --check` — passedThe regression test verifies read-only enforcement, WAL visibility, the configured busy timeout, and that writes fail with `readonly database`.## ContextThis is intended for deployments where LCM reads the live Hermes `state.db` from auxiliary lifecycle/child-session probes while the gateway owns the write path. Readers should not mutate journal mode or compete as implicit SQLite writers.first_ingest.py tests/test_crash_safe_wal.py -q` — **33 passed**- Two targeted lifecycle/auxiliary engine tests — **2 passed**- `python -m compileall` on all touched Python files — passed- `git diff --check` — passedThe regression test verifies read-only enforcement, WAL visibility, the configured busy timeout, and that writes fail with `readonly database`.## ContextThis is intended for deployments where LCM reads the live Hermes `state.db` from auxiliary lifecycle/child-session probes while the gateway owns the write path. Readers should not mutate journal mode or compete as implicit SQLite writers.
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [ ] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
-

Refs #
