### PR TITLE
fix: preserve active context below the compaction threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ moved back to that assistant even when doing so exceeds a configured bound.
 | `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content is excluded from LCM storage |
 | `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
 | `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files; generic non-tool text remains unchanged in active replay |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
 | `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` | `false` | Replace token-heavy textual tool results with recoverable externalized refs in active replay; current-turn ingest is immediate and historical assembly respects the protected fresh tail; requires large-output externalization |
 | `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS` | `25000` | Token-aware threshold for active-replay tool-result stubbing |
@@ -412,6 +412,14 @@ moved back to that assistant even when doing so exceeds a configured bound.
 | `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
 | `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires |
 | `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
+
+Large-output externalization is a durable-storage policy, not an early context
+compression boundary. Generic user, assistant, system, and other non-tool text
+remains provider-visible in active replay until normal compaction selects it.
+Only `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` opts textual tool results
+into recoverable active-replay refs. Sensitive-value redaction, ignored-message
+filtering, and suspicious-assistant quarantine remain separate safety policies
+and may still change active replay according to their own settings.
 
 ### Model and timeout settings
 
@@ -461,6 +469,13 @@ When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
 threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
 compressor. Hermes core `compression.enabled` is still the global gate that
 allows compaction, so leave it enabled when using LCM.
+
+During ordinary automatic preflight below this threshold, ingest protection may
+still ask the host to publish a sanitized replay (for example a recoverable
+tool-result ref or sensitive-value redaction), but that cleanup-only pass does
+not call the summarizer or create a DAG node. Manual ``force`` requests,
+overflow recovery, and explicitly enabled deferred maintenance keep their own
+compaction semantics.
 
 If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the

--- a/compaction.py
+++ b/compaction.py
@@ -117,6 +117,12 @@ class CompactionMixin:
                 return False
         if replay_messages is not None and replay_messages != messages:
             replay_rough = count_messages_tokens(replay_messages)
+            # If ingest restores a smaller cached canonical replay, the host
+            # still retains the larger original list unless compression is
+            # requested. Use both views for pressure so semantic normalization
+            # (for example whitespace-heavy JSON tool arguments) cannot hide a
+            # prompt that has already crossed the configured threshold.
+            pressure_rough = max(rough, replay_rough)
             cleanup_requested = self._replay_diff_requests_ingest_cleanup(
                 messages,
                 replay_messages,
@@ -149,27 +155,39 @@ class CompactionMixin:
                 self._last_compression_noop_reason = pre_ingest_noop_reason
                 logger.info("LCM preflight compression no-op: %s", pre_ingest_noop_reason)
                 return False
-            eligible, reason = self._leaf_compaction_candidate_status(
-                replay_messages,
-                allow_partial_leaf=bool(
-                    self._config.threshold_full_sweep_enabled
-                    and self.threshold_tokens > 0
-                    and replay_rough >= self.threshold_tokens
-                ),
-            )
-            if eligible:
-                return self._mark_preflight_compression_requested()
-            if self._has_ignored_backlog_outside_fresh_tail(replay_messages):
-                return self._mark_preflight_compression_requested()
-            if self.threshold_tokens > 0 and replay_rough >= self.threshold_tokens:
-                if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
+            if self.threshold_tokens > 0 and pressure_rough >= self.threshold_tokens:
+                # A replay can differ only because the host added provider
+                # metadata after the previous turn and ingest restored the
+                # cached canonical prefix. Equality alone is not context
+                # pressure: ordinary leaf/ignored-backlog work must remain
+                # behind the configured threshold just like the non-divergent
+                # path below. Explicit cleanup, overflow, and opt-in deferred
+                # maintenance keep their separate gates.
+                eligible, reason = self._leaf_compaction_candidate_status(
+                    replay_messages,
+                    allow_partial_leaf=self._config.threshold_full_sweep_enabled,
+                )
+                if eligible:
+                    return self._mark_preflight_compression_requested()
+                if self._has_ignored_backlog_outside_fresh_tail(replay_messages):
+                    return self._mark_preflight_compression_requested()
+                if self._should_run_deferred_maintenance(
+                    replay_messages,
+                    observed_tokens=pressure_rough,
+                ):
                     return self._mark_preflight_compression_requested()
                 self._last_compression_status = "noop"
                 self._last_compression_noop_reason = reason
                 logger.info("LCM preflight compression no-op: %s", reason)
                 return False
-            self._refresh_raw_backlog_debt(replay_messages, observed_tokens=replay_rough)
-            if self._should_run_deferred_maintenance(replay_messages, observed_tokens=replay_rough):
+            self._refresh_raw_backlog_debt(
+                replay_messages,
+                observed_tokens=pressure_rough,
+            )
+            if self._should_run_deferred_maintenance(
+                replay_messages,
+                observed_tokens=pressure_rough,
+            ):
                 return self._mark_preflight_compression_requested()
             return False
         if self._compression_boundary_cooldown_active():
@@ -233,6 +251,54 @@ class CompactionMixin:
             ):
                 return True
         return False
+
+    def _cleanup_reached_normal_compaction_threshold(
+        self,
+        original_messages: List[Dict[str, Any]],
+        replay_messages: List[Dict[str, Any]],
+        *,
+        observed_tokens: Optional[int] = None,
+    ) -> bool:
+        """Return whether cleanup coincides with normal threshold pressure.
+
+        Preflight has only the message estimator, while ``compress()`` may get a
+        more accurate host-side prompt count.  When present, that observed count
+        is authoritative; otherwise use the larger original/replay estimate.
+        This prevents a preflight cleanup decision from masking real pressure.
+        """
+        if self.threshold_tokens <= 0:
+            return False
+        if observed_tokens is not None and observed_tokens > 0:
+            return observed_tokens >= self.threshold_tokens
+        token_counts = [
+            count_messages_tokens(original_messages),
+            count_messages_tokens(replay_messages),
+        ]
+        return max(token_counts, default=0) >= self.threshold_tokens
+
+    def _leading_replayed_context_scaffold_span(
+        self,
+        working_messages: List[Dict[str, Any]],
+        pressure_messages: List[Dict[str, Any]],
+    ) -> tuple[int, int, int]:
+        """Return anchor, fresh-tail, and leading-scaffold end indexes.
+
+        Replayed LCM summaries/objective anchors at the start of the compactable
+        prefix are derived context. Both summary-producing compaction and
+        cleanup-only replay adoption must replace that prefix from the DAG
+        instead of carrying stale scaffolding forward as literal user input.
+        """
+        leading_anchor_count = self._leading_anchor_count(working_messages)
+        fresh_tail_start = self._fresh_tail_start(pressure_messages)
+        scaffold_end = leading_anchor_count
+        while (
+            scaffold_end < fresh_tail_start
+            and self._is_replayed_context_scaffold_message(
+                working_messages[scaffold_end]
+            )
+        ):
+            scaffold_end += 1
+        return leading_anchor_count, fresh_tail_start, scaffold_end
 
     def _has_ignored_backlog_outside_fresh_tail(self, messages: List[Dict[str, Any]]) -> bool:
         if not self._compiled_ignore_message_patterns or not messages:
@@ -428,34 +494,32 @@ class CompactionMixin:
         # or provider context after the durable row has been written.
         working_messages = self._ingest_messages(messages)
         ingest_cleanup_changed_active_context = working_messages != messages
+        ingest_cleanup_requested = bool(
+            ingest_cleanup_changed_active_context
+            and self._replay_diff_requests_ingest_cleanup(
+                messages,
+                working_messages,
+            )
+        )
         cleanup_only_due_to_boundary_cooldown = bool(
             self._preflight_cleanup_only_due_to_boundary_cooldown
+            or self._compression_boundary_cooldown_active()
+        )
+        cleanup_reached_threshold = self._cleanup_reached_normal_compaction_threshold(
+            messages,
+            working_messages,
+            observed_tokens=observed_prompt_tokens,
+        )
+        ingest_cleanup_only = bool(
+            ingest_cleanup_requested
+            and not force
             and not force_overflow
+            and (
+                cleanup_only_due_to_boundary_cooldown
+                or not cleanup_reached_threshold
+            )
         )
         self._preflight_cleanup_only_due_to_boundary_cooldown = False
-        if cleanup_only_due_to_boundary_cooldown:
-            sanitized_messages = self._sanitize_active_context_messages(
-                working_messages,
-                insert_missing_tool_stubs=False,
-            )
-            self._refresh_raw_backlog_debt(
-                sanitized_messages,
-                observed_tokens=observed_prompt_tokens,
-            )
-            self._ingest_cursor = len(sanitized_messages)
-            self._last_compression_status = "sanitized"
-            self._last_compression_noop_reason = ""
-            self._write_generated_ignored_placeholder_hash_counts(
-                self._generated_placeholder_digest_budget_for_active_replay(
-                    sanitized_messages
-                )
-            )
-            self._write_generated_ignored_placeholder_hash_ordinals(
-                self._generated_placeholder_digest_ordinals_for_active_replay(
-                    sanitized_messages
-                )
-            )
-            return sanitized_messages
         anchor_source_messages = list(working_messages)
         pressure_messages = messages if len(messages) == len(working_messages) else working_messages
         leaf_compacted_this_turn = False
@@ -468,6 +532,7 @@ class CompactionMixin:
         )
         threshold_full_sweep_active = bool(
             self._config.threshold_full_sweep_enabled
+            and not ingest_cleanup_only
             and not force_overflow
             and self.threshold_tokens > 0
             and estimated_active_tokens >= self.threshold_tokens
@@ -503,7 +568,8 @@ class CompactionMixin:
             messages=working_messages,
         )
         deferred_maintenance_active = (
-            not force_overflow
+            not ingest_cleanup_only
+            and not force_overflow
             and not threshold_full_sweep_active
             and self._should_run_deferred_maintenance(
                 working_messages,
@@ -531,13 +597,18 @@ class CompactionMixin:
             if threshold_full_sweep_active and time.monotonic() >= sweep_deadline:
                 sweep_stop_reason = "time_budget_exhausted"
                 break
-            fresh_tail_start = self._fresh_tail_start(pressure_messages)
-
             # Keep only a real system prompt anchored. Gateway sessions may
             # pass only conversation messages, so index 0 can be an old user
             # turn; that must remain eligible for compaction instead of being
             # replayed forever as fresh-looking intent.
-            leading_anchor_count = self._leading_anchor_count(working_messages)
+            (
+                leading_anchor_count,
+                fresh_tail_start,
+                candidate_start,
+            ) = self._leading_replayed_context_scaffold_span(
+                working_messages,
+                pressure_messages,
+            )
             if fresh_tail_start <= leading_anchor_count:
                 noop_reason = "no eligible raw backlog outside fresh tail"
                 if threshold_full_sweep_active:
@@ -545,12 +616,6 @@ class CompactionMixin:
                     sweep_stop_reason = "raw_prefix_drained"
                 break
 
-            candidate_start = leading_anchor_count
-            while (
-                candidate_start < fresh_tail_start
-                and self._is_replayed_context_scaffold_message(working_messages[candidate_start])
-            ):
-                candidate_start += 1
             if candidate_start > leading_anchor_count:
                 dropped_replayed_scaffold_messages = True
                 working_messages = working_messages[:leading_anchor_count] + working_messages[candidate_start:]
@@ -645,6 +710,15 @@ class CompactionMixin:
                 if dropped_ignored_backlog and fresh_tail_start <= leading_anchor_count:
                     noop_reason = "selected leaf chunk lacks raw store lineage"
                     break
+
+            if ingest_cleanup_only:
+                # The deterministic scaffold/ignore/dependent-reply cleanup
+                # above must still run, but this maintenance pass may not cross
+                # into summary-producing work below the normal threshold (or
+                # while a compression-boundary cooldown is active). The common
+                # no-leaf finalizer below sanitizes/reassembles from the DAG.
+                noop_reason = "ingest cleanup does not permit summary work"
+                break
 
             # Auto-derive focus topic from the post-filter compaction view when
             # not explicitly provided.  The derived focus is summarizer-visible,

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -201,7 +201,7 @@ environment variables:
 | `LCM_IGNORE_MESSAGE_PATTERNS` | empty | Comma-separated regex patterns; matching message content (plain text, extracted text parts for structured/multimodal content, or normalized JSON fallback when no text parts exist) is excluded from LCM storage |
 | `LCM_SENSITIVE_PATTERNS_ENABLED` | `false` | Opt in to deterministic redaction before LCM storage, FTS indexing, summarization, active replay, and externalized ingest payloads |
 | `LCM_SENSITIVE_PATTERNS` | `api_key,bearer_token,password_assignment,private_key` | Comma-separated named sensitive pattern catalog entries to apply when redaction is enabled |
-| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files |
+| `LCM_LARGE_OUTPUT_EXTERNALIZATION_ENABLED` | `false` | Store oversized ingest payloads, including tool results, media blocks, and generic raw content, in plugin-managed JSON files; generic non-tool text remains unchanged in active replay |
 | `LCM_LARGE_OUTPUT_EXTERNALIZATION_THRESHOLD_CHARS` | `12000` | Externalization threshold for normalized payload text |
 | `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` | `false` | Replace token-heavy textual tool results with recoverable externalized refs in active replay; current-turn ingest is immediate and historical assembly respects the protected fresh tail; requires large-output externalization |
 | `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUB_THRESHOLD_TOKENS` | `25000` | Token-aware threshold for active-replay tool-result stubbing |
@@ -238,6 +238,14 @@ environment variables:
 | `LCM_EMPTY_LIFECYCLE_GC_ENABLED` | `true` | Master toggle for automatic pruning of lifecycle rows for sessions that never ingested any messages or summary nodes |
 | `LCM_EMPTY_LIFECYCLE_GC_THRESHOLD` | `200` | Number of lifecycle rows at which the GC pass fires (default 200 so fresh installs skip the work) |
 | `LCM_EMPTY_LIFECYCLE_GC_MAX_AGE_HOURS` | `24` | Automatic GC only deletes empty lifecycle rows at least this old; set `0` only in trusted/test environments that intentionally want immediate empty-row pruning |
+
+Large-output externalization is a durable-storage policy, not an early context
+compression boundary. Generic user, assistant, system, and other non-tool text
+remains provider-visible in active replay until normal compaction selects it.
+Only `LCM_LARGE_OUTPUT_ACTIVE_REPLAY_STUBBING_ENABLED` opts textual tool results
+into recoverable active-replay refs. Sensitive-value redaction, ignored-message
+filtering, and suspicious-assistant quarantine remain separate safety policies
+and may still change active replay according to their own settings.
 
 ### Evidence and adaptive retrieval (0.21 RC)
 
@@ -388,6 +396,13 @@ When `context.engine: lcm` is active, `LCM_CONTEXT_THRESHOLD` is the compaction
 threshold LCM uses. Hermes core `compression.threshold` belongs to the built-in
 compressor. Hermes core `compression.enabled` is still the global gate that
 allows compaction, so leave it enabled when using LCM.
+
+During ordinary automatic preflight below this threshold, ingest protection may
+still ask the host to publish a sanitized replay (for example a recoverable
+tool-result ref or sensitive-value redaction), but that cleanup-only pass does
+not call the summarizer or create a DAG node. Manual ``force`` requests,
+overflow recovery, and explicitly enabled deferred maintenance keep their own
+compaction semantics.
 
 If startup/status output shows a host-side compression percentage that disagrees
 with LCM, trust live LCM status after a normal message has initialized the

--- a/engine.py
+++ b/engine.py
@@ -4842,16 +4842,6 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
             messages_to_store_with_index,
             protected_messages,
         ):
-            if self._protected_message_uses_raw_payload_active_stub(protected_msg):
-                if active_replay_messages is replay_messages:
-                    active_replay_messages = self._copy_active_replay_messages_preserving_generated_ids(
-                        replay_messages
-                    )
-                active_message = dict(active_replay_messages[absolute_idx])
-                active_message["content"] = protected_msg["content"]
-                active_replay_messages[absolute_idx] = active_message
-                continue
-
             active_message = active_replay_messages[absolute_idx]
             stubbed_message = self._maybe_stub_active_tool_result(
                 active_message,
@@ -4884,18 +4874,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._compression_boundary_stored_placeholder_digest_counts = {}
         logger.debug("Ingested %d messages into LCM store", len(messages_to_store_with_index))
         self._clear_foreground_rebind_candidate_if_bound_session_confirmed()
-        # Most ``protected_messages`` changes are storage-only: inline media and
-        # data/base64 substrings stay provider-usable in active replay. The
-        # exceptions are whole-message ``raw_payload`` externalization and the
-        # separately opt-in textual tool-result interceptor above.
+        # ``protected_messages`` is the durable-store view only: inline media,
+        # data/base64 substrings, and generic whole-message ``raw_payload``
+        # externalization must not shrink provider-visible active context before
+        # the configured compression threshold. The separately opt-in textual
+        # tool-result interceptor above remains an active-replay policy.
         return self._remember_active_replay_messages(messages, active_replay_messages)
-
-    @staticmethod
-    def _protected_message_uses_raw_payload_active_stub(message: Dict[str, Any]) -> bool:
-        content = message.get("content")
-        return isinstance(content, str) and content.startswith(
-            "[Externalized payload: kind=raw_payload;"
-        )
 
     def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
         ids_by_message_id = self._get_store_id_map_for_messages(messages)

--- a/tests/test_ingest_protection.py
+++ b/tests/test_ingest_protection.py
@@ -242,13 +242,39 @@ def test_sensitive_patterns_redact_before_summary_serialization(tmp_path, monkey
             {"role": "user", "content": f"api_key={secret} should be hidden"},
             {"role": "user", "content": "fresh tail"},
         ],
-        current_tokens=10_000,
+        current_tokens=engine.threshold_tokens,
     )
 
     assert captured["text"]
     assert "[LCM sensitive redaction:" in captured["text"]
     node = engine._dag.get_session_nodes(engine.current_session_id)[0]
     assert secret not in node.summary
+
+
+def test_sensitive_patterns_subthreshold_cleanup_does_not_summarize(tmp_path, monkeypatch):
+    engine = _sensitive_engine(tmp_path, fresh_tail_count=1, leaf_chunk_tokens=1)
+    secret = "sk-test-subthreshold-1234567890abcdef"
+    messages = [
+        {"role": "user", "content": f"api_key={secret} should be hidden"},
+        {"role": "user", "content": "fresh tail"},
+    ]
+
+    def fail_summary(**_kwargs):
+        raise AssertionError("sub-threshold redaction cleanup must not summarize")
+
+    monkeypatch.setattr(lcm_engine_module, "summarize_with_escalation", fail_summary)
+
+    assert engine.should_compress_preflight(messages) is True
+    active_context = engine.compress(
+        messages,
+        current_tokens=engine.threshold_tokens // 4,
+    )
+    active_text = "\n".join(str(message.get("content", "")) for message in active_context)
+
+    assert secret not in active_text
+    assert "[LCM sensitive redaction:" in active_text
+    assert engine._dag.get_session_node_count(engine.current_session_id) == 0
+    assert engine.last_compression_status == "sanitized"
 
 
 def test_sensitive_patterns_visible_in_status_and_doctor(tmp_path):

--- a/tests/test_lcm_core.py
+++ b/tests/test_lcm_core.py
@@ -6494,19 +6494,21 @@ class TestIngestExternalization:
         engine, output_dir = self._engine(tmp_path)
         content = "GENERIC_RAW_NEEDLE:" + ("z" * 5000)
 
-        engine._ingest_messages([{"role": "user", "content": content}])
+        provider_replay = engine._ingest_messages([{"role": "user", "content": content}])
 
         stored = engine._store.get_session_messages("ingest-session")
         assert stored[0]["content"].startswith("[Externalized payload: kind=raw_payload;")
         assert "GENERIC_RAW_NEEDLE" not in stored[0]["content"]
         assert engine._store.search("GENERIC_RAW_NEEDLE", session_id="ingest-session") == []
+        assert provider_replay[0]["content"] == content
+        assert engine._last_active_replay_messages[0]["content"] == content
 
         payload = json.loads(next(output_dir.glob("*.json")).read_text())
         assert payload["kind"] == "raw_payload"
         assert payload["role"] == "user"
         assert payload["content"] == content
 
-    def test_compress_returns_externalized_stub_for_oversized_active_tail(self, tmp_path):
+    def test_compress_keeps_oversized_current_user_inline_while_store_uses_ref(self, tmp_path):
         import hermes_lcm.tools as lcm_tools
         from hermes_lcm.engine import LCMEngine
 
@@ -6518,13 +6520,13 @@ class TestIngestExternalization:
 
         assert len(active_context) == 1
         active_content = active_context[0]["content"]
-        assert active_content.startswith("[Externalized payload: kind=raw_payload;")
-        assert "ACTIVE_RAW_NEEDLE" not in active_content
-        assert len(active_content) < 512
+        assert active_content == content
         assert messages[0]["content"] == content
 
         stored = engine._store.get_session_messages("ingest-session")
-        assert stored[0]["content"] == active_content
+        assert stored[0]["content"].startswith("[Externalized payload: kind=raw_payload;")
+        assert "ACTIVE_RAW_NEEDLE" not in stored[0]["content"]
+        assert len(stored[0]["content"]) < 512
         assert engine._get_store_ids_for_messages(active_context) == [stored[0]["store_id"]]
         assert engine._store.search("ACTIVE_RAW_NEEDLE", session_id="ingest-session") == []
         payload_path = next(output_dir.glob("*.json"))
@@ -6537,32 +6539,145 @@ class TestIngestExternalization:
         assert expanded["kind"] == "raw_payload"
         assert expanded["content"] == content
 
+        assert engine._last_active_replay_messages[0]["content"] == content
+
+        durable_history = [{"role": "user", "content": stored[0]["content"]}]
         replay = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
         replay._session_id = "ingest-session"
         replay._ingest_cursor_needs_reconcile = True
-        replay._ingest_messages(active_context)
+        replay._ingest_messages(durable_history)
         assert replay._store.get_session_count("ingest-session") == 1
 
         replay_with_delta = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
         replay_with_delta._session_id = "ingest-session"
         replay_with_delta._ingest_cursor_needs_reconcile = True
-        replay_with_delta._ingest_messages(active_context + [{"role": "user", "content": "followup"}])
+        replay_with_delta._ingest_messages(
+            durable_history + [{"role": "user", "content": "followup"}]
+        )
         rows = replay_with_delta._store.get_session_messages("ingest-session")
         assert len(rows) == 2
         assert rows[-1]["content"] == "followup"
 
-    def test_preflight_requests_cleanup_for_oversized_raw_payload_stub(self, tmp_path):
+    def test_preflight_does_not_replace_oversized_current_user_with_storage_ref(self, tmp_path):
         engine, _output_dir = self._engine(tmp_path)
         content = "PREFLIGHT_RAW_NEEDLE:" + ("r" * 5000)
         messages = [{"role": "user", "content": content}]
 
-        assert engine.should_compress_preflight(messages) is True
+        assert engine.should_compress_preflight(messages) is False
 
-        active_context = engine.compress(messages)
-        assert active_context[0]["content"].startswith("[Externalized payload: kind=raw_payload;")
-        assert "PREFLIGHT_RAW_NEEDLE" not in active_context[0]["content"]
-        assert engine._last_compression_status == "sanitized"
-        assert engine._last_compression_noop_reason == ""
+        provider_replay = engine._ingest_messages(messages)
+        stored = engine._store.get_session_messages("ingest-session")
+        assert provider_replay[0]["content"] == content
+        assert stored[0]["content"].startswith("[Externalized payload: kind=raw_payload;")
+
+    def test_current_raw_user_stays_inline_through_tool_steps_and_next_user(self, tmp_path):
+        engine, _output_dir = self._engine(tmp_path)
+        content = "CURRENT_SKILL_PAYLOAD:" + ("s" * 5000)
+        user = {"role": "user", "content": content}
+
+        first_provider_replay = engine._ingest_messages([user])
+        assert first_provider_replay[0]["content"] == content
+
+        assistant_tool_call = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_current_turn", "function": {"name": "probe", "arguments": "{}"}}
+            ],
+        }
+        tool_result = {
+            "role": "tool",
+            "tool_call_id": "call_current_turn",
+            "content": "probe complete",
+        }
+        same_turn = [user, assistant_tool_call, tool_result]
+        continuation_replay = engine._ingest_messages(same_turn)
+
+        assert continuation_replay[0]["content"] == content
+        assert engine._last_active_replay_messages[0]["content"] == content
+
+        next_turn = same_turn + [
+            {"role": "assistant", "content": "finished"},
+            {"role": "user", "content": "What is next?"},
+        ]
+        next_turn_replay = engine._ingest_messages(next_turn)
+
+        assert next_turn_replay[0]["content"] == content
+        assert next_turn_replay[-1]["content"] == "What is next?"
+
+        stored = engine._store.get_session_messages("ingest-session")
+        assert stored[0]["content"].startswith(
+            "[Externalized payload: kind=raw_payload;"
+        )
+        assert "CURRENT_SKILL_PAYLOAD" not in stored[0]["content"]
+
+    def test_restart_reconciles_provider_visible_raw_payload_history(self, tmp_path):
+        from hermes_lcm.engine import LCMEngine
+
+        engine, _output_dir = self._engine(tmp_path)
+        content = "RESTARTED_RAW_HISTORY:" + ("h" * 5000)
+        active_history = [
+            {"role": "user", "content": content},
+            {"role": "assistant", "content": "completed answer"},
+        ]
+
+        provider_replay = engine._ingest_messages(active_history)
+        assert provider_replay == active_history
+        assert engine._store.get_session_count("ingest-session") == 2
+
+        restarted = LCMEngine(config=engine._config, hermes_home=str(tmp_path / "hermes"))
+        restarted._session_id = "ingest-session"
+        restarted._ingest_cursor_needs_reconcile = True
+        restarted._ingest_messages(provider_replay)
+
+        assert restarted._store.get_session_count("ingest-session") == 2
+        assert restarted._last_ingest_reconciliation["action"] == "advanced cursor"
+
+        restarted_with_delta = LCMEngine(
+            config=engine._config,
+            hermes_home=str(tmp_path / "hermes"),
+        )
+        restarted_with_delta._session_id = "ingest-session"
+        restarted_with_delta._ingest_cursor_needs_reconcile = True
+        next_turn = provider_replay + [{"role": "user", "content": "followup"}]
+        next_replay = restarted_with_delta._ingest_messages(next_turn)
+
+        assert next_replay[0]["content"] == content
+        rows = restarted_with_delta._store.get_session_messages("ingest-session")
+        assert len(rows) == 3
+        assert rows[-1]["content"] == "followup"
+
+    def test_storage_externalization_keeps_ordinary_assistant_payload_active(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import hermes_lcm.engine as lcm_engine
+
+        engine, _output_dir = self._engine(tmp_path)
+        assistant_content = "LONG_ASSISTANT_CONTEXT:" + ("a" * 5000)
+        messages = [
+            {"role": "user", "content": "Explain the result."},
+            {"role": "assistant", "content": assistant_content},
+            {"role": "user", "content": "Use that result for the next step."},
+        ]
+
+        def fail_summary(**_kwargs):
+            raise AssertionError("storage-only assistant externalization must not summarize")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_summary)
+
+        assert engine.should_compress_preflight(messages) is False
+        provider_replay = engine._cached_active_replay_messages(messages)
+
+        assert provider_replay is not None
+        assert provider_replay[1]["content"] == assistant_content
+        assert engine._last_active_replay_messages[1]["content"] == assistant_content
+        stored = engine._store.get_session_messages("ingest-session")
+        assert stored[1]["content"].startswith(
+            "[Externalized payload: kind=raw_payload;"
+        )
+        assert "LONG_ASSISTANT_CONTEXT" not in stored[1]["content"]
 
     def test_non_tool_externalized_placeholder_sanitizes_role_metadata_for_ref_parsing(self, tmp_path):
         import hermes_lcm.tools as lcm_tools

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1678,6 +1678,142 @@ class TestEngineABC:
         finally:
             instance.shutdown()
 
+    def test_provider_metadata_replay_diff_does_not_bypass_configured_threshold(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_metadata_replay_diff.db"),
+            context_threshold=0.5,
+            fresh_tail_count=2,
+            leaf_chunk_tokens=10,
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start(
+            "test-session",
+            platform="api_server",
+            context_length=1_000_000,
+        )
+        first_turn = [
+            {
+                "role": "user" if index % 2 == 0 else "assistant",
+                "content": f"historical turn {index} " + "replay backlog segment " * 40,
+            }
+            for index in range(12)
+        ]
+        try:
+            assert instance.threshold_tokens == 500_000
+            assert count_messages_tokens(first_turn) < instance.threshold_tokens
+            assert instance._leaf_compaction_candidate_status(first_turn)[0] is True
+            assert instance.should_compress_preflight(first_turn) is False
+
+            second_turn = [dict(message) for message in first_turn]
+            # Hermes attaches provider transport metadata after the response.
+            # The semantic replay identity is unchanged, so LCM restores its
+            # cached prefix and the two dictionaries compare unequal.
+            second_turn[1]["reasoning"] = "provider reasoning envelope"
+            second_turn.extend(
+                [
+                    {"role": "assistant", "content": "first turn answer"},
+                    {"role": "user", "content": "next turn request"},
+                ]
+            )
+            observed: dict[str, object] = {}
+            ingest = instance._ingest_messages
+
+            def capture_ingest(messages):
+                replay = ingest(messages)
+                observed["original"] = messages
+                observed["replay"] = replay
+                return replay
+
+            monkeypatch.setattr(instance, "_ingest_messages", capture_ingest)
+
+            assert count_messages_tokens(second_turn) < instance.threshold_tokens
+            assert instance._leaf_compaction_candidate_status(second_turn)[0] is True
+            assert instance.should_compress_preflight(second_turn) is False
+            assert observed["replay"] != observed["original"]
+            assert instance._replay_diff_requests_ingest_cleanup(
+                observed["original"],
+                observed["replay"],
+            ) is False
+            assert instance._dag.get_session_node_count("test-session") == 0
+        finally:
+            instance.shutdown()
+
+    def test_smaller_cached_replay_cannot_hide_original_threshold_pressure(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        config = LCMConfig(
+            database_path=str(tmp_path / "lcm_preflight_cached_replay_pressure.db"),
+            context_threshold=0.5,
+            fresh_tail_count=1,
+            leaf_chunk_tokens=1,
+        )
+        instance = LCMEngine(config=config)
+        instance.on_session_start(
+            "test-session",
+            platform="api_server",
+            context_length=400,
+        )
+
+        def messages_with_arguments(arguments: str):
+            return [
+                {"role": "user", "content": "old backlog that is eligible"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-pressure",
+                            "type": "function",
+                            "function": {"name": "probe", "arguments": arguments},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-pressure",
+                    "content": "small result",
+                },
+                {"role": "user", "content": "fresh request"},
+            ]
+
+        compact_messages = messages_with_arguments('{"a":1}')
+        expanded_messages = messages_with_arguments('{"a":' + " \n" * 1_000 + "1}")
+        try:
+            assert instance.threshold_tokens == 200
+            assert count_messages_tokens(compact_messages) < instance.threshold_tokens
+            assert count_messages_tokens(expanded_messages) >= instance.threshold_tokens
+            assert instance._message_replay_identity(compact_messages[1]) == (
+                instance._message_replay_identity(expanded_messages[1])
+            )
+            assert instance.should_compress_preflight(compact_messages) is False
+
+            observed: dict[str, object] = {}
+            ingest = instance._ingest_messages
+
+            def capture_ingest(messages):
+                replay = ingest(messages)
+                observed["original"] = messages
+                observed["replay"] = replay
+                return replay
+
+            monkeypatch.setattr(instance, "_ingest_messages", capture_ingest)
+
+            assert instance.should_compress_preflight(expanded_messages) is True
+            assert observed["replay"] != observed["original"]
+            assert count_messages_tokens(observed["replay"]) < instance.threshold_tokens
+            assert instance._replay_diff_requests_ingest_cleanup(
+                observed["original"],
+                observed["replay"],
+            ) is False
+        finally:
+            instance.shutdown()
+
     def test_positive_preflight_clears_prior_noop_status(self, tmp_path):
         config = LCMConfig(
             database_path=str(tmp_path / "lcm_preflight_clears_noop.db"),
@@ -5586,6 +5722,40 @@ class TestMessageFiltering:
         assert nodes == []
         assert engine._ignored_message_count == 1
 
+    def test_subthreshold_ignore_cleanup_does_not_create_summary_node(self, tmp_path, monkeypatch):
+        engine = self._make_engine(
+            tmp_path,
+            "lcm_msg_ignore_subthreshold_cleanup.db",
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10,
+            ignore_message_patterns=["SECRET"],
+        )
+        engine.context_length = 1_000_000
+        engine.threshold_tokens = 500_000
+        messages = [
+            {"role": "user", "content": "SECRET ignored backlog " + "x" * 200},
+            {"role": "user", "content": "visible backlog must stay raw " + "y" * 200},
+            {"role": "assistant", "content": "fresh tail response"},
+        ]
+
+        def fail_summary(**_kwargs):
+            raise AssertionError("sub-threshold ignore cleanup must not summarize")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_summary)
+
+        assert engine.should_compress_preflight(messages) is True
+        result = engine.compress(
+            messages,
+            current_tokens=engine.threshold_tokens // 4,
+        )
+        result_text = "\n".join(str(msg.get("content", "")) for msg in result)
+
+        assert "SECRET" not in result_text
+        assert "visible backlog must stay raw" in result_text
+        assert engine._dag.get_session_nodes("user-123") == []
+        assert engine.compression_count == 0
+        assert engine.last_compression_status == "sanitized"
+
     def test_ignored_backlog_is_filtered_before_auto_focus_derivation(self, tmp_path, monkeypatch):
         engine = self._make_engine(
             tmp_path,
@@ -5608,7 +5778,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "SECRET" not in captured["text"]
@@ -5640,7 +5810,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "SECRET" not in captured["text"]
@@ -5691,6 +5861,67 @@ class TestMessageFiltering:
         assert "fresh visible request" in result_text
         assert "SECRET" not in result_text
 
+    def test_subthreshold_cleanup_rebuilds_live_dag_after_dropping_stale_scaffold(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        engine = self._make_engine(
+            tmp_path,
+            "lcm_msg_ignore_rebuild_live_dag.db",
+            fresh_tail_count=1,
+            leaf_chunk_tokens=10,
+            ignore_message_patterns=["SECRET"],
+        )
+        engine.context_length = 1_000_000
+        engine.threshold_tokens = 500_000
+        now = time.time()
+        live_node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="user-123",
+                depth=0,
+                summary="LIVE_DAG_SUMMARY",
+                token_count=4,
+                source_token_count=40,
+                source_ids=[1],
+                source_type="messages",
+                created_at=now,
+                earliest_at=now,
+                latest_at=now,
+                expand_hint="live dag details",
+            )
+        )
+        stale_scaffold = (
+            "[Recent Summary (d0, node 999)]\n"
+            "STALE_REPLAY_SCAFFOLD\n"
+            "[Expand for details: stale replay]"
+        )
+        messages = [
+            {"role": "user", "content": stale_scaffold},
+            {"role": "user", "content": "SECRET ignored backlog"},
+            {"role": "user", "content": "fresh visible request"},
+        ]
+
+        def fail_summary(**_kwargs):
+            raise AssertionError("sub-threshold cleanup must rebuild, not summarize")
+
+        monkeypatch.setattr(lcm_engine, "summarize_with_escalation", fail_summary)
+
+        assert engine.should_compress_preflight(messages) is True
+        result = engine.compress(
+            messages,
+            current_tokens=engine.threshold_tokens // 4,
+        )
+        result_text = "\n".join(str(msg.get("content", "")) for msg in result)
+
+        assert result_text.count("LIVE_DAG_SUMMARY") == 1
+        assert "STALE_REPLAY_SCAFFOLD" not in result_text
+        assert "SECRET" not in result_text
+        nodes = engine._dag.get_session_nodes("user-123")
+        assert [node.node_id for node in nodes] == [live_node_id]
+        assert engine.compression_count == 0
+        assert engine.last_compression_status == "sanitized"
+
     def test_original_ignore_decision_survives_sensitive_active_redaction(self, tmp_path, monkeypatch):
         engine = self._make_engine(
             tmp_path,
@@ -5714,7 +5945,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "api_key" not in captured["text"]
@@ -7204,7 +7435,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog should extract" in captured["serialized"]
         assert "visible backlog should extract" in captured["summary_text"]
@@ -7255,7 +7486,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible historical backlog " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail"},
             ]
-            second.compress(messages, current_tokens=count_messages_tokens(messages))
+            second.compress(messages, current_tokens=second.threshold_tokens)
 
             nodes = second._dag.get_session_nodes("session")
             assert nodes
@@ -7314,7 +7545,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible historical backlog " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail"},
             ]
-            second.compress(messages, current_tokens=count_messages_tokens(messages))
+            second.compress(messages, current_tokens=second.threshold_tokens)
 
             assert "visible historical backlog" in captured["text"]
             assert "SECRET_PAYLOAD_MARKER" not in captured["text"]
@@ -7432,7 +7663,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
-            second.compress(messages, current_tokens=count_messages_tokens(messages))
+            second.compress(messages, current_tokens=second.threshold_tokens)
 
             rows = second._store.get_session_messages("session")
             assert rows[1]["content"].startswith("visible backlog objective")
@@ -7533,7 +7764,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
-            second.compress(messages, current_tokens=count_messages_tokens(messages))
+            second.compress(messages, current_tokens=second.threshold_tokens)
 
             stored_after = second._store.get_session_messages("session")
             externalized_rows = [row for row in stored_after if row["content"].startswith("[Externalized payload:")]
@@ -7614,7 +7845,7 @@ class TestMessageFiltering:
                 {"role": "user", "content": "visible backlog objective " + "v" * 200},
                 {"role": "assistant", "content": "fresh tail response"},
             ]
-            second.compress(messages, current_tokens=count_messages_tokens(messages))
+            second.compress(messages, current_tokens=second.threshold_tokens)
 
             assert "visible backlog objective" in captured["text"]
             assert "visible assistant tool call" not in captured["text"]
@@ -7761,12 +7992,12 @@ class TestMessageFiltering:
         )
         try:
             first.on_session_start("session", platform="telegram", context_length=1000)
-            active = first.compress(
-                [{"role": "user", "content": "SECRET_PAYLOAD_MARKER externalized row " + "x" * 200}],
-                current_tokens=10_000,
+            first._ingest_messages(
+                [{"role": "user", "content": "SECRET_PAYLOAD_MARKER externalized row " + "x" * 200}]
             )
-            active_stub = {"role": "user", "content": active[0]["content"]}
-            ignored_store_id = first._store.get_session_messages("session")[0]["store_id"]
+            stored_row = first._store.get_session_messages("session")[0]
+            active_stub = {"role": "user", "content": stored_row["content"]}
+            ignored_store_id = stored_row["store_id"]
             assert "Externalized payload:" in active_stub["content"]
         finally:
             first.shutdown()
@@ -7808,12 +8039,12 @@ class TestMessageFiltering:
         )
         try:
             first.on_session_start("session", platform="telegram", context_length=1000)
-            active = first.compress(
-                [{"role": "user", "content": "SECRET_PAYLOAD_MARKER externalized row " + "x" * 200}],
-                current_tokens=10_000,
+            first._ingest_messages(
+                [{"role": "user", "content": "SECRET_PAYLOAD_MARKER externalized row " + "x" * 200}]
             )
-            active_stub = {"role": "user", "content": active[0]["content"]}
-            ignored_store_id = first._store.get_session_messages("session")[0]["store_id"]
+            stored_row = first._store.get_session_messages("session")[0]
+            active_stub = {"role": "user", "content": stored_row["content"]}
+            ignored_store_id = stored_row["store_id"]
         finally:
             first.shutdown()
 
@@ -8033,7 +8264,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "dependent assistant reply" not in captured["text"]
@@ -8068,7 +8299,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "fresh tail request"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "assistant reply derived from ignored system" not in captured["text"]
@@ -8097,7 +8328,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        result = engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        result = engine.compress(messages, current_tokens=engine.threshold_tokens)
         result_text = "\n".join(str(msg.get("content", "")) for msg in result)
 
         assert "visible backlog objective" in captured["text"]
@@ -8834,7 +9065,13 @@ class TestMessageFiltering:
                 {"role": "user", "content": "oversized raw payload " + "x" * 200},
             ]
 
-            assert second.should_compress_preflight(messages) is True
+            assert second.should_compress_preflight(messages) is False
+            rows = second._store.get_session_messages("session")
+            assert any(
+                str(row.get("content", "")).startswith("[Externalized payload:")
+                for row in rows
+            )
+            assert second._dag.get_session_nodes("session") == []
         finally:
             second.shutdown()
 
@@ -9209,7 +9446,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "dependent tool result" not in captured["text"]
@@ -9237,7 +9474,7 @@ class TestMessageFiltering:
             {"role": "assistant", "content": "fresh tail response"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "assistant answer derived" not in captured["text"]
@@ -9399,7 +9636,7 @@ class TestMessageFiltering:
             {"role": "user", "content": "SECRET ignored fresh tail must not become focus"},
         ]
 
-        engine.compress(messages, current_tokens=count_messages_tokens(messages))
+        engine.compress(messages, current_tokens=engine.threshold_tokens)
 
         assert "visible backlog objective" in captured["text"]
         assert "SECRET" not in captured["text"]

--- a/tests/test_subthreshold_externalized_cleanup.py
+++ b/tests/test_subthreshold_externalized_cleanup.py
@@ -1,0 +1,262 @@
+"""Regression tests for cleanup-only externalization below the LCM threshold."""
+
+import time
+from unittest.mock import Mock
+
+import pytest
+
+import hermes_lcm.engine as lcm_engine
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+@pytest.fixture
+def make_engine(tmp_path):
+    engines = []
+
+    def build(**overrides):
+        index = len(engines)
+        settings = {
+            "database_path": str(tmp_path / f"cleanup-{index}.db"),
+            "fresh_tail_count": 2,
+            "leaf_chunk_tokens": 1,
+            "dynamic_leaf_chunk_enabled": False,
+            "threshold_full_sweep_enabled": False,
+            "large_output_externalization_enabled": True,
+            "large_output_externalization_threshold_chars": 1_000,
+            "large_output_externalization_path": str(
+                tmp_path / f"externalized-{index}"
+            ),
+        }
+        settings.update(overrides)
+        engine = LCMEngine(
+            config=LCMConfig(**settings),
+            hermes_home=str(tmp_path / f"hermes-{index}"),
+        )
+        engine.on_session_start(
+            f"cleanup-session-{index}",
+            conversation_id=f"cleanup-conversation-{index}",
+            context_length=1_000_000,
+        )
+        engines.append(engine)
+        return engine
+
+    yield build
+
+    for engine in engines:
+        engine.shutdown()
+
+
+RAW_PAYLOAD = "INJECTED_RAW_PAYLOAD:" + ("x" * 5_000)
+
+
+def current_raw_payload_messages():
+    return [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old request " * 20},
+        {"role": "assistant", "content": "old answer " * 20},
+        {"role": "user", "content": RAW_PAYLOAD},
+    ]
+
+
+def tool_pair(call_id, payload):
+    return [
+        {
+            "role": "assistant",
+            "content": "running tool",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": payload},
+    ]
+
+
+def tool_cleanup_case(make_engine):
+    engine = make_engine(
+        large_output_externalization_threshold_chars=1_000_000,
+        large_output_active_replay_stubbing_enabled=True,
+        large_output_active_replay_stub_threshold_tokens=5,
+    )
+    engine.threshold_tokens = 500_000
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old request " * 20},
+        {"role": "assistant", "content": "old answer " * 20},
+        *tool_pair("current-call", "current tool payload " * 100),
+    ]
+    return engine, messages
+
+
+def test_current_oversized_user_stays_provider_visible_without_preflight_cleanup(
+    make_engine,
+    monkeypatch,
+):
+    engine = make_engine()
+    engine.threshold_tokens = 500_000
+    messages = current_raw_payload_messages()
+    summary_spy = Mock(
+        side_effect=AssertionError("current payload must not trigger summarization")
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is False
+    stored = engine._store.get_session_messages(engine._session_id)
+    assert stored[-1]["content"].startswith(
+        "[Externalized payload: kind=raw_payload;"
+    )
+    provider_messages = engine._cached_active_replay_messages(messages)
+
+    assert provider_messages is not None
+    assert provider_messages[-1]["content"] == RAW_PAYLOAD
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.compression_count == 0
+    summary_spy.assert_not_called()
+
+
+def test_subthreshold_tool_result_cleanup_does_not_create_leaf(
+    make_engine,
+    monkeypatch,
+):
+    engine, messages = tool_cleanup_case(make_engine)
+    summary_spy = Mock(
+        side_effect=AssertionError("sub-threshold cleanup must not summarize")
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(
+        messages,
+        current_tokens=engine.threshold_tokens // 4,
+    )
+
+    assert any(
+        str(message.get("content", "")).startswith(
+            "[Externalized tool output:"
+        )
+        for message in result
+    )
+    assert any(message.get("content") == "old request " * 20 for message in result)
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.compression_count == 0
+    assert engine.last_compression_status == "sanitized"
+    summary_spy.assert_not_called()
+
+
+def test_direct_subthreshold_tool_cleanup_does_not_create_leaf(
+    make_engine,
+    monkeypatch,
+):
+    """compress() must enforce cleanup-only even without a preflight handoff."""
+    engine, messages = tool_cleanup_case(make_engine)
+    summary_spy = Mock(
+        side_effect=AssertionError("direct sub-threshold cleanup must not summarize")
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    result = engine.compress(
+        messages,
+        current_tokens=engine.threshold_tokens // 4,
+    )
+
+    assert any(
+        str(message.get("content", "")).startswith(
+            "[Externalized tool output:"
+        )
+        for message in result
+    )
+    assert any(message.get("content") == "old request " * 20 for message in result)
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.compression_count == 0
+    assert engine.last_compression_status == "sanitized"
+    summary_spy.assert_not_called()
+
+
+def test_above_threshold_tool_cleanup_still_compacts(make_engine, monkeypatch):
+    engine, messages = tool_cleanup_case(make_engine)
+    # Preflight only sees the sub-threshold message estimate.  The host-provided
+    # count at compress time is authoritative and must still permit compaction.
+    summary_spy = Mock(
+        return_value=(
+            "old work summary\nExpand for details about: old work",
+            1,
+        )
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=engine.threshold_tokens)
+
+    assert result
+    assert engine._dag.get_session_node_count(engine._session_id) == 1
+    assert engine.compression_count == 1
+    assert engine.last_compression_status == "compacted"
+    assert summary_spy.call_count >= 1
+
+
+def test_manual_force_tool_cleanup_still_compacts(make_engine, monkeypatch):
+    engine, messages = tool_cleanup_case(make_engine)
+    summary_spy = Mock(
+        return_value=(
+            "manually forced summary\nExpand for details about: old work",
+            1,
+        )
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(
+        messages,
+        current_tokens=engine.threshold_tokens // 4,
+        force=True,
+    )
+
+    assert result
+    assert engine._dag.get_session_node_count(engine._session_id) == 1
+    assert engine.compression_count == 1
+    assert engine.last_compression_status == "compacted"
+    assert summary_spy.call_count >= 1
+
+
+def test_boundary_cooldown_cleanup_outranks_threshold(make_engine, monkeypatch):
+    engine, messages = tool_cleanup_case(make_engine)
+    engine.threshold_tokens = 100
+    engine._last_boundary_skip_time = time.time()
+    summary_spy = Mock(
+        side_effect=AssertionError("boundary cooldown cleanup must not summarize")
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=engine.threshold_tokens)
+
+    assert result
+    assert engine._dag.get_session_node_count(engine._session_id) == 0
+    assert engine.compression_count == 0
+    assert engine.last_compression_status == "sanitized"
+    summary_spy.assert_not_called()
+
+
+def test_overflow_tool_cleanup_still_runs_recovery(make_engine, monkeypatch):
+    engine, messages = tool_cleanup_case(make_engine)
+    engine._config.max_assembly_tokens = 100
+    summary_spy = Mock(
+        return_value=(
+            "overflow recovery summary\nExpand for details about: old work",
+            1,
+        )
+    )
+    monkeypatch.setattr(lcm_engine, "summarize_with_escalation", summary_spy)
+
+    assert engine._should_force_overflow_recovery(messages=messages) is True
+    assert engine.should_compress_preflight(messages) is True
+    result = engine.compress(messages, current_tokens=10_000)
+
+    assert result
+    assert engine._dag.get_session_node_count(engine._session_id) >= 1
+    assert engine.last_compression_status in {"compacted", "overflow_recovery"}
+    assert summary_spy.call_count >= 1


### PR DESCRIPTION
## Summary
- keep generic non-tool `raw_payload` externalization storage-only so active provider replay retains the original text until normal compaction
- let below-threshold ingest cleanup sanitize and reassemble context without invoking the summarizer or creating a DAG node
- gate ordinary replay-diff leaf work on the configured threshold while measuring pressure from both the original and replay views
- preserve manual force, overflow recovery, cooldown, explicit deferred maintenance, sensitive filtering, and opt-in tool-result stubbing semantics

## Why
`raw_payload` is the generic fallback classification for oversized non-tool, non-media content. It does not prove that the content is opaque or disposable, so implicitly replacing it in active replay can hide a current user message, injected instructions, or an assistant response before the configured compaction threshold is reached.

Replay cleanup and benign replay differences could also request `compress()` below the normal threshold. If eligible raw backlog existed outside the fresh tail, that maintenance call could piggyback a leaf summary and rewrite active history early.

This intentionally revises the generic-text part of the behavior established in #226: durable SQLite/file externalization is unchanged, but generic non-tool text now remains provider-visible until normal compaction. This can retain more prompt tokens than the prior implicit stub behavior; normal threshold and overflow controls remain responsible for context pressure. Explicit active stubbing of textual tool results remains opt-in.

## Validation
- [x] Focused regression RED on pristine `upstream/main`: the current oversized-user and direct-compress cleanup tests both fail before this change
- [x] `pytest -q tests/test_ingest_protection.py tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_subthreshold_externalized_cleanup.py tests/test_active_tool_stubbing.py` — `1237 passed, 1 skipped`
- [x] Default validation:
  - [x] Linux: `scripts/validate_release.sh --full --output <isolated-output>`
  - [x] `pytest -q` — `2836 passed, 12 xfailed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` — `2836 passed, 12 xfailed`
  - [x] `python -m compileall -q .`
  - [x] script `py_compile` and shell syntax gates
  - [x] benchmark smoke, stress smoke, and release stress
  - [x] `git diff --check upstream/main...HEAD`
- [x] Privacy review: no private paths, endpoints, session identifiers, provider routes, credentials, or operational artifacts are included

## Notes
- This overlaps with #541's cleanup-only goal, and also covers direct `compress()` calls, sensitive/ignored cleanup, stale-scaffold replacement, and live DAG reassembly.
- This is a stricter invariant than #516's optional pressure floor: ordinary divergent-replay leaf work follows the existing configured context threshold by default.
- The branch is one commit on the current `upstream/main`; no production-only commits or configuration are included.

Refs #226, #516, #541
