### PR TITLE
fix(ingest): keep the cursor truthful when a host replays a pre-compaction history

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -4259,6 +4259,34 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             copied_replay_messages.append(copied_message)
         return copied_replay_messages
 
+    def _persisted_prefix_len(self, messages: List[Dict[str, Any]]) -> Optional[int]:
+        """How much of ``messages`` still matches the last history ingest completed.
+
+        ``_last_active_replay_source_identities`` holds the replay identities of
+        the list the previous ingest processed to its end, so every row of that
+        list is accounted for: stored, or deliberately dropped by the ignore and
+        placeholder filters. The session stamp beside it keeps the proof from
+        crossing a rebind.
+
+        The returned length is the longest common prefix, which the caller reads
+        two ways. Longer than the cursor: rows the cursor calls new are already
+        accounted for, so it can advance. Shorter: the history changed inside the
+        range the cursor calls persisted, so the cursor indexes a list that no
+        longer exists and must be re-derived from the store.
+
+        Returns None when there is no usable proof (no cache, or another
+        session's).
+        """
+        cached_source_identities = getattr(self, "_last_active_replay_source_identities", None)
+        cached_session_id = str(getattr(self, "_last_active_replay_session_id", "") or "")
+        if not cached_source_identities or cached_session_id != self._session_id:
+            return None
+        prefix_len = min(len(cached_source_identities), len(messages))
+        for idx in range(prefix_len):
+            if self._message_replay_identity(messages[idx]) != cached_source_identities[idx]:
+                return idx
+        return prefix_len
+
     def _remember_active_replay_messages(
         self,
         original_messages: List[Dict[str, Any]],
@@ -4267,6 +4295,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._last_active_replay_source_identities = [
             self._message_replay_identity(message) for message in original_messages
         ]
+        # Scope the identities above to their session. _persisted_prefix_len reads
+        # them as proof that ingest accounted for those rows, and nothing clears
+        # this cache when the engine rebinds to another session.
+        self._last_active_replay_session_id = self._session_id
         self._last_active_replay_messages = self._copy_active_replay_messages_preserving_generated_ids(
             active_replay_messages
         )
@@ -4504,6 +4536,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return self._redact_active_replay_messages(messages)
 
         n = len(messages)
+        persisted_prefix_len = self._persisted_prefix_len(messages)
         cursor = min(max(self._ingest_cursor, 0), n)
         scan_start = 0 if self._ingest_cursor_needs_reconcile else cursor
         ignored_original_messages = [False] * n
@@ -4561,6 +4594,21 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             ]
             self._ingest_cursor = self._reconcile_ingest_cursor_from_store(reconcile_messages)
             self._ingest_cursor_needs_reconcile = False
+        if persisted_prefix_len is not None and persisted_prefix_len > self._ingest_cursor:
+            # The host handed back a history this session already ingested to its
+            # end, extended or not. compress() lowers the cursor to the compacted
+            # length, and a host that then passes the PRE-compaction list to
+            # on_session_end (end-of-session extraction runs at the compaction
+            # boundary) would have every row past the lowered cursor look new, so
+            # the whole history is appended a second time.
+            logger.info(
+                "LCM ingest cursor advanced past the last persisted history: session=%s cursor=%d -> %d incoming=%d",
+                self._session_id,
+                self._ingest_cursor,
+                persisted_prefix_len,
+                n,
+            )
+            self._ingest_cursor = persisted_prefix_len
         cursor = min(max(self._ingest_cursor, 0), n)
         if cursor > 0:
             cached_source_identities = getattr(self, "_last_active_replay_source_identities", None)

--- a/tests/test_ingest_cursor_after_compaction.py
+++ b/tests/test_ingest_cursor_after_compaction.py
@@ -1,0 +1,113 @@
+"""The ingest cursor must survive a host handing back a pre-compaction history.
+
+``compress()`` lowers ``_ingest_cursor`` to the length of the compacted list.
+A host that runs end-of-session extraction at the compaction boundary then
+passes the PRE-compaction history to ``on_session_end`` before the compacted
+list is ever ingested. Measured against the lowered cursor every row past it
+looks new, so the whole session is appended a second time.
+"""
+
+import pytest
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+SESSION_ID = "20260101_000000_cursor01"
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig()
+    config.fresh_tail_count = 4
+    config.leaf_chunk_tokens = 100
+    config.database_path = str(tmp_path / "lcm_cursor.db")
+    e = LCMEngine(config=config)
+    e._session_id = SESSION_ID
+    e.context_length = 200000
+    e.threshold_tokens = int(200000 * config.context_threshold)
+    try:
+        yield e
+    finally:
+        e.shutdown()
+
+
+def _mock_summarize(prompt, max_tokens, model=""):
+    return "Mock summary of conversation.\nExpand for details about: earlier turns"
+
+
+@pytest.fixture
+def mocked_summary(monkeypatch):
+    import hermes_lcm.escalation as esc
+
+    monkeypatch.setattr(esc, "_call_llm_for_summary", _mock_summarize)
+
+
+def _conversation(n_turns=20):
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": f"Question {i}: " + "x" * 200})
+        messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
+    return messages
+
+
+def _rows(engine):
+    return engine._store.get_session_count(SESSION_ID)
+
+
+def test_pre_compaction_history_after_compress_is_not_stored_again(engine, mocked_summary):
+    """The pre-compaction list handed back after compress() appends nothing."""
+    messages = _conversation(20)
+    engine.compress(messages)
+    stored = _rows(engine)
+    assert stored == len(messages)
+
+    # What a host's end-of-session extraction passes at the compaction boundary.
+    engine._ingest_messages(messages)
+
+    assert _rows(engine) == stored
+
+
+def test_extended_pre_compaction_history_stores_only_the_new_rows(engine, mocked_summary):
+    """The same list plus a new turn appends that turn and nothing else."""
+    messages = _conversation(20)
+    engine.compress(messages)
+    stored = _rows(engine)
+
+    extended = messages + [
+        {"role": "user", "content": "Brand new question"},
+        {"role": "assistant", "content": "Brand new answer"},
+    ]
+    engine._ingest_messages(extended)
+
+    assert _rows(engine) == stored + 2
+
+
+def test_cursor_is_not_advanced_by_another_sessions_history(engine, mocked_summary):
+    """The proof is session-scoped: a rebind must not inherit it.
+
+    The identity cache is not cleared when the engine rebinds, so without a
+    session stamp a new session whose opening history matches the previous
+    one's would have its rows skipped as already accounted for.
+    """
+    messages = _conversation(6)
+    engine._ingest_messages(messages)
+    assert _rows(engine) == len(messages)
+
+    other_session = "20260101_000000_cursor02"
+    engine.on_session_start(other_session, platform="cli")
+    engine._ingest_messages(messages)
+
+    assert engine._store.get_session_count(other_session) == len(messages)
+
+
+def test_shorter_history_does_not_lower_the_cursor(engine, mocked_summary):
+    """A truncated history leaves the cursor where it was."""
+    messages = _conversation(6)
+    engine._ingest_messages(messages)
+    stored = _rows(engine)
+    cursor = engine._ingest_cursor
+
+    engine._ingest_messages(messages[:3])
+
+    assert engine._ingest_cursor == cursor
+    assert _rows(engine) == stored


### PR DESCRIPTION
## Summary
- `_ingest_messages` advances `_ingest_cursor` past an incoming prefix that the previous ingest already accounted for, so a history the host hands back after `compress()` is not appended to the store a second time.
- `_last_active_replay_source_identities` is now stamped with the session it was taken in, because nothing clears that cache when the engine rebinds. The proof is refused across a rebind.
- New `tests/test_ingest_cursor_after_compaction.py` (4 tests).

## Why
`compress()` resets `_ingest_cursor` to `len(compressed)`. A host that runs end-of-session extraction at the compaction boundary then passes the **pre-compaction** history to `on_session_end` before the compacted list is ever ingested. Measured against the lowered cursor every row past it looks new, so the entire session is appended again. The store keeps every message twice from that point, and because the duplicate rows are verbatim they are hard to tell from a genuine repeat.

The engine cannot control when a host replays a list, but it can tell that it has already seen one. `_remember_active_replay_messages` runs at the end of every ingest, so `_last_active_replay_source_identities` describes a list whose rows are all accounted for: stored, or deliberately dropped by the ignore and placeholder filters. If the incoming history still begins with that list, nothing before that prefix needs persisting, whatever lowered the cursor since.

Two properties keep this conservative:

- The rule only ever **raises** the cursor, and never past what the previous ingest accounted for. A shorter or diverging history leaves it untouched, so every existing reconciliation path behaves exactly as before.
- The identity cache outlives a rebind, so using it as durability proof would be wrong across sessions. Hence the session stamp; `test_cursor_is_not_advanced_by_another_sessions_history` covers it.

Reproduced against `main` (10cbb78) with the new tests: a 41-row conversation compacts, the pre-compaction list is handed back, and the store goes to 76 rows instead of staying at 41.

## Validation
- [x] Focused validation: `pytest tests/test_ingest_cursor_after_compaction.py -q` -> `4 passed`. Reverting `engine.py` to `main` and rerunning: `2 failed` (`assert 76 == 41`, `assert 78 == (41 + 2)`), so the tests fail without the fix.
- [x] Focused validation: `pytest tests/test_lcm_core.py tests/test_lcm_engine.py -q` -> `1059 passed, 1 skipped`, identical to the same command on unmodified `main`.
- [ ] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q` -> `2794 passed, 3 failed, 2 skipped, 12 xfailed`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [x] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint` (no workflows changed)

## Notes
The three `pytest -q` failures are `test_packaging_install.py::test_plugin_entrypoint_registers_lcm_context_engine`, `test_path_containment.py::test_path_containment_within_allowed_base` and `test_path_security.py::test_configured_externalization_path_inside_allowed_base_accepted`. They fail identically on unmodified `main` in my environment, which runs the checkout from a symlinked temp path, so I read them as environmental rather than caused by this change. Please re-run them wherever CI normally does. The remaining unchecked items are release and install scripts I did not exercise.

`ruff check engine.py tests/test_ingest_cursor_after_compaction.py` passes.

Scope, deliberately narrow: this fixes the replayed-history case only. Two related shapes are left alone because they are not self-contained. A history that has rows **inserted between** existing turns still moves the cursor past the insertion (an index cannot tell a stored row after that point from a new one). And a compacted history reconciled from the store after a per-turn engine rebind can still fall back to a scaffold-only prefix; that path overlaps #550, so it seems better handled there than stacked here.