### PR TITLE
fix(windows): restore externalization and recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,36 @@ jobs:
       - name: Install test dependencies
         run: pip install pytest numpy
 
+      - name: Stub hermes-agent ABC
+        shell: bash
+        run: |
+          mkdir -p agent
+          cat > agent/__init__.py <<'STUB'
+          STUB
+          cat > agent/context_engine.py <<'STUB'
+          """Minimal stub of hermes-agent ContextEngine ABC for CI."""
+          class ContextEngine:
+              """Base class stub — just enough for LCMEngine to import."""
+              def __init__(self, **kwargs):
+                  self.compression_count = 0
+                  self.last_prompt_tokens = 0
+              def compress(self, messages, current_tokens=None, **kwargs):
+                  raise NotImplementedError
+              def on_session_start(self, session_id, **kwargs):
+                  pass
+              def on_session_end(self, **kwargs):
+                  pass
+              def on_session_reset(self):
+                  self.compression_count = 0
+                  self.last_prompt_tokens = 0
+              def get_tool_schemas(self):
+                  return []
+              def handle_tool_call(self, name, args, **kwargs):
+                  raise NotImplementedError
+              def get_status(self):
+                  return {}
+          STUB
+
       - name: Run Windows externalization and recovery tests
         run: >
           python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,28 @@ jobs:
           python -m py_compile scripts/import_lossless_claw.py
           bash -n scripts/install.sh scripts/update.sh
           git diff --check
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: pip install pytest numpy
+
+      - name: Run Windows externalization and recovery tests
+        run: >
+          python -m pytest -q
+          tests/test_windows_portability.py
+          tests/test_ingest_protection.py
+
+      - name: Run static validation
+        run: |
+          python -m compileall -q .
+          python -m py_compile scripts/import_lossless_claw.py
+          git diff --check

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -645,8 +645,10 @@ platform. POSIX hosts also flush the parent directory after create or replace.
 Portable Python on Windows cannot open a directory descriptor for `fsync`, so
 Windows retains the file flush and same-volume atomic replace but has weaker
 power-loss durability for the directory entry itself. Windows confidentiality
-follows ACL inheritance from `HERMES_HOME`, not POSIX mode bits; review those
-ACLs before storing sensitive payloads.
+follows ACL inheritance from the effective externalization directory and its
+parent, not POSIX mode bits. When `LCM_LARGE_OUTPUT_EXTERNALIZATION_PATH`
+points outside `HERMES_HOME`, the `HERMES_HOME` ACL does not protect those
+payloads; review the ACLs on the resolved configured directory and its parent.
 
 `lcm_grep` keeps history-only behavior by default. Operators and agents may opt
 into bounded active-session payload search with

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -640,6 +640,14 @@ Failure to durably externalize is fail-open: the provider receives the original
 inline payload. Results from `lcm_describe` and `lcm_expand` also stay inline so
 recovery does not recursively create another drilldown step.
 
+Payload files are flushed with `fsync` before publication on every supported
+platform. POSIX hosts also flush the parent directory after create or replace.
+Portable Python on Windows cannot open a directory descriptor for `fsync`, so
+Windows retains the file flush and same-volume atomic replace but has weaker
+power-loss durability for the directory entry itself. Windows confidentiality
+follows ACL inheritance from `HERMES_HOME`, not POSIX mode bits; review those
+ACLs before storing sensitive payloads.
+
 `lcm_grep` keeps history-only behavior by default. Operators and agents may opt
 into bounded active-session payload search with
 `content_scope='externalized'|'both'`; optional `externalized_refs` narrows the

--- a/externalize.py
+++ b/externalize.py
@@ -57,6 +57,11 @@ def _preview_sha256(preview_prefix: Any) -> str:
 
 
 def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        # Windows cannot use this POSIX directory-fsync path: os.open() cannot
+        # obtain a directory handle with FILE_FLAG_BACKUP_SEMANTICS. The
+        # payload file itself has already been flushed by the caller.
+        return
     flags = os.O_RDONLY
     if hasattr(os, "O_DIRECTORY"):
         flags |= os.O_DIRECTORY

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -578,7 +578,22 @@ def recover_hermes_persisted_output_with_file_stat(text: str | None) -> tuple[st
         return None
     recovered, file_stat = recovered_with_stat
     if len(recovered) != expected_chars:
-        return None
+        # Hermes writes LF-based tool results through Windows text mode, which
+        # expands each LF to CRLF on disk while the marker retains the original
+        # character count. Normalize only structurally complete CRLF pairs;
+        # standalone carriage returns remain byte-for-byte intact.
+        if os.name != "nt":
+            return None
+        if any(
+            index == 0 or recovered[index - 1] != chr(13)
+            for index, char in enumerate(recovered)
+            if char == chr(10)
+        ):
+            return None
+        normalized = recovered.replace(chr(13) + chr(10), chr(10))
+        if len(normalized) != expected_chars:
+            return None
+        recovered = normalized
     preview_prefix = _persisted_output_preview_prefix(text)
     if not preview_prefix or not recovered.startswith(preview_prefix):
         return None

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import os
 import re
 import sqlite3
 import stat
@@ -722,7 +723,8 @@ def test_externalized_payload_reassignment_fsyncs_replacement(tmp_path, monkeypa
     )
 
     assert moved == 1
-    assert len(fsync_calls) >= 3
+    expected_minimum = 1 if os.name == "nt" else 3
+    assert len(fsync_calls) >= expected_minimum
     payload = json.loads(result["path"].read_text(encoding="utf-8"))
     assert payload["session_id"] == "new-session"
 
@@ -1263,6 +1265,7 @@ def test_ingest_preserves_inline_payload_when_externalization_fails(tmp_path, mo
     assert _externalized_files(tmp_path) == []
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows confidentiality uses inherited ACLs")
 def test_externalized_payload_files_are_private(tmp_path):
     engine = _engine(tmp_path)
 

--- a/tests/test_windows_portability.py
+++ b/tests/test_windows_portability.py
@@ -1,0 +1,105 @@
+"""Cross-platform regressions for Windows persisted-output I/O."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_lcm import externalize as externalize_module
+from hermes_lcm.ingest_protection import recover_hermes_persisted_output_with_file_stat
+
+
+def _persisted_marker(path: Path, original: str, *, preview: str = "A") -> str:
+    return "\n".join(
+        [
+            "<persisted-output>",
+            f"This tool result was too large ({len(original)} characters, 0 KB).",
+            f"Full output saved to: {path}",
+            f"Preview (first {len(preview)} chars):",
+            preview,
+            "...",
+            "</persisted-output>",
+        ]
+    )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows directory handles are unsupported by this path")
+def test_externalized_payload_write_flushes_file_without_opening_parent_directory(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "payload.json"
+    fsync_calls: list[int] = []
+    real_fsync = externalize_module.os.fsync
+    real_open = externalize_module.os.open
+
+    def recording_fsync(fd: int) -> None:
+        fsync_calls.append(fd)
+        real_fsync(fd)
+
+    def reject_directory_open(path, flags, *args, **kwargs):
+        if Path(path) == tmp_path:
+            raise AssertionError("Windows parent directory must not be opened for fsync")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(externalize_module.os, "fsync", recording_fsync)
+    monkeypatch.setattr(externalize_module.os, "open", reject_directory_open)
+
+    externalize_module._write_externalized_payload(target, {"content": "durable payload"})
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"content": "durable payload"}
+    assert fsync_calls, "the payload file must still be flushed on Windows"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory fsync contract")
+def test_parent_directory_fsync_is_retained_on_posix(tmp_path, monkeypatch):
+    opened_flags: list[int] = []
+    real_open = externalize_module.os.open
+
+    def recording_open(path, flags, *args, **kwargs):
+        opened_flags.append(flags)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(externalize_module.os, "open", recording_open)
+
+    externalize_module._fsync_directory(tmp_path)
+
+    assert opened_flags
+    if hasattr(os, "O_DIRECTORY"):
+        assert all(flags & os.O_DIRECTORY for flags in opened_flags)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows text-mode newline expansion")
+def test_crlf_recovery_preserves_original_bare_carriage_returns(tmp_path, monkeypatch):
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    directory = tmp_path / "hermes-results"
+    directory.mkdir()
+    original = "A\rB\nC"
+    path = directory / "result.txt"
+    path.write_bytes(original.replace("\n", "\r\n").encode("utf-8"))
+
+    recovered = recover_hermes_persisted_output_with_file_stat(
+        _persisted_marker(path, original)
+    )
+
+    assert recovered is not None
+    assert recovered[0] == original
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows text-mode newline expansion")
+def test_crlf_recovery_rejects_mixed_translated_and_bare_lf(tmp_path, monkeypatch):
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    directory = tmp_path / "hermes-results"
+    directory.mkdir()
+    original = "A\nB\nC"
+    path = directory / "mixed.txt"
+    path.write_bytes(b"A\r\nB\nC")
+
+    recovered = recover_hermes_persisted_output_with_file_stat(
+        _persisted_marker(path, original)
+    )
+
+    assert recovered is None


### PR DESCRIPTION
## Summary
- skip unsupported parent-directory `fsync` on Windows while retaining the payload-file flush and same-volume atomic replacement
- recover Hermes persisted outputs written with Windows CRLF expansion without changing standalone carriage returns
- add focused Windows CI and document the platform durability/ACL contract

## Why
Windows cannot open a directory through this POSIX `os.open()` path because it requires `FILE_FLAG_BACKUP_SEMANTICS`, so externalized-payload writes fail with `PermissionError` after the payload file has already been flushed. Hermes can also report the original LF-based character count while Windows text mode stores CRLF, causing otherwise safe persisted-output recovery to fail.

This carries forward the correct direct guard from draft PR #522 against current `main`, credits that prior work, and adds the missing current-main recovery and CI coverage. It fixes the supported Windows write/replay contract without claiming that POSIX directory-entry durability exists on Windows.

## Validation
- [x] Regression proof on unpatched `main`: `python -m pytest -q -o 'addopts=' tests/test_windows_portability.py` -> **2 failed, 1 passed, 1 skipped** (directory open and CRLF recovery both failed)
- [x] Focused validation: `python -m pytest -q -o 'addopts=' tests/test_windows_portability.py tests/test_ingest_protection.py` -> **140 passed, 2 skipped**
- [x] Ruff: `ruff check externalize.py ingest_protection.py tests/test_windows_portability.py tests/test_ingest_protection.py` -> **passed**
- [x] `actionlint` v1.7.7 -> **passed**
- [x] `python -m compileall -q .` -> **passed**
- [x] `python -m py_compile scripts/import_lossless_claw.py` -> **passed**
- [x] `git diff --check` / staged diff check -> **passed**
- [ ] Default Linux validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - These are delegated to existing Ubuntu CI because this change was developed on Windows.

## Notes
- Full `pytest -q` on unprivileged Windows is not currently a valid repository gate: current `main` includes POSIX-only backfill/install tests, symlink-privilege assumptions, and timing/path assertions. This branch recorded **2770 passed, 49 failed, 6 skipped, 12 xfailed**; the focused supported Windows contract above is green and is what the new Windows CI job runs.
- File contents are still flushed before publication on Windows. Only unsupported parent-directory flushing is skipped.
- Windows confidentiality follows ACL inheritance from the effective externalization directory and its parent. `HERMES_HOME` ACLs do not cover a configured path outside `HERMES_HOME`.
- Prior core fix: #522 by @fxhsxm.

Fixes #408
Fixes #523
