### PR TITLE
fix(reconcile): replay contiguous durable blocks when full-replay proof is unavailable

### DIFF
--- a/reconcile.py
+++ b/reconcile.py
@@ -50,6 +50,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 _PRESERVED_OBJECTIVE_CONTEXT_PREFIX = "[Current user objective preserved from compacted history]"
+# Minimum contiguous stored run an incoming prefix must replay before the
+# block-anchored reconciliation trusts it (see _find_replayed_durable_block_cursor).
+_REPLAYED_DURABLE_BLOCK_MIN_ROWS = 4
 
 
 class ReconcileMixin:
@@ -888,6 +891,37 @@ class ReconcileMixin:
             )
             return cursor
 
+        # Full-replay proof is unavailable: the durable session already holds
+        # rows the incoming history does not (a rewound turn's discarded pair,
+        # a row whose stored text differs from its replayed text, or an earlier
+        # ambiguous-delta re-append). The suffix rule above can never advance
+        # again once the store outgrows the history, so every rebind would
+        # re-append the whole history. Accept the longest incoming prefix that
+        # replays a contiguous stored run instead; a fresh delta does not
+        # repeat four-plus consecutive stored rows including both a user and
+        # an assistant turn, so duplicate-over-loss still governs everything
+        # shorter or non-contiguous.
+        block_cursor = self._find_replayed_durable_block_cursor(messages, stored_tail_rows)
+        if block_cursor > 0:
+            self._record_ingest_reconciliation(
+                action="advanced cursor",
+                reason="replayed contiguous durable block",
+                cursor=block_cursor,
+                incoming=len(messages),
+                session_count=session_count,
+                stored_tail_count=len(stored_tail),
+                effective_incoming=len(self._effective_replay_identities(messages)),
+            )
+            logger.warning(
+                "LCM reconciled ingest cursor from a contiguous durable block after existing-session bind: session=%s cursor=%d incoming=%d stored_tail=%d session_count=%d (no full-replay proof; the store already outgrew the history)",
+                self._session_id,
+                block_cursor,
+                len(messages),
+                len(stored_tail),
+                session_count,
+            )
+            return block_cursor
+
         incoming_identities = self._effective_replay_identities(messages)
         stored_head_rows = self._store.get_session_messages(
             self._session_id,
@@ -942,7 +976,78 @@ class ReconcileMixin:
             stored_tail_count=len(stored_tail),
             effective_incoming=len(incoming_identities),
         )
+        logger.warning(
+            "LCM persisted an ambiguous delta after existing-session bind: session=%s incoming=%d effective_incoming=%d stored_tail=%d session_count=%d (no durable-tail overlap; rows the batch replays are now stored twice)",
+            self._session_id,
+            len(messages),
+            len(incoming_identities),
+            len(stored_tail),
+            session_count,
+        )
         return 0
+
+    def _find_replayed_durable_block_cursor(
+        self,
+        messages: List[Dict[str, Any]],
+        stored_rows: List[Dict[str, Any]],
+    ) -> int:
+        """Cursor past the longest incoming prefix that replays contiguous stored runs.
+
+        Compares replay identities of the rows ingest would persist (context
+        scaffolding, ignore-pattern rows, and active-replay placeholders are
+        skipped, as ingest skips them) against the stored rows in store order.
+        The prefix is consumed run by run: each run is the longest contiguous
+        stored match anchored at a stored row equal to the next unconsumed
+        incoming identity, searched only after the previous run, so a rewound
+        turn's discarded pair between two stored runs is stepped over.
+        A run counts only when it has at least
+        ``_REPLAYED_DURABLE_BLOCK_MIN_ROWS`` rows and contains both a user and
+        an assistant identity; the prefix ends at the first run that does not.
+        Returns 0 when no run qualifies.
+        """
+        live: list[tuple[int, tuple[str, str, str, str]]] = []
+        for idx, msg in enumerate(messages):
+            text = text_content_for_pattern_matching(msg.get("content")) or ""
+            if (
+                self._is_replayed_context_scaffold_message(msg)
+                or self._matches_ignore_message_patterns(msg)
+                or self._is_volatile_ignored_quarantine_placeholder(msg, text)
+                or self._is_ignored_active_replay_placeholder(msg, text)
+            ):
+                continue
+            live.append((idx, self._message_replay_identity(msg)))
+        if not stored_rows:
+            return 0
+        stored = [self._message_replay_identity(row, stored_row=True) for row in stored_rows]
+        consumed = 0
+        stored_from = 0
+        while len(live) - consumed >= _REPLAYED_DURABLE_BLOCK_MIN_ROWS:
+            first = live[consumed][1]
+            best = 0
+            best_end = stored_from
+            for start in range(stored_from, len(stored)):
+                if stored[start] != first:
+                    continue
+                n = 0
+                while (
+                    consumed + n < len(live)
+                    and start + n < len(stored)
+                    and stored[start + n] == live[consumed + n][1]
+                ):
+                    n += 1
+                if n > best:
+                    best = n
+                    best_end = start + n
+            if best < _REPLAYED_DURABLE_BLOCK_MIN_ROWS:
+                break
+            roles = {live[consumed + i][1][0] for i in range(best)}
+            if "user" not in roles or "assistant" not in roles:
+                break
+            consumed += best
+            stored_from = best_end
+        if consumed == 0:
+            return 0
+        return live[consumed - 1][0] + 1
 
     def _raw_externalized_placeholder_replay_identity(self, msg: Dict[str, Any]) -> tuple[str, str, str, str]:
         return (

--- a/tests/test_reconcile_replayed_durable_block.py
+++ b/tests/test_reconcile_replayed_durable_block.py
@@ -1,0 +1,128 @@
+"""Existing-session rebinds must not re-append the whole history once the
+durable store holds rows the incoming history lacks.
+
+The stored-tail suffix rule only advances the ingest cursor when the incoming
+prefix covers the entire stored session. After a rewound turn (the discarded
+pair stays in the store), a stored/replayed text mismatch, or one earlier
+ambiguous-delta re-append, that proof is unavailable forever, and every rebind
+re-appended the full history (each burst larger than the last). The
+replayed-durable-block rule accepts the longest incoming prefix that replays a
+contiguous stored run of at least four rows with a user and an assistant turn.
+"""
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _turns(start: int, count: int) -> list[dict]:
+    rows = []
+    for i in range(start, start + count):
+        rows.append({"role": "user", "content": f"question {i}"})
+        rows.append({"role": "assistant", "content": f"answer {i}"})
+    return rows
+
+
+def _rebind(config: LCMConfig, session: str) -> LCMEngine:
+    engine = LCMEngine(config=config)
+    engine.on_session_start(
+        session,
+        platform="telegram",
+        conversation_id=f"{session}-conversation",
+        context_length=200000,
+    )
+    return engine
+
+
+def _close(engine: LCMEngine) -> None:
+    engine._store.close()
+    engine._dag.close()
+    engine._lifecycle.close()
+
+
+def test_rebind_after_rewind_replays_durable_block_instead_of_full_history(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "rewind.db"))
+    session = "rewind-session"
+    engine = _rebind(config, session)
+    history = _turns(0, 6)
+    engine._ingest_messages(history)
+    assert engine._store.get_session_count(session) == 12
+    _close(engine)
+
+    # The user rewinds the last turn and retries: the store keeps the discarded
+    # pair, the replayed history carries the retry instead.
+    retried = history[:-2] + [
+        {"role": "user", "content": "question 5 (retry)"},
+        {"role": "assistant", "content": "answer 5 (retry)"},
+    ]
+    engine = _rebind(config, session)
+    engine._ingest_messages(retried)
+
+    rows = engine._store.get_session_messages(session)
+    assert len(rows) == 14
+    assert [row["content"] for row in rows[-2:]] == [
+        "question 5 (retry)",
+        "answer 5 (retry)",
+    ]
+    assert engine._last_ingest_reconciliation["reason"] == "replayed contiguous durable block"
+    assert engine._ingest_cursor == len(retried)
+    _close(engine)
+
+
+def test_rebind_with_outgrown_store_does_not_reappend_history(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "outgrown.db"))
+    session = "outgrown-session"
+    engine = _rebind(config, session)
+    history = _turns(0, 6)
+    engine._ingest_messages(history)
+    _close(engine)
+
+    # A rewind leaves the discarded pair behind (14 stored rows, 12 replayed).
+    engine = _rebind(config, session)
+    engine._ingest_messages(history + _turns(6, 1))
+    assert engine._store.get_session_count(session) == 14
+    _close(engine)
+
+    # The retry plus two further turns arrive across per-turn rebinds.
+    retried = history + [
+        {"role": "user", "content": "question 6 (retry)"},
+        {"role": "assistant", "content": "answer 6 (retry)"},
+    ]
+    engine = _rebind(config, session)
+    engine._ingest_messages(retried + _turns(7, 1))
+    count_after_first = engine._store.get_session_count(session)
+    assert count_after_first == 18  # 12 replayed rows skipped, 4 tail rows persisted
+    _close(engine)
+
+    engine = _rebind(config, session)
+    engine._ingest_messages(retried + _turns(7, 2))
+    assert engine._store.get_session_count(session) == 20  # only the newest turn
+    assert engine._last_ingest_reconciliation["reason"] == "replayed contiguous durable block"
+    _close(engine)
+
+    # Rebinding with an unchanged history appends nothing.
+    engine = _rebind(config, session)
+    engine._ingest_messages(retried + _turns(7, 2))
+    assert engine._store.get_session_count(session) == 20
+    assert engine._ingest_cursor == len(retried) + 4
+    _close(engine)
+
+
+def test_short_delta_matching_stored_run_is_still_persisted(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "short-delta.db"))
+    session = "short-delta-session"
+    engine = _rebind(config, session)
+    engine._ingest_messages(_turns(0, 6))
+    _close(engine)
+
+    # A three-row delta that happens to repeat stored rows stays below the
+    # replay-evidence threshold: duplicate-over-loss still applies.
+    delta = [
+        {"role": "user", "content": "question 0"},
+        {"role": "assistant", "content": "answer 0"},
+        {"role": "user", "content": "question 1"},
+    ]
+    engine = _rebind(config, session)
+    engine._ingest_messages(delta)
+    assert engine._store.get_session_count(session) == 15
+    assert engine._last_ingest_reconciliation["reason"] == "persisted ambiguous delta"
+    _close(engine)


### PR DESCRIPTION
## Summary

Every rebind of an existing session (a rebuilt gateway agent, a restart, a compaction boundary) resets the ingest cursor and reconciles it against the stored tail. The suffix rule in `_find_reconciled_cursor_for_store_tail` only advances when the incoming prefix covers the **entire** stored session (duplicate-over-loss). Once the store holds any row the replayed history lacks, that proof is unavailable for good:

- a rewound turn (`/undo`, retry) leaves the discarded pair in the store;
- a row whose stored text differs from its replayed text (e.g. a synthetic user turn persisted with empty `content` and its text in a sidecar);
- one earlier ambiguous-delta re-append.

From then on every rebind hits the silent `persisted ambiguous delta` path and re-appends the whole history, each burst larger than the last. On three long-running Telegram gateway stores measured 2026-08-24, 56-68% of user/assistant rows were same-session verbatim duplicates. Related: #441 (same double-ingest signature), #513, #543.

## Fix

When the suffix rule cannot advance, accept the longest incoming prefix that replays contiguous stored runs: each run is the longest contiguous match anchored at a stored row equal to the next unconsumed incoming identity, searched after the previous run (so a discarded pair between two runs is stepped over), and a run counts only with at least four rows including both a user and an assistant turn. A fresh delta does not repeat four-plus consecutive stored rows, so shorter or non-contiguous batches keep the duplicate-over-loss fallthrough, which now logs at WARNING instead of only setting the in-memory telemetry field.

Verified against a real store with the engine: at five burst boundaries the re-append drops from the full history to the genuinely new rows, and a repeat rebind appends nothing. A rewind still costs a few duplicate rows before the runs re-align; a first divergence costs one copy.

## Tests

- `tests/test_reconcile_replayed_durable_block.py`: rewind then retry replays the block instead of the history; an outgrown store no longer re-appends across successive rebinds; a short delta matching a stored run is still persisted.
- Existing restart/rebind reconciliation tests in `tests/test_lcm_engine.py` pass unchanged (72 selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)