### PR TITLE
fix(escalation): acceptance gate must enforce the token budget, not just < source_tokens

### DIFF
--- a/escalation.py
+++ b/escalation.py
@@ -574,7 +574,12 @@ def summarize_with_escalation(
         timeout=timeout,
         circuit_breaker=circuit_breaker,
         spend_guard=spend_guard,
-        accepts_result=lambda result: count_tokens(result) < source_tokens,
+        # ACCEPTANCE GATE (2026-09-01, Clara stall fix): the accepted summary
+        # must be ≤ the token BUDGET (12K cap), not merely < source_tokens.
+        # With a 2.2M-token widened chunk, '< source_tokens' accepted a
+        # source-inclusive ~2.2M echo → 1000→9,223 message blowup (10× tokens).
+        # Enforcing the budget rejects the echo → escalates to L2/L3 → bounded.
+        accepts_result=lambda result: count_tokens(result) <= token_budget,
     )
 
     if l1_result:
@@ -594,7 +599,8 @@ def summarize_with_escalation(
         timeout=timeout,
         circuit_breaker=circuit_breaker,
         spend_guard=spend_guard,
-        accepts_result=lambda result: count_tokens(result) < source_tokens,
+        # Same acceptance gate as L1: ≤ the L2 budget (2026-09-01).
+        accepts_result=lambda result: count_tokens(result) <= l2_budget,
     )
 
     if l2_result:

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -27279,3 +27279,42 @@ class TestExtractionDuringCompress:
         result = eng.compress(messages)
         assert result[0]["role"] == "system"
         assert len(eng._dag.get_session_nodes("extract-fail")) > 0
+
+    def test_escalation_rejects_source_inclusive_echo_bounded_to_budget(self, tmp_path, monkeypatch):
+        """Regression: summarize_with_escalation's acceptance gate was
+        count_tokens(result) < source_tokens — with a large source chunk, a
+        source-inclusive LLM echo is ACCEPTED (it's smaller than the source)
+        even though it far exceeds the token budget. The accepted summary must
+        be <= the token BUDGET (12K cap), so the echo is rejected and the run
+        escalates to L2/L3 (deterministic truncation, bounded).
+        """
+        from hermes_lcm import escalation as esc_mod
+        from hermes_lcm.tokens import count_tokens
+
+        big_source = "s" * 2_000_000
+        captured = {}
+
+        def fake_invoke(l1_prompt, max_tokens, **kwargs):
+            accepts = kwargs.get("accepts_result")
+            captured["accepts"] = accepts
+            if not captured.get("attempted_l2"):
+                captured["attempted_l2"] = True
+                # Return an echo that is < source but > budget (the old gate
+                # would ACCEPT it; the new gate must reject it).
+                echo = "e" * 100_000  # 100K > 12K budget, < 2.2M source
+                return echo if accepts(echo) else None
+            return None
+
+        monkeypatch.setattr(esc_mod, "_invoke_summary_llm_chain", fake_invoke)
+
+        result, level = esc_mod.summarize_with_escalation(
+            text=big_source,
+            source_tokens=2_212_704,
+            token_budget=12_000,
+        )
+        # The result must be bounded (L3 truncation, ~512 tokens), NOT the
+        # 100K echo — the acceptance gate rejected it.
+        assert count_tokens(result) <= 12_000, (
+            f"summary {count_tokens(result)} tokens > budget — echo accepted (old bug)"
+        )
+        assert level == 3, f"expected L3 truncation, got level {level}"


### PR DESCRIPTION
## Summary

- Tighten `summarize_with_escalation`'s acceptance gate: the accepted summary must be **≤ the token budget**, not merely `< source_tokens`.
- L1 gate: `count_tokens(result) <= token_budget` (was `< source_tokens`)
- L2 gate: `count_tokens(result) <= l2_budget` (was `< source_tokens`)
- Adds a regression test: a source-inclusive LLM echo (100K tokens vs 12K budget) is rejected → escalates to L3 deterministic truncation (bounded).

## Why

With a large source chunk, `< source_tokens` is nearly vacuous — the model's max output is always smaller than a multi-hundred-K source, so any model output is accepted regardless of the budget the prompt asked for. The stored summary can be ~an order of magnitude larger than intended (observed at scale: 2.2M-token "summaries" that grew a compaction 10x and stalled it via the anti-growth guard). The budget is already what the L1/L2 prompts communicate ("Target ~{token_budget} tokens"), so this makes the acceptance gate consistent with the prompt contract.

## Validation

- [x] Focused validation: `pytest tests/test_lcm_engine.py -q` -> 1102 passed (focused set: test_lcm_core + test_lcm_engine + test_packaging_install)
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 1102 passed
  - [ ] `pytest -q` (full suite; see Notes)
  - [ ] `scripts/validate_release.sh --full --keep-going --output /tmp/hermes-lcm-release-validation-<topic>` (see Notes)
  - [x] `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check` -> clean
- [ ] Workflow validation: not applicable (no workflow changes)

## Notes

- Full `pytest -q` and `scripts/validate_release.sh --full` were not run in this PR's CI environment (time); the focused set above covers the touched surface (`escalation.py` + one new test in `test_lcm_engine.py`). Happy to run the full suite if the maintainer wants it before merge.
- The fix is deliberately minimal (2 predicates + 1 regression test). The broader widened-backlog compaction behavior is tracked separately in #554 (design question) — this PR only fixes the acceptance gate.

Refs #554
