### PR TITLE
fix(ingest): quarantine short repetitive assistant output below the 64KB gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 ## Unreleased
 
-No additional changes yet.
+### Fixed
+
+- #196 assistant outputs with extremely high repetition are now quarantined
+  regardless of size: a short looped response (for example one sentence
+  repeated 46 times, ~3k chars) previously bypassed the 65,536-char gate and
+  stayed in retrieval context forever.
 
 ## v0.21.0-rc2 - 2026-08-05
 

--- a/ingest_protection.py
+++ b/ingest_protection.py
@@ -105,6 +105,9 @@ _QUARANTINED_ASSISTANT_KIND = "quarantined_assistant_output"
 _QUARANTINED_ASSISTANT_REASON = "high_repetition"
 _QUARANTINED_ASSISTANT_MIN_CHARS = 65_536
 _QUARANTINED_ASSISTANT_MIN_TOKENS = 1_000
+_SHORT_REPEAT_MIN_SEGMENTS = 3
+_SHORT_REPEAT_TOP_RATIO = 0.90
+_SHORT_REPEAT_DUP_RATIO = 0.90
 _WORD_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 _REPETITION_SEGMENT_SPLIT_RE = re.compile(r"(?:\n+|(?<=[.!?])\s+)")
 _HEARTBEAT_NOISE_RE = re.compile(
@@ -856,6 +859,27 @@ def heartbeat_noise_reason(role: str, text: str) -> str | None:
     return None
 
 
+def _short_repetition_reason(segments: list[str]) -> str | None:
+    """Size-independent repetition check for short outputs.
+
+    The 65,536-char gate cannot catch a model loop that repeats one sentence 46
+    times (a few thousand chars). This check fires only when normalized
+    segments are overwhelmingly identical, so it never quarantines varied
+    prose, code, or logs.
+    """
+    if len(segments) < _SHORT_REPEAT_MIN_SEGMENTS:
+        return None
+    segment_counts = Counter(segments)
+    top_segment_ratio = segment_counts.most_common(1)[0][1] / len(segments)
+    duplicate_segment_ratio = 1.0 - len(segment_counts) / len(segments)
+    if (
+        top_segment_ratio >= _SHORT_REPEAT_TOP_RATIO
+        or duplicate_segment_ratio >= _SHORT_REPEAT_DUP_RATIO
+    ):
+        return _QUARANTINED_ASSISTANT_REASON
+    return None
+
+
 def assistant_output_quarantine_reason(text: str) -> str | None:
     """Return a quarantine reason for obviously broken assistant output.
 
@@ -863,39 +887,42 @@ def assistant_output_quarantine_reason(text: str) -> str | None:
     both low token novelty and repeated sentence/line segments. Long diverse
     reports and code with varied identifiers should stay inline.
     """
-    if not isinstance(text, str) or len(text) < _QUARANTINED_ASSISTANT_MIN_CHARS:
+    if not isinstance(text, str):
         return None
 
     normalized = re.sub(r"\s+", " ", text.strip().lower())
-    tokens = _WORD_TOKEN_RE.findall(normalized)
-    if len(tokens) < _QUARANTINED_ASSISTANT_MIN_TOKENS:
-        if len(normalized) >= _QUARANTINED_ASSISTANT_MIN_CHARS and len(set(normalized)) <= 12:
-            return _QUARANTINED_ASSISTANT_REASON
-        return None
-
-    token_counts = Counter(tokens)
-    unique_token_ratio = len(token_counts) / max(1, len(tokens))
-    top_token_ratio = token_counts.most_common(1)[0][1] / max(1, len(tokens))
-
     segments = _normalized_repetition_segments(text)
-    top_segment_ratio = 0.0
-    duplicate_segment_ratio = 0.0
-    if len(segments) >= 20:
-        segment_counts = Counter(segments)
-        top_segment_ratio = segment_counts.most_common(1)[0][1] / len(segments)
-        duplicate_segment_ratio = 1.0 - (len(segment_counts) / len(segments))
+    if len(text) >= _QUARANTINED_ASSISTANT_MIN_CHARS:
+        tokens = _WORD_TOKEN_RE.findall(normalized)
+        if len(tokens) < _QUARANTINED_ASSISTANT_MIN_TOKENS:
+            if len(normalized) >= _QUARANTINED_ASSISTANT_MIN_CHARS and len(set(normalized)) <= 12:
+                return _QUARANTINED_ASSISTANT_REASON
+        else:
+            token_counts = Counter(tokens)
+            unique_token_ratio = len(token_counts) / max(1, len(tokens))
+            top_token_ratio = token_counts.most_common(1)[0][1] / max(1, len(tokens))
 
-    if unique_token_ratio <= 0.03 and (
-        top_segment_ratio >= 0.10
-        or duplicate_segment_ratio >= 0.50
-        or top_token_ratio >= 0.08
-    ):
-        return _QUARANTINED_ASSISTANT_REASON
+            top_segment_ratio = 0.0
+            duplicate_segment_ratio = 0.0
+            if len(segments) >= 20:
+                segment_counts = Counter(segments)
+                top_segment_ratio = segment_counts.most_common(1)[0][1] / len(segments)
+                duplicate_segment_ratio = 1.0 - (len(segment_counts) / len(segments))
 
-    # Covers degenerate long loops with little punctuation/newline structure.
-    if unique_token_ratio <= 0.015 and len(set(normalized)) <= 64:
-        return _QUARANTINED_ASSISTANT_REASON
+            if unique_token_ratio <= 0.03 and (
+                top_segment_ratio >= 0.10
+                or duplicate_segment_ratio >= 0.50
+                or top_token_ratio >= 0.08
+            ):
+                return _QUARANTINED_ASSISTANT_REASON
 
+            # Covers degenerate long loops with little punctuation/newline structure.
+            if unique_token_ratio <= 0.015 and len(set(normalized)) <= 64:
+                return _QUARANTINED_ASSISTANT_REASON
+
+    short_reason = _short_repetition_reason(segments)
+    if short_reason:
+        return short_reason
     return None
 
 

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import os
 import re
 import sqlite3
 import stat
@@ -31,6 +32,7 @@ from hermes_lcm.externalize import (
     reassign_externalized_payloads,
 )
 from hermes_lcm.ingest_protection import (
+    assistant_output_quarantine_reason,
     extract_all_externalized_payload_refs,
     extract_ingest_externalized_refs,
     redact_sensitive_text,
@@ -4199,3 +4201,104 @@ def test_wrapped_base64_scan_preserves_short_terminal_line():
     payload = "\n".join([full_line] * 70 + [terminal])
 
     assert contains_long_base64_run(payload) is True
+
+
+SHORT_REPEAT_MARKER = "SHORT_REPEAT_LOOP_MARKER_196"
+SHORT_REPEAT_LINE = f"{SHORT_REPEAT_MARKER} " + "x" * (72 - len(SHORT_REPEAT_MARKER) - 1)
+SHORT_REPEAT_R1 = (SHORT_REPEAT_LINE + "\n") * 46
+SHORT_REPEAT_R2 = (_broken_assistant_output().splitlines(keepends=True)[0].split(". ")[0] + ".\n") * 6
+SHORT_REPEAT_R3 = ("z" * 40 + "\n") * 3
+# A multi-sentence paragraph looped 6x spreads repetition across 3 distinct
+# sentence segments (top ratio 6/18, dup ratio 12/18) -- below the 0.90 bar
+# by design; low-count coherent-prose loops may be intentional content.
+SHORT_REPEAT_PARAGRAPH_X6_BELOW_BAR = _broken_assistant_output()[: 232 * 6]
+
+
+@pytest.mark.parametrize("text", [SHORT_REPEAT_R1, SHORT_REPEAT_R2, SHORT_REPEAT_R3])
+def test_short_repetitive_assistant_output_is_quarantined(text):
+    assert assistant_output_quarantine_reason(text) == "high_repetition"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "\n".join(_legitimate_long_report().splitlines()[:60]),
+        "\n".join(
+            [
+                "The weather station recorded a calm morning over the northern valley.",
+                "A small bakery opened early and sold fresh bread to commuters.",
+                "The museum added two restored paintings to its spring exhibition.",
+                "Engineers tested a quieter motor design in the downtown workshop.",
+                "A local choir rehearsed harmonies for Saturday's community concert.",
+                "The library extended its evening hours during the exam season.",
+                "Several hikers found a new trail marker beside the eastern ridge.",
+                "The science club built a water filter from simple household materials.",
+                "A gardener planted herbs and tomatoes beside the apartment entrance.",
+                "The ferry timetable changed slightly after maintenance was completed.",
+            ]
+        ),
+        "Hello world.",
+        "\n".join(
+            [
+                "import json",
+                "from pathlib import Path",
+                "DEFAULT_LIMIT = 15",
+                "def load_records(source_path):",
+                "    payload = Path(source_path).read_text()",
+                "    return json.loads(payload)",
+                "def select_record(records, record_id):",
+                "    for candidate in records:",
+                "        if candidate.get(\"id\") == record_id:",
+                "            return candidate",
+                "    return None",
+                "records = load_records(\"records.json\")",
+                "selected = select_record(records, \"alpha\")",
+                "print(selected)",
+            ]
+        ),
+        "\n".join(
+            [
+                "INFO: worker=alpha request=prepare status=ok",
+                "INFO: worker=bravo request=load status=ok",
+                "INFO: worker=charlie request=scan status=ok",
+                "INFO: worker=delta request=write status=ok",
+                "INFO: worker=echo request=close status=ok",
+                "INFO: worker=foxtrot request=sync status=ok",
+                "INFO: worker=golf request=flush status=ok",
+                "INFO: worker=hotel request=wait status=ok",
+            ]
+        ),
+        "\n".join(["A" * 40, "B" * 40, "A" * 40, "B" * 40] * 2),
+        SHORT_REPEAT_PARAGRAPH_X6_BELOW_BAR,
+    ],
+)
+def test_short_normal_output_is_not_quarantined(text):
+    assert assistant_output_quarantine_reason(text) is None
+
+
+def test_short_repetitive_assistant_output_is_quarantined_end_to_end(tmp_path, monkeypatch):
+    # Windows cannot open a directory handle via os.open() (upstream Issue #408,
+    # fixed in PR #522/#563); quarantine then degrades to inline preservation and
+    # this test would fail for an unrelated reason. Isolate the quarantine logic
+    # from the directory-fsync path so the test is portable.
+    if os.name == "nt":
+        monkeypatch.setattr(
+            "hermes_lcm.externalize._fsync_directory", lambda path: None
+        )
+    engine = _engine(tmp_path)
+
+    engine._ingest_messages([{"role": "assistant", "content": SHORT_REPEAT_R1}])
+
+    _store_id, content, _tool_calls = _single_message_row(engine, role="assistant")
+    assert "assistant output quarantined" in content
+    assert "high_repetition" in content
+    assert SHORT_REPEAT_MARKER not in content
+    assert engine._store.search(SHORT_REPEAT_MARKER, session_id=engine.current_session_id) == []
+
+    ref = _extract_ref(content)
+    expanded = _expand_ref(engine, ref)
+    assert expanded["kind"] == "quarantined_assistant_output"
+    assert expanded["content"] == SHORT_REPEAT_R1
+
+    doctor = handle_lcm_command("doctor", engine)
+    assert "quarantined_assistant_rows:" in doctor


### PR DESCRIPTION
## Summary
- Assistant-output quarantine now also catches short degenerate repetition: outputs of any size whose normalized segments are >= 90% repeated across at least 3 segments are quarantined as `high_repetition` instead of being remembered verbatim.

## Why
- The existing gate only fires above 65,536 chars (`_QUARANTINED_ASSISTANT_MIN_CHARS`), so a model loop that repeats one sentence dozens of times (a few KB) bypasses it and stays in retrieval context forever.
- Real-world shape: a session where the model repeated the same sentence 46 times (~3.3k chars) — the gate returned `None` and the polluted content was ingested inline.

## Validation
- [x] Focused validation: `pytest tests/test_ingest_protection.py -k "short_repetitive or legitimate" -q` -> `5 passed`
- [x] Regression: 46x/6x/3x repeated units are quarantined; varied prose, code, and logs are not
- [x] `ruff check ingest_protection.py tests/test_ingest_protection.py` -> `All checks passed!`
- [ ] Default validation:
  - [ ] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q`
  - [ ] `pytest -q`
  - [ ] `bash -lc 'ulimit -n 1024 && pytest -q'`
  - [ ] `python -m compileall -q .`
  - [ ] `python -m py_compile scripts/import_lossless_claw.py`
  - [ ] `bash -n scripts/install.sh scripts/update.sh`
  - [ ] `git diff --check`
- [ ] Workflow validation, if workflows changed: `actionlint`

## Notes
- The large-output analysis (`unique_token_ratio` / `top_segment_ratio` / `top_token_ratio`) is unchanged; short outputs now fall through to the new repetition check instead of returning `None` early.
- The e2e test isolates the Windows directory-fsync path (Issue #408, PR #522/#563) via monkeypatch so it is portable; on Windows the quarantine otherwise degrades to inline preservation for an unrelated reason.
- On Windows, 56 pre-existing tests fail with `[Errno 13] Permission denied` from the directory-fsync path (Issue #408) — identical on the untouched baseline; this PR does not touch that path.

Refs #196
