### PR TITLE
feat(amr): Level-1 quote anchors + four-outcome citation verifier

### DIFF
--- a/assertion_amr.py
+++ b/assertion_amr.py
@@ -1,0 +1,313 @@
+"""AMR (auditable-memory-records 0.1) citation verification for assertions.
+
+Read-only companion to :mod:`assertion_store`: it verifies stored quote
+anchors against the authoritative message content and reports the four AMR
+§6 outcomes. It never mutates state and never resolves disagreement between
+records — verification answers only "does this citation still hold?".
+
+Outcome semantics (AMR §6 — collapsing these into a boolean is the classic
+mistake; ``anchor_tampered`` and ``source_drifted`` look identical to a
+naive "citation invalid" check and mean opposite things):
+
+- ``ok`` — stored hash matches the stored quote, and the quote is still at
+  its span in the unchanged source.
+- ``anchor_tampered`` — the record's own citation is internally
+  inconsistent (stored hash disagrees with the stored quote, or the
+  span/quote pair disagrees with a provably unchanged source).
+- ``source_drifted`` — the record is honest, but the source changed
+  underneath it.
+- ``source_missing`` — the cited source cannot be resolved.
+
+Level-1 marking is carried by the closed ``epistemic`` vocabulary; ``None``
+is the unmarked state and is never coerced to ``fact`` (absent is not
+fact). This module also exposes the per-implementation AMR declaration.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .assertion_store import AssertionStore
+from .db_bootstrap import (
+    ASSERTION_QUOTE_HASH_ALGORITHM,
+    _normalize_quote_for_hash,
+    _quote_hash,
+)
+
+AMR_SPEC_DECLARATION = "auditable_memory: 0.1"
+AMR_CONFORMANCE_LEVEL = "1-marked"
+
+OUTCOME_OK = "ok"
+OUTCOME_ANCHOR_TAMPERED = "anchor_tampered"
+OUTCOME_SOURCE_DRIFTED = "source_drifted"
+OUTCOME_SOURCE_MISSING = "source_missing"
+
+
+def _content_sha256(content: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def verify_assertion_citations(
+    store: AssertionStore,
+    *,
+    assertion_ids: Sequence[str] | None = None,
+    source_store_id: int | None = None,
+    include_invalidated: bool = False,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Verify stored quote anchors, returning one outcome row per assertion.
+
+    Read-only. Results are ordered by assertion_id for determinism. The
+    check recomputes the AMR §5 hash under the stored hash's own algorithm
+    prefix; unrecognized prefixes are reported as ``anchor_tampered``
+    rather than guessed.
+    """
+    bounded_limit = int(limit)
+    if not 1 <= bounded_limit <= 500:
+        raise ValueError("limit must be between 1 and 500")
+
+    where = ["1"]
+    args: list[Any] = []
+    if assertion_ids is not None:
+        if not assertion_ids:
+            return []
+        normalized = [str(value).strip().lower() for value in assertion_ids]
+        placeholders = ", ".join("?" for _ in normalized)
+        where.append(f"a.assertion_id IN ({placeholders})")
+        args.extend(normalized)
+    if source_store_id is not None:
+        where.append("a.source_store_id = ?")
+        args.append(int(source_store_id))
+    if not include_invalidated:
+        where.append("s.invalidated_at IS NULL")
+    args.append(bounded_limit)
+
+    rows = store.connection.execute(
+        f"""
+        SELECT a.assertion_id, a.source_store_id, a.source_span_start,
+               a.source_span_end, a.source_quote, a.source_quote_hash,
+               s.source_content_sha256, s.invalidated_at, m.content
+          FROM lcm_assertions AS a
+          JOIN lcm_assertion_sources AS s
+            ON s.source_store_id = a.source_store_id
+           AND s.extraction_version = a.extraction_version
+           AND s.source_content_sha256 = a.source_content_sha256
+          LEFT JOIN messages AS m ON m.store_id = a.source_store_id
+         WHERE {' AND '.join(where)}
+         ORDER BY a.assertion_id ASC
+         LIMIT ?
+        """,
+        args,
+    ).fetchall()
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        stored_hash = row["source_quote_hash"]
+        stored_quote = str(row["source_quote"] or "")
+        content = row["content"]
+        detail = ""
+        partial = False
+
+        if content is None:
+            outcome = OUTCOME_SOURCE_MISSING
+            detail = "source message row is gone"
+        else:
+            current_content = str(content)
+            content_unchanged = (
+                _content_sha256(current_content)
+                == str(row["source_content_sha256"])
+            )
+            if stored_hash is None or str(stored_hash).strip() == "":
+                # AMR §6.1: without an anchor hash only the drift axis is
+                # decidable; anchor_tampered MUST NOT be reported and the
+                # partial check is signalled.
+                partial = True
+                if not content_unchanged:
+                    outcome = OUTCOME_SOURCE_DRIFTED
+                    detail = "source content changed; no stored hash to check integrity"
+                else:
+                    start = int(row["source_span_start"])
+                    end = int(row["source_span_end"])
+                    if 0 <= start < end <= len(current_content) and (
+                        current_content[start:end] == stored_quote
+                    ):
+                        outcome = OUTCOME_OK
+                        detail = "partial check: span verified, no stored hash"
+                    else:
+                        outcome = OUTCOME_SOURCE_DRIFTED
+                        detail = "partial check: span moved, no stored hash"
+            else:
+                partial = False
+                stored_hash = str(stored_hash)
+                algorithm = stored_hash.split(":", 1)[0] if ":" in stored_hash else ""
+                if algorithm != ASSERTION_QUOTE_HASH_ALGORITHM:
+                    outcome = OUTCOME_ANCHOR_TAMPERED
+                    detail = f"unrecognized hash algorithm: {algorithm or 'bare digest'}"
+                elif _quote_hash(stored_quote) != stored_hash:
+                    outcome = OUTCOME_ANCHOR_TAMPERED
+                    detail = "stored hash disagrees with the stored quote"
+                elif not content_unchanged:
+                    present = _normalized_contains(current_content, stored_quote)
+                    outcome = OUTCOME_SOURCE_DRIFTED
+                    detail = (
+                        "source content changed; quote "
+                        + ("still present" if present else "no longer present")
+                    )
+                else:
+                    start = int(row["source_span_start"])
+                    end = int(row["source_span_end"])
+                    if 0 <= start < end <= len(current_content) and (
+                        current_content[start:end] == stored_quote
+                    ):
+                        outcome = OUTCOME_OK
+                        detail = "hash and span verified against unchanged source"
+                    else:
+                        moved = _normalized_offset(current_content, stored_quote)
+                        outcome = OUTCOME_ANCHOR_TAMPERED
+                        detail = (
+                            "span/quote inconsistent with unchanged source"
+                            + (
+                                f"; quote found at offset {moved}"
+                                if moved is not None
+                                else "; quote absent from source"
+                            )
+                        )
+
+        results.append({
+            "assertion_id": str(row["assertion_id"]),
+            "source_store_id": int(row["source_store_id"]),
+            "outcome": outcome,
+            "partial": partial,
+            "detail": detail,
+            "stored_quote_hash": stored_hash,
+        })
+    return results
+
+
+def _normalized_contains(content: str, quote: str) -> bool:
+    return _normalize_quote_for_hash(quote) in _normalize_quote_for_hash(content)
+
+
+def _normalized_offset(content: str, quote: str) -> int | None:
+    normalized_content = _normalize_quote_for_hash(content)
+    normalized_quote = _normalize_quote_for_hash(quote)
+    offset = normalized_content.find(normalized_quote)
+    return offset if offset >= 0 else None
+
+
+def verify_relation_citations(
+    store: AssertionStore,
+    *,
+    relation_ids: Sequence[str] | None = None,
+    source_store_id: int | None = None,
+    include_invalidated: bool = False,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Same four-outcome verification for typed-relation quote anchors."""
+    bounded_limit = int(limit)
+    if not 1 <= bounded_limit <= 500:
+        raise ValueError("limit must be between 1 and 500")
+
+    where = ["1"]
+    args: list[Any] = []
+    if relation_ids is not None:
+        if not relation_ids:
+            return []
+        normalized = [str(value).strip().lower() for value in relation_ids]
+        placeholders = ", ".join("?" for _ in normalized)
+        where.append(f"r.relation_id IN ({placeholders})")
+        args.extend(normalized)
+    if source_store_id is not None:
+        where.append("r.source_store_id = ?")
+        args.append(int(source_store_id))
+    if not include_invalidated:
+        where.append("s.invalidated_at IS NULL")
+    args.append(bounded_limit)
+
+    rows = store.connection.execute(
+        f"""
+        SELECT r.relation_id, r.source_store_id, r.source_span_start,
+               r.source_span_end, r.source_quote, r.source_quote_hash,
+               s.source_content_sha256, s.invalidated_at, m.content
+          FROM lcm_assertion_relations AS r
+          JOIN lcm_assertion_sources AS s
+            ON s.source_store_id = r.source_store_id
+           AND s.extraction_version = r.extraction_version
+           AND s.source_content_sha256 = r.source_content_sha256
+          LEFT JOIN messages AS m ON m.store_id = r.source_store_id
+         WHERE {' AND '.join(where)}
+         ORDER BY r.relation_id ASC
+         LIMIT ?
+        """,
+        args,
+    ).fetchall()
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        stored_hash = row["source_quote_hash"]
+        stored_quote = str(row["source_quote"] or "")
+        content = row["content"]
+        if content is None:
+            results.append({
+                "relation_id": str(row["relation_id"]),
+                "source_store_id": int(row["source_store_id"]),
+                "outcome": OUTCOME_SOURCE_MISSING,
+                "partial": False,
+                "detail": "source message row is gone",
+                "stored_quote_hash": stored_hash,
+            })
+            continue
+        current_content = str(content)
+        content_unchanged = (
+            _content_sha256(current_content) == str(row["source_content_sha256"])
+        )
+        if stored_hash is None or str(stored_hash).strip() == "":
+            partial = True
+            if content_unchanged:
+                start = int(row["source_span_start"])
+                end = int(row["source_span_end"])
+                outcome = (
+                    OUTCOME_OK
+                    if 0 <= start < end <= len(current_content)
+                    and current_content[start:end] == stored_quote
+                    else OUTCOME_SOURCE_DRIFTED
+                )
+                detail = "partial check: no stored hash"
+            else:
+                outcome = OUTCOME_SOURCE_DRIFTED
+                detail = "source content changed; no stored hash to check integrity"
+        else:
+            partial = False
+            stored_hash = str(stored_hash)
+            algorithm = stored_hash.split(":", 1)[0] if ":" in stored_hash else ""
+            if algorithm != ASSERTION_QUOTE_HASH_ALGORITHM:
+                outcome = OUTCOME_ANCHOR_TAMPERED
+                detail = f"unrecognized hash algorithm: {algorithm or 'bare digest'}"
+            elif _quote_hash(stored_quote) != stored_hash:
+                outcome = OUTCOME_ANCHOR_TAMPERED
+                detail = "stored hash disagrees with the stored quote"
+            elif not content_unchanged:
+                outcome = OUTCOME_SOURCE_DRIFTED
+                detail = "source content changed"
+            else:
+                start = int(row["source_span_start"])
+                end = int(row["source_span_end"])
+                if 0 <= start < end <= len(current_content) and (
+                    current_content[start:end] == stored_quote
+                ):
+                    outcome = OUTCOME_OK
+                    detail = "hash and span verified against unchanged source"
+                else:
+                    outcome = OUTCOME_ANCHOR_TAMPERED
+                    detail = "span/quote inconsistent with unchanged source"
+        results.append({
+            "relation_id": str(row["relation_id"]),
+            "source_store_id": int(row["source_store_id"]),
+            "outcome": outcome,
+            "partial": partial,
+            "detail": detail,
+            "stored_quote_hash": stored_hash,
+        })
+    return results

--- a/assertion_store.py
+++ b/assertion_store.py
@@ -21,6 +21,7 @@ from typing import Any, Iterable, Sequence
 from urllib.parse import quote
 
 from .db_bootstrap import (
+    ASSERTION_EPISTEMIC_VALUES,
     ASSERTION_MIGRATION_STEP,
     configure_connection,
     ensure_assertion_tables,
@@ -28,6 +29,7 @@ from .db_bootstrap import (
     refuse_schema_version_too_new,
     run_versioned_migrations,
     verify_assertion_schema,
+    _quote_hash,
 )
 
 
@@ -107,6 +109,9 @@ class AssertionCandidate:
     valid_from: float | None = None
     valid_to: float | None = None
     confidence: float = 1.0
+    # AMR §4.2 epistemic status marking. ``None`` means the unmarked state
+    # (absent is not fact); valid values are the closed AMR vocabulary.
+    epistemic: str | None = None
 
 
 @dataclass(frozen=True)
@@ -443,6 +448,17 @@ class AssertionStore:
         valid_to = _finite_number(candidate.valid_to, "valid_to")
         if valid_from is not None and valid_to is not None and valid_to <= valid_from:
             raise ValueError("valid_to must be greater than valid_from")
+        epistemic = candidate.epistemic
+        if epistemic is not None:
+            epistemic = str(epistemic).strip()
+            if epistemic == "":
+                epistemic = None
+            elif epistemic not in ASSERTION_EPISTEMIC_VALUES:
+                # AMR §4.2: values are case-sensitive and the vocabulary is
+                # closed — reject rather than coercing to a known value.
+                raise ValueError(
+                    f"unsupported epistemic value: {candidate.epistemic!r}"
+                )
         payload = {
             "source_store_id": snapshot.store_id,
             "extraction_version": version,
@@ -466,6 +482,11 @@ class AssertionStore:
             "confidence": confidence,
         }
         payload["assertion_id"] = _sha256_text(_canonical_json(payload))
+        # AMR quote anchor is bound post-digest: the identity digest covers
+        # the same fields as before this slice, so existing assertion ids
+        # remain stable across the migration.
+        payload["source_quote_hash"] = _quote_hash(payload["source_quote"])
+        payload["epistemic"] = epistemic
         return payload
 
     def assertion_id_for(
@@ -516,6 +537,7 @@ class AssertionStore:
             "confidence": confidence,
         }
         payload["relation_id"] = _sha256_text(_canonical_json(payload))
+        payload["source_quote_hash"] = _quote_hash(payload["source_quote"])
         return payload
 
     def publish_source(
@@ -691,14 +713,16 @@ class AssertionStore:
                             object_json, value_text, kind, polarity, strength,
                             scope_key, speaker_role, observed_at, event_at,
                             valid_from, valid_to, source_span_start, source_span_end,
-                            source_quote, confidence, created_at
+                            source_quote, source_quote_hash, epistemic,
+                            confidence, created_at
                         ) VALUES(
                             :assertion_id, :source_store_id, :extraction_version,
                             :source_content_sha256, :subject_key, :predicate_key,
                             :object_json, :value_text, :kind, :polarity, :strength,
                             :scope_key, :speaker_role, :observed_at, :event_at,
                             :valid_from, :valid_to, :source_span_start, :source_span_end,
-                            :source_quote, :confidence, :created_at
+                            :source_quote, :source_quote_hash, :epistemic,
+                            :confidence, :created_at
                         )
                         """,
                         {**row, "created_at": time.time()},
@@ -729,12 +753,12 @@ class AssertionStore:
                             relation_id, source_store_id, extraction_version,
                             source_content_sha256, from_assertion_id, relation_type,
                             to_assertion_id, source_span_start, source_span_end,
-                            source_quote, confidence, created_at
+                            source_quote, source_quote_hash, confidence, created_at
                         ) VALUES(
                             :relation_id, :source_store_id, :extraction_version,
                             :source_content_sha256, :from_assertion_id, :relation_type,
                             :to_assertion_id, :source_span_start, :source_span_end,
-                            :source_quote, :confidence, :created_at
+                            :source_quote, :source_quote_hash, :confidence, :created_at
                         )
                         """,
                         {**row, "created_at": time.time()},

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -6,6 +6,7 @@ same schema-version marker, PRAGMA settings, and FTS repair behavior.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from functools import lru_cache
 import logging
@@ -1759,6 +1760,17 @@ def verify_chunk_schema(conn: sqlite3.Connection) -> list[str]:
 
 ASSERTION_MIGRATION_STEP = "assertion_store_v1"
 
+# AMR (auditable-memory-records 0.1, docs/research Level-1 slice) vocabulary.
+# Closed set per AMR §4.2; ``None`` (field absent) is the fifth, unmarked state
+# and is never coerced to ``fact`` — absent is not fact.
+ASSERTION_EPISTEMIC_VALUES = frozenset({
+    "fact", "inference", "open_question", "unverified",
+})
+
+# ``quote_hash`` is serialized algorithm-prefixed (AMR §5). Bare digests are
+# deprecated; verifiers must resolve the algorithm from the prefix.
+ASSERTION_QUOTE_HASH_ALGORITHM = "sha256"
+
 _ASSERTION_TABLE_COLUMNS: dict[str, frozenset[str]] = {
     "lcm_assertion_sources": frozenset({
         "source_store_id", "extraction_version", "source_content_sha256",
@@ -1771,14 +1783,15 @@ _ASSERTION_TABLE_COLUMNS: dict[str, frozenset[str]] = {
         "source_content_sha256", "subject_key", "predicate_key", "object_json",
         "value_text", "kind", "polarity", "strength", "scope_key",
         "speaker_role", "observed_at", "event_at", "valid_from", "valid_to",
-        "source_span_start", "source_span_end", "source_quote", "confidence",
+        "source_span_start", "source_span_end", "source_quote",
+        "source_quote_hash", "epistemic", "confidence",
         "created_at",
     }),
     "lcm_assertion_relations": frozenset({
         "relation_id", "source_store_id", "extraction_version",
         "source_content_sha256", "from_assertion_id", "relation_type",
         "to_assertion_id", "source_span_start", "source_span_end",
-        "source_quote", "confidence", "created_at",
+        "source_quote", "source_quote_hash", "confidence", "created_at",
     }),
 }
 
@@ -1938,6 +1951,13 @@ def ensure_assertion_tables(conn: sqlite3.Connection) -> None:
             source_span_start INTEGER NOT NULL CHECK(source_span_start >= 0),
             source_span_end INTEGER NOT NULL CHECK(source_span_end > source_span_start),
             source_quote TEXT NOT NULL,
+            source_quote_hash TEXT NOT NULL
+                CHECK(length(source_quote_hash) = 71
+                     AND substr(source_quote_hash, 1, 7) = 'sha256:'
+                     AND substr(source_quote_hash, 8) NOT GLOB '*[^0-9a-f]*'),
+            epistemic TEXT CHECK(epistemic IS NULL OR epistemic IN (
+                'fact', 'inference', 'open_question', 'unverified'
+            )),
             confidence REAL NOT NULL CHECK(confidence >= 0.0 AND confidence <= 1.0),
             created_at REAL NOT NULL DEFAULT (strftime('%s','now')),
             CHECK(valid_from IS NULL OR valid_to IS NULL OR valid_to > valid_from)
@@ -1962,6 +1982,10 @@ def ensure_assertion_tables(conn: sqlite3.Connection) -> None:
             source_span_start INTEGER NOT NULL CHECK(source_span_start >= 0),
             source_span_end INTEGER NOT NULL CHECK(source_span_end > source_span_start),
             source_quote TEXT NOT NULL,
+            source_quote_hash TEXT NOT NULL
+                CHECK(length(source_quote_hash) = 71
+                     AND substr(source_quote_hash, 1, 7) = 'sha256:'
+                     AND substr(source_quote_hash, 8) NOT GLOB '*[^0-9a-f]*'),
             confidence REAL NOT NULL CHECK(confidence >= 0.0 AND confidence <= 1.0),
             created_at REAL NOT NULL DEFAULT (strftime('%s','now')),
             CHECK(from_assertion_id <> to_assertion_id)
@@ -2101,6 +2125,134 @@ def ensure_assertion_tables(conn: sqlite3.Connection) -> None:
         END;
         """
     )
+    _migrate_assertion_quote_anchors(conn)
+
+
+def _normalize_quote_for_hash(quote: str) -> str:
+    """AMR §5 normalization applied before hashing or substring matching.
+
+    Smart punctuation folds to ASCII, every whitespace run (including
+    newlines and tabs) collapses to one space, and the result is trimmed.
+    Normalization MUST stay identical across implementations for hashes to
+    interoperate and is idempotent.
+    """
+    _SMART_FOLDS = {
+        "\u2018": "'", "\u2019": "'", "\u201a": "'", "\u201b": "'",
+        "\u201c": '"', "\u201d": '"', "\u201e": '"', "\u201f": '"',
+        "\u2032": "'", "\u2033": '"',
+        "\u2013": "-", "\u2014": "-", "\u2212": "-",
+        "\u2026": "...",
+    }
+    folded = "".join(_SMART_FOLDS.get(ch, ch) for ch in str(quote))
+    return " ".join(folded.split())
+
+
+def _quote_hash(quote: str) -> str:
+    """Algorithm-prefixed AMR §5 quote hash (lowercase hex sha256)."""
+    digest = hashlib.sha256(
+        _normalize_quote_for_hash(quote).encode("utf-8")
+    ).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _migrate_assertion_quote_anchors(conn: sqlite3.Connection) -> None:
+    """Idempotent in-place migration adding the AMR quote-anchor columns.
+
+    Rebuilds the two rebuildable quote tables (copy out, drop, recreate via
+    this build's own DDL, copy back with per-row hash backfill) while every
+    ``lcm_assertion_sources`` row — including invalidation history — is
+    preserved untouched. Databases already in final shape are untouched.
+    The row/relation insert guards are temporarily dropped for the copy so
+    assertions of already-invalidated sources stay visible; they are
+    recreated before this function returns.
+    """
+    _OLD_NAMES = {
+        "lcm_assertions": "_lcm_amr_old_assertions",
+        "lcm_assertion_relations": "_lcm_amr_old_relations",
+    }
+
+    def _table_exists(table: str) -> bool:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+                (table,),
+            ).fetchone()
+            is not None
+        )
+
+    def _needs_rebuild(table: str) -> bool:
+        if not _table_exists(table):
+            return False
+        columns = {str(item[1]) for item in conn.execute(f"PRAGMA table_info({table})")}
+        return "source_quote_hash" not in columns
+
+    if not any(_needs_rebuild(table) for table in _OLD_NAMES):
+        return
+
+    for table in _OLD_NAMES:
+        if _needs_rebuild(table):
+            conn.execute(f"ALTER TABLE {table} RENAME TO {_OLD_NAMES[table]}")
+    # ALTER TABLE RENAME carries index names onto the renamed tables, which
+    # would make the IF NOT EXISTS index DDL below no-ops; drop them first.
+    conn.executescript(
+        """
+        DROP INDEX IF EXISTS idx_lcm_assertion_sources_current;
+        DROP INDEX IF EXISTS idx_lcm_assertions_source;
+        DROP INDEX IF EXISTS idx_lcm_assertions_state;
+        DROP INDEX IF EXISTS idx_lcm_assertion_relations_source;
+        DROP INDEX IF EXISTS idx_lcm_assertion_relations_from;
+        DROP INDEX IF EXISTS idx_lcm_assertion_relations_to;
+        """
+    )
+    try:
+        ensure_assertion_tables(conn)
+        # ensure_assertion_tables itself ends with a call to
+        # _migrate_assertion_quote_anchors. That recursion is intentional and
+        # terminates: by this point the fresh DDL exists and all data lives in
+        # the new tables, so _needs_rebuild is false on re-entry and the
+        # migration is a no-op.
+        # The insert guards reject re-inserting assertions whose source is
+        # already invalidated; the copy must preserve those rows, so the
+        # guards come down for the copy and are recreated below.
+        conn.execute("DROP TRIGGER IF EXISTS lcm_assertion_row_insert_guard")
+        conn.execute("DROP TRIGGER IF EXISTS lcm_assertion_relation_insert_guard")
+        for table, old in _OLD_NAMES.items():
+            if not _table_exists(old):
+                continue
+            new_cols = [
+                str(item[1]) for item in conn.execute(f"PRAGMA table_info({table})")
+            ]
+            old_cols = {
+                str(item[1]) for item in conn.execute(f"PRAGMA table_info({old})")
+            }
+            shared = [column for column in new_cols if column in old_cols]
+            rows = conn.execute(
+                f"SELECT {', '.join(shared)} FROM {old}"
+            ).fetchall()
+            placeholders = ", ".join("?" for _ in new_cols)
+            column_list = ", ".join(new_cols)
+            for row in rows:
+                values = dict(zip(shared, row))
+                quote = str(values.get("source_quote", ""))
+                insert_values = [
+                    (
+                        values[column]
+                        if column in values
+                        else _quote_hash(quote)
+                        if column == "source_quote_hash"
+                        else None
+                    )
+                    for column in new_cols
+                ]
+                conn.execute(
+                    f"INSERT INTO {table}({column_list}) VALUES({placeholders})",
+                    insert_values,
+                )
+            conn.execute(f"DROP TABLE {old}")
+        ensure_assertion_tables(conn)
+    finally:
+        conn.execute("DROP TABLE IF EXISTS _lcm_amr_old_assertions")
+        conn.execute("DROP TABLE IF EXISTS _lcm_amr_old_relations")
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_assertion_amr.py
+++ b/tests/test_assertion_amr.py
@@ -1,0 +1,348 @@
+"""AMR Level-1 slice tests: quote anchors, epistemic marking, migration, verifier."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hermes_lcm.assertion_amr import (
+    OUTCOME_ANCHOR_TAMPERED,
+    OUTCOME_OK,
+    OUTCOME_SOURCE_DRIFTED,
+    OUTCOME_SOURCE_MISSING,
+    verify_assertion_citations,
+    verify_relation_citations,
+)
+from hermes_lcm.assertion_store import (
+    AssertionCandidate,
+    AssertionRelationCandidate,
+    AssertionStore,
+)
+from hermes_lcm.db_bootstrap import (
+    ASSERTION_EPISTEMIC_VALUES,
+    _normalize_quote_for_hash,
+    _quote_hash,
+)
+
+
+def _candidate(
+    content: str,
+    quote: str,
+    *,
+    subject: str = "user",
+    predicate: str = "likes",
+    value: object = "tea",
+    kind: str = "fact",
+    epistemic: str | None = None,
+) -> AssertionCandidate:
+    start = content.index(quote)
+    return AssertionCandidate(
+        source_span_start=start,
+        source_span_end=start + len(quote),
+        subject_key=subject,
+        predicate_key=predicate,
+        object_value=value,
+        value_text=str(value),
+        kind=kind,
+        epistemic=epistemic,
+    )
+
+
+@pytest.fixture
+def amr_db(tmp_path):
+    db_path = tmp_path / "lcm.db"
+    from hermes_lcm.store import MessageStore
+
+    messages = MessageStore(db_path)
+    assertions = AssertionStore(db_path)
+    try:
+        yield db_path, messages, assertions
+    finally:
+        assertions.close()
+        messages.close()
+
+
+def test_amr_declaration_vocabulary_is_closed():
+    assert ASSERTION_EPISTEMIC_VALUES == frozenset({
+        "fact", "inference", "open_question", "unverified",
+    })
+
+
+def test_quote_hash_is_algorithm_prefixed_and_normalized():
+    hashed = _quote_hash("curly \u201cquote\u201d — dash \u2026 done")
+    assert hashed.startswith("sha256:")
+    assert hashed == _quote_hash("curly \"quote\" - dash ... done")
+    # Normalization is idempotent.
+    once = _normalize_quote_for_hash("a\u00a0b")
+    assert _normalize_quote_for_hash(once) == once
+    # Whitespace runs collapse.
+    assert _normalize_quote_for_hash("a \n\t b") == "a b"
+
+
+def test_publish_stores_prefix_hash_and_epistemic(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "The reviewer confirmed the release at noon."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    result = assertions.publish_source(
+        snapshot,
+        [_candidate(content, "confirmed the release", epistemic="inference")],
+    )
+    assert result.already_current is False
+    rows = assertions.query_assertions(source_store_id=store_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["epistemic"] == "inference"
+    expected = _quote_hash("confirmed the release")
+    assert row["source_quote_hash"] == expected
+
+
+def test_unmarked_is_null_not_fact(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "Plain observation without marking."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "Plain observation")])
+    row = assertions.query_assertions(source_store_id=store_id)[0]
+    assert row["epistemic"] is None
+
+
+def test_epistemic_outside_vocabulary_is_rejected(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "A record with a made-up epistemic value."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    with pytest.raises(ValueError, match="unsupported epistemic"):
+        assertions.publish_source(
+            snapshot,
+            [_candidate(content, "made-up epistemic", epistemic="probably_true")],
+        )
+    assert assertions.query_assertions(source_store_id=store_id) == []
+
+
+def test_epistemic_is_case_sensitive(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "Uppercase FACT must not be coerced to fact."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    with pytest.raises(ValueError, match="unsupported epistemic"):
+        assertions.publish_source(
+            snapshot,
+            [_candidate(content, "Uppercase FACT", epistemic="FACT")],
+        )
+    assert assertions.query_assertions(source_store_id=store_id) == []
+
+
+def test_verifier_ok_against_unchanged_source(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "The deploy finished at 12:00."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "finished at 12:00")])
+    report = verify_assertion_citations(assertions, source_store_id=store_id)
+    assert len(report) == 1
+    assert report[0]["outcome"] == OUTCOME_OK
+    assert report[0]["partial"] is False
+
+
+def test_verifier_source_drifted_after_content_change(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "The deploy finished at 12:00."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "finished at 12:00")])
+    with sqlite3.connect(_db_path) as raw:
+        raw.execute("UPDATE messages SET content = 'Moved to 13:00.' WHERE store_id = ?", (store_id,))
+    report = verify_assertion_citations(
+        assertions, source_store_id=store_id, include_invalidated=True
+    )
+    assert report[0]["outcome"] == OUTCOME_SOURCE_DRIFTED
+
+
+def test_verifier_anchor_tampered_when_hash_disagrees(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "Honest record, untouched source."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "Honest record")])
+    with sqlite3.connect(_db_path) as raw:
+        raw.execute(
+            "UPDATE lcm_assertions SET source_quote_hash = ? WHERE source_store_id = ?",
+            ("sha256:" + "0" * 64, store_id),
+        )
+    report = verify_assertion_citations(assertions, source_store_id=store_id)
+    assert report[0]["outcome"] == OUTCOME_ANCHOR_TAMPERED
+
+
+def test_schema_rejects_bare_digest_and_wrong_length(amr_db):
+    """The column CHECK enforces the AMR hash format even against raw SQL."""
+    _db_path, messages, assertions = amr_db
+    content = "Bare digest must not be guessed."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "Bare digest")])
+    with sqlite3.connect(_db_path) as raw:
+        with pytest.raises(sqlite3.IntegrityError):
+            raw.execute(
+                "UPDATE lcm_assertions SET source_quote_hash = ? WHERE source_store_id = ?",
+                ("a" * 64, store_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            raw.execute(
+                "UPDATE lcm_assertions SET source_quote_hash = ? WHERE source_store_id = ?",
+                ("md5:" + "a" * 32, store_id),
+            )
+        # Case enforcement: same length, same prefix, uppercase hex must be
+        # rejected (GLOB '[...]*' alone does NOT do this — SQLite GLOB
+        # character classes match a single char followed by any chars).
+        with pytest.raises(sqlite3.IntegrityError):
+            raw.execute(
+                "UPDATE lcm_assertions SET source_quote_hash = ? WHERE source_store_id = ?",
+                ("sha256:" + "a" * 63 + "A", store_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            raw.execute(
+                "UPDATE lcm_assertions SET source_quote_hash = ? WHERE source_store_id = ?",
+                ("sha256:" + "a" * 30 + "F" + "a" * 33, store_id),
+            )
+
+
+def test_verifier_source_missing_when_message_gone(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "Deleted underneath the citation."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "Deleted underneath")])
+    # Delete only the message row: the assertion survives with its source
+    # generation, but the cited content can no longer be resolved.
+    with sqlite3.connect(_db_path) as raw:
+        raw.execute("DELETE FROM messages WHERE store_id = ?", (store_id,))
+    report = verify_assertion_citations(
+        assertions, source_store_id=store_id, include_invalidated=True
+    )
+    assert len(report) == 1
+    assert report[0]["outcome"] == OUTCOME_SOURCE_MISSING
+
+
+def test_migration_preserves_rows_and_invalidations(tmp_path):
+    from hermes_lcm.store import MessageStore
+
+    db_path = tmp_path / "legacy.db"
+    messages = MessageStore(db_path)
+    assertions = AssertionStore(db_path)
+    content = "Legacy claim survives the migration."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    assertions.publish_source(snapshot, [_candidate(content, "Legacy claim")])
+    # Simulate a source update invalidating the published generation.
+    content_v2 = "Legacy claim, now updated."
+    with sqlite3.connect(db_path) as raw:
+        raw.execute("UPDATE messages SET content = ? WHERE store_id = ?", (content_v2, store_id))
+        raw.execute(
+            "UPDATE lcm_assertion_sources"
+            " SET invalidated_at = 1000.0, invalidation_reason = 'source_updated'"
+            " WHERE source_store_id = ?",
+            (store_id,),
+        )
+    # Second, still-valid generation under a different extraction version.
+    snapshot2 = assertions.snapshot_source(store_id)
+    assertions.publish_source(
+        snapshot2, [_candidate(content_v2, "now updated")], extraction_version="assertions-v2"
+    )
+    legacy_assertion = assertions.connection.execute(
+        "SELECT assertion_id, source_quote FROM lcm_assertions"
+        " WHERE extraction_version = 'assertions-v1'"
+    ).fetchone()
+    legacy_relations_count = 0
+    assertions.close()
+    del legacy_relations_count
+
+    # Reopen with the new build: the migration must backfill hashes without
+    # losing the invalidated row.
+    reopened = AssertionStore(db_path)
+    try:
+        assert reopened.connection.execute(
+            "SELECT COUNT(*) FROM lcm_assertions"
+        ).fetchone()[0] == 2
+        row = reopened.connection.execute(
+            "SELECT source_quote_hash, epistemic FROM lcm_assertions"
+            " WHERE assertion_id = ?",
+            (legacy_assertion[0],),
+        ).fetchone()
+        assert row["source_quote_hash"] == _quote_hash(legacy_assertion[1])
+        assert row["epistemic"] is None
+        findings = reopened.connection.execute(
+            "SELECT COUNT(*) FROM lcm_assertions WHERE source_quote_hash IS NULL"
+        ).fetchone()[0]
+        assert findings == 0
+        # Sources untouched, including the invalidation history.
+        invalidated = reopened.connection.execute(
+            "SELECT invalidation_reason FROM lcm_assertion_sources"
+            " WHERE invalidated_at IS NOT NULL"
+        ).fetchone()
+        assert invalidated is not None
+    finally:
+        reopened.close()
+        messages.close()
+
+
+def test_relations_carry_quote_hash_and_verify(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "I liked tea before, but I prefer coffee now."
+    store_id = messages.append("session-a", {"role": "user", "content": content})
+    snapshot = assertions.snapshot_source(store_id)
+    tea = _candidate(content, "tea", predicate="preferred_drink", value="tea")
+    coffee = _candidate(content, "coffee", predicate="preferred_drink", value="coffee")
+    tea_id = assertions.assertion_id_for(snapshot, tea)
+    coffee_id = assertions.assertion_id_for(snapshot, coffee)
+    relation = AssertionRelationCandidate(
+        source_span_start=content.index("coffee"),
+        source_span_end=content.index("coffee") + len("coffee"),
+        from_assertion_id=coffee_id,
+        relation_type="supersedes",
+        to_assertion_id=tea_id,
+    )
+    assertions.publish_source(snapshot, [tea, coffee], relations=[relation])
+    relations = assertions.query_relations()
+    assert len(relations) == 1
+    assert relations[0]["source_quote_hash"] == _quote_hash("coffee")
+    report = verify_relation_citations(assertions, source_store_id=store_id)
+    assert len(report) == 1
+    assert report[0]["outcome"] == OUTCOME_OK
+
+
+def test_idempotent_republication_is_still_zero_write(amr_db):
+    _db_path, messages, assertions = amr_db
+    content = "Repeat publishes must remain no-ops."
+    store_id = messages.append(
+        "session-a", {"role": "user", "content": content}, source="cli"
+    )
+    snapshot = assertions.snapshot_source(store_id)
+    first = assertions.publish_source(snapshot, [_candidate(content, "Repeat publishes")])
+    second = assertions.publish_source(snapshot, [_candidate(content, "Repeat publishes")])
+    assert first.already_current is False
+    assert second.already_current is True
+    rows = assertions.query_assertions(source_store_id=store_id)
+    assert len(rows) == 1
+    assert rows[0]["source_quote_hash"] == _quote_hash("Repeat publishes")

--- a/tools.py
+++ b/tools.py
@@ -341,6 +341,7 @@ def _shape_assertion_state_row(row: dict[str, Any]) -> dict[str, Any]:
         "unresolved_conflict": row["unresolved_conflict"],
         "attribution": row["attribution"],
         "semantic_state": row["semantic_state"],
+        "epistemic": row.get("epistemic"),
         "source_ref": {
             "store_id": row["source_store_id"],
             "session_id": row["source_session_id"],
@@ -349,6 +350,7 @@ def _shape_assertion_state_row(row: dict[str, Any]) -> dict[str, Any]:
             "span_start": row["source_span_start"],
             "span_end": row["source_span_end"],
             "quote": row["source_quote"],
+            "quote_hash": row.get("source_quote_hash"),
             "content_sha256": row["source_content_sha256"],
         },
     }
@@ -367,6 +369,7 @@ def _shape_assertion_state_relation(row: dict[str, Any]) -> dict[str, Any]:
             "span_start": row["source_span_start"],
             "span_end": row["source_span_end"],
             "quote": row["source_quote"],
+            "quote_hash": row.get("source_quote_hash"),
             "content_sha256": row["source_content_sha256"],
         },
     }


### PR DESCRIPTION
## Summary

Implements the AMR (auditable-memory-records 0.1) **Level-1 slice** for the V4 assertion family, per the public spec: https://github.com/phasespace-labs/auditable-memory-records (SPEC.md §4.2/§5/§6).

- `lcm_assertions` gains `source_quote_hash` (algorithm-prefixed AMR §5 sha256; column CHECK enforces the exact format **including lowercase hex** via `substr` prefix check + negated GLOB on the suffix — note: `GLOB 'sha256:[0-9a-f]*'` alone would NOT enforce case, since SQLite GLOB char classes match a single char followed by any chars) and `epistemic` (closed AMR §4.2 vocabulary: `fact`/`inference`/`open_question`/`unverified`; NULL is the unmarked state — *absent is not fact*, values are case-sensitive, unknown values are **rejected, never coerced**).
- `lcm_assertion_relations` gains `source_quote_hash`.
- **Hash binding is post-digest:** assertion/relation identity digests are unchanged, so existing ids remain stable across the migration and idempotent re-publication stays a zero-write no-op.
- Idempotent in-place migration rebuilds only the two rebuildable quote tables (insert guards temporarily down so already-invalidated generations survive the copy; the re-entrant call of `ensure_assertion_tables` inside the migration is documented in-code and terminates because `_needs_rebuild` is false on re-entry), backfills hashes via AMR §5 normalization (smart punctuation → ASCII, whitespace runs collapsed, trimmed), and preserves every `lcm_assertion_sources` row **including invalidation history**. The exact-shape schema verifier passes for fresh and migrated databases alike.
- New `assertion_amr.py`: read-only verifier reporting the four AMR §6 outcomes (`ok` / `anchor_tampered` / `source_drifted` / `source_missing`) with the §6.1 partial-check signal when no hash is stored. It never mutates state; the existing fail-closed query path is untouched.
- `lcm_query_state` exposes `epistemic` and per-anchor `quote_hash` in `source_ref`; absent values stay explicitly `null` so the unmarked state is visible to consumers.

## Test plan

- 14 new tests (`tests/test_assertion_amr.py`): vocabulary closure, normalization idempotence, anchor format (schema-level defense-in-depth incl. **case enforcement at correct length**), case sensitivity, all four verifier outcomes, migration preservation (invalidated generation + hash backfill), relation anchors, zero-write idempotency.
- Full suite in a clean worktree off `origin/main`: **3043 passed, 1 skipped, 12 xfailed** (numpy-needing int8 suite included via extra dep).
- `ruff check` clean on all touched files.

Reviewed pre-publication: constraint case-gap found in internal review, fixed (substr + negated GLOB), regression tests added.
