### PR TITLE
Route MiniMax auxiliary model overrides

### DIFF
--- a/model_routing.py
+++ b/model_routing.py
@@ -26,7 +26,7 @@ ProviderResolver = Callable[[str], bool]
 # custom providers because Hermes auxiliary routing normalizes ``provider`` the
 # same way, but canonical built-ins such as ``custom:openai-codex/...`` remain
 # model-only to avoid accidentally selecting the built-in provider.
-_PROVIDER_PREFIXES = frozenset({"cerebras"})
+_PROVIDER_PREFIXES = frozenset({"cerebras", "minimax"})
 
 
 def _provider_route_is_resolvable(provider: str) -> bool:

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -108,6 +108,18 @@ class TestModelRouting:
         assert route.provider == "cerebras"
         assert route.model == "gpt-oss-120b"
 
+    def test_minimax_model_is_split_when_registered(self, monkeypatch):
+        from hermes_lcm.model_routing import parse_lcm_model_override
+
+        self._install_fake_provider_modules(
+            monkeypatch, registry={"minimax": {}}
+        )
+
+        route = parse_lcm_model_override("minimax/MiniMax-M3")
+
+        assert route.provider == "minimax"
+        assert route.model == "MiniMax-M3"
+
     def test_custom_provider_prefixed_model_is_split_when_provider_resolves(self):
         from hermes_lcm.model_routing import parse_lcm_model_override
 


### PR DESCRIPTION
Reason: MiniMax-prefixed auxiliary model overrides were not split into the registered MiniMax provider.

- Allow MiniMax in the built-in provider route allowlist.
- Add regression coverage for routing `minimax/MiniMax-M3` into provider and model fields.
- Checks: `python3 -m pytest tests/test_lcm_core.py -q` (309 passed); `python3 -m pytest tests/test_lcm_engine.py -q` (not run: missing optional `agent` module).
