### PR TITLE
fix(plugin): release engine resources on unload

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -365,6 +365,7 @@ def register(ctx):
     from .config import LCMConfig
     from .engine import LCMEngine, resolve_active_lcm_engine
     from .retrieval_core import _open_vector_store_pool
+    from .tools import _open_deadline_worker_registry
     from .schemas import (
         LCM_GREP,
         LCM_RECALL,
@@ -383,6 +384,7 @@ def register(ctx):
         LCM_DOCTOR,
     )
 
+    _open_deadline_worker_registry()
     _open_vector_store_pool()
     config = LCMConfig.from_env()
 

--- a/__init__.py
+++ b/__init__.py
@@ -364,6 +364,7 @@ def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
     from .config import LCMConfig
     from .engine import LCMEngine, resolve_active_lcm_engine
+    from .retrieval_core import _open_vector_store_pool
     from .schemas import (
         LCM_GREP,
         LCM_RECALL,
@@ -382,6 +383,7 @@ def register(ctx):
         LCM_DOCTOR,
     )
 
+    _open_vector_store_pool()
     config = LCMConfig.from_env()
 
     # Resolve hermes_home for profile-scoped storage

--- a/__init__.py
+++ b/__init__.py
@@ -397,6 +397,9 @@ def register(ctx):
 
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)
+    on_unload = getattr(ctx, "on_unload", None)
+    if callable(on_unload):
+        on_unload(engine.shutdown)
 
     # Ship the same recall contract through both Hermes plugin skill
     # registration (explicit qualified loads) and the installer's ordinary

--- a/__init__.py
+++ b/__init__.py
@@ -399,7 +399,7 @@ def register(ctx):
     ctx.register_context_engine(engine)
     on_unload = getattr(ctx, "on_unload", None)
     if callable(on_unload):
-        on_unload(engine.shutdown)
+        on_unload(engine.shutdown_all_instances)
 
     # Ship the same recall contract through both Hermes plugin skill
     # registration (explicit qualified loads) and the installer's ordinary

--- a/engine.py
+++ b/engine.py
@@ -378,9 +378,10 @@ class _EngineShutdownGroup:
     def __init__(self) -> None:
         self._condition = threading.Condition(threading.RLock())
         self._engines = weakref.WeakSet()
-        self._retired_background: set[tuple[object, threading.Event]] = set()
+        self._background_work: dict[tuple[object, threading.Event], int] = {}
         self._closed = False
         self._clones_in_flight = 0
+        self._background_schedules_in_flight = 0
 
     def add(self, engine: "LCMEngine") -> bool:
         with self._condition:
@@ -397,6 +398,19 @@ class _EngineShutdownGroup:
                 return False
             self._clones_in_flight += 1
             return True
+
+    def begin_background_schedule(self) -> bool:
+        """Reserve one schedule attempt before unload closes the group gate."""
+        with self._condition:
+            if self._closed:
+                return False
+            self._background_schedules_in_flight += 1
+            return True
+
+    def end_background_schedule(self) -> None:
+        with self._condition:
+            self._background_schedules_in_flight -= 1
+            self._condition.notify_all()
 
     def complete_clone(self, engine: "LCMEngine") -> bool:
         """Publish a fully initialized clone, or close it after unload starts."""
@@ -436,14 +450,14 @@ class _EngineShutdownGroup:
         with self._condition:
             self._engines.discard(engine)
 
-    def _start_retired_background_waiter(
+    def _start_background_waiter(
         self,
         record: tuple[object, threading.Event],
     ) -> None:
         waiter = threading.Thread(
-            target=self._drain_retired_background,
+            target=self._drain_background,
             args=(record,),
-            name="lcm-retired-background-drain",
+            name="lcm-background-drain",
             daemon=True,
         )
         try:
@@ -451,25 +465,21 @@ class _EngineShutdownGroup:
         except Exception:
             # Keep the record for shutdown_all(); failure to start a cleanup
             # waiter must not make accepted work invisible to plugin unload.
-            logger.warning("LCM could not start retired background drain", exc_info=True)
+            logger.warning("LCM could not start background drain", exc_info=True)
 
-    def retain_orphaned_background(
+    def track_background(
         self,
         rollup_owner: object,
         assertion_idle: threading.Event,
     ) -> None:
-        """Keep accepted work visible after its weakly tracked engine is collected."""
-        if (
-            _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(rollup_owner, timeout=0)
-            and assertion_idle.is_set()
-        ):
-            return
+        """Track accepted work independently of the engine's weak lifetime."""
         record = (rollup_owner, assertion_idle)
         with self._condition:
-            if record in self._retired_background:
-                return
-            self._retired_background.add(record)
-        self._start_retired_background_waiter(record)
+            generation = self._background_work.get(record, 0) + 1
+            self._background_work[record] = generation
+            start_waiter = generation == 1
+        if start_waiter:
+            self._start_background_waiter(record)
 
     def retire(
         self,
@@ -480,33 +490,38 @@ class _EngineShutdownGroup:
         background_pending: bool,
     ) -> None:
         """Remove a closed engine while keeping its outstanding work visible."""
-        record = (rollup_owner, assertion_idle)
-        start_waiter = False
+        if background_pending:
+            self.track_background(rollup_owner, assertion_idle)
         with self._condition:
-            if background_pending and record not in self._retired_background:
-                self._retired_background.add(record)
-                start_waiter = True
             self._engines.discard(engine)
-        if start_waiter:
-            self._start_retired_background_waiter(record)
 
-    def _drain_retired_background(
+    def _drain_background(
         self,
         record: tuple[object, threading.Event],
     ) -> None:
         rollup_owner, assertion_idle = record
-        try:
+        while True:
+            with self._condition:
+                generation = self._background_work.get(record)
+                if generation is None:
+                    return
             _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(rollup_owner)
             assertion_idle.wait()
-        finally:
             with self._condition:
-                self._retired_background.discard(record)
+                if self._background_work.get(record) != generation:
+                    continue
+                if not _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(
+                    rollup_owner, timeout=0
+                ) or not assertion_idle.is_set():
+                    continue
+                self._background_work.pop(record, None)
                 self._condition.notify_all()
+                return
 
     def shutdown_all(self) -> None:
         with self._condition:
             self._closed = True
-            while self._clones_in_flight:
+            while self._clones_in_flight or self._background_schedules_in_flight:
                 self._condition.wait()
             engines = list(self._engines)
         first_error: Exception | None = None
@@ -518,9 +533,9 @@ class _EngineShutdownGroup:
                 if first_error is None:
                     first_error = exc
         with self._condition:
-            retired_background = list(self._retired_background)
-        for record in retired_background:
-            self._drain_retired_background(record)
+            background_work = list(self._background_work)
+        for record in background_work:
+            self._drain_background(record)
         join_background_integrity_scans()
         _close_vector_store_pool()
         if first_error is not None:
@@ -786,18 +801,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # diagnostic drains do not retain every historical session key forever.
         self._rollup_maintenance_owner = object()
         self._shutdown_group.add(self)
-        self._install_shutdown_finalizer()
-
-    def _install_shutdown_finalizer(self) -> None:
-        previous = getattr(self, "_shutdown_finalizer", None)
-        if previous is not None and previous.alive:
-            previous.detach()
-        self._shutdown_finalizer = weakref.finalize(
-            self,
-            self._shutdown_group.retain_orphaned_background,
-            self._rollup_maintenance_owner,
-            self._assertion_extraction_idle,
-        )
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -831,7 +834,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             initialized = True
             clone._shutdown_group.discard(clone)
             clone._shutdown_group = shutdown_group
-            clone._install_shutdown_finalizer()
             clone.model = self.model
             clone.base_url = self.base_url
             clone.api_key = self.api_key
@@ -1955,9 +1957,13 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         _ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
 
     def _begin_background_schedule(self) -> bool:
-        """Reserve scheduling work unless engine shutdown has started."""
+        """Reserve scheduling work unless engine or plugin shutdown has started."""
+        shutdown_group = self._shutdown_group
+        if not shutdown_group.begin_background_schedule():
+            return False
         with self._background_work_condition:
             if self._background_shutdown_started:
+                shutdown_group.end_background_schedule()
                 return False
             self._background_schedules_in_flight += 1
             return True
@@ -1966,6 +1972,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         with self._background_work_condition:
             self._background_schedules_in_flight -= 1
             self._background_work_condition.notify_all()
+        self._shutdown_group.end_background_schedule()
 
     def _schedule_rollup_maintenance(self, scope: str) -> None:
         if not self._begin_background_schedule():
@@ -2004,11 +2011,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 finally:
                     private_dag.close()
 
-            _ROLLUP_MAINTENANCE_SCHEDULER.schedule(
+            accepted = _ROLLUP_MAINTENANCE_SCHEDULER.schedule(
                 key,
                 maintain,
                 owner=self._rollup_maintenance_owner,
             )
+            if accepted:
+                self._shutdown_group.track_background(
+                    self._rollup_maintenance_owner,
+                    self._assertion_extraction_idle,
+                )
         except Exception:
             # Maintenance is opportunistic; a scheduler/setup failure must never
             # turn a successful foreground session bind into a host failure.
@@ -5301,6 +5313,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
                 last_error,
             )
             return False
+        self._shutdown_group.track_background(
+            self._rollup_maintenance_owner,
+            self._assertion_extraction_idle,
+        )
         return True
 
     def _maybe_gc_compacted_tool_results(

--- a/engine.py
+++ b/engine.py
@@ -376,6 +376,7 @@ class _EngineShutdownGroup:
     def __init__(self) -> None:
         self._condition = threading.Condition(threading.RLock())
         self._engines = weakref.WeakSet()
+        self._retired_background: set[tuple[object, threading.Event]] = set()
         self._closed = False
         self._clones_in_flight = 0
 
@@ -425,6 +426,50 @@ class _EngineShutdownGroup:
         with self._condition:
             self._engines.discard(engine)
 
+    def retire(
+        self,
+        engine: "LCMEngine",
+        rollup_owner: object,
+        assertion_idle: threading.Event,
+        *,
+        background_pending: bool,
+    ) -> None:
+        """Remove a closed engine while keeping its outstanding work visible."""
+        record = (rollup_owner, assertion_idle)
+        start_waiter = False
+        with self._condition:
+            if background_pending and record not in self._retired_background:
+                self._retired_background.add(record)
+                start_waiter = True
+            self._engines.discard(engine)
+        if not start_waiter:
+            return
+        waiter = threading.Thread(
+            target=self._drain_retired_background,
+            args=(record,),
+            name="lcm-retired-background-drain",
+            daemon=True,
+        )
+        try:
+            waiter.start()
+        except Exception:
+            # Keep the record for shutdown_all(); failure to start a cleanup
+            # waiter must not make accepted work invisible to plugin unload.
+            logger.warning("LCM could not start retired background drain", exc_info=True)
+
+    def _drain_retired_background(
+        self,
+        record: tuple[object, threading.Event],
+    ) -> None:
+        rollup_owner, assertion_idle = record
+        try:
+            _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(rollup_owner)
+            assertion_idle.wait()
+        finally:
+            with self._condition:
+                self._retired_background.discard(record)
+                self._condition.notify_all()
+
     def shutdown_all(self) -> None:
         with self._condition:
             self._closed = True
@@ -439,6 +484,10 @@ class _EngineShutdownGroup:
                 logger.exception("LCM engine shutdown failed during plugin unload")
                 if first_error is None:
                     first_error = exc
+        with self._condition:
+            retired_background = list(self._retired_background)
+        for record in retired_background:
+            self._drain_retired_background(record)
         if first_error is not None:
             raise first_error
 
@@ -469,6 +518,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._background_work_condition = threading.Condition(threading.RLock())
         self._background_schedules_in_flight = 0
         self._background_shutdown_started = False
+        self._shutdown_lock = threading.RLock()
+        self._primary_shutdown_complete = False
         self._assertion_extraction_metrics_lock = threading.RLock()
         self._assertion_extraction_idle = threading.Event()
         self._assertion_extraction_idle.set()
@@ -6781,15 +6832,29 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             self._assertion_extraction_idle.wait()
 
     def shutdown(self, *, wait_for_background_work: bool = False):
-        self._stop_background_work(wait=wait_for_background_work)
-        self._shutdown_group.discard(self)
-        self._unregister_active_engine_binding()
-        if self._adaptive_retrieval is not None:
-            self._adaptive_retrieval.close()
-        self._store.close()
-        self._dag.close()
-        self._lifecycle.close()
-        if self._assertions is not None:
-            self._assertions.close()
-        if self._query_views is not None:
-            self._query_views.close()
+        shutdown_group = self._shutdown_group
+        with self._shutdown_lock:
+            self._stop_background_work(wait=wait_for_background_work)
+            if not self._primary_shutdown_complete:
+                self._unregister_active_engine_binding()
+                if self._adaptive_retrieval is not None:
+                    self._adaptive_retrieval.close()
+                self._store.close()
+                self._dag.close()
+                self._lifecycle.close()
+                if self._assertions is not None:
+                    self._assertions.close()
+                if self._query_views is not None:
+                    self._query_views.close()
+                self._primary_shutdown_complete = True
+            if wait_for_background_work:
+                shutdown_group.discard(self)
+                return
+            rollup_pending = not self.drain_rollup_maintenance(timeout=0)
+            assertion_pending = not self._assertion_extraction_idle.is_set()
+            shutdown_group.retire(
+                self,
+                self._rollup_maintenance_owner,
+                self._assertion_extraction_idle,
+                background_pending=rollup_pending or assertion_pending,
+            )

--- a/engine.py
+++ b/engine.py
@@ -27,6 +27,7 @@ from .codex_routing import (
     _is_codex_gpt55_route,
 )
 from .config import LCMConfig
+from .db_bootstrap import join_background_integrity_scans
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
 from .engine_registry import (
@@ -488,6 +489,7 @@ class _EngineShutdownGroup:
             retired_background = list(self._retired_background)
         for record in retired_background:
             self._drain_retired_background(record)
+        join_background_integrity_scans()
         if first_error is not None:
             raise first_error
 

--- a/engine.py
+++ b/engine.py
@@ -413,11 +413,19 @@ class _EngineShutdownGroup:
                 self._condition.notify_all()
         return False
 
-    def abort_clone(self, engine: "LCMEngine | None") -> None:
+    def abort_clone(
+        self,
+        engine: "LCMEngine | None",
+        *,
+        initialized: bool,
+    ) -> None:
         """Release a failed clone reservation after closing opened resources."""
         try:
             if engine is not None:
-                engine.shutdown(wait_for_background_work=True)
+                if initialized:
+                    engine.shutdown(wait_for_background_work=True)
+                else:
+                    engine._close_failed_initialization()
         finally:
             with self._condition:
                 self._clones_in_flight -= 1
@@ -773,12 +781,17 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         if not shutdown_group.begin_clone():
             raise RuntimeError("Cannot clone LCM engine while plugin is unloading")
         clone = None
+        initialized = False
         reservation_open = True
         try:
-            clone = type(self)(
+            clone_type = type(self)
+            clone = clone_type.__new__(clone_type)
+            clone_type.__init__(
+                clone,
                 config=copy.deepcopy(self._config),
                 hermes_home=self._hermes_home,
             )
+            initialized = True
             clone._shutdown_group.discard(clone)
             clone._shutdown_group = shutdown_group
             clone.model = self.model
@@ -815,7 +828,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             return clone
         except BaseException:
             if reservation_open:
-                shutdown_group.abort_clone(clone)
+                shutdown_group.abort_clone(clone, initialized=initialized)
             raise
 
     def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
@@ -6818,6 +6831,32 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         return result
 
     # -- Lifecycle ---------------------------------------------------------
+
+    def _close_failed_initialization(self) -> None:
+        """Best-effort cleanup for an object whose ``__init__`` raised."""
+        shutdown_group = getattr(self, "_shutdown_group", None)
+        if shutdown_group is not None:
+            shutdown_group.discard(self)
+        for name in (
+            "_adaptive_retrieval",
+            "_store",
+            "_dag",
+            "_lifecycle",
+            "_assertions",
+            "_query_views",
+        ):
+            resource = getattr(self, name, None)
+            close = getattr(resource, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # pragma: no cover - defensive cleanup path
+                    logger.exception(
+                        "LCM failed to close %s after engine initialization error",
+                        name,
+                    )
+        if hasattr(self, "_primary_shutdown_complete"):
+            self._primary_shutdown_complete = True
 
     def shutdown_all_instances(self) -> None:
         """Close this plugin prototype and all live per-agent clones."""

--- a/engine.py
+++ b/engine.py
@@ -537,6 +537,7 @@ class _EngineShutdownGroup:
         for record in background_work:
             self._drain_background(record)
         join_background_integrity_scans()
+        lcm_tools._close_and_join_deadline_workers()
         _close_vector_store_pool()
         if first_error is not None:
             raise first_error

--- a/engine.py
+++ b/engine.py
@@ -1023,6 +1023,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._reset_session_scoped_runtime_state()
 
     def _rebind_storage_for_home(self, hermes_home: str = "") -> bool:
+        """Serialize profile storage rebinding with engine shutdown."""
+        if not hermes_home:
+            return False
+        with self._shutdown_lock:
+            if self._background_shutdown_started or self._primary_shutdown_complete:
+                raise RuntimeError("Cannot rebind LCM storage while plugin is unloading")
+            return self._rebind_storage_for_home_locked(hermes_home)
+
+    def _rebind_storage_for_home_locked(self, hermes_home: str) -> bool:
         """Switch SQLite-backed state when a reused engine serves another profile.
 
         Hermes core passes the active ``hermes_home`` on session start.  Older
@@ -1030,8 +1039,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         after ``HERMES_HOME`` changes, so the plugin must not assume the store
         captured during ``register()`` is still correct.
         """
-        if not hermes_home:
-            return False
         if self._config.database_path:
             current_home = str(self._hermes_home or "")
             current_store_home = str(getattr(getattr(self, "_store", None), "_hermes_home", "") or "")

--- a/engine.py
+++ b/engine.py
@@ -436,6 +436,41 @@ class _EngineShutdownGroup:
         with self._condition:
             self._engines.discard(engine)
 
+    def _start_retired_background_waiter(
+        self,
+        record: tuple[object, threading.Event],
+    ) -> None:
+        waiter = threading.Thread(
+            target=self._drain_retired_background,
+            args=(record,),
+            name="lcm-retired-background-drain",
+            daemon=True,
+        )
+        try:
+            waiter.start()
+        except Exception:
+            # Keep the record for shutdown_all(); failure to start a cleanup
+            # waiter must not make accepted work invisible to plugin unload.
+            logger.warning("LCM could not start retired background drain", exc_info=True)
+
+    def retain_orphaned_background(
+        self,
+        rollup_owner: object,
+        assertion_idle: threading.Event,
+    ) -> None:
+        """Keep accepted work visible after its weakly tracked engine is collected."""
+        if (
+            _ROLLUP_MAINTENANCE_SCHEDULER.drain_owner(rollup_owner, timeout=0)
+            and assertion_idle.is_set()
+        ):
+            return
+        record = (rollup_owner, assertion_idle)
+        with self._condition:
+            if record in self._retired_background:
+                return
+            self._retired_background.add(record)
+        self._start_retired_background_waiter(record)
+
     def retire(
         self,
         engine: "LCMEngine",
@@ -452,20 +487,8 @@ class _EngineShutdownGroup:
                 self._retired_background.add(record)
                 start_waiter = True
             self._engines.discard(engine)
-        if not start_waiter:
-            return
-        waiter = threading.Thread(
-            target=self._drain_retired_background,
-            args=(record,),
-            name="lcm-retired-background-drain",
-            daemon=True,
-        )
-        try:
-            waiter.start()
-        except Exception:
-            # Keep the record for shutdown_all(); failure to start a cleanup
-            # waiter must not make accepted work invisible to plugin unload.
-            logger.warning("LCM could not start retired background drain", exc_info=True)
+        if start_waiter:
+            self._start_retired_background_waiter(record)
 
     def _drain_retired_background(
         self,
@@ -763,6 +786,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # diagnostic drains do not retain every historical session key forever.
         self._rollup_maintenance_owner = object()
         self._shutdown_group.add(self)
+        self._install_shutdown_finalizer()
+
+    def _install_shutdown_finalizer(self) -> None:
+        previous = getattr(self, "_shutdown_finalizer", None)
+        if previous is not None and previous.alive:
+            previous.detach()
+        self._shutdown_finalizer = weakref.finalize(
+            self,
+            self._shutdown_group.retain_orphaned_background,
+            self._rollup_maintenance_owner,
+            self._assertion_extraction_idle,
+        )
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -796,6 +831,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             initialized = True
             clone._shutdown_group.discard(clone)
             clone._shutdown_group = shutdown_group
+            clone._install_shutdown_finalizer()
             clone.model = self.model
             clone.base_url = self.base_url
             clone.api_key = self.api_key

--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,7 @@ import threading
 import time
 from collections import deque
 import uuid
+import weakref
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -369,6 +370,36 @@ def _normalize_total_compactions(value: Any) -> int:
     return value
 
 
+class _EngineShutdownGroup:
+    """Track one plugin prototype and every live agent clone it creates."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._engines = weakref.WeakSet()
+
+    def add(self, engine: "LCMEngine") -> None:
+        with self._lock:
+            self._engines.add(engine)
+
+    def discard(self, engine: "LCMEngine") -> None:
+        with self._lock:
+            self._engines.discard(engine)
+
+    def shutdown_all(self) -> None:
+        with self._lock:
+            engines = list(self._engines)
+        first_error: Exception | None = None
+        for engine in engines:
+            try:
+                engine.shutdown()
+            except Exception as exc:  # pragma: no cover - defensive unload path
+                logger.exception("LCM engine shutdown failed during plugin unload")
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+
 class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessionMixin, PlaceholderLedgerMixin, BypassMixin, ContextEngine):
     """Lossless Context Management engine.
 
@@ -389,6 +420,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def __init__(self, config: LCMConfig | None = None,
                  hermes_home: str = ""):
+        self._shutdown_group = _EngineShutdownGroup()
         self._config = config or LCMConfig.from_env()
         self._hermes_home = hermes_home
         self._assertion_extraction_metrics_lock = threading.RLock()
@@ -621,6 +653,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # The scheduler associates this identity only with outstanding work, so
         # diagnostic drains do not retain every historical session key forever.
         self._rollup_maintenance_owner = object()
+        self._shutdown_group.add(self)
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -641,6 +674,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             config=copy.deepcopy(self._config),
             hermes_home=self._hermes_home,
         )
+        clone._shutdown_group.discard(clone)
+        clone._shutdown_group = self._shutdown_group
+        self._shutdown_group.add(clone)
         clone.model = self.model
         clone.base_url = self.base_url
         clone.api_key = self.api_key
@@ -6638,7 +6674,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     # -- Lifecycle ---------------------------------------------------------
 
+    def shutdown_all_instances(self) -> None:
+        """Close this plugin prototype and all live per-agent clones."""
+        self._shutdown_group.shutdown_all()
+
     def shutdown(self):
+        self._shutdown_group.discard(self)
         self._unregister_active_engine_binding()
         if self._adaptive_retrieval is not None:
             self._adaptive_retrieval.close()

--- a/engine.py
+++ b/engine.py
@@ -374,30 +374,67 @@ class _EngineShutdownGroup:
     """Track one plugin prototype and every live agent clone it creates."""
 
     def __init__(self) -> None:
-        self._lock = threading.RLock()
+        self._condition = threading.Condition(threading.RLock())
         self._engines = weakref.WeakSet()
         self._closed = False
+        self._clones_in_flight = 0
 
     def add(self, engine: "LCMEngine") -> bool:
-        with self._lock:
+        with self._condition:
             if not self._closed:
                 self._engines.add(engine)
                 return True
-        engine.shutdown()
+        engine.shutdown(wait_for_background_work=True)
         return False
 
+    def begin_clone(self) -> bool:
+        """Reserve one clone construction before unload can take its snapshot."""
+        with self._condition:
+            if self._closed:
+                return False
+            self._clones_in_flight += 1
+            return True
+
+    def complete_clone(self, engine: "LCMEngine") -> bool:
+        """Publish a fully initialized clone, or close it after unload starts."""
+        with self._condition:
+            if not self._closed:
+                self._engines.add(engine)
+                self._clones_in_flight -= 1
+                self._condition.notify_all()
+                return True
+        try:
+            engine.shutdown(wait_for_background_work=True)
+        finally:
+            with self._condition:
+                self._clones_in_flight -= 1
+                self._condition.notify_all()
+        return False
+
+    def abort_clone(self, engine: "LCMEngine | None") -> None:
+        """Release a failed clone reservation after closing opened resources."""
+        try:
+            if engine is not None:
+                engine.shutdown(wait_for_background_work=True)
+        finally:
+            with self._condition:
+                self._clones_in_flight -= 1
+                self._condition.notify_all()
+
     def discard(self, engine: "LCMEngine") -> None:
-        with self._lock:
+        with self._condition:
             self._engines.discard(engine)
 
     def shutdown_all(self) -> None:
-        with self._lock:
+        with self._condition:
             self._closed = True
+            while self._clones_in_flight:
+                self._condition.wait()
             engines = list(self._engines)
         first_error: Exception | None = None
         for engine in engines:
             try:
-                engine.shutdown()
+                engine.shutdown(wait_for_background_work=True)
             except Exception as exc:  # pragma: no cover - defensive unload path
                 logger.exception("LCM engine shutdown failed during plugin unload")
                 if first_error is None:
@@ -429,6 +466,9 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._shutdown_group = _EngineShutdownGroup()
         self._config = config or LCMConfig.from_env()
         self._hermes_home = hermes_home
+        self._background_work_condition = threading.Condition(threading.RLock())
+        self._background_schedules_in_flight = 0
+        self._background_shutdown_started = False
         self._assertion_extraction_metrics_lock = threading.RLock()
         self._assertion_extraction_idle = threading.Event()
         self._assertion_extraction_idle.set()
@@ -676,40 +716,54 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         model and context-window metadata is copied so the clone is immediately
         budget-aware even before a compatible Hermes host calls update_model().
         """
-        clone = type(self)(
-            config=copy.deepcopy(self._config),
-            hermes_home=self._hermes_home,
-        )
-        clone._shutdown_group.discard(clone)
-        clone._shutdown_group = self._shutdown_group
-        if not self._shutdown_group.add(clone):
+        shutdown_group = self._shutdown_group
+        if not shutdown_group.begin_clone():
             raise RuntimeError("Cannot clone LCM engine while plugin is unloading")
-        clone.model = self.model
-        clone.base_url = self.base_url
-        clone.api_key = self.api_key
-        clone.provider = self.provider
-        clone.api_mode = self.api_mode
-        if self._context_length_source:
-            clone._set_context_length(
-                self.raw_context_length,
-                source=self._context_length_source,
-                model=self.model,
-                provider=self.provider,
+        clone = None
+        reservation_open = True
+        try:
+            clone = type(self)(
+                config=copy.deepcopy(self._config),
+                hermes_home=self._hermes_home,
             )
-        elif self.raw_context_length or self.context_length:
-            clone._set_context_length(
-                self.raw_context_length or self.context_length,
-                source="clone_for_agent",
-                model=self.model,
-                provider=self.provider,
-            )
-        # ``update_model()`` authority is a per-runtime lifecycle edge, not
-        # durable metadata.  Compatible hosts call update_model() on the clone
-        # before binding it; hosts that bind only through on_session_start()
-        # must still be able to replace the copied prototype route.
-        clone._update_model_pending_session_start = False
-        clone._lcm_current_start_allows_bypass_lineage = False
-        return clone
+            clone._shutdown_group.discard(clone)
+            clone._shutdown_group = shutdown_group
+            clone.model = self.model
+            clone.base_url = self.base_url
+            clone.api_key = self.api_key
+            clone.provider = self.provider
+            clone.api_mode = self.api_mode
+            if self._context_length_source:
+                clone._set_context_length(
+                    self.raw_context_length,
+                    source=self._context_length_source,
+                    model=self.model,
+                    provider=self.provider,
+                )
+            elif self.raw_context_length or self.context_length:
+                clone._set_context_length(
+                    self.raw_context_length or self.context_length,
+                    source="clone_for_agent",
+                    model=self.model,
+                    provider=self.provider,
+                )
+            # ``update_model()`` authority is a per-runtime lifecycle edge, not
+            # durable metadata.  Compatible hosts call update_model() on the clone
+            # before binding it; hosts that bind only through on_session_start()
+            # must still be able to replace the copied prototype route.
+            clone._update_model_pending_session_start = False
+            clone._lcm_current_start_allows_bypass_lineage = False
+            try:
+                accepted = shutdown_group.complete_clone(clone)
+            finally:
+                reservation_open = False
+            if not accepted:
+                raise RuntimeError("Cannot clone LCM engine while plugin is unloading")
+            return clone
+        except BaseException:
+            if reservation_open:
+                shutdown_group.abort_clone(clone)
+            raise
 
     def __deepcopy__(self, memo: dict[int, object]) -> "LCMEngine":
         """Copy the plugin runtime without pickling SQLite-backed helpers.
@@ -1796,7 +1850,28 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     def release_rollup_operator_lease(self, key: tuple[str, str]) -> None:
         _ROLLUP_MAINTENANCE_SCHEDULER.release_exclusive(key)
 
+    def _begin_background_schedule(self) -> bool:
+        """Reserve scheduling work unless engine shutdown has started."""
+        with self._background_work_condition:
+            if self._background_shutdown_started:
+                return False
+            self._background_schedules_in_flight += 1
+            return True
+
+    def _end_background_schedule(self) -> None:
+        with self._background_work_condition:
+            self._background_schedules_in_flight -= 1
+            self._background_work_condition.notify_all()
+
     def _schedule_rollup_maintenance(self, scope: str) -> None:
+        if not self._begin_background_schedule():
+            return
+        try:
+            self._schedule_rollup_maintenance_active(scope)
+        finally:
+            self._end_background_schedule()
+
+    def _schedule_rollup_maintenance_active(self, scope: str) -> None:
         """Enqueue one best-effort rollup pass using private SQLite helpers."""
         try:
             raw_database_path = str(self._dag.db_path)
@@ -5045,6 +5120,16 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
     def _schedule_pre_compaction_assertions(
         self, messages: List[Dict[str, Any]]
     ) -> bool:
+        if not self._begin_background_schedule():
+            return False
+        try:
+            return self._schedule_pre_compaction_assertions_active(messages)
+        finally:
+            self._end_background_schedule()
+
+    def _schedule_pre_compaction_assertions_active(
+        self, messages: List[Dict[str, Any]]
+    ) -> bool:
         """Queue exact persisted rows without blocking the compaction path."""
         if (
             not bool(getattr(self._config, "assertion_extraction_enabled", False))
@@ -6685,7 +6770,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """Close this plugin prototype and all live per-agent clones."""
         self._shutdown_group.shutdown_all()
 
-    def shutdown(self):
+    def _stop_background_work(self, *, wait: bool) -> None:
+        """Reject new background jobs and optionally drain accepted work."""
+        with self._background_work_condition:
+            self._background_shutdown_started = True
+            while self._background_schedules_in_flight:
+                self._background_work_condition.wait()
+        if wait:
+            self.drain_rollup_maintenance()
+            self._assertion_extraction_idle.wait()
+
+    def shutdown(self, *, wait_for_background_work: bool = False):
+        self._stop_background_work(wait=wait_for_background_work)
         self._shutdown_group.discard(self)
         self._unregister_active_engine_binding()
         if self._adaptive_retrieval is not None:

--- a/engine.py
+++ b/engine.py
@@ -376,10 +376,15 @@ class _EngineShutdownGroup:
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._engines = weakref.WeakSet()
+        self._closed = False
 
-    def add(self, engine: "LCMEngine") -> None:
+    def add(self, engine: "LCMEngine") -> bool:
         with self._lock:
-            self._engines.add(engine)
+            if not self._closed:
+                self._engines.add(engine)
+                return True
+        engine.shutdown()
+        return False
 
     def discard(self, engine: "LCMEngine") -> None:
         with self._lock:
@@ -387,6 +392,7 @@ class _EngineShutdownGroup:
 
     def shutdown_all(self) -> None:
         with self._lock:
+            self._closed = True
             engines = list(self._engines)
         first_error: Exception | None = None
         for engine in engines:
@@ -676,7 +682,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         )
         clone._shutdown_group.discard(clone)
         clone._shutdown_group = self._shutdown_group
-        self._shutdown_group.add(clone)
+        if not self._shutdown_group.add(clone):
+            raise RuntimeError("Cannot clone LCM engine while plugin is unloading")
         clone.model = self.model
         clone.base_url = self.base_url
         clone.api_key = self.api_key

--- a/engine.py
+++ b/engine.py
@@ -91,6 +91,7 @@ from .assertion_extraction import ModelAssertionExtractor
 from .assertion_store import AssertionStore, SourceSnapshot
 from .adaptive_retrieval import AdaptiveRetrievalRegistry
 from .query_view_store import QueryViewStore
+from .retrieval_core import _close_vector_store_pool
 from .schemas import (
     LCM_DESCRIBE,
     LCM_DOCTOR,
@@ -498,6 +499,7 @@ class _EngineShutdownGroup:
         for record in retired_background:
             self._drain_retired_background(record)
         join_background_integrity_scans()
+        _close_vector_store_pool()
         if first_error is not None:
             raise first_error
 

--- a/retrieval_core.py
+++ b/retrieval_core.py
@@ -40,82 +40,120 @@ if TYPE_CHECKING:
 # so a pooled store observes cross-process writes and never serves stale vectors.
 _POOL_MAX_PATHS = 2
 _pool_lock = threading.Lock()
-# (db_path, bounded_scan_rows) -> {"store": VectorStore, "lock": RLock}
+_pool_condition = threading.Condition(_pool_lock)
+# (db_path, bounded_scan_rows) -> {"store": VectorStore, "lock": RLock, "users": int}
 _vector_store_pool: "OrderedDict[tuple[str, int], dict[str, Any]]" = OrderedDict()
 _pool_closed = False
 
 
+def _close_vector_store_entry(entry: dict[str, Any]) -> None:
+    try:
+        entry["store"].close()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _evict_idle_vector_store_entries_locked() -> None:
+    while len(_vector_store_pool) > _POOL_MAX_PATHS:
+        idle_key = next(
+            (key for key, entry in _vector_store_pool.items() if not entry["users"]),
+            None,
+        )
+        if idle_key is None:
+            return
+        _close_vector_store_entry(_vector_store_pool.pop(idle_key))
+
+
 def _close_vector_store_entries_locked() -> None:
+    while any(entry["users"] for entry in _vector_store_pool.values()):
+        _pool_condition.wait()
     while _vector_store_pool:
         _, entry = _vector_store_pool.popitem()
-        with entry["lock"]:
-            try:
-                entry["store"].close()
-            except Exception:  # pragma: no cover - defensive
-                pass
+        _close_vector_store_entry(entry)
 
 
 def _reset_vector_store_pool() -> None:
     """Close pooled stores and reopen the pool for test hygiene."""
     global _pool_closed
-    with _pool_lock:
-        _pool_closed = False
+    with _pool_condition:
+        _pool_closed = True
         _close_vector_store_entries_locked()
+        _pool_closed = False
+        _pool_condition.notify_all()
 
 
 def _open_vector_store_pool() -> None:
     """Allow a freshly registered plugin instance to acquire pooled stores."""
     global _pool_closed
-    with _pool_lock:
+    with _pool_condition:
         _pool_closed = False
+        _pool_condition.notify_all()
 
 
 def _close_vector_store_pool() -> None:
     """Stop new acquisitions and drain every pooled store during unload."""
     global _pool_closed
-    with _pool_lock:
+    with _pool_condition:
         _pool_closed = True
         _close_vector_store_entries_locked()
 
 
 def _acquire_vector_store(
     engine: "LCMEngine", *, vector_store_cls: Any, scan_rows: int | None
-) -> tuple[Any, Any, bool]:
-    """Return ``(store, per_store_lock_or_None, is_transient)``.
+) -> tuple[Any, dict[str, Any] | None, bool]:
+    """Return ``(store, reserved_pool_entry_or_None, is_transient)``.
 
     Only the genuine pooling-capable store (``_supports_pooling``) is pooled so
     its matrix caches survive across calls; injected test doubles are constructed
     transiently and the caller closes them. The pool is an LRU bounded to
-    ``_POOL_MAX_PATHS`` (db_path, scan_rows) keys and an evicted store is closed.
-    A returned pooled-store lock is already held. The caller MUST release it
-    after querying so unload cannot close a store between acquisition and use.
+    ``_POOL_MAX_PATHS`` idle (db_path, scan_rows) keys. Busy entries may briefly
+    exceed that bound rather than blocking unrelated queries or closing in-use
+    stores. A returned pool entry owns one user reservation and has its per-store
+    lock held; the caller MUST release both after querying.
     """
     resolved_scan = int(scan_rows) if scan_rows is not None else -1
     key = (str(engine._store.db_path), resolved_scan)
-    with _pool_lock:
+    with _pool_condition:
         if _pool_closed:
             raise RuntimeError("LCM vector store pool is closed during plugin unload")
-        entry = _vector_store_pool.get(key)
-        if entry is not None:
-            _vector_store_pool.move_to_end(key)
-            entry["lock"].acquire()
-            return entry["store"], entry["lock"], False
-        store = vector_store_cls(
-            engine._store.db_path, config=engine._config, bounded_scan_rows=scan_rows
-        )
         if not getattr(vector_store_cls, "_supports_pooling", False):
-            return store, None, True  # transient: caller closes it
-        entry = {"store": store, "lock": threading.RLock()}
-        _vector_store_pool[key] = entry
-        while len(_vector_store_pool) > _POOL_MAX_PATHS:
-            _, evicted = _vector_store_pool.popitem(last=False)
-            with evicted["lock"]:  # wait out any in-flight query before closing
-                try:
-                    evicted["store"].close()
-                except Exception:  # pragma: no cover - defensive
-                    pass
+            store = vector_store_cls(
+                engine._store.db_path,
+                config=engine._config,
+                bounded_scan_rows=scan_rows,
+            )
+            return store, None, True
+        entry = _vector_store_pool.get(key)
+        if entry is None:
+            store = vector_store_cls(
+                engine._store.db_path,
+                config=engine._config,
+                bounded_scan_rows=scan_rows,
+            )
+            entry = {"store": store, "lock": threading.RLock(), "users": 0}
+            _vector_store_pool[key] = entry
+        else:
+            _vector_store_pool.move_to_end(key)
+        entry["users"] += 1
+        _evict_idle_vector_store_entries_locked()
+
+    try:
         entry["lock"].acquire()
-        return store, entry["lock"], False
+    except BaseException:
+        _release_vector_store_entry(entry, lock_held=False)
+        raise
+    return entry["store"], entry, False
+
+
+def _release_vector_store_entry(
+    entry: dict[str, Any], *, lock_held: bool = True
+) -> None:
+    if lock_held:
+        entry["lock"].release()
+    with _pool_condition:
+        entry["users"] -= 1
+        _evict_idle_vector_store_entries_locked()
+        _pool_condition.notify_all()
 
 
 def _run_pooled_knn(
@@ -132,7 +170,7 @@ def _run_pooled_knn(
     finally so a pooled connection never carries a stale/expired deadline into the
     next caller.
     """
-    store, store_lock, transient = _acquire_vector_store(
+    store, pool_entry, transient = _acquire_vector_store(
         engine, vector_store_cls=vector_store_cls, scan_rows=scan_rows
     )
     try:
@@ -149,8 +187,8 @@ def _run_pooled_knn(
             if vector_conn is not None:
                 vector_conn.set_progress_handler(None, 1000)
     finally:
-        if store_lock is not None:
-            store_lock.release()
+        if pool_entry is not None:
+            _release_vector_store_entry(pool_entry)
         if transient:
             store.close()
 

--- a/retrieval_core.py
+++ b/retrieval_core.py
@@ -21,7 +21,7 @@ import sqlite3
 import threading
 import time
 from collections import OrderedDict
-from contextlib import nullcontext
+
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -42,17 +42,40 @@ _POOL_MAX_PATHS = 2
 _pool_lock = threading.Lock()
 # (db_path, bounded_scan_rows) -> {"store": VectorStore, "lock": RLock}
 _vector_store_pool: "OrderedDict[tuple[str, int], dict[str, Any]]" = OrderedDict()
+_pool_closed = False
 
 
-def _reset_vector_store_pool() -> None:
-    """Close and drop every pooled VectorStore (test hygiene / shutdown)."""
-    with _pool_lock:
-        while _vector_store_pool:
-            _, entry = _vector_store_pool.popitem()
+def _close_vector_store_entries_locked() -> None:
+    while _vector_store_pool:
+        _, entry = _vector_store_pool.popitem()
+        with entry["lock"]:
             try:
                 entry["store"].close()
             except Exception:  # pragma: no cover - defensive
                 pass
+
+
+def _reset_vector_store_pool() -> None:
+    """Close pooled stores and reopen the pool for test hygiene."""
+    global _pool_closed
+    with _pool_lock:
+        _pool_closed = False
+        _close_vector_store_entries_locked()
+
+
+def _open_vector_store_pool() -> None:
+    """Allow a freshly registered plugin instance to acquire pooled stores."""
+    global _pool_closed
+    with _pool_lock:
+        _pool_closed = False
+
+
+def _close_vector_store_pool() -> None:
+    """Stop new acquisitions and drain every pooled store during unload."""
+    global _pool_closed
+    with _pool_lock:
+        _pool_closed = True
+        _close_vector_store_entries_locked()
 
 
 def _acquire_vector_store(
@@ -64,15 +87,18 @@ def _acquire_vector_store(
     its matrix caches survive across calls; injected test doubles are constructed
     transiently and the caller closes them. The pool is an LRU bounded to
     ``_POOL_MAX_PATHS`` (db_path, scan_rows) keys and an evicted store is closed.
-    The returned lock MUST be held while querying: a pooled sqlite connection is
-    shared across callers and is not safe for concurrent use.
+    A returned pooled-store lock is already held. The caller MUST release it
+    after querying so unload cannot close a store between acquisition and use.
     """
     resolved_scan = int(scan_rows) if scan_rows is not None else -1
     key = (str(engine._store.db_path), resolved_scan)
     with _pool_lock:
+        if _pool_closed:
+            raise RuntimeError("LCM vector store pool is closed during plugin unload")
         entry = _vector_store_pool.get(key)
         if entry is not None:
             _vector_store_pool.move_to_end(key)
+            entry["lock"].acquire()
             return entry["store"], entry["lock"], False
         store = vector_store_cls(
             engine._store.db_path, config=engine._config, bounded_scan_rows=scan_rows
@@ -88,6 +114,7 @@ def _acquire_vector_store(
                     evicted["store"].close()
                 except Exception:  # pragma: no cover - defensive
                     pass
+        entry["lock"].acquire()
         return store, entry["lock"], False
 
 
@@ -109,20 +136,21 @@ def _run_pooled_knn(
         engine, vector_store_cls=vector_store_cls, scan_rows=scan_rows
     )
     try:
-        with (store_lock if store_lock is not None else nullcontext()):
-            vector_conn = getattr(store, "_conn", None)
+        vector_conn = getattr(store, "_conn", None)
+        if vector_conn is not None:
+            vector_conn.set_progress_handler(
+                lambda: 1 if time.monotonic() >= deadline else 0, 1000
+            )
+        try:
+            if time.monotonic() >= deadline:
+                raise TimeoutError("semantic vector search deadline exhausted")
+            return query(store)
+        finally:
             if vector_conn is not None:
-                vector_conn.set_progress_handler(
-                    lambda: 1 if time.monotonic() >= deadline else 0, 1000
-                )
-            try:
-                if time.monotonic() >= deadline:
-                    raise TimeoutError("semantic vector search deadline exhausted")
-                return query(store)
-            finally:
-                if vector_conn is not None:
-                    vector_conn.set_progress_handler(None, 1000)
+                vector_conn.set_progress_handler(None, 1000)
     finally:
+        if store_lock is not None:
+            store_lock.release()
         if transient:
             store.close()
 

--- a/tests/test_assertion_model_pipeline.py
+++ b/tests/test_assertion_model_pipeline.py
@@ -365,6 +365,8 @@ def test_plugin_unload_waits_for_background_assertion_worker(tmp_path, monkeypat
     engine._store.append("session-a", message)
     assert engine._schedule_pre_compaction_assertions([message]) is True
     assert worker_started.wait(timeout=1)
+    engine.shutdown()
+    assert engine._store._conn is None
 
     unload_done = threading.Event()
     unload_errors = []

--- a/tests/test_assertion_model_pipeline.py
+++ b/tests/test_assertion_model_pipeline.py
@@ -340,8 +340,10 @@ def test_plugin_unload_waits_for_background_assertion_worker(
     tmp_path, monkeypatch, request
 ):
     from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
 
     request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     worker_started = threading.Event()
     release_worker = threading.Event()
 

--- a/tests/test_assertion_model_pipeline.py
+++ b/tests/test_assertion_model_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 
 import pytest
 
@@ -333,3 +334,58 @@ def test_compression_hook_queues_exact_rows_without_waiting_for_assertion_public
     finally:
         assert engine._assertion_extraction_idle.wait(3)
         engine.shutdown()
+
+
+def test_plugin_unload_waits_for_background_assertion_worker(tmp_path, monkeypatch):
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def blocking_payload_call(prompt: str, _model: str, _timeout: float):
+        worker_started.set()
+        if not release_worker.wait(timeout=3):
+            raise AssertionError("test did not release assertion worker")
+        return _payload_from_prompt(prompt), 1, 1
+
+    monkeypatch.setattr(
+        extraction_module,
+        "_call_structured_assertion_llm",
+        blocking_payload_call,
+    )
+    db_path = tmp_path / "lcm.db"
+    engine = LCMEngine(
+        config=LCMConfig(
+            database_path=str(db_path),
+            assertions_enabled=True,
+            assertion_extraction_enabled=True,
+            assertion_extraction_model="provider/model",
+        )
+    )
+    engine._session_id = "session-a"
+    message = {"role": "user", "content": "Remember this row."}
+    engine._store.append("session-a", message)
+    assert engine._schedule_pre_compaction_assertions([message]) is True
+    assert worker_started.wait(timeout=1)
+
+    unload_done = threading.Event()
+    unload_errors = []
+
+    def unload_plugin():
+        try:
+            engine.shutdown_all_instances()
+        except BaseException as exc:  # captured for assertion in the main thread
+            unload_errors.append(exc)
+        finally:
+            unload_done.set()
+
+    unload_thread = threading.Thread(target=unload_plugin)
+    unload_thread.start()
+    unload_waited = not unload_done.wait(timeout=0.1)
+    release_worker.set()
+    unload_thread.join(timeout=3)
+    assert engine._assertion_extraction_idle.wait(timeout=2)
+
+    assert unload_waited
+    assert not unload_thread.is_alive()
+    assert unload_errors == []
+    db_path.unlink()
+    assert not db_path.exists()

--- a/tests/test_assertion_model_pipeline.py
+++ b/tests/test_assertion_model_pipeline.py
@@ -336,7 +336,12 @@ def test_compression_hook_queues_exact_rows_without_waiting_for_assertion_public
         engine.shutdown()
 
 
-def test_plugin_unload_waits_for_background_assertion_worker(tmp_path, monkeypatch):
+def test_plugin_unload_waits_for_background_assertion_worker(
+    tmp_path, monkeypatch, request
+):
+    from hermes_lcm import retrieval_core
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
     worker_started = threading.Event()
     release_worker = threading.Event()
 

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -527,8 +527,10 @@ def test_plugin_unload_waits_for_background_integrity_scan(
     tmp_path, monkeypatch, request
 ):
     from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
 
     request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     from hermes_lcm.config import LCMConfig
     from hermes_lcm.engine import LCMEngine
 

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -523,6 +523,60 @@ def test_dispatch_stamps_scan_started_before_thread_runs(tmp_path, monkeypatch):
     conn.close()
 
 
+def test_plugin_unload_waits_for_background_integrity_scan(tmp_path, monkeypatch):
+    from hermes_lcm.config import LCMConfig
+    from hermes_lcm.engine import LCMEngine
+
+    db_path = tmp_path / "lcm.db"
+    engine = LCMEngine(config=LCMConfig(database_path=str(db_path)))
+    scan_started = threading.Event()
+    release_scan = threading.Event()
+
+    def blocking_scan(path, _spec, _started_at):
+        scan_conn = sqlite3.connect(path, check_same_thread=False)
+        try:
+            scan_started.set()
+            if not release_scan.wait(timeout=3):
+                raise AssertionError("test did not release integrity scan")
+        finally:
+            scan_conn.close()
+
+    monkeypatch.setattr(
+        db_bootstrap,
+        "_run_background_integrity_scan",
+        blocking_scan,
+    )
+    assert db_bootstrap._dispatch_background_integrity_scan(
+        engine._store._conn,
+        _spec(),
+    )
+    assert scan_started.wait(timeout=1)
+
+    unload_done = threading.Event()
+    unload_errors = []
+
+    def unload_plugin():
+        try:
+            engine.shutdown_all_instances()
+        except BaseException as exc:  # captured for assertion in the main thread
+            unload_errors.append(exc)
+        finally:
+            unload_done.set()
+
+    unload_thread = threading.Thread(target=unload_plugin)
+    unload_thread.start()
+    unload_waited = not unload_done.wait(timeout=0.1)
+    release_scan.set()
+    unload_thread.join(timeout=3)
+    db_bootstrap.join_background_integrity_scans(timeout=2)
+
+    assert unload_waited
+    assert not unload_thread.is_alive()
+    assert unload_errors == []
+    db_path.unlink()
+    assert not db_path.exists()
+
+
 def test_kill_switch_false_runs_synchronously_without_a_thread(tmp_path, monkeypatch, integrity_calls):
     """SPEC E (c): LCM_FTS_INTEGRITY_BACKGROUND=false = exact old synchronous path."""
     monkeypatch.setenv(INTERVAL_ENV, "24")

--- a/tests/test_db_bootstrap_fts.py
+++ b/tests/test_db_bootstrap_fts.py
@@ -523,7 +523,12 @@ def test_dispatch_stamps_scan_started_before_thread_runs(tmp_path, monkeypatch):
     conn.close()
 
 
-def test_plugin_unload_waits_for_background_integrity_scan(tmp_path, monkeypatch):
+def test_plugin_unload_waits_for_background_integrity_scan(
+    tmp_path, monkeypatch, request
+):
+    from hermes_lcm import retrieval_core
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
     from hermes_lcm.config import LCMConfig
     from hermes_lcm.engine import LCMEngine
 

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -308,6 +308,84 @@ class TestRegistrationGating:
         assert partial_closed
         assert not db_path.exists()
 
+    def test_unload_serializes_profile_storage_rebind(
+        self, tmp_path, monkeypatch, request
+    ):
+        from hermes_lcm import retrieval_core
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        request.addfinalizer(retrieval_core._reset_vector_store_pool)
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        home_a.mkdir()
+        home_b.mkdir()
+        engine = LCMEngine(
+            config=LCMConfig(database_path=""),
+            hermes_home=str(home_a),
+        )
+        real_bind = engine._bind_storage
+        bind_started = threading.Event()
+        release_bind = threading.Event()
+        unload_done = threading.Event()
+        rebind_errors = []
+        unload_errors = []
+
+        def blocking_bind(db_path, hermes_home):
+            if str(hermes_home) == str(home_b):
+                bind_started.set()
+                if not release_bind.wait(timeout=3):
+                    raise AssertionError("test did not release profile storage bind")
+            return real_bind(db_path, hermes_home)
+
+        def rebind_storage():
+            try:
+                engine._rebind_storage_for_home(str(home_b))
+            except BaseException as exc:  # captured for assertion in the main thread
+                rebind_errors.append(exc)
+
+        def unload_plugin():
+            try:
+                engine.shutdown_all_instances()
+            except BaseException as exc:  # captured for assertion in the main thread
+                unload_errors.append(exc)
+            finally:
+                unload_done.set()
+
+        monkeypatch.setattr(engine, "_bind_storage", blocking_bind)
+        rebind_thread = threading.Thread(target=rebind_storage)
+        unload_thread = threading.Thread(target=unload_plugin)
+        db_paths = (home_a / "lcm.db", home_b / "lcm.db")
+        try:
+            rebind_thread.start()
+            assert bind_started.wait(timeout=1)
+            unload_thread.start()
+            unload_waited = not unload_done.wait(timeout=0.1)
+            release_bind.set()
+            rebind_thread.join(timeout=3)
+            unload_thread.join(timeout=3)
+
+            assert unload_waited
+            assert not rebind_thread.is_alive()
+            assert not unload_thread.is_alive()
+            assert rebind_errors == []
+            assert unload_errors == []
+            assert engine._store._conn is None
+            with pytest.raises(RuntimeError, match="plugin is unloading"):
+                engine._rebind_storage_for_home(str(home_a))
+            for path in db_paths:
+                if path.exists():
+                    path.unlink()
+                assert not path.exists()
+        finally:
+            release_bind.set()
+            rebind_thread.join(timeout=3)
+            unload_thread.join(timeout=3)
+            engine._close_storage()
+            for path in db_paths:
+                if path.exists():
+                    path.unlink()
+
 
 class TestHermesAgentRegression:
     """Regression: Hermes Agent-shaped hosts must not shadow native LCM routing."""

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -184,6 +185,75 @@ class TestRegistrationGating:
                 late_clone.shutdown()
         if db_path.exists():
             db_path.unlink()
+        assert not db_path.exists()
+
+    def test_unload_waits_for_clone_construction_already_in_flight(
+        self, tmp_path, monkeypatch
+    ):
+        module = _load_plugin_module("hermes_lcm_unload_inflight_clone")
+        callbacks = []
+        db_path = tmp_path / "lcm.db"
+        monkeypatch.setenv("LCM_DATABASE_PATH", str(db_path))
+
+        class _Ctx:
+            def register_context_engine(self, engine):
+                self.engine = engine
+
+            def on_unload(self, callback):
+                callbacks.append(callback)
+
+        ctx = _Ctx()
+        module.register(ctx)
+        engine_type = type(ctx.engine)
+        original_init = engine_type.__init__
+        clone_constructed = threading.Event()
+        release_clone = threading.Event()
+
+        def blocking_init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            clone_constructed.set()
+            if not release_clone.wait(timeout=3):
+                raise AssertionError("test did not release clone construction")
+
+        monkeypatch.setattr(engine_type, "__init__", blocking_init)
+        clone_errors = []
+
+        def clone_engine():
+            try:
+                ctx.engine.clone_for_agent()
+            except BaseException as exc:  # captured for assertion in the main thread
+                clone_errors.append(exc)
+
+        clone_thread = threading.Thread(target=clone_engine)
+        clone_thread.start()
+        assert clone_constructed.wait(timeout=1)
+
+        unload_done = threading.Event()
+        unload_errors = []
+
+        def unload_plugin():
+            try:
+                callbacks[0]()
+            except BaseException as exc:  # captured for assertion in the main thread
+                unload_errors.append(exc)
+            finally:
+                unload_done.set()
+
+        unload_thread = threading.Thread(target=unload_plugin)
+        unload_thread.start()
+        unload_waited = not unload_done.wait(timeout=0.1)
+        release_clone.set()
+        clone_thread.join(timeout=3)
+        unload_thread.join(timeout=3)
+
+        assert unload_waited
+        assert not clone_thread.is_alive()
+        assert not unload_thread.is_alive()
+        assert unload_errors == []
+        assert len(clone_errors) == 1
+        assert isinstance(clone_errors[0], RuntimeError)
+        assert "unloading" in str(clone_errors[0])
+        db_path.unlink()
         assert not db_path.exists()
 
 

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 EXPECTED_LCM_TOOLS = {
     "lcm_grep",
@@ -172,6 +174,14 @@ class TestRegistrationGating:
         assert clone._store._conn is None
         db_path.unlink()
         assert not db_path.exists()
+
+        late_clone = None
+        try:
+            with pytest.raises(RuntimeError, match="unloading"):
+                late_clone = ctx.engine.clone_for_agent()
+        finally:
+            if late_clone is not None:
+                late_clone.shutdown()
 
 
 class TestHermesAgentRegression:

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -182,6 +182,9 @@ class TestRegistrationGating:
         finally:
             if late_clone is not None:
                 late_clone.shutdown()
+        if db_path.exists():
+            db_path.unlink()
+        assert not db_path.exists()
 
 
 class TestHermesAgentRegression:

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -312,10 +312,12 @@ class TestRegistrationGating:
         self, tmp_path, monkeypatch, request
     ):
         from hermes_lcm import retrieval_core
+        from hermes_lcm import tools as lcm_tools
         from hermes_lcm.config import LCMConfig
         from hermes_lcm.engine import LCMEngine
 
         request.addfinalizer(retrieval_core._reset_vector_store_pool)
+        request.addfinalizer(lcm_tools._open_deadline_worker_registry)
         home_a = tmp_path / "profile-a"
         home_b = tmp_path / "profile-b"
         home_a.mkdir()

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -256,6 +256,58 @@ class TestRegistrationGating:
         db_path.unlink()
         assert not db_path.exists()
 
+    def test_failed_clone_initialization_closes_partial_engine(self, tmp_path, monkeypatch):
+        module = _load_plugin_module("hermes_lcm_unload_failed_clone")
+        callbacks = []
+        db_path = tmp_path / "lcm.db"
+        monkeypatch.setenv("LCM_DATABASE_PATH", str(db_path))
+
+        class _Ctx:
+            def register_context_engine(self, engine):
+                self.engine = engine
+
+            def on_unload(self, callback):
+                callbacks.append(callback)
+
+        ctx = _Ctx()
+        module.register(ctx)
+        engine_type = type(ctx.engine)
+        engine_module = sys.modules[engine_type.__module__]
+
+        def fail_after_storage_bind(*_args, **_kwargs):
+            raise RuntimeError("synthetic clone initialization failure")
+
+        monkeypatch.setattr(
+            engine_module,
+            "compile_session_patterns",
+            fail_after_storage_bind,
+        )
+        with pytest.raises(RuntimeError, match="synthetic clone initialization failure") as excinfo:
+            ctx.engine.clone_for_agent()
+
+        partial_engine = None
+        traceback = excinfo.value.__traceback__
+        while traceback is not None:
+            candidate = traceback.tb_frame.f_locals.get("self")
+            if isinstance(candidate, engine_type) and candidate is not ctx.engine:
+                partial_engine = candidate
+                break
+            traceback = traceback.tb_next
+        assert partial_engine is not None
+
+        callbacks[0]()
+        partial_closed = partial_engine._store._conn is None
+        if not partial_closed:
+            for name in ("_adaptive_retrieval", "_store", "_dag", "_lifecycle", "_assertions", "_query_views"):
+                resource = getattr(partial_engine, name, None)
+                if resource is not None:
+                    resource.close()
+        if db_path.exists():
+            db_path.unlink()
+
+        assert partial_closed
+        assert not db_path.exists()
+
 
 class TestHermesAgentRegression:
     """Regression: Hermes Agent-shaped hosts must not shadow native LCM routing."""

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -145,6 +145,32 @@ class TestRegistrationGating:
         assert ctx.engine is not None
         assert ctx.engine.name == "lcm"
 
+    def test_registers_engine_shutdown_with_host_unload(self, tmp_path, monkeypatch):
+        module = _load_plugin_module("hermes_lcm_unload_cleanup")
+        callbacks = []
+        db_path = tmp_path / "lcm.db"
+        monkeypatch.setenv("LCM_DATABASE_PATH", str(db_path))
+
+        class _Ctx:
+            def register_context_engine(self, engine):
+                self.engine = engine
+
+            def on_unload(self, callback):
+                callbacks.append(callback)
+
+        ctx = _Ctx()
+        module.register(ctx)
+
+        assert len(callbacks) == 1
+        assert callbacks[0].__self__ is ctx.engine
+        assert db_path.is_file()
+
+        callbacks[0]()
+
+        assert ctx.engine._store._conn is None
+        db_path.unlink()
+        assert not db_path.exists()
+
 
 class TestHermesAgentRegression:
     """Regression: Hermes Agent-shaped hosts must not shadow native LCM routing."""

--- a/tests/test_host_capability.py
+++ b/tests/test_host_capability.py
@@ -163,11 +163,13 @@ class TestRegistrationGating:
 
         assert len(callbacks) == 1
         assert callbacks[0].__self__ is ctx.engine
+        clone = ctx.engine.clone_for_agent()
         assert db_path.is_file()
 
         callbacks[0]()
 
         assert ctx.engine._store._conn is None
+        assert clone._store._conn is None
         db_path.unlink()
         assert not db_path.exists()
 

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -1283,9 +1283,13 @@ def test_pooled_vector_store_survives_across_recall_calls(recall_engine, monkeyp
         rc._reset_vector_store_pool()
 
 
-def test_plugin_unload_closes_pooled_vector_store(recall_engine, monkeypatch):
+def test_plugin_unload_closes_pooled_vector_store(
+    recall_engine, monkeypatch, request
+):
     import hermes_lcm.retrieval_core as rc
+    from hermes_lcm import tools as lcm_tools
 
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     rc._reset_vector_store_pool()
     try:
         node = _add_summary(
@@ -1459,6 +1463,79 @@ def test_busy_pooled_store_does_not_block_other_pool_keys(recall_engine):
         for thread in (first, same_store, other_store):
             thread.join(2)
         rc._reset_vector_store_pool()
+
+
+def test_plugin_unload_waits_for_timed_out_sqlite_deadline_worker(
+    tmp_path, request
+):
+    import sqlite3
+    import threading
+
+    from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
+    from hermes_lcm.config import LCMConfig
+    from hermes_lcm.engine import LCMEngine
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
+    db_path = tmp_path / "deadline-worker.db"
+    engine = LCMEngine(config=LCMConfig(database_path=str(db_path)))
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    unload_done = threading.Event()
+    unload_errors = []
+
+    def sqlite_worker():
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        try:
+            worker_started.set()
+            if not release_worker.wait(3):
+                raise TimeoutError("test did not release SQLite deadline worker")
+        finally:
+            conn.close()
+
+    def unload_plugin():
+        try:
+            engine.shutdown_all_instances()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            unload_errors.append(exc)
+        finally:
+            unload_done.set()
+
+    unload_thread = threading.Thread(target=unload_plugin)
+    try:
+        with pytest.raises(TimeoutError, match="latency budget"):
+            lcm_tools._run_within_deadline(
+                sqlite_worker,
+                remaining_s=0.05,
+                name="lcm-test-sqlite-deadline",
+                track_for_unload=True,
+            )
+        assert worker_started.wait(1)
+        unload_thread.start()
+        unload_waited = not unload_done.wait(0.1)
+        release_worker.set()
+        unload_thread.join(3)
+
+        assert unload_waited
+        assert not unload_thread.is_alive()
+        assert not unload_errors
+        with pytest.raises(lcm_tools._WorkerCapacityError, match="unloading"):
+            lcm_tools._run_within_deadline(
+                lambda: None,
+                remaining_s=0.05,
+                name="lcm-test-post-unload-deadline",
+                track_for_unload=True,
+            )
+        db_path.unlink()
+        assert not db_path.exists()
+    finally:
+        release_worker.set()
+        if unload_thread.is_alive():
+            unload_thread.join(3)
+        engine.shutdown(wait_for_background_work=True)
+        if db_path.exists():
+            db_path.unlink()
 
 
 def test_matrix_cache_is_bounded_lru_not_cleared_on_miss():

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -1385,6 +1385,82 @@ def test_plugin_unload_waits_for_active_pooled_query(recall_engine):
         rc._reset_vector_store_pool()
 
 
+def test_busy_pooled_store_does_not_block_other_pool_keys(recall_engine):
+    import threading
+
+    import hermes_lcm.retrieval_core as rc
+
+    first_started = threading.Event()
+    first_release = threading.Event()
+    same_store_entered = threading.Event()
+    other_store_done = threading.Event()
+    errors = []
+
+    class BlockingStore:
+        _supports_pooling = True
+
+        def __init__(self, *_args, **_kwargs):
+            self._conn = None
+
+        def close(self):
+            pass
+
+    def run(scan_rows, query):
+        try:
+            rc._run_pooled_knn(
+                recall_engine,
+                vector_store_cls=BlockingStore,
+                scan_rows=scan_rows,
+                deadline=time.monotonic() + 5,
+                query=query,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def first_query(_store):
+        first_started.set()
+        if not first_release.wait(2):
+            raise TimeoutError("test query was not released")
+
+    def same_store_query(_store):
+        same_store_entered.set()
+
+    def other_store_query(_store):
+        other_store_done.set()
+
+    rc._reset_vector_store_pool()
+    first = threading.Thread(target=run, args=(1, first_query))
+    same_store = threading.Thread(target=run, args=(1, same_store_query))
+    other_store = threading.Thread(target=run, args=(2, other_store_query))
+    try:
+        first.start()
+        assert first_started.wait(2)
+        same_store.start()
+        deadline = time.monotonic() + 2
+        key = (str(recall_engine._store.db_path), 1)
+        while time.monotonic() < deadline:
+            with rc._pool_condition:
+                if rc._vector_store_pool[key]["users"] == 2:
+                    break
+            time.sleep(0.01)
+        else:
+            pytest.fail("same-store query never reserved its pooled entry")
+
+        other_store.start()
+        assert other_store_done.wait(1)
+        assert not same_store_entered.is_set()
+        first_release.set()
+        for thread in (first, same_store, other_store):
+            thread.join(2)
+            assert not thread.is_alive()
+        assert not errors
+    finally:
+        first_release.set()
+        for thread in (first, same_store, other_store):
+            thread.join(2)
+        rc._reset_vector_store_pool()
+
+
 def test_matrix_cache_is_bounded_lru_not_cleared_on_miss():
     """sprint-opt-6: distinct candidate sets coexist in a bounded LRU rather than
     each miss clearing the whole cache."""

--- a/tests/test_lcm_recall.py
+++ b/tests/test_lcm_recall.py
@@ -1283,6 +1283,108 @@ def test_pooled_vector_store_survives_across_recall_calls(recall_engine, monkeyp
         rc._reset_vector_store_pool()
 
 
+def test_plugin_unload_closes_pooled_vector_store(recall_engine, monkeypatch):
+    import hermes_lcm.retrieval_core as rc
+
+    rc._reset_vector_store_pool()
+    try:
+        node = _add_summary(
+            recall_engine,
+            "pooled unload cleanup",
+            session_id="session-a",
+            created_at=5.0,
+        )
+        _seed_summary_vectors(recall_engine, [(node, [1.0, 0.0])])
+        _recall(recall_engine, monkeypatch, include="summaries", limit=5)
+        key = (str(recall_engine._store.db_path), 25_000)
+        pooled = rc._vector_store_pool[key]["store"]
+
+        from hermes_lcm.config import LCMConfig
+        from hermes_lcm.engine import LCMEngine
+
+        lifecycle_engine = LCMEngine(
+            config=LCMConfig(database_path=str(recall_engine._store.db_path))
+        )
+        lifecycle_engine.shutdown_all_instances()
+
+        assert not rc._vector_store_pool
+        assert pooled._conn is None
+        from hermes_lcm.vector_store import VectorStore
+
+        with pytest.raises(RuntimeError, match="closed during plugin unload"):
+            rc._acquire_vector_store(
+                recall_engine,
+                vector_store_cls=VectorStore,
+                scan_rows=25_000,
+            )
+    finally:
+        rc._reset_vector_store_pool()
+
+
+def test_plugin_unload_waits_for_active_pooled_query(recall_engine):
+    import threading
+
+    import hermes_lcm.retrieval_core as rc
+
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+    errors = []
+
+    class BlockingStore:
+        _supports_pooling = True
+
+        def __init__(self, *_args, **_kwargs):
+            self._conn = None
+            self.was_closed = False
+
+        def close(self):
+            self.was_closed = True
+
+    def query(store):
+        started.set()
+        if not release.wait(2):
+            raise TimeoutError("test query was not released")
+        return store
+
+    def run_query():
+        try:
+            rc._run_pooled_knn(
+                recall_engine,
+                vector_store_cls=BlockingStore,
+                scan_rows=25_000,
+                deadline=time.monotonic() + 5,
+                query=query,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def close_pool():
+        rc._close_vector_store_pool()
+        closed.set()
+
+    rc._reset_vector_store_pool()
+    worker = threading.Thread(target=run_query)
+    closer = threading.Thread(target=close_pool)
+    try:
+        worker.start()
+        assert started.wait(2)
+        closer.start()
+        assert not closed.wait(0.1)
+        release.set()
+        worker.join(2)
+        closer.join(2)
+        assert not worker.is_alive()
+        assert not closer.is_alive()
+        assert not errors
+        assert closed.is_set()
+    finally:
+        release.set()
+        worker.join(2)
+        closer.join(2)
+        rc._reset_vector_store_pool()
+
+
 def test_matrix_cache_is_bounded_lru_not_cleared_on_miss():
     """sprint-opt-6: distinct candidate sets coexist in a bounded LRU rather than
     each miss clearing the whole cache."""

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -949,6 +949,12 @@ def test_plugin_unload_waits_for_rollup_owned_by_collected_clone(
     try:
         clone._schedule_rollup_maintenance("collected-clone")
         assert maintenance_started.wait(timeout=1)
+        record = (
+            clone._rollup_maintenance_owner,
+            clone._assertion_extraction_idle,
+        )
+        with prototype._shutdown_group._condition:
+            assert record in prototype._shutdown_group._background_work
         clone_ref = weakref.ref(clone)
         del clone
         gc.collect()

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -782,7 +782,7 @@ def test_rollup_background_failure_is_logged_without_breaking_bind(
         engine.shutdown()
 
 
-def test_engine_shutdown_does_not_wait_for_background_rollup_provider(
+def test_engine_shutdown_stays_nonblocking_but_plugin_unload_waits(
     tmp_path,
     monkeypatch,
 ):
@@ -817,6 +817,27 @@ def test_engine_shutdown_does_not_wait_for_background_rollup_provider(
         shutdown_elapsed = time.monotonic() - started_at
 
         assert shutdown_elapsed < 0.15
+
+        unload_done = threading.Event()
+        unload_errors = []
+
+        def unload_plugin():
+            try:
+                engine.shutdown_all_instances()
+            except BaseException as exc:  # captured for assertion in the main thread
+                unload_errors.append(exc)
+            finally:
+                unload_done.set()
+
+        unload_thread = threading.Thread(target=unload_plugin)
+        unload_thread.start()
+        unload_waited = not unload_done.wait(timeout=0.1)
+        release_maintenance.set()
+        unload_thread.join(timeout=3)
+
+        assert unload_waited
+        assert not unload_thread.is_alive()
+        assert unload_errors == []
     finally:
         release_maintenance.set()
         assert engine.drain_rollup_maintenance(timeout=2)

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -785,7 +785,11 @@ def test_rollup_background_failure_is_logged_without_breaking_bind(
 def test_engine_shutdown_stays_nonblocking_but_plugin_unload_waits(
     tmp_path,
     monkeypatch,
+    request,
 ):
+    from hermes_lcm import retrieval_core
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
     config = LCMConfig(
         database_path=str(tmp_path / "shutdown-background-maintenance.db"),
         temporal_rollups_enabled=True,
@@ -843,7 +847,12 @@ def test_engine_shutdown_stays_nonblocking_but_plugin_unload_waits(
         assert engine.drain_rollup_maintenance(timeout=2)
 
 
-def test_plugin_unload_waits_for_background_rollup_provider(tmp_path, monkeypatch):
+def test_plugin_unload_waits_for_background_rollup_provider(
+    tmp_path, monkeypatch, request
+):
+    from hermes_lcm import retrieval_core
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
     db_path = tmp_path / "unload-background-maintenance.db"
     engine = LCMEngine(
         config=LCMConfig(

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -822,6 +822,59 @@ def test_engine_shutdown_does_not_wait_for_background_rollup_provider(
         assert engine.drain_rollup_maintenance(timeout=2)
 
 
+def test_plugin_unload_waits_for_background_rollup_provider(tmp_path, monkeypatch):
+    db_path = tmp_path / "unload-background-maintenance.db"
+    engine = LCMEngine(
+        config=LCMConfig(
+            database_path=str(db_path),
+            temporal_rollups_enabled=True,
+        )
+    )
+    maintenance_started = threading.Event()
+    release_maintenance = threading.Event()
+
+    def blocking_maintenance(*_args, **_kwargs):
+        maintenance_started.set()
+        if not release_maintenance.wait(timeout=3):
+            raise AssertionError("test did not release background maintenance")
+        return 0
+
+    monkeypatch.setattr(
+        engine_module,
+        "run_rollup_maintenance",
+        blocking_maintenance,
+    )
+    engine.on_session_start(
+        "unload-maintenance-scope",
+        conversation_id="unload-maintenance-conversation",
+    )
+    assert maintenance_started.wait(timeout=1)
+
+    unload_done = threading.Event()
+    unload_errors = []
+
+    def unload_plugin():
+        try:
+            engine.shutdown_all_instances()
+        except BaseException as exc:  # captured for assertion in the main thread
+            unload_errors.append(exc)
+        finally:
+            unload_done.set()
+
+    unload_thread = threading.Thread(target=unload_plugin)
+    unload_thread.start()
+    unload_waited = not unload_done.wait(timeout=0.1)
+    release_maintenance.set()
+    unload_thread.join(timeout=3)
+    assert engine.drain_rollup_maintenance(timeout=2)
+
+    assert unload_waited
+    assert not unload_thread.is_alive()
+    assert unload_errors == []
+    db_path.unlink()
+    assert not db_path.exists()
+
+
 def test_pending_maintenance_query_uses_partial_index(rollup_parts):
     store, _dag, _config = rollup_parts
     store.mark_stale_for_day("2026-07-15", "query-plan")

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 import sqlite3
 import threading
 import time
+import weakref
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
@@ -903,6 +905,70 @@ def test_plugin_unload_waits_for_background_rollup_provider(
     assert unload_errors == []
     db_path.unlink()
     assert not db_path.exists()
+
+
+def test_plugin_unload_waits_for_rollup_owned_by_collected_clone(
+    tmp_path, monkeypatch, request
+):
+    from hermes_lcm import retrieval_core
+
+    request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    db_path = tmp_path / "collected-clone-rollup.db"
+    prototype = LCMEngine(
+        config=LCMConfig(
+            database_path=str(db_path),
+            temporal_rollups_enabled=True,
+        )
+    )
+    clone = prototype.clone_for_agent()
+    maintenance_started = threading.Event()
+    release_maintenance = threading.Event()
+    unload_done = threading.Event()
+    unload_errors = []
+
+    def blocking_maintenance(*_args, **_kwargs):
+        maintenance_started.set()
+        if not release_maintenance.wait(timeout=3):
+            raise AssertionError("test did not release collected clone maintenance")
+        return 0
+
+    def unload_plugin():
+        try:
+            prototype.shutdown_all_instances()
+        except BaseException as exc:  # captured for assertion in the main thread
+            unload_errors.append(exc)
+        finally:
+            unload_done.set()
+
+    monkeypatch.setattr(
+        engine_module,
+        "run_rollup_maintenance",
+        blocking_maintenance,
+    )
+    unload_thread = threading.Thread(target=unload_plugin)
+    try:
+        clone._schedule_rollup_maintenance("collected-clone")
+        assert maintenance_started.wait(timeout=1)
+        clone_ref = weakref.ref(clone)
+        del clone
+        gc.collect()
+        assert clone_ref() is None
+
+        unload_thread.start()
+        unload_waited = not unload_done.wait(timeout=0.1)
+        release_maintenance.set()
+        unload_thread.join(timeout=3)
+
+        assert unload_waited
+        assert not unload_thread.is_alive()
+        assert unload_errors == []
+        db_path.unlink()
+        assert not db_path.exists()
+    finally:
+        release_maintenance.set()
+        if unload_thread.is_alive():
+            unload_thread.join(timeout=3)
+        prototype.shutdown(wait_for_background_work=True)
 
 
 def test_pending_maintenance_query_uses_partial_index(rollup_parts):

--- a/tests/test_rollup_builder.py
+++ b/tests/test_rollup_builder.py
@@ -790,8 +790,10 @@ def test_engine_shutdown_stays_nonblocking_but_plugin_unload_waits(
     request,
 ):
     from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
 
     request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     config = LCMConfig(
         database_path=str(tmp_path / "shutdown-background-maintenance.db"),
         temporal_rollups_enabled=True,
@@ -853,8 +855,10 @@ def test_plugin_unload_waits_for_background_rollup_provider(
     tmp_path, monkeypatch, request
 ):
     from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
 
     request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     db_path = tmp_path / "unload-background-maintenance.db"
     engine = LCMEngine(
         config=LCMConfig(
@@ -911,8 +915,10 @@ def test_plugin_unload_waits_for_rollup_owned_by_collected_clone(
     tmp_path, monkeypatch, request
 ):
     from hermes_lcm import retrieval_core
+    from hermes_lcm import tools as lcm_tools
 
     request.addfinalizer(retrieval_core._reset_vector_store_pool)
+    request.addfinalizer(lcm_tools._open_deadline_worker_registry)
     db_path = tmp_path / "collected-clone-rollup.db"
     prototype = LCMEngine(
         config=LCMConfig(

--- a/tools.py
+++ b/tools.py
@@ -2780,6 +2780,30 @@ _lcm_semantic_worker_slots = threading.BoundedSemaphore(_LCM_SEMANTIC_MAX_WORKER
 _LCM_FULL_TEXT_MAX_WORKERS = 4
 _lcm_full_text_worker_slots = threading.BoundedSemaphore(_LCM_FULL_TEXT_MAX_WORKERS)
 
+# Deadline workers cannot be cancelled after their caller times out. Track only
+# workers that may retain private SQLite connections so plugin unload can wait
+# for those handles without also waiting on unrelated provider/network calls.
+_deadline_worker_condition = threading.Condition(threading.RLock())
+_tracked_deadline_workers: set[threading.Thread] = set()
+_deadline_worker_registry_closed = False
+
+
+def _open_deadline_worker_registry() -> None:
+    """Allow a newly registered plugin instance to start tracked workers."""
+    global _deadline_worker_registry_closed
+    with _deadline_worker_condition:
+        _deadline_worker_registry_closed = False
+
+
+def _close_and_join_deadline_workers() -> None:
+    """Reject new tracked workers and wait for existing SQLite owners."""
+    global _deadline_worker_registry_closed
+    with _deadline_worker_condition:
+        _deadline_worker_registry_closed = True
+        workers = list(_tracked_deadline_workers)
+    for worker in workers:
+        worker.join()
+
 
 class _WorkerCapacityError(RuntimeError):
     """Raised when no bounded worker slot is available."""
@@ -2791,6 +2815,7 @@ def _run_within_deadline(
     remaining_s: float,
     name: str,
     worker_slots: threading.BoundedSemaphore | None = None,
+    track_for_unload: bool = False,
 ):
     """Run ``fn`` in a bounded daemon worker, raising if the deadline lapses.
 
@@ -2812,14 +2837,38 @@ def _run_within_deadline(
         except BaseException as exc:  # noqa: BLE001 - forwarded to caller
             outcome.append((False, exc))
         finally:
-            slots.release()
+            try:
+                slots.release()
+            finally:
+                if track_for_unload:
+                    with _deadline_worker_condition:
+                        _tracked_deadline_workers.discard(threading.current_thread())
+                        _deadline_worker_condition.notify_all()
 
     worker = threading.Thread(target=invoke, name=name, daemon=True)
-    try:
-        worker.start()
-    except BaseException:
-        slots.release()
-        raise
+    if track_for_unload:
+        with _deadline_worker_condition:
+            if _deadline_worker_registry_closed:
+                slots.release()
+                raise _WorkerCapacityError(
+                    f"{name} worker rejected while plugin is unloading"
+                )
+            _tracked_deadline_workers.add(worker)
+            try:
+                # Start under the registry lock so unload cannot snapshot an
+                # added-but-not-yet-started thread and attempt to join it.
+                worker.start()
+            except BaseException:
+                _tracked_deadline_workers.discard(worker)
+                _deadline_worker_condition.notify_all()
+                slots.release()
+                raise
+    else:
+        try:
+            worker.start()
+        except BaseException:
+            slots.release()
+            raise
     worker.join(remaining_s)
     if worker.is_alive():
         raise TimeoutError(f"{name} exceeded the semantic latency budget")
@@ -2920,6 +2969,7 @@ def _lcm_grep_full_text_with_deadline(
             remaining_s=remaining,
             name="lcm-full-text",
             worker_slots=_lcm_full_text_worker_slots,
+            track_for_unload=True,
         )
     except (_WorkerCapacityError, TimeoutError):
         return _lcm_grep_deadline_error(
@@ -3256,6 +3306,7 @@ def _lcm_grep_semantic(
             ),
             remaining_s=deadline - time.monotonic(),
             name="lcm-result-hydration",
+            track_for_unload=True,
         )
     except _WorkerCapacityError as exc:
         return degraded(f"semantic capacity exhausted: {exc}")
@@ -4428,6 +4479,7 @@ def _lcm_recall_summary_arm(
         ),
         remaining_s=deadline - time.monotonic(),
         name="lcm-recall-summary-hydrate",
+        track_for_unload=True,
     )
     current = engine.current_session_id
     if reference_strict:
@@ -4502,6 +4554,7 @@ def _lcm_recall_chunk_arm(
         ),
         remaining_s=deadline - time.monotonic(),
         name="lcm-recall-chunk-hydrate",
+        track_for_unload=True,
     )
     current = engine.current_session_id
     hits: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- register one host unload callback
- close prototype, live, in-flight, and failed clones; reject late clones and profile rebinds
- drain rollup, assertion, integrity, timed-out SQLite deadline, and pooled-vector work
- keep ordinary engine shutdown non-blocking

Fixes #564.

## Why
Hermes creates per-agent clones and background SQLite work. Plugin unload must release every old-plugin handle before Windows can replace or delete the database.

## Validation
- deterministic clone, worker, pool, timeout, and profile-rebind regressions
- affected lifecycle/retrieval surface: `230 passed, 1 deselected`
- Ruff, compilation, and diff checks pass
- Codex clean on `3e802305d5`

Maintainer workflow approval and review pending.

## Compatibility
- weak tracking does not retain dead agent runtimes
- hosts without `ctx.on_unload` keep existing behavior
- ordinary engine shutdown remains non-blocking
