### PR TITLE
fix(storage): remove clock uniqueness assumptions

### DIFF
--- a/externalize.py
+++ b/externalize.py
@@ -17,6 +17,7 @@ import os
 import re
 import stat
 import time
+import uuid
 from pathlib import Path
 from typing import Any, BinaryIO, Dict
 
@@ -48,6 +49,11 @@ def _safe_stub(value: str, fallback: str) -> str:
 
 def _content_digest_prefix(content: str) -> str:
     return hashlib.sha256((content or "").encode("utf-8")).hexdigest()[:12]
+
+
+def _unique_file_suffix() -> str:
+    # Keep references compact while avoiding any clock-resolution assumption.
+    return uuid.uuid4().hex[:16]
 
 
 def _preview_sha256(preview_prefix: Any) -> str:
@@ -167,7 +173,7 @@ def _write_externalized_payload(path: Path, payload: Dict[str, Any]) -> None:
 
 
 def _replace_externalized_payload(path: Path, payload: Dict[str, Any]) -> None:
-    tmp_path = path.with_name(f"{path.name}.{time.time_ns():x}.tmp")
+    tmp_path = path.with_name(f"{path.name}.{_unique_file_suffix()}.tmp")
     try:
         _write_externalized_payload(tmp_path, payload)
         tmp_path.replace(path)
@@ -1088,7 +1094,7 @@ def externalize_ingest_payload(
 
     digest_prefix = _content_digest_prefix(content)
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
-    unique_suffix = f"{time.time_ns():x}"
+    unique_suffix = _unique_file_suffix()
     kind_stub = _safe_stub(kind, "ingest_payload")
     field_stub = re.sub(r"[^A-Za-z0-9_.-]+", "-", field_path or "payload")[:48]
     filename = f"{timestamp}_{kind_stub}_{field_stub}_{digest_prefix}_{unique_suffix}.json"
@@ -1206,7 +1212,7 @@ def maybe_externalize_payload(
 
     digest_prefix = _content_digest_prefix(content)
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
-    unique_suffix = f"{time.time_ns():x}"
+    unique_suffix = _unique_file_suffix()
     if kind == "tool_result":
         # Keep the original filename shape for compatibility with existing
         # externalized tool-output stores and tests.

--- a/store.py
+++ b/store.py
@@ -465,11 +465,18 @@ class MessageStore:
             token_estimates = [0] * len(messages)
 
         ids = []
+        last_timestamp = -math.inf
         with self._write_lock, self._conn:
             for msg, est in zip(messages, token_estimates):
                 tc = msg.get("tool_calls")
                 tc_json = json.dumps(tc) if tc else None
-                ts = time.time()
+                candidate_timestamp = time.time()
+                ts = (
+                    candidate_timestamp
+                    if candidate_timestamp > last_timestamp
+                    else math.nextafter(last_timestamp, math.inf)
+                )
+                last_timestamp = ts
                 observed_at = _normalize_observed_at(msg.get("timestamp"))
                 cur = self._conn.execute(
                     """INSERT INTO messages

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -11,6 +11,7 @@ import stat
 import sys
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -498,6 +499,38 @@ def test_externalized_payload_write_fsyncs_file_and_parent_directory(tmp_path, m
     assert result["path"].exists()
     assert file_fsync_calls
     assert result["path"].parent in fsynced_dirs
+
+
+def test_ingest_payload_names_do_not_depend_on_clock_uniqueness(tmp_path, monkeypatch):
+    engine = _engine(tmp_path)
+    monkeypatch.setattr(externalize_module, "_fsync_directory", lambda _path: None)
+    monkeypatch.setattr(
+        externalize_module.time,
+        "time_ns",
+        lambda: pytest.fail("filename identity must not depend on clock resolution"),
+    )
+    suffixes = iter(("1" * 32, "2" * 32))
+    monkeypatch.setattr(
+        externalize_module.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex=next(suffixes)),
+    )
+    kwargs = {
+        "role": "user",
+        "session_id": engine.current_session_id,
+        "field_path": "content",
+        "config": engine._config,
+        "hermes_home": str(tmp_path),
+    }
+
+    first = externalize_ingest_payload("same payload", **kwargs)
+    second = externalize_ingest_payload("same payload", **kwargs)
+
+    assert first is not None
+    assert second is not None
+    assert first["path"] != second["path"]
+    assert first["path"].stem.endswith("_" + "1" * 16)
+    assert second["path"].stem.endswith("_" + "2" * 16)
 
 
 def test_externalized_search_prefix_rejects_path_replaced_during_open(tmp_path, monkeypatch):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -16,6 +16,7 @@ import pytest
 
 from hermes_lcm.config import LCMConfig
 from hermes_lcm.tokens import count_tokens, count_message_tokens, count_messages_tokens
+import hermes_lcm.store as store_module
 from hermes_lcm.store import MessageStore
 from hermes_lcm.dag import SummaryDAG, SummaryNode
 from hermes_lcm.escalation import (
@@ -2681,13 +2682,14 @@ class TestMessageStore:
         # unlimited search — i.e. the sort order is deterministic.
         assert [result["store_id"] for result in short_results] == [result["store_id"] for result in long_results[:5]]
 
-    def test_append_batch_timestamps_are_unique_per_row(self, store):
+    def test_append_batch_timestamps_are_unique_per_row(self, store, monkeypatch):
         """Regression: each message in a batch must get its own timestamp.
 
         The old code called time.time() once before the loop, giving every
         message in the batch the same timestamp.  This broke date-based
         queries (journal entries, time-range filtering).
         """
+        monkeypatch.setattr(store_module.time, "time", lambda: 1234.0)
         n = 50
         ids = store.append_batch(
             "ts-sess",


### PR DESCRIPTION
## Summary
- replace `time.time_ns()` filename suffixes with compact UUID-derived suffixes for externalized and temporary payload files
- guarantee strictly increasing message timestamps within each `append_batch()` call even when the clock repeats or moves backward
- make the existing timestamp regression deterministic and add a deterministic filename-collision regression

## Why
`time.time()` and `time.time_ns()` report clock values, not uniqueness guarantees. Current `main` already has a test requiring distinct per-row batch timestamps, but on this Windows host 50 rows received only 2 distinct values. When `time_ns()` repeats, same-content externalizations select the same path; the exclusive create fails and the second payload falls back inline.

This fixes the whole adjacent clock-identity class without changing persisted schema or filename parsing.

## Validation
- [x] Unpatched current-main deterministic regressions: the two focused tests -> **2 failed**
- [x] Candidate focused validation: the two focused tests -> **2 passed**
- [x] Ruff on changed Python files -> **passed**
- [x] `python -m compileall -q .` -> **passed**
- [x] `git diff --check` / staged diff check -> **passed**
- [ ] Default Linux validation is delegated to existing CI on this independent branch.

## Notes
- Timestamp monotonicity is guaranteed within each batch, matching the existing contract and test; this does not introduce a global timestamp sequence across processes or restarts.
- The 16-hex-character suffix keeps existing placeholder sizes stable while removing clock resolution as an identity source.
- A broader local Windows run recorded **361 passed, 83 failed, 3 skipped** because this branch intentionally does not include the independent parent-directory `fsync` fix in #563; those failures are not reported as green.

Fixes #566