### PR TITLE
chore(release): prepare v1.0.0-rc.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Version and branch
       description: hermes-lcm version, branch, commit, or release tag.
-      placeholder: v0.21.0-rc2, main, or commit SHA
+      placeholder: v1.0.0-rc.1, main, or commit SHA
     validations:
       required: true
 

--- a/.github/release-notes/v1.0.0-rc.1.md
+++ b/.github/release-notes/v1.0.0-rc.1.md
@@ -1,0 +1,22 @@
+# hermes-lcm v1.0.0-rc.1
+
+Lossless Context Management for Hermes: a release candidate focused on storage safety, durable telemetry, and concurrent-startup reliability.
+
+## Highlights
+
+- Hardens untrusted prompt, externalized-payload, dependency, backup, and SQLite file boundaries while optional assertion, query-view, pre-answer evidence, embedding, and adaptive-retrieval paths remain disabled by default.
+- Preserves active-runtime slash-command routing and durable cumulative compaction telemetry across session rollover, restart, concurrent updates, and response-hook persistence.
+- Serializes deep FTS bootstrap repair and tolerates only verified transient SQLite rollback-journal disappearance during concurrent startup without relaxing stable symlink, hardlink, or path-swap rejection.
+- Adds exact 900,000-token safety caps for the three proven bare Codex routes only when the provider is `openai-codex`.
+
+## Changes
+
+- #526 Bind slash commands to the active runtime and persist cumulative compaction telemetry across restart and session rollover.
+- #557 Add exact Codex 900k route caps, publish the host-owned dependency assurance contract, and harden prompt, payload, storage, backup, and sidecar boundaries.
+- #570 Serialize constructor-time FTS bootstrap repair and preserve transaction and lock provenance under concurrent startup.
+- c368323 Reconcile verified transient SQLite rollback-journal disappearance while keeping stable link and path-swap defenses fail closed.
+
+## Contributors
+
+- @stephenschoettler
+- @100yenadmin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 No additional changes yet.
 
+## v1.0.0-rc.1 - 2026-09-03
+
+### Highlights
+
+- Harden untrusted prompt, externalized-payload, dependency, and SQLite file
+  boundaries while keeping optional assertion, query-view, pre-answer evidence,
+  embedding, and adaptive-retrieval paths disabled by default (#557).
+- Preserve active-runtime slash-command routing and durable cumulative
+  compaction telemetry across session rollover, restart, concurrent updates,
+  and response-hook persistence (#526).
+- Make concurrent startup safer by serializing deep FTS bootstrap repair and by
+  reconciling legitimate transient SQLite rollback-journal disappearance
+  without relaxing stable symlink, hardlink, or path-swap rejection (#570,
+  `c368323`).
+
+### Changed
+
+- #526 binds slash commands to the active runtime and makes cumulative
+  compaction counts durable across restart and session rollover.
+- #557 adds exact 900,000-token caps for the three proven bare Codex routes on
+  `openai-codex`, publishes the host-owned dependency assurance contract, and
+  hardens prompt, payload, storage, backup, and sidecar boundaries.
+- #570 serializes constructor-time FTS repair, rechecks the complete FTS state
+  after acquiring ownership, and preserves caller-owned transaction behavior.
+- `c368323` tolerates only verified transient rollback-journal disappearance or
+  unlink windows during SQLite artifact restriction. It also replaces a
+  scheduler-sensitive Voyage timing assertion with deterministic bounded-return
+  and exactly-once-dispatch synchronization; production provider behavior is
+  unchanged.
+
+### Upgrade and rollback notes
+
+- This is a prerelease candidate, not the stable v1.0.0 release. The tag-driven
+  workflow marks it as a prerelease and does not make it the latest release.
+- Before updating, use `/lcm backup` while Hermes is live, or stop every SQLite
+  writer and copy `lcm.db`, `lcm.db-wal`, and `lcm.db-shm` together as one
+  quiescent snapshot. Update the plugin, restart Hermes, send one normal
+  message, then verify `plugin_version: 1.0.0-rc.1` and the expected database
+  path with `lcm_status`.
+- The core schema remains version 5. No manual migration or embedding backfill
+  is required, and a stock/default-off upgrade creates no optional feature
+  tables. Restore the pre-upgrade snapshot before downgrading if an optional
+  store was enabled after the update.
+
 ## v0.21.0-rc2 - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
+  ✓ hermes-lcm v1.0.0-rc.1 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm
@@ -249,7 +249,7 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
-For the `v0.21.0-rc2` line, take a normal backup of `lcm.db` before updating,
+For the `v1.0.0-rc.1` line, take a normal backup of `lcm.db` before updating,
 then update the checkout and restart Hermes. No manual core migration or
 backfill is required: the core schema remains version 5. New assertion,
 query-view, and adaptive-retrieval state is additive, created only after the
@@ -257,7 +257,7 @@ corresponding opt-in is enabled, and stored in the same profile database under
 named feature markers. The five new query/evidence tool schemas are visible in
 the tool list on stock installs, but automatic extraction, pre-answer evidence,
 assertion storage, query-view storage, and adaptive retrieval remain off. See
-[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0200-to-v0210-rc2)
+[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0210-rc2-to-v100-rc1)
 before enabling them.
 
 ## Commands and tools

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ corresponding opt-in is enabled, and stored in the same profile database under
 named feature markers. The five new query/evidence tool schemas are visible in
 the tool list on stock installs, but automatic extraction, pre-answer evidence,
 assertion storage, query-view storage, and adaptive retrieval remain off. See
-[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0210-rc2-to-v100-rc1)
+[the operator upgrade and opt-in notes](docs/operator-guide.md#upgrade-from-v0200-or-v0210-rc2-to-v100-rc1)
 before enabling them.
 
 ## Commands and tools

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -79,7 +79,7 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
-## Upgrade from v0.21.0-rc2 to v1.0.0-rc.1
+## Upgrade from v0.20.0 or v0.21.0-rc2 to v1.0.0-rc.1
 
 1. While the old runtime is running, run `/lcm backup`. If Hermes or any other
    SQLite writer may still be running, this is the only supported online backup
@@ -96,14 +96,14 @@ Restart Hermes after updating.
    `SELECT value FROM metadata WHERE key = 'schema_version';`; the expected
    result is `5`.
 
-No manual core migration, data import, or embedding backfill is required. An
-existing v0.21.0-rc2 database opens in place and remains on core schema version
-5. The assertion, query-view, and trajectory families use additive named
-feature markers and create their tables only when the corresponding store or
-workflow is invoked. A stock/default-off upgrade therefore creates none of
-those optional tables. If you later enable an optional store, treat the
-pre-upgrade backup as the rollback path rather than opening that modified
-database with an older plugin.
+No manual core migration, data import, or embedding backfill is required. A
+database created by either v0.20.0 or v0.21.0-rc2 opens in place and remains on
+core schema version 5. The assertion, query-view, and trajectory families use
+additive named feature markers and create their tables only when the
+corresponding store or workflow is invoked. A stock/default-off upgrade
+therefore creates none of those optional tables. For rollback to either
+v0.20.0 or v0.21.0-rc2, restore the pre-upgrade backup rather than opening a
+database modified by v1.0.0-rc.1 with the older plugin.
 
 Temporal rollup settings do not change. When rollups are enabled, maintenance
 now runs through bounded eventual background work instead of blocking session

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -79,7 +79,7 @@ If you installed a symlink from a separate checkout:
 
 Restart Hermes after updating.
 
-## Upgrade from v0.20.0 to v0.21.0-rc2
+## Upgrade from v0.21.0-rc2 to v1.0.0-rc.1
 
 1. While the old runtime is running, run `/lcm backup`. If Hermes or any other
    SQLite writer may still be running, this is the only supported online backup
@@ -91,18 +91,18 @@ Restart Hermes after updating.
    live.
 3. Update the plugin checkout to the RC and restart Hermes.
 4. Send one normal message, then confirm `lcm_status` reports plugin version
-   `0.21.0-rc2` and the expected database path.
+   `1.0.0-rc.1` and the expected database path.
 5. For a migration-shape audit, query that database with
    `SELECT value FROM metadata WHERE key = 'schema_version';`; the expected
    result is `5`.
 
 No manual core migration, data import, or embedding backfill is required. An
-existing v0.20 database opens in place and remains on core schema version 5.
-The 0.21 assertion, query-view, and trajectory families use additive named
+existing v0.21.0-rc2 database opens in place and remains on core schema version
+5. The assertion, query-view, and trajectory families use additive named
 feature markers and create their tables only when the corresponding store or
 workflow is invoked. A stock/default-off upgrade therefore creates none of
-those optional tables. If you later enable a 0.21-only store, treat the
-pre-upgrade backup as the downgrade path rather than opening that modified
+those optional tables. If you later enable an optional store, treat the
+pre-upgrade backup as the rollback path rather than opening that modified
 database with an older plugin.
 
 Temporal rollup settings do not change. When rollups are enabled, maintenance
@@ -135,7 +135,7 @@ Typical output:
 
 ```text
 Plugins (1):
-  ✓ hermes-lcm v0.21.0-rc2 (15 tools)
+  ✓ hermes-lcm v1.0.0-rc.1 (15 tools)
 
 Provider Plugins:
   Context Engine: lcm

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-lcm
-version: 0.21.0-rc2
+version: 1.0.0-rc.1
 description: "Lossless Context Management — standalone Hermes plugin with a DAG-based context engine that never loses a message"
 author: "Voltropy / Hermes Community"
 provides_tools:

--- a/sqlite_util.py
+++ b/sqlite_util.py
@@ -36,6 +36,16 @@ def _validate_sqlite_artifact(path: Path, file_stat: os.stat_result) -> None:
         raise _sqlite_artifact_error(path, "link count is not one")
 
 
+def _require_sqlite_artifact_absent(path: Path, *, directory_fd: int) -> None:
+    """Accept a vanished sidecar only while its directory entry stays absent."""
+    try:
+        current = os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    _validate_sqlite_artifact(path, current)
+    raise _sqlite_artifact_error(path, "directory entry changed while opening")
+
+
 def _open_private_sqlite_directory(path: Path) -> int:
     directory = path.parent
     expected = os.stat(directory, follow_symlinks=False)
@@ -58,6 +68,7 @@ def _chmod_sqlite_artifact_at(
     *,
     directory_fd: int,
     create: bool,
+    allow_sidecar_disappearance: bool = False,
 ) -> bool:
     expected: os.stat_result | None
     try:
@@ -83,13 +94,27 @@ def _chmod_sqlite_artifact_at(
             directory_fd=directory_fd,
             create=False,
         )
+    except FileNotFoundError:
+        if not allow_sidecar_disappearance:
+            raise
+        _require_sqlite_artifact_absent(path, directory_fd=directory_fd)
+        return False
     try:
         opened = os.fstat(fd)
-        _validate_sqlite_artifact(path, opened)
+        if not stat.S_ISREG(opened.st_mode):
+            raise _sqlite_artifact_error(path, "not a regular file")
         if expected is not None and not _same_file_identity(expected, opened):
             raise _sqlite_artifact_error(path, "directory entry changed while opening")
+        if opened.st_nlink == 0 and allow_sidecar_disappearance:
+            _require_sqlite_artifact_absent(path, directory_fd=directory_fd)
+            return False
+        _validate_sqlite_artifact(path, opened)
         os.fchmod(fd, 0o600)
-        if os.fstat(fd).st_nlink != 1:
+        restricted = os.fstat(fd)
+        if restricted.st_nlink == 0 and allow_sidecar_disappearance:
+            _require_sqlite_artifact_absent(path, directory_fd=directory_fd)
+            return False
+        if restricted.st_nlink != 1:
             raise _sqlite_artifact_error(path, "link count changed while restricting permissions")
     finally:
         os.close(fd)
@@ -111,14 +136,17 @@ def _restrict_existing_sqlite_artifacts(db_path: Path) -> None:
 
     directory_fd = _open_private_sqlite_directory(db_path)
     try:
-        for artifact in (
+        _chmod_sqlite_artifact_at(
             db_path,
-            *(db_path.with_name(db_path.name + suffix) for suffix in _SQLITE_SIDECAR_SUFFIXES),
-        ):
+            directory_fd=directory_fd,
+            create=False,
+        )
+        for suffix in _SQLITE_SIDECAR_SUFFIXES:
             _chmod_sqlite_artifact_at(
-                artifact,
+                db_path.with_name(db_path.name + suffix),
                 directory_fd=directory_fd,
                 create=False,
+                allow_sidecar_disappearance=True,
             )
     finally:
         os.close(directory_fd)
@@ -147,6 +175,7 @@ def _prepare_private_sqlite_file(path: Path) -> None:
                 path.with_name(path.name + suffix),
                 directory_fd=directory_fd,
                 create=False,
+                allow_sidecar_disappearance=True,
             )
     finally:
         os.close(directory_fd)

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -1083,12 +1083,19 @@ def test_voyage_slow_response_decode_is_inside_absolute_deadline(monkeypatch):
 def test_voyage_slow_error_body_scrub_is_bounded_and_never_resent(monkeypatch):
     monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
     scrub_started = threading.Event()
+    release_scrub = threading.Event()
+    scrub_finished = threading.Event()
+    request_finished = threading.Event()
+    request_errors: list[BaseException] = []
     original_scrub = provider_mod._scrub_response_body
 
     def slow_scrub(body):
         scrub_started.set()
-        time.sleep(0.05)
-        return original_scrub(body)
+        try:
+            assert release_scrub.wait(timeout=2.0)
+            return original_scrub(body)
+        finally:
+            scrub_finished.set()
 
     monkeypatch.setattr(provider_mod, "_scrub_response_body", slow_scrub)
     transport = FakeTransport(
@@ -1097,15 +1104,33 @@ def test_voyage_slow_error_body_scrub_is_bounded_and_never_resent(monkeypatch):
     )
     provider = VoyageProvider("voyage-test", transport=transport, timeout=0.01)
 
-    started = time.monotonic()
-    with pytest.raises(VoyageError) as exc_info:
-        provider.embed_query("slow error body")
+    def request():
+        try:
+            provider.embed_query("slow error body")
+        except BaseException as exc:
+            request_errors.append(exc)
+        finally:
+            request_finished.set()
 
-    assert exc_info.value.kind == "server_error"
-    assert scrub_started.is_set()
+    caller = threading.Thread(target=request, daemon=True)
+    caller.start()
+    try:
+        assert scrub_started.wait(timeout=2.0)
+        # The scrub stays blocked here. Completion before release proves the
+        # request path obeys its deadline instead of waiting for diagnostics.
+        assert request_finished.wait(timeout=2.0), "request blocked on diagnostic body scrub"
+        assert not release_scrub.is_set()
+    finally:
+        release_scrub.set()
+        caller.join(timeout=2.0)
+
+    assert not caller.is_alive()
+    assert scrub_finished.wait(timeout=2.0)
+    assert len(request_errors) == 1
+    request_error = request_errors[0]
+    assert isinstance(request_error, VoyageError)
+    assert getattr(request_error, "kind", None) == "server_error"
     assert len(transport.calls) == 1
-    assert time.monotonic() - started < 0.04
-    time.sleep(0.06)
 
 
 def test_voyage_timeout_after_possible_acceptance_is_not_resent(monkeypatch):

--- a/tests/test_lcm_command.py
+++ b/tests/test_lcm_command.py
@@ -417,7 +417,7 @@ def test_lcm_status_reports_runtime_identity(engine):
     repo_root = Path(__file__).resolve().parent.parent
 
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.21.0-rc2" in result
+    assert "plugin_version: 1.0.0-rc.1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "module_path:" in result
     assert "database_path_source: config.database_path" in result
@@ -457,7 +457,7 @@ def test_lcm_doctor_reports_health_checks(engine):
     assert "messages_fts: ok" in result
     assert "nodes_fts: ok" in result
     assert "plugin_name: hermes-lcm" in result
-    assert "plugin_version: 0.21.0-rc2" in result
+    assert "plugin_version: 1.0.0-rc.1" in result
     assert f"plugin_path: {repo_root}" in result
     assert "plugin_git_commit:" in result
     assert "triage_guidance:\n- none" in result

--- a/tests/test_lcm_engine.py
+++ b/tests/test_lcm_engine.py
@@ -1194,7 +1194,7 @@ def test_get_status_exposes_runtime_identity_for_loaded_plugin_tree(tmp_path):
 
     assert identity["engine"] == "lcm"
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.21.0-rc2"
+    assert identity["plugin_version"] == "1.0.0-rc.1"
     assert Path(identity["plugin_path"]) == repo_root
     assert Path(identity["module_path"]).name == "engine.py"
     assert Path(identity["database_path"]) == db_path
@@ -1220,11 +1220,11 @@ def test_plugin_metadata_refreshes_when_manifest_changes(tmp_path, monkeypatch):
 
     initial = identity_mod._plugin_metadata()
     assert initial["name"] == "hermes-lcm"
-    assert initial["version"] == "0.21.0-rc2"
+    assert initial["version"] == "1.0.0-rc.1"
 
-    updated = original.replace('version: "0.21.0-rc2"', 'version: "9.9.9-test"')
+    updated = original.replace('version: "1.0.0-rc.1"', 'version: "9.9.9-test"')
     if updated == original:
-        updated = original.replace('version: 0.21.0-rc2', 'version: 9.9.9-test')
+        updated = original.replace('version: 1.0.0-rc.1', 'version: 9.9.9-test')
     assert updated != original
 
     try:
@@ -1262,7 +1262,7 @@ def test_lcm_doctor_json_includes_runtime_identity(engine):
     payload = json.loads(engine.handle_tool_call("lcm_doctor", {}))
 
     assert payload["runtime_identity"]["plugin_name"] == "hermes-lcm"
-    assert payload["runtime_identity"]["plugin_version"] == "0.21.0-rc2"
+    assert payload["runtime_identity"]["plugin_version"] == "1.0.0-rc.1"
     assert "plugin_git_commit" in payload["runtime_identity"]
 
 

--- a/tests/test_packaging_install.py
+++ b/tests/test_packaging_install.py
@@ -425,7 +425,7 @@ def test_plugin_entrypoint_registers_lcm_context_engine():
     identity = engine.get_status()["runtime_identity"]
     repo_root = Path(__file__).resolve().parent.parent
     assert identity["plugin_name"] == "hermes-lcm"
-    assert identity["plugin_version"] == "0.21.0-rc2"
+    assert identity["plugin_version"] == "1.0.0-rc.1"
     assert Path(identity["plugin_path"]) == repo_root
     assert identity["database_path_source"] in {"config.database_path", "hermes_home", "default_home"}
     assert identity["plugin_git_commit"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
-RELEASE_VERSION = "0.21.0-rc2"
+RELEASE_VERSION = "1.0.0-rc.1"
 RELEASE_NOTES = REPO_ROOT / ".github" / "release-notes" / f"v{RELEASE_VERSION}.md"
 
 
@@ -72,9 +72,14 @@ def test_release_candidate_notes_cover_only_the_merged_release_scope():
     notes = RELEASE_NOTES.read_text(encoding="utf-8")
 
     assert notes.startswith(f"# hermes-lcm v{RELEASE_VERSION}\n")
-    assert "#492" in notes
+    assert "#526" in notes
+    assert "#557" in notes
+    assert "#570" in notes
+    assert "c368323" in notes
     assert "## Highlights" in notes
     assert "## Changes" in notes
     assert "## Contributors" in notes
-    assert "UTF-8 character boundaries" in notes
+    assert "release candidate" in notes.lower()
+    assert "disabled by default" in notes
+    assert "rollback-journal" in notes
     assert len(notes.splitlines()) <= 60

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -55,6 +55,29 @@ def test_upgrade_guide_requires_sqlite_safe_backup_semantics():
     assert "one quiescent snapshot" in operator_guide
 
 
+def test_upgrade_guide_covers_stable_and_prerelease_paths():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    operator_guide = " ".join(
+        (REPO_ROOT / "docs" / "operator-guide.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "## Upgrade from v0.20.0 or v0.21.0-rc2 to v1.0.0-rc.1" in operator_guide
+    assert (
+        "A database created by either v0.20.0 or v0.21.0-rc2 opens in place"
+        in operator_guide
+    )
+    assert (
+        "For rollback to either v0.20.0 or v0.21.0-rc2, restore the pre-upgrade "
+        "backup" in operator_guide
+    )
+    assert (
+        "docs/operator-guide.md#upgrade-from-v0200-or-v0210-rc2-to-v100-rc1"
+        in readme
+    )
+
+
 def test_preanswer_guide_discloses_inherited_embedding_provider_behavior():
     operator_guide = " ".join(
         (REPO_ROOT / "docs" / "operator-guide.md")

--- a/tests/test_storage_permissions.py
+++ b/tests/test_storage_permissions.py
@@ -11,10 +11,11 @@ from types import SimpleNamespace
 
 import pytest
 
+import hermes_lcm.db_bootstrap as db_bootstrap_module
 import hermes_lcm.maintenance as maintenance_module
 import hermes_lcm.sqlite_util as sqlite_util_module
 from hermes_lcm.maintenance import backup_database, rotate_backup_database
-from hermes_lcm.store import MessageStore
+from hermes_lcm.store import MessageStore, build_message_fts_spec
 
 
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
@@ -44,6 +45,33 @@ def _assert_private_sqlite_artifacts(path: Path) -> None:
     assert {artifact.name: _mode(artifact) for artifact in artifacts} == {
         artifact.name: 0o600 for artifact in artifacts
     }
+
+
+def _seed_searchable_store(db_path: Path) -> None:
+    store = MessageStore(db_path)
+    try:
+        store.append(
+            "sidecar-race",
+            {"role": "user", "content": "durable sidecar lifecycle token"},
+        )
+        store.commit()
+    finally:
+        store.close()
+
+
+def _assert_searchable_store_integrity(store: MessageStore) -> None:
+    conn = store.connection
+    assert conn is not None
+    assert conn.execute("SELECT content FROM messages").fetchone()[0] == (
+        "durable sidecar lifecycle token"
+    )
+    assert store.search("lifecycle", limit=10)[0]["content"] == (
+        "durable sidecar lifecycle token"
+    )
+    assert db_bootstrap_module.check_external_content_fts_integrity(
+        conn, build_message_fts_spec()
+    )["status"] == "pass"
+    assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
 
 
 def test_message_store_creates_private_database_and_sidecars_under_umask_022(tmp_path):
@@ -201,6 +229,101 @@ def test_message_store_refuses_sidecar_link_swap_before_chmod(
 
     assert swapped is True
     assert _mode(target) == 0o644
+
+
+def test_message_store_refuses_sidecar_replacement_after_open_before_fstat(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "lcm.db"
+    sidecar = db_path.with_name(db_path.name + "-journal")
+    replacement = tmp_path / "replacement-journal"
+    sidecar.write_bytes(b"replace me")
+    replacement.write_bytes(b"unrelated")
+    sidecar.chmod(0o644)
+    replacement.chmod(0o644)
+    real_open = os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is not None and path == sidecar.name:
+            swapped = True
+            sidecar.unlink()
+            replacement.rename(sidecar)
+        return fd
+
+    monkeypatch.setattr(sqlite_util_module.os, "open", swapping_open)
+
+    with pytest.raises(OSError, match="directory entry changed while opening"):
+        MessageStore(db_path)
+
+    assert swapped is True
+    assert _mode(sidecar) == 0o644
+
+
+def test_message_store_tolerates_sidecar_disappearing_between_stat_and_open(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "lcm.db"
+    _seed_searchable_store(db_path)
+    journal = db_path.with_name(db_path.name + "-journal")
+    journal.write_bytes(b"transient rollback journal")
+    real_open = os.open
+    disappeared = False
+
+    def disappearing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal disappeared
+        if not disappeared and dir_fd is not None and path == journal.name:
+            disappeared = True
+            journal.unlink()
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(sqlite_util_module.os, "open", disappearing_open)
+
+    store = MessageStore(db_path)
+    try:
+        assert disappeared is True
+        _assert_searchable_store_integrity(store)
+    finally:
+        store.close()
+
+
+def test_message_store_tolerates_sidecar_unlinked_between_open_and_fstat(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "lcm.db"
+    _seed_searchable_store(db_path)
+    journal = db_path.with_name(db_path.name + "-journal")
+    journal.write_bytes(b"transient rollback journal")
+    real_open = os.open
+    unlinked = False
+
+    def unlinking_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal unlinked
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        if not unlinked and path == journal.name:
+            unlinked = True
+            journal.unlink()
+        return fd
+
+    monkeypatch.setattr(sqlite_util_module.os, "open", unlinking_open)
+
+    store = MessageStore(db_path)
+    try:
+        assert unlinked is True
+        _assert_searchable_store_integrity(store)
+    finally:
+        store.close()
 
 
 def test_message_store_preserves_sqlite_memory_sentinel_and_cwd_permissions(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Prepare the reviewed `v1.0.0-rc.1` release candidate on `release/v1.0.0-rc.1`.
- Carry the exact accepted SQLite/Voyage repair commit `c368323bc167dbf96a5c46732fbfab6d9dc56e6d` on unchanged baseline `7c5c9605a30f7ae828cb0afd69ccf4051c7840f7`.
- Synchronize canonical version surfaces, upgrade/rollback guidance, changelog, release-note validation, and curated tag-specific notes.

## Why
- The accepted release baseline needed one fail-closed SQLite rollback-journal lifecycle repair before the first v1.0 prerelease candidate could be cut.
- The tag workflow requires version-consistent repository metadata and curated `.github/release-notes/v1.0.0-rc.1.md` before publication.

## Validation
- [x] Focused validation: repair, adversarial storage, version, install, prerelease, and default-off nodes -> `32 passed`.
- [x] Default validation:
  - [x] `pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py -q` (covered by the repository focused and full gates)
  - [x] `pytest -q` -> `3028 passed, 1 skipped, 12 xfailed`
  - [x] `bash -lc 'ulimit -n 1024 && pytest -q'` -> `3028 passed, 1 skipped, 12 xfailed`
  - [x] `python -m compileall -q .`
  - [x] `python -m py_compile scripts/import_lossless_claw.py`
  - [x] `bash -n scripts/install.sh scripts/update.sh`
  - [x] `git diff --check`
- [x] Workflow validation, if workflows changed: no workflow bytes changed; `actionlint` passed and release-workflow contract tests passed.
- [x] `scripts/validate_release.sh --full --keep-going` -> PASS; focused `482 passed`, normal and FD1024 full suites green, release stress failures `0`.
- [x] Supported-Python FD1024 CI parity: Python 3.11–3.13 each `3028 passed, 1 skipped, 12 xfailed`; Python 3.14 `3029 passed, 12 xfailed`.
- [x] Concurrent startup: `50/50` normal and `50/50` FD1024; focused SQLite/bootstrap/storage/embedding suite `129 passed` at each limit.
- [x] Voyage load controls: bounded scrub `10/10` normal and `10/10` FD1024 with 16 CPU burners; adjacent deadline/decode/no-resend set `5/5` at each limit.
- [x] Disposable upgrades from stable `v0.20.0` and prerelease `v0.21.0-rc2`: schema remains `5`, canaries remain retrievable, all 12 optional flags remain false, both downgrade-open checks stay healthy, and each pre-upgrade database copy restores byte-identically before open.
- [x] Isolated install smoke created only workspace-local profile links and loaded version `1.0.0-rc.1` from candidate `6cfeea4fe8c74f6655f9c0cb00ae40c2558fed3d`.

## Notes
- Final candidate tree: `a7fbe8481392a8138478597f4b0cbbb78437387c`.
- `v1.0.0-rc.1` is a prerelease; the existing tag workflow sets `prerelease: true`, `make_latest: false`, and consumes the curated tag-specific notes file.
- No push, PR, merge, tag, release, deployment, real-profile install, service restart, or runtime/config/database mutation was performed while preparing this local candidate.

Refs #526, #557, #570
