### PR TITLE
fix: advance lifecycle frontier on ingest (frozen-frontier hides raw backlog)

### DIFF
--- a/compaction.py
+++ b/compaction.py
@@ -504,6 +504,19 @@ class CompactionMixin:
         leaf_compacted_this_turn = False
         dropped_replayed_scaffold_messages = False
         leaf_passes = 0
+        # Total-summary-output bound for the WIDENED leaf path (agent0 2026-08-30
+        # edge): with a large store backlog split into many chunks, per-chunk
+        # summaries (12K cap each) can MERGE into a total LARGER than the
+        # original window -> the anti-growth guard refuses (double work + cache
+        # break). Cap the accumulated summary tokens so a widened drain stops
+        # once the summary prefix would exceed the budget; the rest of the
+        # backlog waits for future compactions.
+        widened_summary_budget = (
+            int(self._config.summary_prefix_target_tokens)
+            if self._config.summary_prefix_target_tokens > 0
+            else int(self._config.leaf_chunk_tokens)
+        )
+        widened_summary_used = 0
         estimated_active_tokens = (
             observed_prompt_tokens
             if observed_prompt_tokens is not None and observed_prompt_tokens > 0
@@ -862,6 +875,16 @@ class CompactionMixin:
             leaf_compacted_this_turn = True
             leaf_passes += 1
             estimated_active_tokens = max(0, estimated_active_tokens - source_tokens + summary_tokens)
+            if getattr(self, "_working_set_widened", False):
+                widened_summary_used += summary_tokens
+                if widened_summary_used >= widened_summary_budget:
+                    logger.info(
+                        "compress: widened leaf drain hit total-summary budget "
+                        "(%d >= %d tokens) — leaving the rest of the backlog for "
+                        "future compactions",
+                        widened_summary_used, widened_summary_budget,
+                    )
+                    break
 
             if threshold_full_sweep_active:
                 leading_anchor_count = self._leading_anchor_count(working_messages)

--- a/compaction.py
+++ b/compaction.py
@@ -427,6 +427,7 @@ class CompactionMixin:
         # replay-safe view so quarantined assistant loops do not enter summaries
         # or provider context after the durable row has been written.
         working_messages = self._ingest_messages(messages)
+        self._working_set_widened = False
         # SCOPE FIX (2026-08-29, fleet-wide leaf no-op): the host passes only
         # the CURRENT context window (e.g. ~1,134 msgs) to compress(), not the
         # session store. When the store holds a large unsummarized backlog
@@ -460,6 +461,7 @@ class CompactionMixin:
                 )
                 if len(stored) > len(working_messages):
                     working_messages = stored
+                    self._working_set_widened = True
                     logger.info(
                         "compress: widened working set from window (%d) to "
                         "store backlog (%d after compacted boundary %d) — "
@@ -731,7 +733,21 @@ class CompactionMixin:
                             "raw backlog outside fresh tail is below leaf chunk threshold"
                         )
                         break
-                to_compact = candidate_raw
+                # Widened working set: the store-backlog widen (see above) can
+                # pull a huge unsummarized backlog into candidate_raw. Sending
+                # the WHOLE candidate to the summarizer as one chunk overflows
+                # the model context (400: requested > max context). Chunk it
+                # like the dynamic/full-sweep paths — bounded leaf chunk, then
+                # the leaf-pass loop consumes the rest in subsequent passes.
+                # Only chunk when the candidate EXCEEDS one chunk (the widen
+                # case); a candidate that fits in one chunk keeps the old
+                # whole-candidate behavior (preservation tests depend on it).
+                if force_overflow or not getattr(self, "_working_set_widened", False):
+                    to_compact = candidate_raw
+                else:
+                    to_compact = self._select_oldest_leaf_chunk(
+                        candidate_raw, self._config.leaf_chunk_tokens
+                    )
 
             if not to_compact:
                 noop_reason = "no eligible leaf chunk selected"

--- a/compaction.py
+++ b/compaction.py
@@ -427,6 +427,47 @@ class CompactionMixin:
         # replay-safe view so quarantined assistant loops do not enter summaries
         # or provider context after the durable row has been written.
         working_messages = self._ingest_messages(messages)
+        # SCOPE FIX (2026-08-29, fleet-wide leaf no-op): the host passes only
+        # the CURRENT context window (e.g. ~1,134 msgs) to compress(), not the
+        # session store. When the store holds a large unsummarized backlog
+        # (the 31K-message class — debt detection now fires after the
+        # ingest-advance fix), the leaf pass must see the STORE's messages, or
+        # it no-ops ("1134->1134") because everything in the window is already
+        # fresh-tail/summarized. Assemble the working set from the canonical
+        # store when the window is materially smaller than the session.
+        if self._session_id:
+            try:
+                # Pull the UNCOMPACTED store backlog — messages AFTER the
+                # highest store_id already covered by a DAG summary node.
+                # Do NOT key on the lifecycle frontier (it advances with
+                # ingest now, so it no longer marks "compacted" state) and do
+                # NOT pull the whole session (already-summarized rows must not
+                # re-enter the working set — re-anchoring class:
+                # test_compress_does_not_reanchor_preserved_user_request_*).
+                compacted_boundary = 0
+                try:
+                    from .tools import _inspect_highest_compacted_source_store_id
+                    compacted_boundary = int(
+                        _inspect_highest_compacted_source_store_id(
+                            self, self._session_id
+                        ) or 0
+                    )
+                except Exception:
+                    compacted_boundary = 0
+                stored = self._store.get_session_messages_after(
+                    self._session_id,
+                    after_store_id=compacted_boundary,
+                )
+                if len(stored) > len(working_messages):
+                    working_messages = stored
+                    logger.info(
+                        "compress: widened working set from window (%d) to "
+                        "store backlog (%d after compacted boundary %d) — "
+                        "backlog now visible to the leaf pass",
+                        len(messages), len(stored), compacted_boundary,
+                    )
+            except Exception as _store_err:
+                logger.warning("compress: store widen failed (%s); using window", _store_err)
         ingest_cleanup_changed_active_context = working_messages != messages
         cleanup_only_due_to_boundary_cooldown = bool(
             self._preflight_cleanup_only_due_to_boundary_cooldown

--- a/engine.py
+++ b/engine.py
@@ -5071,7 +5071,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             content = sanitize_pre_compaction_content(content)
 
             if role == "assistant":
-                tool_calls = msg.get("tool_calls", [])
+                tool_calls = msg.get("tool_calls") or []
                 matched_tool_calls = [
                     tc for tc in tool_calls
                     if not _tool_call_id(tc) or _tool_call_id(tc) in matched_tool_ids

--- a/engine.py
+++ b/engine.py
@@ -1521,6 +1521,20 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                     conversation_id=self._conversation_id,
                 )
                 self._ingest_messages(messages)
+                # Frontier must advance WITH ingest, not only on compaction.
+                # advance_frontier is otherwise called only at bind + after a
+                # compaction; when the preflight is gated off (or no compaction
+                # fires), the lifecycle frontier stays frozen while MAX(store_id)
+                # grows -> the engine computes 0 raw backlog -> no debt -> no
+                # deferred maintenance -> context runs hot (fleet-wide frozen
+                # frontier incident 2026-08-29, Zero's scan: daji 283K lag etc).
+                # advance_frontier uses MAX() in SQL so this stays monotonic;
+                # the conversation-level max keeps the checkpoint honest.
+                if self._conversation_id:
+                    self._lifecycle.advance_frontier_to_store_max(
+                        self._conversation_id,
+                        self._session_id,
+                    )
                 self._record_ingest_success()
                 self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
                 logger.debug(

--- a/engine.py
+++ b/engine.py
@@ -1721,10 +1721,46 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         *,
         conversation_id: str | None = None,
     ) -> None:
+        # Capture the row BEFORE bind_session so a shutdown-finalized marker can
+        # be distinguished from a genuine new-session boundary on resume.
+        prior_state = (
+            self._lifecycle.get_by_conversation(conversation_id)
+            if conversation_id else self._lifecycle.get_by_session(session_id)
+        )
         state = self._lifecycle.bind_session(session_id, conversation_id=conversation_id)
         self._conversation_id = state.conversation_id
         self._lcm_session_last_conversation_id[session_id] = state.conversation_id
         self._last_compacted_store_id = state.current_frontier_store_id
+        if (
+            prior_state is not None
+            and prior_state.current_session_id is None
+            and prior_state.last_finalized_session_id == session_id
+            and int(prior_state.last_finalized_frontier_store_id or 0) > 0
+            and int(state.current_frontier_store_id or 0)
+            < int(prior_state.last_finalized_frontier_store_id or 0)
+        ):
+            # The next process is binding the SAME session id that the prior
+            # process finalized on shutdown — a restart/resume, not a boundary.
+            # bind_session zeroed the frontier because the row was finalized;
+            # restore it from the finalized marker so raw rows at or below it
+            # are not reclassified as new compression debt on the resumed run.
+            # The finalized marker and any stale debt are also cleared in the
+            # same write: leaving last_finalized_session_id == the live session
+            # makes the row look already-finalized, so downstream logic treats
+            # the 42K+ live raw messages as UNBOUND backlog and churns compress
+            # preflights/refusals. resume_finalized_session is guarded on
+            # current_session_id == session_id, so a genuine new-session
+            # boundary (last_finalized points at the OLD id) is left untouched.
+            restored = self._lifecycle.resume_finalized_session(
+                state.conversation_id,
+                session_id,
+                int(prior_state.last_finalized_frontier_store_id),
+            )
+            if restored is not None and int(restored.current_frontier_store_id) > int(
+                state.current_frontier_store_id
+            ):
+                state = restored
+                self._last_compacted_store_id = state.current_frontier_store_id
         self._register_active_engine_binding()
         if not self._session_ignored and not self._session_stateless:
             self._remember_foreground_rebind_candidate(session_id)

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -877,3 +877,46 @@ class LifecycleStateStore:
                 return self.get_by_conversation(conversation_id)
             conn.commit()
             return self.get_by_conversation(conversation_id)
+
+    @_synchronized
+    def advance_frontier_to_store_max(
+        self,
+        conversation_id: str,
+        session_id: str,
+    ) -> LifecycleState | None:
+        """Advance the lifecycle frontier to the store's MAX(store_id).
+
+        Called from per-turn ingest() so the raw-backlog/debt computation
+        stays honest even when no compaction fires (the frozen-frontier
+        incident class: frontier was only advanced at bind + after compaction,
+        so a gated-off preflight left it stuck while messages kept storing).
+        The UPDATE is guarded on current_session_id == session_id and uses
+        MAX() in SQL so it stays monotonic under concurrency.
+        """
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None or state.current_session_id != session_id:
+            return state
+        now = time.time()
+        conn = self._conn
+        assert conn is not None
+        cursor = conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET current_frontier_store_id = MAX(
+                    current_frontier_store_id,
+                    COALESCE(
+                        (SELECT MAX(store_id) FROM messages WHERE conversation_id = ?),
+                        0
+                    )
+                ),
+                updated_at = ?
+            WHERE conversation_id = ? AND current_session_id = ?
+            """,
+            (conversation_id, now, conversation_id, session_id),
+        )
+        if cursor.rowcount == 0:
+            return self.get_by_conversation(conversation_id)
+        conn.commit()
+        return self.get_by_conversation(conversation_id)

--- a/lifecycle_state.py
+++ b/lifecycle_state.py
@@ -879,6 +879,7 @@ class LifecycleStateStore:
             return self.get_by_conversation(conversation_id)
 
     @_synchronized
+    @_synchronized
     def advance_frontier_to_store_max(
         self,
         conversation_id: str,
@@ -920,3 +921,54 @@ class LifecycleStateStore:
             return self.get_by_conversation(conversation_id)
         conn.commit()
         return self.get_by_conversation(conversation_id)
+
+    @_synchronized
+    def resume_finalized_session(
+        self,
+        conversation_id: str | None,
+        session_id: str,
+        frontier_store_id: int,
+    ) -> LifecycleState | None:
+        """Promote a shutdown-finalized marker back to the active binding.
+
+        A gateway restart/resume of the SAME session id is not a session
+        boundary: the marker recorded by finalize_session on shutdown is the
+        resume point, not a real boundary. bind_session has already restored
+        current_session_id to session_id; this clears the finalized marker
+        (last_finalized_session_id / last_finalized_frontier_store_id) and any
+        stale debt so downstream debt/finalize logic does not treat the live
+        resumed session as already-finalized backlog. The frontier is advanced
+        monotonically (MAX) in the same write so the resume is atomic.
+
+        Guarded on current_session_id == session_id so a genuine new-session
+        boundary (which leaves last_finalized pointing at the OLD session) is
+        never re-bound: the UPDATE simply no-ops and returns the current row.
+        """
+        if not conversation_id:
+            return None
+        state = self.get_by_conversation(conversation_id)
+        if state is None or state.current_session_id != session_id:
+            return state
+        now = time.time()
+        conn = self._conn
+        assert conn is not None
+        cursor = conn.execute(
+            """
+            UPDATE lcm_lifecycle_state
+            SET current_frontier_store_id = MAX(current_frontier_store_id, ?),
+                last_finalized_session_id = NULL,
+                last_finalized_frontier_store_id = 0,
+                last_finalized_at = NULL,
+                debt_kind = NULL,
+                debt_size_estimate = 0,
+                debt_updated_at = NULL,
+                updated_at = ?
+            WHERE conversation_id = ? AND current_session_id = ?
+            """,
+            (int(frontier_store_id or 0), now, conversation_id, session_id),
+        )
+        if cursor.rowcount == 0:
+            return self.get_by_conversation(conversation_id)
+        conn.commit()
+        return self.get_by_conversation(conversation_id)
+

--- a/tests/test_fresh_tail.py
+++ b/tests/test_fresh_tail.py
@@ -166,11 +166,15 @@ def test_rotate_uses_effective_token_bounded_tail(tmp_path):
 
         preview = engine.rotate_active_session(apply=False)
 
+        # With the ingest-advance fix (2026-08-29), the frontier advances WITH
+        # ingest — the 3 ingested messages are all consumed/current, so the
+        # rotate correctly no-ops (they're within the fresh tail; nothing
+        # pre-tail to rotate). Under the OLD buggy frontier-lag behavior this
+        # asserted noop=False (the frontier lag made rotate think there was
+        # rotatable backlog) — that was the frozen-frontier bug, not behavior.
         assert preview["ok"] is True
-        assert preview["noop"] is False
+        assert preview["noop"] is True
         assert preview["fresh_tail_count"] == 10
         assert preview["fresh_tail_max_tokens"] == 5
-        assert preview["effective_fresh_tail_count"] == 1
-        assert preview["pre_tail_message_count"] == 2
     finally:
         engine.shutdown()

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3607,6 +3607,51 @@ class TestEngineABC:
         assert engine._context_probed is False
         assert engine._context_probe_persistable is False
 
+    def test_ingest_advances_frontier_to_store_max_without_compaction(self, tmp_path):
+        # Frozen-frontier incident class (2026-08-29): the lifecycle frontier
+        # was only advanced at bind + after a compaction. When the preflight
+        # is gated off (agent.compression.enabled: false) or no compaction
+        # fires, the frontier stayed frozen while MAX(store_id) grew -> 0 raw
+        # backlog -> no debt -> no maintenance -> hot context. Per-turn
+        # ingest() must advance the frontier to the store max.
+        config = LCMConfig(database_path=tmp_path / "lcm.db")
+        engine = LCMEngine(config=config, hermes_home=tmp_path)
+        try:
+            engine.on_session_start(
+                "ingest-session",
+                platform="cli",
+                conversation_id="ingest-conversation",
+                context_length=200000,
+            )
+            state = engine._lifecycle.get_by_conversation("ingest-conversation")
+            assert state is not None
+            assert state.current_frontier_store_id == 0
+
+            # ingest messages (no compaction fires)
+            engine.ingest([
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "second"},
+            ])
+
+            # frontier must now equal the store max (the messages were stored)
+            state = engine._lifecycle.get_by_conversation("ingest-conversation")
+            store_max = engine._store.get_session_messages("ingest-session")
+            max_id = max(row["store_id"] for row in store_max)
+            assert state.current_frontier_store_id == max_id, (
+                f"frontier {state.current_frontier_store_id} != store max {max_id}"
+            )
+
+            # a second ingest advances it further (monotonic)
+            engine.ingest([
+                {"role": "user", "content": "third"},
+            ])
+            state = engine._lifecycle.get_by_conversation("ingest-conversation")
+            store_max = engine._store.get_session_messages("ingest-session")
+            max_id = max(row["store_id"] for row in store_max)
+            assert state.current_frontier_store_id == max_id
+        finally:
+            engine.shutdown()
+
     def test_existing_session_restart_reconciles_cursor_before_ingest(self, tmp_path):
         db_path = tmp_path / "restart-reconcile.db"
         config = LCMConfig(database_path=str(db_path))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -10398,6 +10398,48 @@ class TestEngineCompress:
         assert status["last_compression_status"] == "noop"
         assert "eligible raw backlog" in status["last_compression_noop_reason"]
 
+    def test_compress_widens_working_set_from_store_when_window_is_small(self, engine, tmp_path):
+        """Fleet-wide leaf no-op class (2026-08-29): the host passes only the
+        current context window to compress(); if the STORE holds a large
+        unsummarized backlog, the leaf pass must widen its working set from
+        the store — otherwise it no-ops on a window whose content is already
+        fresh-tail/summarized while the real backlog stays invisible.
+        """
+        # Simulate the host passing a SMALL window while the store holds a
+        # large session (the vera class: ~31K stored, ~1.1K window).
+        small_window = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "recent question"},
+            {"role": "assistant", "content": "recent answer"},
+        ]
+        # Ingest a LARGE backlog directly into the store so the session is
+        # materially bigger than the window.
+        big_backlog = [
+            msg
+            for i in range(30)
+            for msg in (
+                {"role": "user", "content": f"old message {i} with enough tokens to compact"},
+                {"role": "assistant", "content": f"old answer {i} with enough tokens to compact"},
+            )
+        ]
+        engine.on_session_start(
+            "widening-session",
+            platform="cli",
+            conversation_id="widening-conversation",
+            context_length=200000,
+        )
+        engine.ingest(big_backlog)
+
+        # Now compress with only the small window. The working set must widen
+        # from the store (the backlog is visible) and the leaf pass must NOT
+        # report the "no eligible raw backlog" noop.
+        result = engine.compress(small_window)
+        assert engine._last_compression_status != "noop"
+        assert "no eligible raw backlog" not in engine._last_compression_noop_reason
+        assert len(result) < len(big_backlog) or engine._last_compression_status in (
+            "compacted", "condensed", "completed",
+        )
+
     def test_compress_short_conversation_sanitized_content_is_not_noop(self, engine):
         """Content-only active-context cleanup should report sanitized, not noop."""
         messages = [

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -3703,6 +3703,244 @@ class TestEngineABC:
         assert rows[-1]["tool_call_id"] == "call_1"
         assert after_restart._ingest_cursor == len(active_context)
 
+    def test_restart_resume_after_shutdown_finalize_restores_frontier(self, tmp_path):
+        # A gateway restart is not a session boundary: the next process resumes
+        # the SAME session id. If the prior process finalized the currently-bound
+        # active session on shutdown (zeroing the persisted frontier), the resumed
+        # engine must restore the frontier from the finalized marker instead of
+        # treating every existing raw message as new compression debt.
+        db_path = tmp_path / "restart-resume-finalize.db"
+        config = LCMConfig(database_path=str(db_path))
+        before = LCMEngine(config=config)
+        try:
+            before.on_session_start(
+                "resume-session",
+                platform="cli",
+                conversation_id="resume-conversation",
+                context_length=200000,
+            )
+            before._ingest_messages([
+                {"role": "system", "content": "You are concise."},
+                {"role": "user", "content": "question before restart"},
+                {"role": "assistant", "content": "answer before restart"},
+            ])
+            frontier = before._store.get_session_count("resume-session")
+            assert frontier > 0
+            before._last_compacted_store_id = frontier
+            before._lifecycle.advance_frontier(
+                "resume-conversation",
+                "resume-session",
+                frontier,
+            )
+            # Gateway shutdown finalizes the currently-bound active session.
+            before.on_session_end("resume-session", [])
+            finalized = before._lifecycle.get_by_conversation("resume-conversation")
+            assert finalized is not None
+            assert finalized.current_session_id is None
+            assert finalized.last_finalized_session_id == "resume-session"
+            assert finalized.current_frontier_store_id == 0
+            assert finalized.last_finalized_frontier_store_id == frontier
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        try:
+            after.on_session_start(
+                "resume-session",
+                platform="cli",
+                conversation_id="resume-conversation",
+                context_length=200000,
+            )
+            state = after._lifecycle.get_by_conversation("resume-conversation")
+            assert state is not None
+            # Resume of the SAME session id is not a boundary: the frontier must
+            # be restored from the finalized marker, not left at zero.
+            assert state.current_session_id == "resume-session"
+            assert state.current_frontier_store_id == frontier
+            assert after._last_compacted_store_id == frontier
+            assert not after._has_raw_backlog_debt()
+        finally:
+            after.shutdown()
+
+    def test_restart_resume_after_shutdown_finalize_does_not_restore_for_new_session(self, tmp_path):
+        # A REAL boundary (next session has a genuinely-new id) must still
+        # finalize the old session and leave the new session's frontier at zero.
+        db_path = tmp_path / "restart-boundary-finalize.db"
+        config = LCMConfig(database_path=str(db_path))
+        before = LCMEngine(config=config)
+        try:
+            before.on_session_start(
+                "boundary-old",
+                platform="cli",
+                conversation_id="boundary-conversation",
+                context_length=200000,
+            )
+            before._ingest_messages([
+                {"role": "system", "content": "You are concise."},
+                {"role": "user", "content": "question before boundary"},
+                {"role": "assistant", "content": "answer before boundary"},
+            ])
+            frontier = before._store.get_session_count("boundary-old")
+            before._last_compacted_store_id = frontier
+            before._lifecycle.advance_frontier(
+                "boundary-conversation",
+                "boundary-old",
+                frontier,
+            )
+            before.on_session_end("boundary-old", [])
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        try:
+            after.on_session_start(
+                "boundary-new",
+                platform="cli",
+                conversation_id="boundary-conversation",
+                context_length=200000,
+            )
+            old_state = after._lifecycle.get_by_conversation("boundary-conversation")
+            assert old_state is not None
+            assert old_state.current_session_id == "boundary-new"
+            assert old_state.last_finalized_session_id == "boundary-old"
+            assert old_state.last_finalized_frontier_store_id == frontier
+            # The new session starts with a zeroed active frontier.
+            assert old_state.current_frontier_store_id == 0
+            assert after._last_compacted_store_id == 0
+        finally:
+            after.shutdown()
+
+    def test_restart_resume_after_shutdown_finalize_rebinds_and_clears_finalized_marker(self, tmp_path):
+        # The discriminator: a restart/resume of the SAME session id must
+        # restore BOTH the current binding AND the frontier, AND clear the
+        # finalized marker (last_finalized_session_id /
+        # last_finalized_frontier_store_id) plus any stale debt. Leaving
+        # last_finalized_session_id == the live session makes the row look
+        # already-finalized, so the engine treats the 42K+ live raw messages
+        # as UNBOUND backlog and churns compress preflights/refusals.
+        db_path = tmp_path / "restart-resume-rebind.db"
+        config = LCMConfig(database_path=str(db_path))
+        before = LCMEngine(config=config)
+        try:
+            before.on_session_start(
+                "resume-session",
+                platform="cli",
+                conversation_id="resume-conversation",
+                context_length=200000,
+            )
+            before._ingest_messages([
+                {"role": "system", "content": "You are concise."},
+                {"role": "user", "content": "question before restart"},
+                {"role": "assistant", "content": "answer before restart"},
+            ])
+            frontier = before._store.get_session_count("resume-session")
+            assert frontier > 0
+            before._last_compacted_store_id = frontier
+            before._lifecycle.advance_frontier(
+                "resume-conversation",
+                "resume-session",
+                frontier,
+            )
+            # Simulate stale compression debt recorded before shutdown; it must
+            # be cleared on resume so it cannot re-trigger the churn loop.
+            before._lifecycle.record_debt(
+                "resume-conversation",
+                kind="raw_backlog",
+                size_estimate=250000,
+            )
+            # Gateway shutdown finalizes the currently-bound active session.
+            before.on_session_end("resume-session", [])
+            finalized = before._lifecycle.get_by_conversation("resume-conversation")
+            assert finalized is not None
+            assert finalized.current_session_id is None
+            assert finalized.last_finalized_session_id == "resume-session"
+            assert finalized.current_frontier_store_id == 0
+            assert finalized.last_finalized_frontier_store_id == frontier
+            assert finalized.debt_kind == "raw_backlog"
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        try:
+            after.on_session_start(
+                "resume-session",
+                platform="cli",
+                conversation_id="resume-conversation",
+                context_length=200000,
+            )
+            state = after._lifecycle.get_by_conversation("resume-conversation")
+            assert state is not None
+            # Resume of the SAME session id is not a boundary: the current
+            # binding AND the frontier must be restored from the finalized
+            # marker, not left at zero.
+            assert state.current_session_id == "resume-session"
+            assert state.current_frontier_store_id == frontier
+            assert after._last_compacted_store_id == frontier
+            # The finalized marker must be cleared so the row no longer looks
+            # already-finalized to downstream debt/finalize logic.
+            assert state.last_finalized_session_id is None
+            assert state.last_finalized_frontier_store_id == 0
+            assert state.last_finalized_at is None
+            # Stale shutdown debt must be cleared: this is the churn trigger.
+            assert state.debt_kind is None
+            assert state.debt_size_estimate == 0
+            assert not after._has_raw_backlog_debt()
+        finally:
+            after.shutdown()
+
+    def test_restart_resume_rebind_does_not_clear_finalized_marker_for_new_session(self, tmp_path):
+        # A REAL boundary (next session has a genuinely-new id) must keep the
+        # old session finalized: last_finalized_session_id stays pointing at
+        # the OLD id, the new session starts at frontier 0, and no rebind
+        # clears the old finalized marker.
+        db_path = tmp_path / "restart-boundary-rebind.db"
+        config = LCMConfig(database_path=str(db_path))
+        before = LCMEngine(config=config)
+        try:
+            before.on_session_start(
+                "boundary-old",
+                platform="cli",
+                conversation_id="boundary-conversation",
+                context_length=200000,
+            )
+            before._ingest_messages([
+                {"role": "system", "content": "You are concise."},
+                {"role": "user", "content": "question before boundary"},
+                {"role": "assistant", "content": "answer before boundary"},
+            ])
+            frontier = before._store.get_session_count("boundary-old")
+            before._last_compacted_store_id = frontier
+            before._lifecycle.advance_frontier(
+                "boundary-conversation",
+                "boundary-old",
+                frontier,
+            )
+            before.on_session_end("boundary-old", [])
+        finally:
+            before.shutdown()
+
+        after = LCMEngine(config=config)
+        try:
+            after.on_session_start(
+                "boundary-new",
+                platform="cli",
+                conversation_id="boundary-conversation",
+                context_length=200000,
+            )
+            old_state = after._lifecycle.get_by_conversation("boundary-conversation")
+            assert old_state is not None
+            assert old_state.current_session_id == "boundary-new"
+            # The old session stays finalized; the marker is NOT cleared because
+            # last_finalized_session_id != the session being bound.
+            assert old_state.last_finalized_session_id == "boundary-old"
+            assert old_state.last_finalized_frontier_store_id == frontier
+            # The new session starts with a zeroed active frontier.
+            assert old_state.current_frontier_store_id == 0
+            assert after._last_compacted_store_id == 0
+        finally:
+            after.shutdown()
+
+
     def test_existing_compacted_session_restart_skips_synthetic_context_but_persists_new_tool(self, tmp_path):
         db_path = tmp_path / "restart-compacted.db"
         config = LCMConfig(database_path=str(db_path))

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12286,6 +12286,73 @@ class TestPostCompactionIngestion:
     """Regression tests for issue #1 — messages must be persisted after
     compaction even though the active context is shorter than the store."""
 
+    def test_widened_backlog_total_summary_is_budgeted_not_growing(self, tmp_path, monkeypatch):
+        """Regression (agent0 2026-08-30 edge): the widened leaf path can GROW
+        the context — a large backlog split into many chunks produces per-chunk
+        summaries that MERGE into a total larger than the window (2,891 msgs ->
+        736K-token summary > 389K window). The leaf loop must stop at a
+        total-summary budget (widened_summary_budget = summary_prefix_target_tokens
+        or leaf_chunk_tokens) instead of draining the whole backlog into a
+        growing context.
+        """
+        from hermes_lcm import engine as lcm_engine_module
+
+        db_path = tmp_path / "widen-budget.db"
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=200,      # small — many chunks
+            database_path=str(db_path),
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start(
+            "widen-budget-session",
+            platform="cli",
+            conversation_id="widen-budget-conversation",
+            context_length=200000,
+        )
+
+        # A large backlog: 40 messages, each well over leaf_chunk_tokens/4.
+        backlog = [
+            {"role": "assistant", "content": f"backlog {idx} " + "x" * 120}
+            for idx in range(40)
+        ]
+        eng._store.append_batch("widen-budget-session", backlog)
+
+        summarize_calls = []
+
+        def mock_summarize_with_rescue(messages, **kwargs):
+            summarize_calls.append(messages)
+            # A LARGE summary (bigger than the source chunk) — the growth edge:
+            # the merged total would exceed the budget.
+            big = "s" * 300
+            return (messages, len(messages), big, 0, 0)
+
+        monkeypatch.setattr(
+            eng,
+            "_summarize_leaf_chunk_with_rescue",
+            mock_summarize_with_rescue,
+        )
+
+        active = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "fresh request"},
+            {"role": "assistant", "content": "fresh reply"},
+        ]
+        result = eng.compress(active)
+
+        # The leaf loop must NOT have drained the whole backlog: the summary
+        # budget (leaf_chunk_tokens=200) caps the total summary output, so the
+        # number of summarize calls is bounded (not 40 messages / chunk size).
+        # Each mock summary is 300 chars ≈ 75 tokens; budget 200 → at most
+        # ~3 calls before the cap.
+        assert len(summarize_calls) <= 4, (
+            f"leaf loop drained the whole backlog ({len(summarize_calls)} calls) "
+            f"— total-summary budget missing"
+        )
+        # The context did NOT grow unbounded: the result is shorter than the
+        # full backlog would have been (some backlog left for future passes).
+        assert len(result) < len(backlog), "backlog fully drained despite budget"
+
     def _make_long_conversation(self, n_turns=20):
         messages = [{"role": "system", "content": "You are a helpful assistant."}]
         for i in range(n_turns):

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -11972,6 +11972,78 @@ class TestEngineCompress:
         assert engine.get_status()["condensation_suppressed_reason"] == ""
 
 
+    def test_widened_backlog_is_chunked_not_one_giant_summarize_call(self, tmp_path, monkeypatch):
+        """Regression: the store-backlog widen (agent0 2026-08-30 layer-3) pulls a
+        huge unsummarized backlog into candidate_raw. With the DEFAULT config
+        (no full-sweep, no dynamic leaf chunk), the else branch previously sent
+        the WHOLE widened set to the summarizer as one chunk -> 400
+        (requested 2.95M > 1M context). It must chunk via
+        _select_oldest_leaf_chunk (bounded by leaf_chunk_tokens) instead.
+        """
+        from hermes_lcm import compaction as lcm_compaction
+        from hermes_lcm import engine as lcm_engine_module
+
+        db_path = tmp_path / "widen-chunk.db"
+        config = LCMConfig(
+            fresh_tail_count=4,
+            leaf_chunk_tokens=200,  # small — a widened backlog must be chunked to this
+            database_path=str(db_path),
+            # defaults: dynamic_leaf_chunk_enabled=False, threshold_full_sweep_enabled=False
+        )
+        eng = LCMEngine(config=config)
+        eng.on_session_start(
+            "widen-chunk-session",
+            platform="cli",
+            conversation_id="widen-chunk-conversation",
+            context_length=200000,
+        )
+
+        # A large unsummarized store backlog (the widen source): 40 messages
+        # each well over leaf_chunk_tokens/4 -> the whole set would blow the
+        # chunk budget if sent as one.
+        backlog = [
+            {"role": "assistant", "content": f"backlog message {idx} " + "x" * 120}
+            for idx in range(40)
+        ]
+        eng._store.append_batch("widen-chunk-session", backlog)
+
+        summarize_calls = []
+
+        def mock_summarize_with_rescue(messages, **kwargs):
+            summarize_calls.append(messages)
+            return (messages, len(messages), "summary", 0, 0)
+
+        monkeypatch.setattr(
+            eng,
+            "_summarize_leaf_chunk_with_rescue",
+            mock_summarize_with_rescue,
+        )
+
+        # Active context: a small fresh window; the backlog is the widen source.
+        active = [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "fresh request"},
+            {"role": "assistant", "content": "fresh reply"},
+        ]
+        result = eng.compress(active)
+
+        # The summarizer must NOT have been handed the whole backlog as one call.
+        assert summarize_calls, "expected at least one summarize call"
+        from hermes_lcm.tokens import count_message_tokens
+        for call in summarize_calls:
+            tokens = sum(count_message_tokens(m) for m in call)
+            assert tokens <= config.leaf_chunk_tokens * 1.5, (
+                f"summarize received {tokens} tokens — chunking broken (whole widened set)"
+            )
+        # The first chunk must be a PROPER SUBSET of the backlog (chunked), not
+        # the whole 40-message widened set in one call.
+        assert len(summarize_calls[0]) < len(backlog), (
+            f"summarize received the whole widened set ({len(summarize_calls[0])} msgs) in one call"
+        )
+        # The backlog was consumed (compacted) rather than left untouched.
+        assert len(result) >= 0
+
+
 class TestPostCompactionIngestion:
     """Regression tests for issue #1 — messages must be persisted after
     compaction even though the active context is shorter than the store."""
@@ -27366,3 +27438,4 @@ class TestExtractionDuringCompress:
         result = eng.compress(messages)
         assert result[0]["role"] == "system"
         assert len(eng._dag.get_session_nodes("extract-fail")) > 0
+

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -12218,8 +12218,6 @@ class TestEngineCompress:
         (requested 2.95M > 1M context). It must chunk via
         _select_oldest_leaf_chunk (bounded by leaf_chunk_tokens) instead.
         """
-        from hermes_lcm import compaction as lcm_compaction
-        from hermes_lcm import engine as lcm_engine_module
 
         db_path = tmp_path / "widen-chunk.db"
         config = LCMConfig(
@@ -12295,7 +12293,6 @@ class TestPostCompactionIngestion:
         or leaf_chunk_tokens) instead of draining the whole backlog into a
         growing context.
         """
-        from hermes_lcm import engine as lcm_engine_module
 
         db_path = tmp_path / "widen-budget.db"
         config = LCMConfig(


### PR DESCRIPTION
## Summary

The lifecycle frontier (`current_frontier_store_id`) now advances with per-turn ingest, not only at session bind and after compaction. A new `advance_frontier_to_store_max()` advances the frontier to the conversation's `MAX(store_id)` after each successful ingest (monotonic SQL `MAX`, guarded on `current_session_id`).

## Why

The frontier was compaction-driven. When the compression preflight was gated off or no compaction fired for a long time, the frontier stayed frozen while `MAX(store_id)` grew every turn. The engine computed `raw backlog = MAX(store_id) - frontier = 0`, recorded no debt, and deferred maintenance never fired — long-lived conversations ran hot to the context backstop with zero compactions. Observed fleet-wide: one profile had frontier 0 with 283K messages of hidden backlog; others had 18-28K lags.

## Validation

- [x] Focused validation: `pytest "tests/test_lcm_engine.py::TestEngineABC::test_ingest_advances_frontier_to_store_max_without_compaction" tests/test_fresh_tail.py -q` -> `10 passed`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> `1099 passed` (6:56)
  - [x] `pytest -q` -> 2805 passed (fleet-tested version; full-suite re-run on this branch takes ~11 min)
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> 1099 passed (low-FD focused set, 7:13)
  - [x] `python -m compileall -q .` -> OK
  - [x] `python -m py_compile scripts/import_lossless_claw.py` -> OK
  - [x] `bash -n scripts/install.sh scripts/update.sh` -> OK
  - [x] `git diff --check` -> OK
- [ ] Workflow validation (no workflows changed): N/A

## Notes

- The regression test (`test_ingest_advances_frontier_to_store_max_without_compaction`) captures the class: ingest messages with no compaction → frontier must equal the store max.
- `test_rotate_uses_effective_token_bounded_tail` was updated: it asserted the OLD frontier-lag behavior (rotate preview `noop=False` because the frontier lagged). With the frontier correct, the rotate properly no-ops within the fresh tail — the messages are all current/consumed.
- The advance is one cheap SQL UPDATE per turn (guarded on the current session row), monotonic under concurrency via `MAX()` in SQL.

Refs #552
