### PR TITLE
fix(codex): preserve host context for validated 900k variants

### DIFF
--- a/codex_routing.py
+++ b/codex_routing.py
@@ -16,6 +16,11 @@ from __future__ import annotations
 # when that value was explicitly overridden above the real Codex OAuth window,
 # we still have to budget against the effective provider window or compaction
 # fires too late and provider requests can overflow.
+# Hermes-side marker for explicitly selected, host-validated long-context aliases.
+_CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"
+_CODEX_CONTEXT_VARIANT_CAP = 900_000
+
+
 _CODEX_OAUTH_CONTEXT_CAPS: dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
@@ -39,19 +44,45 @@ def _is_openai_codex_route(provider: str | None) -> bool:
     return (provider or "").strip().lower() == "openai-codex"
 
 
+def _is_host_verified_codex_context_variant(model: str | None) -> bool:
+    """Return whether Hermes recognises *model* as a valid context variant.
+
+    Newer Hermes hosts expose ``is_codex_context_variant`` as the single source
+    of truth for ``-900k`` eligibility.  Older hosts do not, so fail closed and
+    retain LCM's conservative Codex OAuth cap rather than trusting the suffix
+    alone.
+    """
+    try:
+        from agent.model_metadata import is_codex_context_variant
+    except (ImportError, AttributeError):
+        return False
+
+    try:
+        return bool(is_codex_context_variant(model))
+    except Exception:
+        return False
+
+
 def _codex_oauth_context_cap(model: str | None, provider: str | None) -> int | None:
     """Return LCM's best-known Codex OAuth effective context cap.
 
     This intentionally mirrors Hermes Agent's hardcoded fallback policy, not the
     direct OpenAI model catalog. A host-provided context_length may be a user
     override or stale cache entry; Codex OAuth still enforces these lower route
-    windows.
+    windows. Explicit long-context variants validated by Hermes use their named
+    900K ceiling so LCM preserves the host-resolved window without accepting a
+    stale value above the provider limit.
     """
     if not _is_openai_codex_route(provider):
         return None
     bare_model = _bare_model_slug(model)
     if not bare_model:
         return None
+    if (
+        bare_model.endswith(_CODEX_CONTEXT_VARIANT_SUFFIX)
+        and _is_host_verified_codex_context_variant(model)
+    ):
+        return _CODEX_CONTEXT_VARIANT_CAP
     for slug, cap in sorted(
         _CODEX_OAUTH_CONTEXT_CAPS.items(), key=lambda item: len(item[0]), reverse=True
     ):

--- a/tests/test_codex_routing.py
+++ b/tests/test_codex_routing.py
@@ -1,0 +1,72 @@
+"""Focused tests for Codex OAuth context-cap routing."""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from hermes_lcm.codex_routing import _codex_oauth_context_cap
+
+
+def _install_host_variant_predicate(monkeypatch, predicate):
+    host_metadata = ModuleType("agent.model_metadata")
+    host_metadata.is_codex_context_variant = predicate
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", host_metadata)
+
+
+def test_base_gpt56_route_keeps_conservative_cap_without_host_lookup(monkeypatch):
+    calls = []
+    _install_host_variant_predicate(monkeypatch, calls.append)
+
+    assert _codex_oauth_context_cap("gpt-5.6-sol", "openai-codex") == 372_000
+    assert calls == []
+
+
+def test_unrecognised_900k_suffix_does_not_bypass_cap(monkeypatch):
+    _install_host_variant_predicate(monkeypatch, lambda _model: False)
+
+    assert _codex_oauth_context_cap("gpt-5.5-900k", "openai-codex") == 272_000
+
+
+def test_missing_host_variant_predicate_fails_closed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", None)
+
+    assert (
+        _codex_oauth_context_cap("gpt-5.6-sol-900k", "openai-codex")
+        == 372_000
+    )
+
+
+def test_broken_host_variant_predicate_fails_closed(monkeypatch):
+    def fail(_model):
+        raise RuntimeError("host predicate failed")
+
+    _install_host_variant_predicate(monkeypatch, fail)
+
+    assert (
+        _codex_oauth_context_cap("gpt-5.6-sol-900k", "openai-codex")
+        == 372_000
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.6-sol-900k",
+        "openai/GPT-5.6-TERRA-900K",
+        "gpt-5.6-luna-2026-08-16-900k",
+        "gpt-5.4-900k",
+        "gpt-daybreak-blue-latest-900k",
+    ],
+)
+def test_host_recognised_900k_variants_use_named_cap(model, monkeypatch):
+    recognised = {
+        "gpt-5.6-sol-900k",
+        "openai/GPT-5.6-TERRA-900K",
+        "gpt-5.6-luna-2026-08-16-900k",
+        "gpt-5.4-900k",
+        "gpt-daybreak-blue-latest-900k",
+    }
+    _install_host_variant_predicate(monkeypatch, lambda candidate: candidate in recognised)
+
+    assert _codex_oauth_context_cap(model, "openai-codex") == 900_000

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -408,6 +408,48 @@ def test_update_model_updates_runtime_metadata_and_context_window(engine):
     assert engine.threshold_tokens == int(1_000_000 * engine._config.context_threshold)
 
 
+@pytest.mark.parametrize(
+    ("raw_context_length", "expected_context_length", "expected_cap", "expected_reason"),
+    [
+        (900_000, 900_000, None, ""),
+        (1_000_000, 900_000, 900_000, "codex_oauth_context_cap"),
+    ],
+)
+def test_codex_900k_variant_preserves_named_window(
+    tmp_path,
+    monkeypatch,
+    raw_context_length,
+    expected_context_length,
+    expected_cap,
+    expected_reason,
+):
+    host_metadata = ModuleType("agent.model_metadata")
+    host_metadata.is_codex_context_variant = (
+        lambda model: model == "gpt-5.6-sol-900k"
+    )
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", host_metadata)
+
+    config = LCMConfig(
+        context_threshold=0.75,
+        database_path=str(tmp_path / f"codex-gpt56-{raw_context_length}.db"),
+    )
+    engine = LCMEngine(config=config)
+    try:
+        engine.update_model(
+            model="gpt-5.6-sol-900k",
+            provider="openai-codex",
+            context_length=raw_context_length,
+        )
+
+        assert engine.raw_context_length == raw_context_length
+        assert engine.context_length == expected_context_length
+        assert engine.effective_context_length_cap == expected_cap
+        assert engine.effective_context_length_reason == expected_reason
+        assert engine.threshold_tokens == int(expected_context_length * 0.75)
+    finally:
+        engine.shutdown()
+
+
 def test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold(tmp_path):
     config = LCMConfig(
         context_threshold=0.68,


### PR DESCRIPTION
## Summary
- apply a 900K ceiling only to Codex `-900k` variants that Hermes validates, instead of letting LCM's 372K family cap win
- delegate variant eligibility to Hermes' `is_codex_context_variant()` predicate while failing closed on older or broken hosts
- avoid loading the optional host predicate for ordinary model slugs
- add focused routing and engine-level regression coverage

## Why
Hermes now exposes explicit `-900k` Codex aliases for live-verified long-context routes. LCM's independent `"gpt-5.6": 372_000` substring cap also matched `gpt-5.6-sol-900k`, replacing the host-resolved 900,000-token window with 372,000 and triggering compression early.

The plugin should retain its conservative cap for ordinary Codex slugs and invalid aliases, but apply the variant's named 900K ceiling—not the lower family cap—when the host recognises it. This preserves a correctly resolved 900K window while still clamping stale host values above the provider limit. Importing the host predicate lazily preserves compatibility: hosts that do not expose it keep the existing conservative behavior.

This follows the single eligibility authority introduced in NousResearch/hermes-agent commits [`63a9c26`](https://github.com/NousResearch/hermes-agent/commit/63a9c26fbe6ca50138814111c21a4f4550ea85c1) and [`7b89e17`](https://github.com/NousResearch/hermes-agent/commit/7b89e177745fab390d2e7bdbf5e231bf164be24f).

## Validation
- [x] Focused routing/engine regression: `PYTHONPATH=/usr/local/lib/hermes-agent pytest tests/test_codex_routing.py tests/test_lcm_engine.py::test_codex_900k_variant_preserves_named_window tests/test_lcm_engine.py::test_codex_gpt55_uses_route_cap_and_hermes_autoraise_threshold tests/test_lcm_engine.py::test_codex_oauth_context_cap_applies_without_gpt55_threshold_magic -q` -> 13 passed
- [x] CI-minimal-host reproduction: same focused command with `PYTHONPATH=/tmp/hermes-lcm-ci-stub` -> 13 passed
- [x] Real-host route probe: valid Sol 900K -> 900K cap; base Sol -> 372K; invalid GPT-5.5 900K alias -> 272K
- [x] `uvx ruff check codex_routing.py tests/test_codex_routing.py tests/test_lcm_engine.py`
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` -> 1,103 passed
  - [x] `pytest -q` -> 2,831 passed, 1 skipped, 12 xfailed
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> 2,831 passed, 1 skipped, 12 xfailed
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Extended validation: benchmark smoke, stress smoke, and release stress passed
- [x] Workflow validation: not applicable (no workflow changes)

The first full-suite pass in `validate_release.sh --full` hit one unrelated timing failure in `test_background_scan_flags_corruption_without_rebuilding`: its captured log showed that corruption was detected, but the flag assertion observed `None`. The same test passed in the subsequent low-FD full suite, 5/5 isolated retries, and the clean standard full-suite retry reported above.

## Notes
- Ordinary `gpt-5.6*` Codex routes remain capped at 372K.
- Invalid aliases such as `gpt-5.5-900k` remain capped and cannot bypass safety by suffix alone.
- Older Hermes hosts without `is_codex_context_variant()` retain the current conservative cap.
- No configuration, schema, storage, or public tool contract changes.

Follow-up to #369.
