### PR TITLE
feat: add rerank support for openai-compatible providers

### DIFF
--- a/config.py
+++ b/config.py
@@ -372,6 +372,7 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("embeddings_enabled", "LCM_EMBEDDINGS_ENABLED", bool),
     _EnvFieldSpec("rerank_enabled", "LCM_RERANK_ENABLED", bool),
     _EnvFieldSpec("rerank_model", "LCM_RERANK_MODEL", str),
+    _EnvFieldSpec("rerank_base_url", "LCM_RERANK_BASE_URL", str),
     _EnvFieldSpec("recall_scan_rows", "LCM_RECALL_SCAN_ROWS", int),
     _EnvFieldSpec("recall_scan_max_rows", "LCM_RECALL_SCAN_MAX_ROWS", int),
     _EnvFieldSpec("recall_scan_budget_s", "LCM_RECALL_SCAN_BUDGET_S", float),
@@ -619,6 +620,10 @@ class LCMConfig:
     rerank_enabled: bool = False
     # Empty preserves the selected provider's rerank default.
     rerank_model: str = ""
+    # Empty keeps rerank co-located with the embedding endpoint (same
+    # base_url). Set to point rerank at a dedicated endpoint (e.g. a
+    # separate reranker container alongside an embedding server).
+    rerank_base_url: str = ""
     embedding_bounded_scan_rows: int = 2_000
     # Vector storage dtype for NEWLY-registered embedding profiles: float32
     # (default; a stock install keeps summary vectors byte-identical) or int8

--- a/config.py
+++ b/config.py
@@ -371,6 +371,7 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("database_path", "LCM_DATABASE_PATH", str),
     _EnvFieldSpec("embeddings_enabled", "LCM_EMBEDDINGS_ENABLED", bool),
     _EnvFieldSpec("rerank_enabled", "LCM_RERANK_ENABLED", bool),
+    _EnvFieldSpec("rerank_model", "LCM_RERANK_MODEL", str),
     _EnvFieldSpec("recall_scan_rows", "LCM_RECALL_SCAN_ROWS", int),
     _EnvFieldSpec("recall_scan_max_rows", "LCM_RECALL_SCAN_MAX_ROWS", int),
     _EnvFieldSpec("recall_scan_budget_s", "LCM_RECALL_SCAN_BUDGET_S", float),
@@ -611,10 +612,13 @@ class LCMConfig:
 
     # -- Embeddings (default-off until a provider/model are configured) ---
     embeddings_enabled: bool = False
-    # lcm_recall cross-encoder rerank stage (voyage rerank-2.5-lite over the top
-    # fused candidates). Default-off: recall ships value on RRF order alone, and
-    # rerank is one extra billable API call the operator opts into.
+    # lcm_recall cross-encoder rerank stage for capable providers (Voyage
+    # rerank-2.5-lite, or a Cohere-compatible local endpoint through the
+    # openai-compatible provider). Default-off: recall ships value on RRF order
+    # alone, and rerank is one extra call the operator opts into.
     rerank_enabled: bool = False
+    # Empty preserves the selected provider's rerank default.
+    rerank_model: str = ""
     embedding_bounded_scan_rows: int = 2_000
     # Vector storage dtype for NEWLY-registered embedding profiles: float32
     # (default; a stock install keeps summary vectors byte-identical) or int8
@@ -682,12 +686,9 @@ class LCMConfig:
     # otherwise have to lcm_recall by hand. Default-off => byte-identical
     # assembly; when disabled the whole path is skipped before any work.
     proactive_recall_enabled: bool = False
-    # Relevance floor on the lcm_recall composite score. Two regimes:
-    #  - rerank OFF (default): the score is RRF-scale (~0.014-0.05); a single
-    #    top-ranked arm hit is ~0.016, so this floor mainly drops ancient or
-    #    low-ranked hits. The default keeps fresh top-of-arm hits.
-    #  - rerank ON: a cross-encoder relevance in [0,1] dominates the score;
-    #    raise this floor (e.g. ~0.3) for a true semantic gate.
+    # Relevance floor on the lcm_recall composite RRF-scale score (~0.014-0.05).
+    # Reranking only permutes the selected window; it never replaces or splices
+    # cross-encoder relevance scores onto this scale.
     proactive_recall_min_score: float = 0.01
     # Hard token budget for the single injected "relevant memories" block.
     proactive_recall_budget_tokens: int = 500

--- a/config.py
+++ b/config.py
@@ -392,6 +392,12 @@ ENV_FIELD_SPECS: tuple[_EnvFieldSpec, ...] = (
     _EnvFieldSpec("embedding_model", "LCM_EMBEDDING_MODEL", str),
     _EnvFieldSpec("embedding_content_policy", "LCM_EMBED_CONTENT_POLICY", str),
     _EnvFieldSpec("ollama_base_url", "LCM_OLLAMA_BASE_URL", str),
+    _EnvFieldSpec(
+        "embedding_base_url", "LCM_EMBEDDING_BASE_URL", str
+    ),
+    _EnvFieldSpec(
+        "embedding_api_key_env", "LCM_EMBEDDING_API_KEY_ENV", str
+    ),
     _EnvFieldSpec("embedding_query_timeout_s", "LCM_EMBEDDING_QUERY_TIMEOUT_S", float),
     _EnvFieldSpec("recall_query_timeout_s", "LCM_RECALL_QUERY_TIMEOUT_S", float),
     _EnvFieldSpec("embedding_backfill_timeout_s", "LCM_EMBEDDING_BACKFILL_TIMEOUT_S", float),
@@ -710,6 +716,8 @@ class LCMConfig:
     # default in the chunker's normalize_content_policy.
     embedding_content_policy: str = "conversational"
     ollama_base_url: str = "http://localhost:11434"
+    embedding_base_url: str = ""
+    embedding_api_key_env: str = "LCM_EMBEDDING_API_KEY"
     embedding_query_timeout_s: float = 3.0
     # Dedicated deadline for lcm_recall. It fans out three sequential arms (FTS +
     # summary KNN + chunk KNN) plus fusion, hydration, and an optional rerank, so

--- a/docs/embeddings-setup.md
+++ b/docs/embeddings-setup.md
@@ -127,6 +127,28 @@ remote providers: `LCM_EMBEDDING_QUERY_TIMEOUT_S` bounds interactive queries,
 stored under the full `(provider, model, ...)` identity so switching back to
 this provider reactivates existing vectors without re-backfilling.
 
+### Reranking via the same endpoint
+
+[infinity](https://github.com/michaelfeil/infinity) can serve both the embedding
+model (`BAAI/bge-m3`) and cross-encoder reranker (`BAAI/bge-reranker-v2-m3`) from
+the same endpoint:
+
+```bash
+infinity serve --model-id BAAI/bge-m3 --model-id BAAI/bge-reranker-v2-m3
+```
+
+Enable the optional recall rerank stage with:
+
+```bash
+export LCM_RERANK_ENABLED=true
+# Optional: overrides the provider's default rerank model.
+export LCM_RERANK_MODEL=BAAI/bge-reranker-v2-m3
+```
+
+For a local endpoint, rerank requests do not require an API key. The rerank
+route is Cohere-compatible (`/rerank`), while embeddings continue to use the
+OpenAI-compatible `/embeddings` route.
+
 ## What you get
 
 `lcm_grep` gains two modes on top of the existing ones:

--- a/docs/embeddings-setup.md
+++ b/docs/embeddings-setup.md
@@ -149,6 +149,19 @@ For a local endpoint, rerank requests do not require an API key. The rerank
 route is Cohere-compatible (`/rerank`), while embeddings continue to use the
 OpenAI-compatible `/embeddings` route.
 
+### Reranking via a dedicated endpoint
+
+If embeddings and reranker live on different endpoints (e.g. an embedding
+server plus a separate reranker container), point rerank at its own base URL.
+The value follows the same convention as `LCM_EMBEDDING_BASE_URL` (vLLM
+exposes Cohere `/rerank` under `/v1`, Infinity at the root):
+
+```bash
+export LCM_RERANK_BASE_URL=http://gpu-host:7998/v1
+```
+
+When unset (default), rerank requests go to the embedding endpoint.
+
 ## What you get
 
 `lcm_grep` gains two modes on top of the existing ones:

--- a/docs/embeddings-setup.md
+++ b/docs/embeddings-setup.md
@@ -11,6 +11,7 @@ FTS-only exactly as before.
 | Voyage AI | free tier (200M tokens for the voyage-4 group), then ~$0.02–0.12 per million tokens | yes (no credit card) | none | best quality, zero local footprint |
 | fastembed | $0 | no | `pip install fastembed` (ONNX, no torch) | local default — no accounts, no daemon |
 | Ollama | $0 | no | Ollama app/daemon | you already run Ollama |
+| OpenAI-compatible | provider pricing | yes (per provider) | none | reuse an existing `/v1/embeddings` service (SiliconFlow, llama.cpp, vLLM) |
 
 All providers feed the same store. Switching provider/model is one config change plus a backfill;
 each full identity keeps its own vectors, so switching **back** to a
@@ -98,6 +99,33 @@ batch or local model load is not aborted by the interactive query policy. The
 optional `LCM_EMBEDDING_BACKFILL_BUDGET_S` still caps the whole apply run
 between batches (`0`, the default, means no whole-run cap); the lease and
 post-call ownership CAS remain authoritative independently of both timeouts.
+
+## Option 4 — OpenAI-compatible API (reuse an existing embeddings service)
+
+If you already run any OpenAI-format `/v1/embeddings` endpoint — SiliconFlow,
+llama.cpp server, vLLM, or a local embedding model on a workstation — point
+LCM at it instead of running a second embedding stack:
+
+```bash
+export LCM_EMBEDDINGS_ENABLED=true
+export LCM_EMBEDDING_PROVIDER=openai-compatible
+export LCM_EMBEDDING_MODEL=BAAI/bge-m3     # any model id your endpoint serves
+export LCM_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+export LCM_EMBEDDING_API_KEY=sk-...        # falls back to SILICONFLOW_API_KEY
+/lcm embed warmup && /lcm embed backfill --apply
+```
+
+`LCM_EMBEDDING_BASE_URL` is the API root (a trailing slash is stripped) and
+`/embeddings` is appended. The request body is the standard OpenAI shape —
+`{"model": ..., "input": [...]}` with a `Bearer` authorization header — so any
+compatible server works, including local llama.cpp/vLLM instances that cost
+nothing per call.
+
+The same deadline, spend-guard, and identity rules apply as for the other
+remote providers: `LCM_EMBEDDING_QUERY_TIMEOUT_S` bounds interactive queries,
+`LCM_EMBEDDING_BACKFILL_TIMEOUT_S` bounds each backfill batch, and vectors are
+stored under the full `(provider, model, ...)` identity so switching back to
+this provider reactivates existing vectors without re-backfilling.
 
 ## What you get
 

--- a/docs/specs/openai-compatible-rerank.md
+++ b/docs/specs/openai-compatible-rerank.md
@@ -1,0 +1,166 @@
+# Spec: Reranking via OpenAI-Compatible Provider (self-hosted rerankers)
+
+Status: draft for build (Codex) · Target repo: `hermes-lcm` (branch on top of PR #519's `OpenAICompatibleProvider`) · Author: Mandy · Date: 2026-08-28
+
+## 1. Goal
+
+Enable `lcm_recall`'s cross-encoder rerank stage against **any OpenAI-compatible endpoint that also serves a Cohere-format `/rerank` route** (e.g. [michaelfeil/infinity](https://github.com/michaelfeil/infinity), which implements `/rerank` aligned with the Cohere API). Today the rerank stage is hard-locked to the Voyage cloud provider; this spec unlocks local/self-hosted rerankers with zero external API dependency.
+
+Non-goals:
+- No changes to embedding behavior, identity hashing, or backfill logic.
+- No changes to `VoyageProvider` — its `rerank()` stays as-is.
+- No new HTTP transport; reuse the existing `_default_http_transport` / injectable-transport pattern.
+
+## 2. Current state (verified against main @ 10cbb78, v0.21.0-rc2)
+
+| Fact | Location |
+|---|---|
+| Rerank gate requires `provider_id == "voyage"` | `tools.py:4539–4544` (`_lcm_recall_rerank`) |
+| Rerank call: `provider.rerank(query, documents, top_k=..., timeout=...)` | `tools.py:4550–4557` |
+| Voyage rerank returns `list[tuple[int, float]]` sorted by `(-score, index)` | `embedding_provider.py:1258–1319` |
+| Rerank toggle: `rerank_enabled` / env `LCM_RERANK_ENABLED`, default `False` | `config.py:373, 611` |
+| Local-provider set (skips `--confirm-raw-text`): `{"fastembed", "ollama"}` | `command.py:4498` |
+| PR #519 adds `OpenAICompatibleProvider` (embeddings only, no `rerank` method) | PR #519 diff |
+
+**Build sequencing (answers Codex's context question):** the PR #519 `OpenAICompatibleProvider` is applied to the working branch BEFORE this spec is implemented (local patch until upstream merges). The implementer builds `rerank()` against the real class in-tree — constructor shape, URL construction, api-key chain, and deadline helpers come from that code, not from this spec.
+
+## 3. Contracts
+
+### 3.1 `OpenAICompatibleProvider.rerank`
+
+Signature and semantics are contract-identical to `VoyageProvider.rerank`:
+
+```python
+def rerank(
+    self,
+    query: str,
+    documents: Sequence[str],
+    *,
+    top_k: int | None = None,
+    timeout: float,
+    model: str = "",
+) -> list[tuple[int, float]]:
+```
+
+- Returns `(original_index, relevance_score)` pairs **ordered by descending relevance** (tie-break by ascending original index). Callers treat any raised error as "skip rerank" and keep prior order.
+- Empty `documents` → return `[]` **without any transport call** (mirror Voyage's short-circuit; no wasted request).
+- `model`: `""` (default) means "use `_OPENAI_COMPATIBLE_RERANK_MODEL`"; any non-empty string overrides. This keeps the setting alive (Codex finding: otherwise `config.rerank_model` would be dead config, because `_lcm_recall_rerank` never passed `model=`).
+- `top_k` validation: `top_k <= 0` → return `[]` without a transport call; a non-integer `top_k` raises `ValueError` (programmer error → fail loud). Positive values map to `top_n` per §3.2.
+- `top_k` is LCM-side API surface. On the wire it maps to Infinity/Cohere's `top_n` (see §3.2).
+
+### 3.2 Wire format (Cohere shape, as implemented by Infinity `0.0.77`)
+
+Request — `POST {base_url}/rerank`:
+
+```json
+{
+  "model": "BAAI/bge-reranker-v2-m3",
+  "query": "Where is Munich?",
+  "documents": ["Munich is in Germany.", "The sky is blue."],
+  "top_n": 2
+}
+```
+
+- `model`: the rerank model id. Default constant `_OPENAI_COMPATIBLE_RERANK_MODEL = "BAAI/bge-reranker-v2-m3"`, overridable per call via `model=` and globally via new config field `rerank_model` (env `LCM_RERANK_MODEL`, default `""` meaning "use the constant"). NOTE: Cohere/Infinity use **`top_n`**, not `top_k` — do not copy Voyage's payload key.
+- `top_n`: `len(documents)` when `top_k` is `None`, else `min(top_k, len(documents))`. Rationale: LCM's caller always wants the full window scored back; Infinity defaults to returning all results anyway, but explicit is safer across Cohere-compatible servers.
+
+Response — parse `results`:
+
+```json
+{
+  "results": [
+    {"index": 0, "relevance_score": 0.97, "document": null}
+  ]
+}
+```
+
+- Map to `[(index, relevance_score), ...]`. Drop rows whose `index` is out of `[0, len(documents))` (mirror Voyage's `test_voyage_rerank_drops_out_of_range_index`).
+- Sort by `(-score, index)`.
+- Malformed-row policy (Codex finding): non-dict rows → skipped; missing, `null`, or non-numeric `relevance_score` → row skipped (a null score is a server bug — never silently score it 0.0); missing or non-coercible `index` → row skipped. Duplicate indexes are preserved at the provider level (mirror Voyage's dumb parser); the recall reorder already dedupes (tools.py `seen` set) — document this split in the PR.
+
+### 3.3 Auth header
+
+Read the API key via the same env chain as embeddings (`LCM_EMBEDDING_API_KEY`, falling back to `SILICONFLOW_API_KEY`), **but**: if no key is set, send the request **without** an `Authorization` header instead of raising. Rationale: self-hosted endpoints (infinity on LAN) need no key; raising would force a dummy-key convention. This is deliberately more lenient than #519's embedding path and should be called out in the PR description (embeddings keep #519's stricter contract; rerank is local-first).
+
+### 3.4 Config additions (`config.py`)
+
+```python
+_EnvFieldSpec("rerank_model", "LCM_RERANK_MODEL", str),
+# class field:
+rerank_model: str = ""
+```
+
+`resolve_provider` wiring is unchanged (rerank rides on the existing `OpenAICompatibleProvider` instance; no new provider id).
+
+Call-site rule (closes the §3.2/§4 gap Codex flagged): `_lcm_recall_rerank` forwards `model=config.rerank_model` **only when non-empty** — otherwise each provider keeps its own default (voyage → `rerank-2.5-lite`, openai-compatible → `BAAI/bge-reranker-v2-m3`). `LCM_RERANK_MODEL` therefore overrides whichever provider serves rerank; unset keeps both defaults and never forwards an empty string into a provider payload.
+
+## 4. Gate change (`tools.py` `_lcm_recall_rerank`)
+
+Replace the voyage-only gate:
+
+```python
+if (
+    provider is None
+    or getattr(provider, "provider_id", "") != "voyage"
+    or not hasattr(provider, "rerank")
+):
+    return ordered, "skipped: rerank requires the voyage provider"
+```
+
+with capability-based gating:
+
+```python
+if provider is None or not hasattr(provider, "rerank"):
+    return ordered, "skipped: provider does not support rerank"
+```
+
+Everything else (window slicing, `_run_within_deadline`, permutation-only reorder, `skipped: <reason>` / `applied` / `disabled` status strings, RERANK-1 score-scale rule) stays byte-identical. The ONE deliberate change beyond the gate: the `provider.rerank(...)` call gains `model=config.rerank_model` **only when that config value is non-empty** (see §3.4 — empty default preserves Voyage's constant).
+
+## 5. Error & edge semantics
+
+1. Any exception inside `rerank()` (network, non-2xx, parse, deadline) propagates to the existing `except` in `tools.py` → `skipped: {exc}`, order unchanged. Do not swallow errors inside the provider.
+2. Non-2xx → raise `EmbeddingProviderError(f"OpenAI-compatible rerank request failed ({status})")`.
+3. Transport `OSError/TimeoutError/URLError` → wrap as `EmbeddingProviderError("OpenAI-compatible rerank network error: ...")`, **no automatic identical resend** (same rationale as #519's embedding path).
+4. `results` missing or not a list → raise `EmbeddingProviderError("OpenAI-compatible rerank response did not contain result data")`.
+5. Deadline exceeded at any stage → raise (same deadline discipline as `VoyageProvider.rerank`).
+6. `rerank_enabled=False` (default) → status `disabled`, no call. Unchanged.
+7. **Empty-snippet policy (review finding):** `_lcm_recall_rerank` builds documents from `entry["hit"].get("snippet")`, which can be empty (e.g. under chunk hits). Do NOT send empty strings to the cross-encoder. Implementation is an **eligible-index map**, not a plain filter (Codex finding: returned rerank indexes refer to the eligible subset, not to `head`): build `eligible = [(head_pos, doc) for head_pos, entry in enumerate(head) if str(entry["hit"].get("snippet") or "").strip()]`, send only the docs, map returned document-positions back through `eligible` to head positions before the reorder. Slot-preserving merge — worked example: head `[A, empty, B, C]`, eligible rerank order `[C, B, A]` → result `[C, empty, B, A]` (the empty row keeps its slot). Make this exact example the executable assertion in §6 test 10. Status notes partial coverage: `applied (n=42/50)` when any row was skipped.
+8. **All-empty case (Codex finding):** if every row in the window has an empty snippet, make NO provider call and return `skipped: no non-empty snippets to rerank` — never `applied (n=0/N)`.
+
+## 6. Tests (mirror the Voyage rerank suite, `tests/test_embedding_provider.py`)
+
+Use the existing `FakeTransport` pattern; all tests inject transport, no real network.
+
+1. `test_openai_compatible_rerank_request_shape_and_success` — asserts URL `{base}/rerank`, payload `{"model", "query", "documents", "top_n"}` with `top_n == len(documents)`, parses `results` into descending `[(index, score)]`.
+2. `test_openai_compatible_rerank_top_k_maps_to_top_n` — `top_k=2` over 5 docs → wire `top_n=2`; response may return fewer rows than documents. The fake response is deliberately UNsorted and the assertion checks the provider output is sorted by `(-score, index)` (Codex finding: "reflect wire order" contradicted the §3.2 sort contract — the test must prove the sort happens, not inherit wire order).
+3. `test_openai_compatible_rerank_drops_out_of_range_index` — index 5 over 2 docs is dropped, not crashed.
+4. `test_openai_compatible_rerank_non_2xx_raises` — 500 → `EmbeddingProviderError`.
+5. `test_openai_compatible_rerank_empty_documents_short_circuits` — `[]` with zero transport calls.
+6. `test_openai_compatible_rerank_no_api_key_sends_no_auth_header` — key envs unset → no `Authorization` header, request still succeeds (fake 200).
+7. `test_openai_compatible_rerank_network_error_not_retried` — `OSError` → single call, raises.
+8. `test_rerank_applies_with_openai_compatible_provider` (in `tests/test_lcm_recall.py`) — engine with `rerank_enabled=True` and an openai-compatible provider exposing `rerank` → provenance `applied`, order permuted, score stays RRF-scale (mirror `test_rerank_does_not_splice_voyage_score_onto_rrf_scale`).
+9. `test_rerank_gate_is_capability_based` — a non-voyage provider **without** `rerank` → `skipped: provider does not support rerank`; update the existing voyage-gate test accordingly.
+10. `test_rerank_passes_through_empty_snippets` (in `tests/test_lcm_recall.py`) — window `[A, empty, B, C]` with eligible rerank order `[C, B, A]` → result `[C, empty, B, A]` (the §5.7 worked example, verbatim); empty row is NOT in the rerank documents; status reads `applied (n=3/4)`.
+11. `test_rerank_all_empty_snippets_skips_call` — every snippet empty → zero transport calls, status `skipped: no non-empty snippets to rerank`.
+12. `test_openai_compatible_rerank_skips_malformed_rows` — response containing a non-dict row, a `null` score, and a missing index → those rows skipped, valid rows parsed; duplicate indexes preserved.
+
+## 7. Docs
+
+- `docs/embeddings-setup.md`, PR #519's "Option 4" section: add subsection "Reranking via the same endpoint" — show infinity serving `BAAI/bge-m3` + `BAAI/bge-reranker-v2-m3`, env `LCM_RERANK_ENABLED=true`, optional `LCM_RERANK_MODEL`, note `rerank` requires no API key for local endpoints.
+- `config.py` comment block at `rerank_enabled` (line ~608): reword "voyage rerank-2.5-lite" → "provider-capable rerank (voyage rerank-2.5-lite, or a Cohere-compatible local endpoint via the openai-compatible provider)".
+- `config.py` comment at `proactive_recall_min_score` (Codex finding): currently claims rerank scores dominate the score scale — factually wrong (rerank only permutes; scores stay RRF-scale, RERANK-1). Correct that comment in the same PR; it contradicts this spec's score semantics.
+
+## 8. Exit criteria
+
+- [ ] All new tests pass; existing suite green (`uv run --extra test pytest tests/ -q`).
+- [ ] `grep -n "voyage provider" tools.py` returns nothing (gate message gone).
+- [ ] Voyage rerank tests untouched and passing (no behavioral change to voyage path).
+- [ ] `provenance.rerank` semantics unchanged: `disabled` / `skipped: ...` / `applied`.
+- [ ] Docs updated.
+
+## 9. Deliberate non-changes (do not touch)
+
+- `_LOCAL_EMBEDDING_PROVIDERS` — `openai-compatible` must NOT be added: the provider string cannot distinguish LAN infinity from cloud SiliconFlow, so the raw-text confirmation gate stays conservative.
+- Voyage constants, URL, parser.
+- `benchmarking/longmemeval.py` — its separate rerank path ( Voyage-locked `RERANK_MODE_VOYAGE`) stays untouched; this spec covers ONLY the runtime recall path (`tools.py`).
+- Identity hashing, backfill, chunker.

--- a/embedding_provider.py
+++ b/embedding_provider.py
@@ -1550,6 +1550,7 @@ class OpenAICompatibleProvider(_ResilientProvider):
         sleeper: Callable[[float], None] = time.sleep,
         breaker: EmbeddingCircuitBreaker | None = None,
         spend_guard: EmbeddingSpendGuard | None = None,
+        rerank_base_url: str = "",
     ) -> None:
         super().__init__(breaker=breaker, spend_guard=spend_guard)
         self._model_id = str(model).strip()
@@ -1560,6 +1561,9 @@ class OpenAICompatibleProvider(_ResilientProvider):
             raise ValueError(
                 "LCM_EMBEDDING_BASE_URL must be set for openai-compatible provider"
             )
+        # Optional dedicated rerank endpoint; empty keeps rerank co-located
+        # with the embedding base_url (default behavior, wire unchanged).
+        self.rerank_base_url = str(rerank_base_url).strip().rstrip("/")
         self.api_key_env = str(api_key_env).strip() or "LCM_EMBEDDING_API_KEY"
         self._transport = transport or _default_http_transport
         self.timeout = float(timeout)
@@ -1573,6 +1577,11 @@ class OpenAICompatibleProvider(_ResilientProvider):
     @property
     def dim(self) -> int:
         return self._dim
+
+    @property
+    def rerank_url(self) -> str:
+        """Rerank endpoint URL; defaults to the embedding base_url."""
+        return f"{self.rerank_base_url or self.base_url}/rerank"
 
     def _request(
         self,
@@ -1784,7 +1793,7 @@ class OpenAICompatibleProvider(_ResilientProvider):
             headers["Authorization"] = f"Bearer {api_key}"
         try:
             response = self._transport(
-                url=f"{self.base_url}/rerank",
+                url=self.rerank_url,
                 payload={
                     "model": str(model) or _OPENAI_COMPATIBLE_RERANK_MODEL,
                     "query": str(query),
@@ -2073,6 +2082,7 @@ def resolve_provider(
             api_key_env=getattr(config, "embedding_api_key_env", "LCM_EMBEDDING_API_KEY"),
             timeout=timeout,
             spend_guard=spend_guard,
+            rerank_base_url=getattr(config, "rerank_base_url", ""),
         )
     raise ProviderUnavailable(
         f"Unsupported embedding provider {provider!r}; use voyage, ollama, "

--- a/embedding_provider.py
+++ b/embedding_provider.py
@@ -1521,6 +1521,240 @@ def _load_fastembed():
     return TextEmbedding
 
 
+class OpenAICompatibleProvider(_ResilientProvider):
+    """OpenAI-compatible ``/v1/embeddings`` provider (SiliconFlow, etc.).
+
+    Local patch (Vocllum): hermes-lcm ships only voyage/ollama/fastembed.
+    This provider reuses any OpenAI-format embeddings endpoint — e.g.
+    SiliconFlow's ``BAAI/bge-m3`` — so the operator can share the same
+    embedding service already used by OpenViking instead of running a
+    second local model server.
+
+    Env contract (via LCMConfig):
+      LCM_EMBEDDING_PROVIDER=openai-compatible
+      LCM_EMBEDDING_MODEL=BAAI/bge-m3
+      LCM_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+      LCM_EMBEDDING_API_KEY=...   (falls back to SILICONFLOW_API_KEY)
+    """
+
+    provider_id = "openai-compatible"
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        base_url: str = "",
+        api_key_env: str = "LCM_EMBEDDING_API_KEY",
+        transport: HttpTransport | None = None,
+        timeout: float = 3.0,
+        sleeper: Callable[[float], None] = time.sleep,
+        breaker: EmbeddingCircuitBreaker | None = None,
+        spend_guard: EmbeddingSpendGuard | None = None,
+    ) -> None:
+        super().__init__(breaker=breaker, spend_guard=spend_guard)
+        self._model_id = str(model).strip()
+        if not self._model_id:
+            raise ValueError("OpenAI-compatible embedding model must not be empty")
+        self.base_url = str(base_url).strip().rstrip("/")
+        if not self.base_url:
+            raise ValueError(
+                "LCM_EMBEDDING_BASE_URL must be set for openai-compatible provider"
+            )
+        self.api_key_env = str(api_key_env).strip() or "LCM_EMBEDDING_API_KEY"
+        self._transport = transport or _default_http_transport
+        self.timeout = float(timeout)
+        self._sleep = sleeper
+        self._dim = 0
+
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def _request(
+        self,
+        texts: Sequence[str],
+        *,
+        timeout: float | None = None,
+        max_attempts: int = _MAX_ATTEMPTS,
+        deadline_budget_s: float | None = None,
+        before_transport: Callable[[], None] | None = None,
+    ) -> list[list[float]]:
+        api_key = os.environ.get(self.api_key_env, "").strip()
+        if not api_key:
+            # Convenience fallback: SiliconFlow key name used by OpenViking.
+            api_key = os.environ.get("SILICONFLOW_API_KEY", "").strip()
+        if not api_key:
+            raise EmbeddingProviderError(
+                f"{self.api_key_env} (or SILICONFLOW_API_KEY) is not set"
+            )
+        request_timeout = self.timeout if timeout is None else max(0.001, float(timeout))
+        attempts = max(1, int(max_attempts))
+        deadline = (
+            time.monotonic() + max(0.0, float(deadline_budget_s))
+            if deadline_budget_s is not None
+            else None
+        )
+        for attempt in range(attempts):
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise EmbeddingProviderError(
+                        "OpenAI-compatible operation deadline exceeded"
+                    )
+            if before_transport is not None:
+                before_transport()
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ProviderPreDispatchError(
+                        "OpenAI-compatible operation deadline exceeded before transport"
+                    )
+                attempt_timeout = min(request_timeout, remaining)
+            else:
+                attempt_timeout = request_timeout
+            try:
+                response = self._transport(
+                    url=f"{self.base_url}/embeddings",
+                    payload={
+                        "model": self.model_id,
+                        "input": list(texts),
+                    },
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=attempt_timeout,
+                )
+            except (OSError, TimeoutError, urllib.error.URLError) as exc:
+                # Transport start makes an automatic identical resend unsafe.
+                raise EmbeddingProviderError(
+                    f"OpenAI-compatible network error: {exc}"
+                ) from exc
+            if not 200 <= response.status < 300:
+                raise EmbeddingProviderError(
+                    f"OpenAI-compatible embedding request failed ({response.status})"
+                )
+            remaining = (
+                None if deadline is None else deadline - time.monotonic()
+            )
+            if remaining is not None and remaining <= 0:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible operation deadline exceeded before response processing"
+                )
+
+            def parse_success() -> list[list[float]]:
+                payload = _response_json(response, provider="OpenAI-compatible")
+                raw = payload.get("data")
+                if isinstance(raw, list):
+                    ordered = sorted(
+                        raw, key=lambda row: int(row.get("index", 0))
+                        if isinstance(row, dict)
+                        else 0
+                    )
+                    rows = [
+                        row.get("embedding")
+                        for row in ordered
+                        if isinstance(row, dict)
+                    ]
+                else:
+                    rows = None
+                parsed = _coerce_vectors(rows, provider="OpenAI-compatible")
+                if len(parsed) != len(texts):
+                    raise EmbeddingProviderError(
+                        "OpenAI-compatible returned a different number of embeddings than requested"
+                    )
+                return parsed
+
+            vectors = (
+                parse_success()
+                if remaining is None
+                else _run_blocking_with_deadline(
+                    parse_success,
+                    timeout=remaining,
+                    provider="OpenAI-compatible response processing",
+                )
+            )
+            if deadline is not None and time.monotonic() >= deadline:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible operation deadline exceeded during response processing"
+                )
+            return vectors
+        raise EmbeddingProviderError("OpenAI-compatible embedding request failed")
+
+    def _embed(
+        self,
+        texts: Sequence[str],
+        *,
+        timeout: float | None = None,
+        max_attempts: int = _MAX_ATTEMPTS,
+        deadline_budget_s: float | None = None,
+        before_transport: Callable[[], None] | None = None,
+    ) -> list[list[float]]:
+        if not texts:
+            return []
+        vectors = self._guarded(
+            lambda: self._request(
+                tuple(str(text) for text in texts),
+                timeout=timeout,
+                max_attempts=max_attempts,
+                deadline_budget_s=deadline_budget_s,
+                before_transport=before_transport,
+            )
+        )
+        for vector in vectors:
+            if not vector:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible returned an empty embedding"
+                )
+            if self._dim and len(vector) != self._dim:
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible embedding dimension changed within the process"
+                )
+            self._dim = len(vector)
+        return vectors
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        return self._embed(texts, deadline_budget_s=self.timeout)
+
+    def embed_document_batches(
+        self,
+        texts: Sequence[str],
+        *,
+        before_dispatch: BeforeDispatch | None = None,
+    ) -> Iterator[EmbeddedDocumentBatch]:
+        normalized = tuple(str(text) for text in texts)
+        if not normalized:
+            return
+        indexes = tuple(range(len(normalized)))
+        vectors = self._embed(
+            normalized,
+            max_attempts=1 if before_dispatch is not None else _MAX_ATTEMPTS,
+            deadline_budget_s=self.timeout,
+            before_transport=(
+                (lambda: before_dispatch(indexes))
+                if before_dispatch is not None
+                else None
+            ),
+        )
+        yield EmbeddedDocumentBatch(
+            indexes,
+            tuple(tuple(vector) for vector in vectors),
+        )
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed((text,), deadline_budget_s=self.timeout)[0]
+
+    def embed_query_interactive(self, text: str, *, timeout: float) -> list[float]:
+        """Embed a latency-sensitive query under one absolute time budget."""
+        return self._embed(
+            (text,), timeout=timeout, deadline_budget_s=timeout
+        )[0]
+
+
 class FastembedProvider(_ResilientProvider):
     provider_id = "fastembed"
 
@@ -1748,8 +1982,17 @@ def resolve_provider(
         return FastembedProvider(
             model, timeout=timeout, spend_guard=spend_guard
         )
+    if provider in {"openai-compatible", "openai", "siliconflow"}:
+        return OpenAICompatibleProvider(
+            model,
+            base_url=getattr(config, "embedding_base_url", ""),
+            api_key_env=getattr(config, "embedding_api_key_env", "LCM_EMBEDDING_API_KEY"),
+            timeout=timeout,
+            spend_guard=spend_guard,
+        )
     raise ProviderUnavailable(
-        f"Unsupported embedding provider {provider!r}; use voyage, ollama, or fastembed"
+        f"Unsupported embedding provider {provider!r}; use voyage, ollama, "
+        "fastembed, or openai-compatible (SiliconFlow)"
     )
 
 

--- a/embedding_provider.py
+++ b/embedding_provider.py
@@ -36,6 +36,7 @@ _VOYAGE_RERANK_URL = "https://api.voyageai.com/v1/rerank"
 # lcm_recall's cross-encoder rerank model. A lite model keeps the single extra
 # API call cheap and inside the latency-sensitive recall deadline.
 _VOYAGE_RERANK_MODEL = "rerank-2.5-lite"
+_OPENAI_COMPATIBLE_RERANK_MODEL = "BAAI/bge-reranker-v2-m3"
 _VOYAGE_MAX_BATCH_TOKENS = 80_000
 _VOYAGE_MAX_DOCUMENT_TOKENS = 27_000
 # Voyage caps a single request at 1000 input items regardless of token count;
@@ -1513,7 +1514,6 @@ class OllamaProvider(_ResilientProvider):
             (text,), timeout=timeout, deadline_budget_s=timeout
         )[0]
 
-
 def _load_fastembed():
     """Import the optional dependency in one patchable location."""
     from fastembed import TextEmbedding
@@ -1753,6 +1753,90 @@ class OpenAICompatibleProvider(_ResilientProvider):
         return self._embed(
             (text,), timeout=timeout, deadline_budget_s=timeout
         )[0]
+
+    def rerank(
+        self,
+        query: str,
+        documents: Sequence[str],
+        *,
+        top_k: int | None = None,
+        timeout: float,
+        model: str = "",
+    ) -> list[tuple[int, float]]:
+        """Rerank documents through a Cohere-compatible ``/rerank`` endpoint."""
+        docs = [str(document) for document in documents]
+        if not docs:
+            return []
+        if top_k is not None and (
+            isinstance(top_k, bool) or not isinstance(top_k, int)
+        ):
+            raise ValueError("top_k must be an integer or None")
+        if top_k is not None and top_k <= 0:
+            return []
+
+        budget = max(0.001, float(timeout))
+        deadline = time.monotonic() + budget
+        api_key = os.environ.get(self.api_key_env, "").strip()
+        if not api_key:
+            api_key = os.environ.get("SILICONFLOW_API_KEY", "").strip()
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        try:
+            response = self._transport(
+                url=f"{self.base_url}/rerank",
+                payload={
+                    "model": str(model) or _OPENAI_COMPATIBLE_RERANK_MODEL,
+                    "query": str(query),
+                    "documents": docs,
+                    "top_n": len(docs) if top_k is None else min(top_k, len(docs)),
+                },
+                headers=headers,
+                timeout=budget,
+            )
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise EmbeddingProviderError(
+                f"OpenAI-compatible rerank network error: {exc}"
+            ) from exc
+        if not 200 <= response.status < 300:
+            raise EmbeddingProviderError(
+                f"OpenAI-compatible rerank request failed ({response.status})"
+            )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise EmbeddingProviderError("OpenAI-compatible rerank deadline exceeded")
+
+        def parse() -> list[tuple[int, float]]:
+            payload = _response_json(response, provider="OpenAI-compatible rerank")
+            rows = payload.get("results")
+            if not isinstance(rows, list):
+                raise EmbeddingProviderError(
+                    "OpenAI-compatible rerank response did not contain result data"
+                )
+            ranked: list[tuple[int, float]] = []
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                try:
+                    raw_index = row["index"]
+                    raw_score = row["relevance_score"]
+                    if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float)):
+                        continue
+                    index = int(raw_index)
+                    score = float(raw_score)
+                except (KeyError, TypeError, ValueError):
+                    continue
+                if not 0 <= index < len(docs):
+                    continue
+                ranked.append((index, score))
+            ranked.sort(key=lambda item: (-item[1], item[0]))
+            return ranked
+
+        return _run_blocking_with_deadline(
+            parse,
+            timeout=remaining,
+            provider="OpenAI-compatible rerank response processing",
+        )
 
 
 class FastembedProvider(_ResilientProvider):

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -18,6 +18,7 @@ from hermes_lcm.embedding_provider import (
     EmbeddingSpendGuard,
     FastembedProvider,
     HttpResponse,
+    OpenAICompatibleProvider,
     OllamaProvider,
     ProviderCircuitOpen,
     ProviderNotWarmedUp,
@@ -1323,3 +1324,135 @@ def test_voyage_rerank_empty_documents_short_circuits(monkeypatch):
 
     assert provider.rerank("q", [], timeout=5.0) == []
     assert transport.calls == []
+
+
+def _openai_compatible_success(count: int, dim: int = 3) -> HttpResponse:
+    return _response(
+        200,
+        {
+            "data": [
+                {"index": index, "embedding": [float(index + 1)] * dim}
+                for index in range(count)
+            ]
+        },
+    )
+
+
+def test_openai_compatible_request_shape_and_success(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(_openai_compatible_success(2))
+    provider = OpenAICompatibleProvider(
+        "BAAI/bge-m3",
+        base_url="https://api.example.com/v1/",
+        transport=transport,
+    )
+
+    vectors = provider.embed_documents(["first", "second"])
+
+    assert len(vectors) == 2
+    assert provider.dim == 3
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    # Trailing slash on the base URL is stripped before joining.
+    assert call["url"] == "https://api.example.com/v1/embeddings"
+    assert call["payload"] == {
+        "model": "BAAI/bge-m3",
+        "input": ["first", "second"],
+    }
+    assert call["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_openai_compatible_query_and_interactive(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_success(1, dim=4),
+        _openai_compatible_success(1, dim=4),
+    )
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="http://localhost:8080/v1", transport=transport
+    )
+
+    assert provider.embed_query("question") == [1.0, 1.0, 1.0, 1.0]
+    assert provider.embed_query_interactive("q", timeout=5.0) == [1.0, 1.0, 1.0, 1.0]
+
+    assert [call["url"] for call in transport.calls] == [
+        "http://localhost:8080/v1/embeddings",
+        "http://localhost:8080/v1/embeddings",
+    ]
+
+
+def test_openai_compatible_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("LCM_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("SILICONFLOW_API_KEY", raising=False)
+    transport = FakeTransport(_openai_compatible_success(1))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="LCM_EMBEDDING_API_KEY"):
+        provider.embed_query("q")
+
+    assert transport.calls == []
+
+
+def test_openai_compatible_siliconflow_key_fallback(monkeypatch):
+    monkeypatch.delenv("LCM_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.setenv("SILICONFLOW_API_KEY", "fallback-key")
+    transport = FakeTransport(_openai_compatible_success(1))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    provider.embed_query("q")
+
+    assert transport.calls[0]["headers"]["Authorization"] == "Bearer fallback-key"
+
+
+def test_openai_compatible_empty_base_url_raises():
+    with pytest.raises(ValueError, match="LCM_EMBEDDING_BASE_URL"):
+        OpenAICompatibleProvider("bge-m3", base_url="   ")
+
+
+def test_openai_compatible_empty_model_raises():
+    with pytest.raises(ValueError, match="must not be empty"):
+        OpenAICompatibleProvider("  ", base_url="https://api.example.com/v1")
+
+
+def test_openai_compatible_network_error_is_not_retried(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(OSError("boom"))
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="network error"):
+        provider.embed_documents(["doc"])
+
+    # The transport start makes an automatic identical resend unsafe.
+    assert len(transport.calls) == 1
+
+
+def test_openai_compatible_response_count_mismatch_raises(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(_openai_compatible_success(1))  # 1 vector for 2 texts
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=transport
+    )
+
+    with pytest.raises(EmbeddingProviderError, match="different number of embeddings"):
+        provider.embed_documents(["a", "b"])
+
+
+def test_resolve_provider_openai_compatible(monkeypatch):
+    config = LCMConfig(
+        embedding_provider="openai-compatible",
+        embedding_model="BAAI/bge-m3",
+        embedding_base_url="https://api.example.com/v1",
+    )
+    provider = resolve_provider(config)
+    assert isinstance(provider, OpenAICompatibleProvider)
+    assert provider.model_id == "BAAI/bge-m3"
+    assert provider.base_url == "https://api.example.com/v1"
+
+    config.embedding_provider = "siliconflow"
+    assert isinstance(resolve_provider(config), OpenAICompatibleProvider)

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -1368,6 +1368,45 @@ def test_openai_compatible_rerank_request_shape_and_success(monkeypatch):
     assert call["headers"]["Authorization"] == "Bearer test-key"
 
 
+def test_openai_compatible_rerank_url_defaults_to_embedding_base_url():
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1/"
+    )
+
+    assert provider.rerank_base_url == ""
+    assert provider.rerank_url == "https://api.example.com/v1/rerank"
+
+
+def test_openai_compatible_rerank_dedicated_base_url(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_rerank_response([{"index": 0, "relevance_score": 0.9}])
+    )
+    provider = OpenAICompatibleProvider(
+        "BAAI/bge-m3",
+        base_url="https://embed.example.com/v1",
+        rerank_base_url="https://rerank.example.com/v1/",
+        transport=transport,
+    )
+
+    assert provider.rerank_url == "https://rerank.example.com/v1/rerank"
+    assert provider.rerank("q", ["only"], timeout=5.0) == [(0, 0.9)]
+    assert transport.calls[0]["url"] == "https://rerank.example.com/v1/rerank"
+
+
+def test_rerank_base_url_env_and_resolve_pass_through(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("LCM_EMBEDDING_MODEL", "BAAI/bge-m3")
+    monkeypatch.setenv("LCM_EMBEDDING_BASE_URL", "https://embed.example.com/v1")
+    monkeypatch.setenv("LCM_RERANK_BASE_URL", "https://rerank.example.com")
+    config = LCMConfig.from_env()
+
+    assert config.rerank_base_url == "https://rerank.example.com"
+    provider = resolve_provider(config)
+    assert provider.base_url == "https://embed.example.com/v1"
+    assert provider.rerank_url == "https://rerank.example.com/rerank"
+
+
 def test_openai_compatible_rerank_top_k_maps_to_top_n(monkeypatch):
     monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
     transport = FakeTransport(

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -1338,6 +1338,117 @@ def _openai_compatible_success(count: int, dim: int = 3) -> HttpResponse:
     )
 
 
+def _openai_compatible_rerank_response(rows) -> HttpResponse:
+    return _response(200, {"results": rows})
+
+
+def test_openai_compatible_rerank_request_shape_and_success(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_rerank_response(
+            [
+                {"index": 0, "relevance_score": 0.1},
+                {"index": 1, "relevance_score": 0.9},
+            ]
+        )
+    )
+    provider = OpenAICompatibleProvider(
+        "BAAI/bge-m3", base_url="https://api.example.com/v1/", transport=transport
+    )
+
+    assert provider.rerank("q", ["first", "second"], timeout=5.0) == [(1, 0.9), (0, 0.1)]
+    call = transport.calls[0]
+    assert call["url"] == "https://api.example.com/v1/rerank"
+    assert call["payload"] == {
+        "model": "BAAI/bge-reranker-v2-m3",
+        "query": "q",
+        "documents": ["first", "second"],
+        "top_n": 2,
+    }
+    assert call["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_openai_compatible_rerank_top_k_maps_to_top_n(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_rerank_response(
+            [{"index": 1, "relevance_score": 0.5}, {"index": 0, "relevance_score": 0.9}]
+        )
+    )
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    assert provider.rerank("q", ["a", "b", "c", "d", "e"], top_k=2, timeout=5.0) == [(0, 0.9), (1, 0.5)]
+    assert transport.calls[0]["payload"]["top_n"] == 2
+
+
+def test_openai_compatible_rerank_drops_out_of_range_index(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_rerank_response(
+            [{"index": 0, "relevance_score": 0.8}, {"index": 5, "relevance_score": 0.99}]
+        )
+    )
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    assert provider.rerank("q", ["a", "b"], timeout=5.0) == [(0, 0.8)]
+
+
+def test_openai_compatible_rerank_non_2xx_raises(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    provider = OpenAICompatibleProvider(
+        "bge-m3", base_url="https://api.example.com/v1", transport=FakeTransport(_response(500, {}))
+    )
+
+    with pytest.raises(EmbeddingProviderError, match=r"rerank request failed \(500\)"):
+        provider.rerank("q", ["a"], timeout=5.0)
+
+
+def test_openai_compatible_rerank_empty_documents_short_circuits():
+    transport = FakeTransport()
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    assert provider.rerank("q", [], timeout=5.0) == []
+    assert transport.calls == []
+
+
+def test_openai_compatible_rerank_no_api_key_sends_no_auth_header(monkeypatch):
+    monkeypatch.delenv("LCM_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("SILICONFLOW_API_KEY", raising=False)
+    transport = FakeTransport(_openai_compatible_rerank_response([]))
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    assert provider.rerank("q", ["a"], timeout=5.0) == []
+    assert "Authorization" not in transport.calls[0]["headers"]
+
+
+def test_openai_compatible_rerank_network_error_not_retried(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(OSError("boom"))
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    with pytest.raises(EmbeddingProviderError, match="rerank network error"):
+        provider.rerank("q", ["a"], timeout=5.0)
+    assert len(transport.calls) == 1
+
+
+def test_openai_compatible_rerank_skips_malformed_rows(monkeypatch):
+    monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
+    transport = FakeTransport(
+        _openai_compatible_rerank_response(
+            [
+                "not-a-row",
+                {"index": 0, "relevance_score": None},
+                {"relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.5},
+                {"index": 1, "relevance_score": 0.7},
+            ]
+        )
+    )
+    provider = OpenAICompatibleProvider("bge-m3", base_url="https://api.example.com/v1", transport=transport)
+
+    assert provider.rerank("q", ["a", "b"], timeout=5.0) == [(1, 0.7), (1, 0.5)]
+
+
 def test_openai_compatible_request_shape_and_success(monkeypatch):
     monkeypatch.setenv("LCM_EMBEDDING_API_KEY", "test-key")
     transport = FakeTransport(_openai_compatible_success(2))

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -387,13 +387,13 @@ def test_rerank_disabled_by_default(recall_engine, monkeypatch):
     assert payload["provenance"]["rerank"] == "disabled"
 
 
-def test_rerank_skips_silently_on_non_voyage_provider(recall_engine, monkeypatch):
+def test_rerank_gate_is_capability_based(recall_engine, monkeypatch):
     recall_engine._config.rerank_enabled = True
     node = _add_summary(recall_engine, "kanban rerank skip", session_id="session-a", created_at=5.0)
     _seed_summary_vectors(recall_engine, [(node, [1.0, 0.0])])
 
     payload = _recall(recall_engine, monkeypatch, include="summaries", limit=5)
-    assert payload["provenance"]["rerank"].startswith("skipped")
+    assert payload["provenance"]["rerank"] == "skipped: provider does not support rerank"
     assert payload["hits"]  # order preserved from RRF, not dropped
 
 
@@ -420,6 +420,89 @@ def test_rerank_applies_and_reorders_with_voyage_provider(recall_engine, monkeyp
     )
     assert payload["provenance"]["rerank"] == "applied"
     assert payload["hits"][0]["node_id"] == b
+
+
+def test_rerank_applies_with_openai_compatible_provider(recall_engine, monkeypatch):
+    recall_engine._config.rerank_enabled = True
+    recall_engine._config.rerank_model = "custom-reranker"
+    a = _add_summary(recall_engine, "kanban alpha", session_id="session-a", created_at=5.0)
+    b = _add_summary(recall_engine, "kanban beta", session_id="session-b", created_at=5.0)
+    _seed_summary_vectors(
+        recall_engine, [(a, [1.0, 0.0]), (b, [0.95, 0.312])], provider="openai-compatible"
+    )
+
+    class RerankProvider(MockProvider):
+        provider_id = "openai-compatible"
+
+        def __init__(self):
+            super().__init__()
+            self.rerank_models = []
+
+        def rerank(self, query, documents, *, top_k=None, timeout, model=""):
+            self.rerank_models.append(model)
+            return [(1, 0.9), (0, 0.1)]
+
+    provider = RerankProvider()
+    payload = _recall(
+        recall_engine, monkeypatch, provider=provider, include="summaries", scope_bias=0.0, limit=5
+    )
+    assert payload["provenance"]["rerank"] == "applied"
+    assert payload["hits"][0]["node_id"] == b
+    assert all(hit["score"] < 0.1 for hit in payload["hits"])
+    assert provider.rerank_models == ["custom-reranker"]
+
+
+def test_rerank_passes_through_empty_snippets():
+    class RerankProvider:
+        calls = []
+
+        def rerank(self, query, documents, **kwargs):
+            self.calls.append((documents, kwargs))
+            return [(2, 0.9), (1, 0.8), (0, 0.7)]
+
+    provider = RerankProvider()
+    head = [
+        {"hit": {"snippet": "A"}},
+        {"hit": {"snippet": ""}},
+        {"hit": {"snippet": "B"}},
+        {"hit": {"snippet": "C"}},
+    ]
+    ordered, status = lcm_tools._lcm_recall_rerank(
+        provider,
+        "q",
+        head,
+        window=4,
+        deadline=time.monotonic() + 5.0,
+        config=SimpleNamespace(rerank_enabled=True, rerank_model=""),
+    )
+
+    assert [entry["hit"]["snippet"] for entry in ordered] == ["C", "", "B", "A"]
+    assert provider.calls[0][0] == ["A", "B", "C"]
+    assert "model" not in provider.calls[0][1]
+    assert status == "applied (n=3/4)"
+
+
+def test_rerank_all_empty_snippets_skips_call():
+    class RerankProvider:
+        calls = 0
+
+        def rerank(self, *args, **kwargs):
+            self.calls += 1
+            return []
+
+    provider = RerankProvider()
+    ordered, status = lcm_tools._lcm_recall_rerank(
+        provider,
+        "q",
+        [{"hit": {"snippet": ""}}, {"hit": {"snippet": "  "}}],
+        window=2,
+        deadline=time.monotonic() + 5.0,
+        config=SimpleNamespace(rerank_enabled=True, rerank_model=""),
+    )
+
+    assert status == "skipped: no non-empty snippets to rerank"
+    assert provider.calls == 0
+    assert [entry["hit"]["snippet"] for entry in ordered] == ["", "  "]
 
 
 def test_rerank_failure_falls_back_to_rrf_order(recall_engine, monkeypatch):

--- a/tools.py
+++ b/tools.py
@@ -4531,28 +4531,37 @@ def _lcm_recall_rerank(
 
     ``ordered`` MUST already carry the scope/recency prior so the window reflects
     the true top-N rather than the raw RRF order (RERANK-1). Any failure (no
-    provider, non-voyage, network, deadline) skips silently back to the incoming
+    provider, unavailable capability, network, deadline) skips silently back to the incoming
     order with a ``skipped: <reason>`` status.
     """
     if not bool(getattr(config, "rerank_enabled", False)):
         return ordered, "disabled"
-    if (
-        provider is None
-        or getattr(provider, "provider_id", "") != "voyage"
-        or not hasattr(provider, "rerank")
-    ):
-        return ordered, "skipped: rerank requires the voyage provider"
+    if provider is None or not hasattr(provider, "rerank"):
+        return ordered, "skipped: provider does not support rerank"
     head = ordered[:window]
     if not head:
         return ordered, "skipped: no candidates to rerank"
-    documents = [str(entry["hit"].get("snippet") or "") for entry in head]
+    eligible = [
+        (head_pos, snippet)
+        for head_pos, entry in enumerate(head)
+        if (snippet := str(entry["hit"].get("snippet") or "")).strip()
+    ]
+    if not eligible:
+        return ordered, "skipped: no non-empty snippets to rerank"
+    documents = [snippet for _head_pos, snippet in eligible]
+    rerank_kwargs: dict[str, Any] = {
+        "top_k": len(documents),
+        "timeout": max(0.001, deadline - time.monotonic()),
+    }
+    rerank_model = getattr(config, "rerank_model", "")
+    if rerank_model:
+        rerank_kwargs["model"] = rerank_model
     try:
         ranked = _run_within_deadline(
             lambda: provider.rerank(
                 query,
                 documents,
-                top_k=len(documents),
-                timeout=max(0.001, deadline - time.monotonic()),
+                **rerank_kwargs,
             ),
             remaining_s=deadline - time.monotonic(),
             name="lcm-recall-rerank",
@@ -4561,17 +4570,23 @@ def _lcm_recall_rerank(
         return ordered, f"skipped: {exc}"
     if not ranked:
         return ordered, "skipped: empty rerank result"
-    reordered: list[dict[str, Any]] = []
+    ranked_head_positions: list[int] = []
     seen: set[int] = set()
     for index, _relevance in ranked:
-        if 0 <= index < len(head) and index not in seen:
-            reordered.append(head[index])
+        if 0 <= index < len(eligible) and index not in seen:
+            ranked_head_positions.append(eligible[index][0])
             seen.add(index)
-    for index, entry in enumerate(head):
-        if index not in seen:
-            reordered.append(entry)
+    for eligible_index, (head_pos, _document) in enumerate(eligible):
+        if eligible_index not in seen:
+            ranked_head_positions.append(head_pos)
+    reordered = list(head)
+    for (destination_pos, _document), source_pos in zip(eligible, ranked_head_positions):
+        reordered[destination_pos] = head[source_pos]
     reordered.extend(ordered[window:])
-    return reordered, "applied"
+    status = "applied"
+    if len(eligible) != len(head):
+        status = f"applied (n={len(eligible)}/{len(head)})"
+    return reordered, status
 
 
 def lcm_recall(args: Dict[str, Any], **kwargs) -> str:


### PR DESCRIPTION
Originally stacked on #519 (`OpenAICompatibleProvider`). #519 was closed
without merging, so this PR now carries both pieces directly: the
`OpenAICompatibleProvider` base provider from #519 (commit `a2fe642`,
embeddings via `/v1/embeddings`) plus the rerank support described
below. Reviewing this PR means reviewing both in one pass — there is no
separate base PR to land first.

## What this adds

- **`OpenAICompatibleProvider.rerank()`** — Cohere-compatible `/rerank`
  wire contract (sends `top_n` on the wire, **not** Voyage's `top_k`),
  local-first auth (no `Authorization` header when no key is configured,
  for self-hosted endpoints), malformed-row skip policy (null/non-numeric
  `relevance_score` or bad `index` → row skipped, never silent 0.0),
  deadline discipline mirroring `VoyageProvider.rerank`.
- **Capability-based rerank gate in `lcm_recall`** (`tools.py`): replaces
  the voyage-only `provider_id == "voyage"` check with
  `hasattr(provider, "rerank")`. Exit criterion: no "voyage provider"
  string remains in tools.py.
- **Empty-snippet handling:** chunk hits can carry empty snippets; those
  rows are excluded from the cross-encoder call via an eligible-index map
  and re-inserted at their original positions (slot-preserving merge).
  All-empty windows skip the provider call entirely. Partial coverage is
  reported as `applied (n=X/Y)`.
- **`LCM_RERANK_MODEL`** (optional, default empty → provider default).
- **`LCM_RERANK_BASE_URL`** (optional, default empty → rerank goes to the
  embedding endpoint). For split deployments where embeddings and the
  reranker live on different endpoints (e.g. vLLM embedding server on one
  port, dedicated vLLM reranker container on another).
- **Docs:** "Reranking via the same openai-compatible endpoint" under the
  embeddings-setup options (self-hosted e.g. michaelfeil/infinity serving
  `BAAI/bge-m3` + `BAAI/bge-reranker-v2-m3` from one container).
- Corrected the `proactive_recall_min_score` comment: rerank only
  permutes the selected window — it never splices cross-encoder scores
  onto the RRF scale.

## Deliberate non-changes

- `openai-compatible` is NOT added to `_LOCAL_EMBEDDING_PROVIDERS` —
  the provider string can't distinguish a LAN endpoint from a cloud one,
  so the raw-text confirmation gate stays conservative.
- `VoyageProvider` rerank constants/URL/parser untouched.
- `benchmarking/longmemeval.py`'s separate rerank path untouched.
- Identity hashing, backfill, chunker untouched.

## Verification

- Full suite (CI replica): **2817 passed, 1 skipped, 12 xfailed**
  (ruff 0.15.13 + pytest under `ulimit -n 1024`; one pre-existing
  Voyage deadline test flaked under full-suite load and passed twice
  individually — untouched by this change).
- 15 new tests in `tests/test_embedding_provider.py` +
  `tests/test_lcm_recall.py`, incl. `test_rerank_passes_through_empty_snippets`
  asserting the exact worked-example reorder `["C", "", "B", "A"]` and
  `applied (n=3/4)`. Voyage rerank suite untouched and green (20/20
  rerank-related tests pass individually).
- Live smoke against self-hosted endpoints: embeddings via
  `/v1/embeddings` matched the existing ollama-dialect path with
  **cosine 1.000000** (same backend model server), and rerank fails loud
  (`404`) against an endpoint without a Cohere route — no silent 0.0
  fallback. Successful end-to-end rerank verified against a local
  [michaelfeil/infinity](https://github.com/michaelfeil/infinity) instance
  serving `BAAI/bge-reranker-v2-m3` (~50 ms per pair, ~110 ms for a
  12-document window).

Closes nothing by itself; enables `LCM_RERANK_ENABLED=true` for any
OpenAI-compatible endpoint that also serves Cohere-format `/rerank`.
