### PR TITLE
feat(sufficiency): explicit sufficiency verdict and disclosure at the preanswer finalize seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
   performed no evidence work (feature boundaries, unsupported questions,
   ordinary routes) receive no claim at all: unmarked stays unmarked.
   The gate never calls a provider and never mutates evidence, computation,
-  or the delivered context of sufficient results.  Default-off; every other
-  mode is byte-identical to its previous behavior.
+  or the delivered context of sufficient results.  Gate application is
+  atomic (a gate crash can never leave a partially marked result; the
+  wrapper fails open to the legacy result), delivered compiler states are
+  never overridden by reason-code classification, and the compiler's trace
+  digest remains re-derivable from every gated result.  Default-off; every
+  other mode is byte-identical to its previous behavior.
 
 ## v1.0.0-rc.1 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ This repo also publishes GitHub Releases. This file is the repo-root release sur
 
 ## Unreleased
 
-No additional changes yet.
+### Added
+
+- Sufficiency gate (`sufficiency_gate.py`, mode
+  `LCM_PREANSWER_EVIDENCE_MODE=sufficiency_v1`): the preanswer evidence
+  pipeline now delivers an explicit sufficiency verdict with every result —
+  `answer_sufficient` / `computation_sufficient` / `finite_coverage` map to
+  *answer*, `partial` to *answer with disclosure* (rendered exclusively from
+  fields already stored on the result), and `unknown` / `conflicted` to
+  *annotate* (disclose rather than stay silent).  States where the pipeline
+  performed no evidence work (feature boundaries, unsupported questions,
+  ordinary routes) receive no claim at all: unmarked stays unmarked.
+  The gate never calls a provider and never mutates evidence, computation,
+  or the delivered context of sufficient results.  Default-off; every other
+  mode is byte-identical to its previous behavior.
 
 ## v1.0.0-rc.1 - 2026-09-03
 

--- a/__init__.py
+++ b/__init__.py
@@ -256,8 +256,6 @@ def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
             question_date=question_date,
             enabled=True,
         )
-        if mode == "sufficiency_v1":
-            _apply_hook_sufficiency_gate(config, result)
         compiler_result = None
         selector_usage = None
         if bool(getattr(config, "selective_compiler_enabled", False)):

--- a/__init__.py
+++ b/__init__.py
@@ -159,7 +159,27 @@ def _effective_preanswer_mode(config) -> str:
     raw = str(getattr(config, "preanswer_evidence_mode", "") or "").strip().casefold()
     if not raw:
         return "legacy_selective"
-    return raw if raw in {"off", "legacy_selective", "requirements_v1"} else "off"
+    return (
+        raw
+        if raw in {"off", "legacy_selective", "requirements_v1", "sufficiency_v1"}
+        else "off"
+    )
+
+
+def _apply_hook_sufficiency_gate(config, result) -> None:
+    """Attach the sufficiency verdict to a hook-path result dict, in place.
+
+    Fail-open: any gate error leaves the result untouched so the ordinary
+    evidence path is never disturbed by policy rendering.
+    """
+    if not isinstance(result, dict):
+        return
+    try:
+        from .sufficiency_gate import apply_sufficiency_gate
+
+        apply_sufficiency_gate(result, enabled=True)
+    except Exception as exc:  # noqa: BLE001 - policy must fail open
+        logger.warning("LCM sufficiency gate failed open: %s", exc)
 
 
 def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
@@ -179,7 +199,7 @@ def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
             return {"context": recall_policy}
         question_date = _hook_question_date(payload)
 
-        if mode == "requirements_v1":
+        if mode in {"requirements_v1", "sufficiency_v1"}:
             from .answer_contract import compile_answer_contract
             from .evidence_compiler import compile_preanswer_evidence
 
@@ -201,6 +221,8 @@ def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
                 enabled=True,
                 render_baseline_context=baseline_was_internal,
             )
+            if mode == "sufficiency_v1":
+                _apply_hook_sufficiency_gate(config, result)
             try:
                 active_engine._last_preanswer_evidence_trace = result
             except Exception:
@@ -234,6 +256,8 @@ def _pre_llm_context(active_engine, recall_policy: str, payload: dict) -> dict:
             question_date=question_date,
             enabled=True,
         )
+        if mode == "sufficiency_v1":
+            _apply_hook_sufficiency_gate(config, result)
         compiler_result = None
         selector_usage = None
         if bool(getattr(config, "selective_compiler_enabled", False)):

--- a/config.py
+++ b/config.py
@@ -695,8 +695,8 @@ class LCMConfig:
     preanswer_evidence_enabled: bool = False
     # Empty preserves the historical boolean-only behavior: when the master
     # flag is true it resolves to ``legacy_selective``. Explicit values are
-    # off | legacy_selective | requirements_v1. The master flag remains the
-    # default-off activation boundary.
+    # off | legacy_selective | requirements_v1 | sufficiency_v1. The master
+    # flag remains the default-off activation boundary.
     preanswer_evidence_mode: str = ""
     # Optional minimal semantic selector for code-derived closed operations.
     # It is independent and default-off; enabling pre-answer evidence alone

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -264,7 +264,7 @@ engine. Exposure is not activation. On a stock install:
 | `LCM_QUERY_VIEWS_ENABLED` | `false` | Create and bind demand-shaped evidence views without invoking a model or retrieval provider. |
 | `LCM_ADAPTIVE_RETRIEVAL_ENABLED` | `false` | Enable `lcm_retrieve` and bind query views for evidence reuse. Episodes are bounded to existing retrieval tools and store evidence/traces, never final prose. |
 | `LCM_PREANSWER_EVIDENCE_ENABLED` | `false` | Enable the automatic pre-answer evidence hook. Disabled preserves the ordinary hook context and performs no retrieval or computation. |
-| `LCM_PREANSWER_EVIDENCE_MODE` | empty | When the master flag is enabled, empty selects legacy selective behavior; explicit values are `off`, `legacy_selective`, or `requirements_v1`. |
+| `LCM_PREANSWER_EVIDENCE_MODE` | empty | When the master flag is enabled, empty selects legacy selective behavior; explicit values are `off`, `legacy_selective`, `requirements_v1`, or `sufficiency_v1` (requirements compiler plus a sufficiency verdict/disclosure on every result). |
 | `LCM_SELECTIVE_COMPILER_ENABLED` | `false` | Separately opt into the semantic selector for code-derived closed operations. Disabling the selective compiler does not prevent the pre-answer hook from retrieving a baseline. |
 | `LCM_SELECTIVE_COMPILER_MODEL` | empty | Optional model override for the selective compiler. |
 

--- a/preanswer_evidence.py
+++ b/preanswer_evidence.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from .evidence_pack import build_evidence_pack, normalize_question_date
 from .reasoning import EvidencePlan, compile_evidence_plan
+from .sufficiency_gate import apply_sufficiency_gate
 
 
 PREANSWER_EVIDENCE_VERSION = "preanswer-evidence-v1"
@@ -477,13 +478,45 @@ def build_preanswer_evidence(
     enabled: bool = False,
     context_engine_enabled: bool = True,
     budgets: Mapping[str, Any] | None = None,
+    sufficiency_gate: bool = False,
 ) -> dict[str, Any]:
     """Return one bounded ephemeral context addition, or no augmentation.
 
     Runtime inputs are restricted to the question, its explicit date anchor,
     bounded exact refs, and product retrieval.  The function is fail-open for
-    the host: it converts every error into ``context=None``.
+    the host: it converts every error into ``context=None``.  With
+    ``sufficiency_gate=True`` the finished result passes through the
+    sufficiency policy at the finalize seam (default-off preserves the exact
+    legacy result bytes).
     """
+    gate_started = time.perf_counter()
+    result = _build_preanswer_evidence_inner(
+        question,
+        engine=engine,
+        baseline_refs=baseline_refs,
+        question_date=question_date,
+        retrieve=retrieve,
+        enabled=enabled,
+        context_engine_enabled=context_engine_enabled,
+        budgets=budgets,
+    )
+    if sufficiency_gate and isinstance(result, dict):
+        apply_sufficiency_gate(result, enabled=True, started=gate_started)
+    return result
+
+
+def _build_preanswer_evidence_inner(
+    question: Any,
+    *,
+    engine: Any,
+    baseline_refs: Sequence[Any] = (),
+    question_date: Any = None,
+    retrieve: Callable[[dict[str, Any]], Any] | None = None,
+    enabled: bool = False,
+    context_engine_enabled: bool = True,
+    budgets: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Legacy body: every return path below is the pre-gate contract."""
 
     started = time.perf_counter()
     limits = _budgets(budgets)

--- a/preanswer_evidence.py
+++ b/preanswer_evidence.py
@@ -501,7 +501,15 @@ def build_preanswer_evidence(
         budgets=budgets,
     )
     if sufficiency_gate and isinstance(result, dict):
-        apply_sufficiency_gate(result, enabled=True, started=gate_started)
+        try:
+            apply_sufficiency_gate(result, enabled=True, started=gate_started)
+        except Exception:  # noqa: BLE001 - the gate must stay fail-open
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "LCM sufficiency gate failed open in build_preanswer_evidence",
+                exc_info=True,
+            )
     return result
 
 

--- a/sufficiency_gate.py
+++ b/sufficiency_gate.py
@@ -122,21 +122,35 @@ def _refine_unknown_state(state: str, result: Mapping[str, Any]) -> str:
 def _classify_legacy_result(result: Mapping[str, Any]) -> tuple[str, str] | None:
     """Map legacy (status, reason_code) pairs onto the state vocabulary.
 
-    Unknown future reason codes make no claim: the gate stays silent rather
-    than guessing a state the pipeline did not define.
+    A recognized delivered ``state`` is always honored before any
+    reason-code table: the compiler's own verdict is never overridden by a
+    later classification table (e.g. a no-claim code that was recorded on a
+    result whose state was already delivered).  Unknown future reason codes
+    make no claim: the gate stays silent rather than guessing a state the
+    pipeline did not define.
     """
     status = str(result.get("status") or "")
     reason_code = str(result.get("reason_code") or "")
+    state = result.get("state")
+    if isinstance(state, str) and state in _KNOWN_STATES:
+        if state == "unknown":
+            # ``unknown`` is the compiler's BASE state, not always a verdict:
+            # refusal paths and budget truncation leave it untouched.
+            if reason_code in _NO_CLAIM_REASON_CODES:
+                # No evidence work happened; the reason code is the honest
+                # classification and the result stays unmarked.
+                return None
+            if reason_code == "context_budget_exhausted":
+                return ("partial", "answer_with_disclosure")
+            # Only the compiler's blanket ``unknown`` needs refinement;
+            # delivered states are the pipeline's own verdict and are never
+            # overridden.
+            return _policy_for_state(_refine_unknown_state(state, result))
+        return _policy_for_state(state)
     if reason_code in _NO_CLAIM_REASON_CODES:
         return None
     if reason_code == "context_budget_exhausted":
         return ("partial", "answer_with_disclosure")
-    state = result.get("state")
-    if isinstance(state, str) and state in _KNOWN_STATES:
-        # Only the compiler's blanket ``unknown`` needs refinement; delivered
-        # states are the pipeline's own verdict and are never overridden.
-        refined = _refine_unknown_state(state, result) if state == "unknown" else state
-        return _policy_for_state(refined)
     if status == "computed":
         return ("computation_sufficient", "answer")
     if status == "augmented":
@@ -236,9 +250,19 @@ def apply_sufficiency_gate(
 
     With ``enabled=False`` the result is returned untouched.  With the gate
     enabled, non-sufficient states with an empty context get their disclosure
-    rendered as the ephemeral context block; the trace digest and context
-    metrics are kept consistent with that block.  Existing evidence,
-    computation, and status fields are never modified.
+    rendered as the ephemeral context block; ``trace.context_sha256`` (which
+    is not part of the compiler trace digest material) is kept consistent
+    with that block.  Existing evidence, computation, status, and metrics are
+    never modified, so the compiler's ``trace.digest_sha256`` remains
+    re-derivable from every gated result.  Budget metrics describe the
+    compiler-delivered context only; the disclosure's size is recorded in the
+    gate-owned section (``disclosure_context_chars``).
+
+    The gate is ATOMIC: all verdict writes happen on a shallow copy and are
+    copied back only if the whole operation completes, so a crash can never
+    leave a partially marked result behind.  Exceptions from classification
+    or rendering propagate to the caller; the hook path converts them into
+    fail-open behavior.
     """
     if not enabled:
         return result
@@ -250,21 +274,29 @@ def apply_sufficiency_gate(
     disclosure: str | None = None
     if policy_action != "answer":
         disclosure = render_disclosure(result, state, policy_action)
-    result["sufficiency"] = {
+    marked = dict(result)
+    marked["sufficiency"] = {
         "version": SUFFICIENCY_GATE_VERSION,
         "state": state,
         "policy_action": policy_action,
         "disclosure_context": disclosure,
+        "disclosure_context_chars": len(disclosure) if disclosure else 0,
+        "gate_latency_ms": round(
+            (time.perf_counter() - gate_started) * 1_000.0, 3
+        ),
     }
     if disclosure is not None and not isinstance(result.get("context"), str):
-        result["context"] = disclosure
-        result["trace"]["context_sha256"] = hashlib.sha256(
-            disclosure.encode("utf-8")
-        ).hexdigest()
-        result["metrics"]["context_chars"] = len(disclosure)
-    result["metrics"]["sufficiency_gate_latency_ms"] = round(
-        (time.perf_counter() - gate_started) * 1_000.0, 3
-    )
+        marked["context"] = disclosure
+        trace = result.get("trace")
+        if isinstance(trace, dict):
+            marked["trace"] = {
+                **trace,
+                "context_sha256": hashlib.sha256(
+                    disclosure.encode("utf-8")
+                ).hexdigest(),
+            }
+    result.clear()
+    result.update(marked)
     return result
 
 

--- a/sufficiency_gate.py
+++ b/sufficiency_gate.py
@@ -1,0 +1,278 @@
+"""Provider-free sufficiency policy at the preanswer finalize seam.
+
+The gate is the single place where a finished preanswer-evidence result is
+classified into the sufficiency vocabulary and mapped to one answer-contract
+policy action:
+
+- ``answer_sufficient`` / ``computation_sufficient`` / ``finite_coverage``
+  → ``answer`` (the augmentation speaks for itself).
+- ``partial`` → ``answer_with_disclosure``: a bounded disclosure of what is
+  missing, rendered exclusively from fields already stored on the result.
+- ``unknown`` / ``conflicted`` → ``annotate``: disclose rather than stay
+  silent; unmarked absence is never presented as fact.
+
+The gate never calls a provider, never mutates evidence or computation, and
+never fabricates content.  For states where the gate itself makes no claim
+(feature disabled, unsupported question, invalid host input) it adds nothing:
+absence of a sufficiency section is itself the honest state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Mapping
+
+SUFFICIENCY_GATE_VERSION = "sufficiency-gate-v1"
+
+_ANSWER_STATES = frozenset(
+    {"answer_sufficient", "computation_sufficient", "finite_coverage"}
+)
+_ANNOTATE_STATES = frozenset({"unknown", "conflicted"})
+_KNOWN_STATES = _ANSWER_STATES | _ANNOTATE_STATES | {"partial"}
+
+# Outcomes where the gate itself makes no claim at all: the ordinary answer
+# path ran untouched, and adding a sufficiency section would fabricate a
+# judgment the pipeline never made.
+_NO_CLAIM_REASON_CODES = frozenset(
+    {
+        # gate/feature boundaries
+        "feature_disabled",
+        "context_engine_toolset_disabled",
+        "question_required",
+        "question_date_invalid",
+        "unsupported_or_ambiguous_operation",
+        "no_supported_operation",
+        # answer-contract planning refusals (no evidence work was performed)
+        "not_applicable",
+        "question_too_long",
+        "unsupported_operation",
+        "question_as_of_invalid",
+        "question_as_of_required",
+        "insufficient_anchors",
+        "generic_question_low_confidence",
+        "ordinary_or_low_confidence",
+        # hook-route refusals (no evidence work was performed)
+        "ordinary_baseline",
+        "disabled",
+        "selector_unavailable",
+    }
+)
+
+# Evidence work happened but did not close: the answer may proceed with an
+# explicit disclosure of what is missing and why.
+_PARTIAL_REASON_CODES = frozenset(
+    {
+        "baseline_not_actionable",
+        "baseline_validation_failed",
+        "open_cardinality",
+        "retrieval_budget_exhausted",
+        "retrieval_unavailable",
+        "retrieval_error",
+        "retrieval_timeout",
+        "novel_exact_ref_not_hydratable",
+        "delta_validation_failed",
+        "context_budget_exhausted",
+        "novel_ref_budget_exhausted",
+    }
+)
+
+# Nothing usable was found at all: annotate instead of answering or refusing.
+_UNKNOWN_REASON_CODES = frozenset(
+    {
+        "no_hit",
+        "no_novel_exact_ref",
+    }
+)
+
+# Two grounded candidates disagree: not unknown, but an unresolved conflict.
+_CONFLICTED_REASON_CODES = frozenset({"state_conflicted"})
+
+
+def _policy_for_state(state: str) -> tuple[str, str]:
+    if state in _ANSWER_STATES:
+        return state, "answer"
+    if state == "partial":
+        return state, "answer_with_disclosure"
+    return state, "annotate"
+
+
+def _refine_unknown_state(state: str, result: Mapping[str, Any]) -> str:
+    """Split the compiler's blanket ``unknown`` into its honest sub-states.
+
+    The requirements compiler only delivers ``answer_sufficient`` /
+    ``computation_sufficient`` and otherwise leaves the base ``unknown``
+    state.  The reason code says which kind of non-sufficiency happened;
+    the gate surfaces that instead of flattening every miss to unknown.
+    """
+    reason_code = str(result.get("reason_code") or "")
+    if reason_code in _CONFLICTED_REASON_CODES or reason_code.startswith(
+        "ambiguous_"
+    ):
+        return "conflicted"
+    evidence = result.get("evidence")
+    if isinstance(evidence, list) and evidence:
+        # Grounded evidence exists but the contract did not close: partial,
+        # not unknown.  Absence of a delivered context is not absence of work.
+        return "partial"
+    return state
+
+
+def _classify_legacy_result(result: Mapping[str, Any]) -> tuple[str, str] | None:
+    """Map legacy (status, reason_code) pairs onto the state vocabulary.
+
+    Unknown future reason codes make no claim: the gate stays silent rather
+    than guessing a state the pipeline did not define.
+    """
+    status = str(result.get("status") or "")
+    reason_code = str(result.get("reason_code") or "")
+    if reason_code in _NO_CLAIM_REASON_CODES:
+        return None
+    if reason_code == "context_budget_exhausted":
+        return ("partial", "answer_with_disclosure")
+    state = result.get("state")
+    if isinstance(state, str) and state in _KNOWN_STATES:
+        # Only the compiler's blanket ``unknown`` needs refinement; delivered
+        # states are the pipeline's own verdict and are never overridden.
+        refined = _refine_unknown_state(state, result) if state == "unknown" else state
+        return _policy_for_state(refined)
+    if status == "computed":
+        return ("computation_sufficient", "answer")
+    if status == "augmented":
+        return ("answer_sufficient", "answer")
+    if status == "no_augmentation":
+        if reason_code in _PARTIAL_REASON_CODES:
+            return ("partial", "answer_with_disclosure")
+        if reason_code in _UNKNOWN_REASON_CODES:
+            return ("unknown", "annotate")
+    return None
+
+
+def _missing_line(missing: Any) -> str | None:
+    if not isinstance(missing, Mapping):
+        return None
+    kind = str(missing.get("kind") or "").strip()
+    query = str(missing.get("query") or "").strip()
+    current = missing.get("current_operands")
+    minimum = missing.get("minimum_operands")
+    parts = [f"missing: {kind}"]
+    if query:
+        parts.append(f'query "{query}"')
+    if current is not None and minimum is not None:
+        parts.append(f"operands {current}/{minimum}")
+    return " ".join(part for part in parts if part)
+
+
+def render_disclosure(
+    result: dict[str, Any], state: str, policy_action: str
+) -> str:
+    """Render the bounded disclosure from fields already stored on the result.
+
+    Every line value is copied from the result; the template is the only
+    authored text.  The block is an annotation about evidence state, never
+    evidence itself.
+    """
+    decision = result.get("decision")
+    decision_map = decision if isinstance(decision, dict) else {}
+    retrieval = result.get("retrieval")
+    retrieval_map = retrieval if isinstance(retrieval, dict) else {}
+    baseline = result.get("baseline")
+    baseline_map = baseline if isinstance(baseline, dict) else {}
+    trace = result.get("trace")
+    trace_map = trace if isinstance(trace, dict) else {}
+
+    lines = [
+        "<lcm-sufficiency-disclosure>",
+        f"gate: {SUFFICIENCY_GATE_VERSION}",
+        f"state: {state}",
+        f"policy_action: {policy_action}",
+    ]
+    reason_code = str(result.get("reason_code") or "")
+    if reason_code:
+        lines.append(f"reason_code: {reason_code}")
+    operation = str(decision_map.get("operation") or "").strip()
+    if operation:
+        lines.append(f"operation: {operation}")
+    missing_line = _missing_line(decision_map.get("missing_requirement"))
+    if missing_line:
+        lines.append(missing_line)
+    retrieval_status = str(retrieval_map.get("status") or "").strip()
+    retrieval_calls = retrieval_map.get("calls")
+    if retrieval_status and retrieval_status != "not_called":
+        lines.append(f"retrieval: {retrieval_status} (calls: {retrieval_calls})")
+    if trace_map.get("truncated"):
+        lines.append("context_truncated: true")
+    if baseline_map:
+        lines.append(f"baseline exact refs: {baseline_map.get('exact_ref_count', 0)}")
+    lines.extend(
+        [
+            "stored evidence did not establish sufficiency; disclose rather than imply sufficiency",
+            "this block is an annotation, not evidence",
+            "</lcm-sufficiency-disclosure>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def classify_preanswer_result(
+    result: dict[str, Any],
+) -> tuple[str, str] | None:
+    """Return ``(state, policy_action)`` for a finished result, or ``None``.
+
+    ``None`` means the gate makes no claim: the result stays unmarked and the
+    ordinary answer path is untouched.
+    """
+    return _classify_legacy_result(result)
+
+
+def apply_sufficiency_gate(
+    result: dict[str, Any],
+    *,
+    enabled: bool = False,
+    started: float | None = None,
+) -> dict[str, Any]:
+    """Attach the sufficiency verdict to a finished preanswer result.
+
+    With ``enabled=False`` the result is returned untouched.  With the gate
+    enabled, non-sufficient states with an empty context get their disclosure
+    rendered as the ephemeral context block; the trace digest and context
+    metrics are kept consistent with that block.  Existing evidence,
+    computation, and status fields are never modified.
+    """
+    if not enabled:
+        return result
+    gate_started = started if started is not None else time.perf_counter()
+    verdict = classify_preanswer_result(result)
+    if verdict is None:
+        return result
+    state, policy_action = verdict
+    disclosure: str | None = None
+    if policy_action != "answer":
+        disclosure = render_disclosure(result, state, policy_action)
+    result["sufficiency"] = {
+        "version": SUFFICIENCY_GATE_VERSION,
+        "state": state,
+        "policy_action": policy_action,
+        "disclosure_context": disclosure,
+    }
+    if disclosure is not None and not isinstance(result.get("context"), str):
+        result["context"] = disclosure
+        result["trace"]["context_sha256"] = hashlib.sha256(
+            disclosure.encode("utf-8")
+        ).hexdigest()
+        result["metrics"]["context_chars"] = len(disclosure)
+    result["metrics"]["sufficiency_gate_latency_ms"] = round(
+        (time.perf_counter() - gate_started) * 1_000.0, 3
+    )
+    return result
+
+
+def sufficiency_digest(result: dict[str, Any]) -> str | None:
+    """Stable digest of the sufficiency section, or ``None`` when unmarked."""
+    section = result.get("sufficiency")
+    if not isinstance(section, Mapping):
+        return None
+    return hashlib.sha256(
+        json.dumps(section, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()

--- a/tests/test_sufficiency_gate.py
+++ b/tests/test_sufficiency_gate.py
@@ -1,0 +1,246 @@
+"""Contract tests for the sufficiency gate at the preanswer finalize seam."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_lcm.preanswer_evidence import build_preanswer_evidence
+from hermes_lcm.store import MessageStore
+
+from types import SimpleNamespace
+
+from hermes_lcm.config import LCMConfig
+
+
+def _engine(tmp_path):
+    config = LCMConfig(database_path=str(tmp_path / "lcm.db"))
+    store = MessageStore(config.database_path, ingest_protection_config=config)
+    return SimpleNamespace(_config=config, _store=store, _assertions=None)
+
+
+def _append(engine, content, *, observed_at=None, session_id="session-a"):
+    message = {"role": "user", "content": content}
+    if observed_at is not None:
+        message["timestamp"] = observed_at
+    store_id = engine._store.append(session_id, message)
+    return {
+        "exact_ref": f"lcm:{store_id}:0-{len(content)}",
+        "quote": content,
+    }
+
+
+def _result(engine, question, *, refs=(), retrieve=None, **kwargs):
+    return build_preanswer_evidence(
+        question,
+        engine=engine,
+        baseline_refs=list(refs),
+        retrieve=retrieve,
+        **kwargs,
+    )
+
+
+def _taxi_train(engine):
+    taxi = _append(engine, "The taxi cost $60.", observed_at=1_710_000_000)
+    train = _append(engine, "The train cost $20.", observed_at=1_720_000_000)
+    return taxi, train
+
+
+def test_gate_disabled_is_byte_identical_to_legacy_result(tmp_path):
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        legacy = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+        )
+        gated_off = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+        )
+    finally:
+        engine._store.close()
+
+    # Two legacy runs differ only in wall-clock metrics.
+    assert _without_timing(gated_off) == _without_timing(legacy)
+    assert "sufficiency" not in gated_off
+
+
+_TIMING_KEYS = frozenset({"latency_ms", "sufficiency_gate_latency_ms"})
+
+
+def _without_timing(result):
+    stripped = {k: v for k, v in result.items() if k != "sufficiency"}
+    stripped["metrics"] = {
+        k: v for k, v in stripped["metrics"].items() if k not in _TIMING_KEYS
+    }
+    return stripped
+
+
+def test_gate_adds_only_sufficiency_section_to_sufficient_results(tmp_path):
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        ungated = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+        )
+        gated = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    # The gate only appends its section; every pre-gate field is identical.
+    assert _without_timing(gated) == _without_timing(ungated)
+
+
+def test_gate_marks_computation_sufficient_without_touching_evidence(tmp_path):
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        result = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    section = result["sufficiency"]
+    assert section["state"] == "computation_sufficient"
+    assert section["policy_action"] == "answer"
+    assert section["disclosure_context"] is None
+    assert result["computation"]["result"] == "$80"
+    assert result["status"] == "computed"
+
+
+def test_open_cardinality_partial_discloses_from_stored_fields_only(tmp_path):
+    engine = _engine(tmp_path)
+    bali = _append(
+        engine, "I took a vacation to Bali this year.", observed_at=1_710_000_000
+    )
+    kyoto = _append(
+        engine, "I took a vacation to Kyoto this year.", observed_at=1_720_000_000
+    )
+    try:
+        result = _result(
+            engine,
+            "How many vacations did I take this year?",
+            refs=[bali, kyoto],
+            enabled=True,
+            question_date="2024-12-31",
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    assert result["status"] == "no_augmentation"
+    assert result["reason_code"] == "open_cardinality"
+    section = result["sufficiency"]
+    assert section["state"] == "partial"
+    assert section["policy_action"] == "answer_with_disclosure"
+    disclosure = section["disclosure_context"]
+    assert "<lcm-sufficiency-disclosure>" in disclosure
+    assert "state: partial" in disclosure
+    assert "open_cardinality" in disclosure
+    # The disclosure block is the only authored text; every other value is a
+    # stored field.  It must never invent an operand or a result value.
+    assert "Bali" not in disclosure and "Kyoto" not in disclosure
+    # Partial with empty context renders the disclosure as the context block.
+    assert result["context"] == disclosure
+    assert result["trace"]["context_sha256"] is not None
+
+
+def test_no_hit_annotates_instead_of_staying_silent(tmp_path):
+    engine = _engine(tmp_path)
+    austin = _append(engine, "I used to live in Austin.", observed_at=1_710_000_000)
+    calls = []
+
+    def retrieve(args):
+        calls.append(args)
+        return json.dumps({"hits": []})
+
+    try:
+        result = _result(
+            engine,
+            "Where do I live now?",
+            refs=[austin],
+            retrieve=retrieve,
+            enabled=True,
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    assert result["reason_code"] == "no_hit"
+    section = result["sufficiency"]
+    assert section["state"] == "unknown"
+    assert section["policy_action"] == "annotate"
+    assert "state: unknown" in result["context"]
+    assert "disclose rather than imply sufficiency" in result["context"]
+
+
+def test_no_claim_paths_stay_unmarked_and_ordinary(tmp_path):
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        disabled = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=False,
+            sufficiency_gate=True,
+        )
+        unsupported = _result(
+            engine,
+            "Tell me about the Atlas project.",
+            enabled=True,
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    assert disabled["reason_code"] == "feature_disabled"
+    assert "sufficiency" not in disabled
+    assert unsupported["reason_code"] == "no_supported_operation"
+    assert "sufficiency" not in unsupported
+    assert unsupported["context"] is None
+
+
+def test_gate_never_modifies_evidence_computation_or_status(tmp_path):
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        gated = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+            sufficiency_gate=True,
+        )
+    finally:
+        engine._store.close()
+
+    assert gated["sufficiency"]["state"] == "computation_sufficient"
+    assert gated["evidence"]
+    assert gated["computation"] is not None
+    assert gated["status"] == "computed"
+    # The gate may only append provenance about itself, never rewrite fields.
+    assert set(gated["sufficiency"]) == {
+        "version",
+        "state",
+        "policy_action",
+        "disclosure_context",
+    }

--- a/tests/test_sufficiency_gate.py
+++ b/tests/test_sufficiency_gate.py
@@ -184,9 +184,12 @@ def test_gate_failure_is_atomic_and_wrapper_fails_open(
     def _boom_classify(_result):
         raise RuntimeError("classify boom")
 
-    monkeypatch.setattr(sg, "classify_preanswer_result", _boom_classify)
-    with pytest.raises(RuntimeError):
-        sg.apply_sufficiency_gate(broken, enabled=True)
+    # (a) Classification crash: zero mutation, zero partial marking.  The
+    # patch lives in its own scope so (b) can exercise the real classifier.
+    with monkeypatch.context() as m:
+        m.setattr(sg, "classify_preanswer_result", _boom_classify)
+        with pytest.raises(RuntimeError, match="classify boom"):
+            sg.apply_sufficiency_gate(broken, enabled=True)
     assert broken == {
         "status": "no_augmentation",
         "state": None,
@@ -197,7 +200,9 @@ def test_gate_failure_is_atomic_and_wrapper_fails_open(
     }
 
     # (b) Render crash after classification: still no mutation, because the
-    # verdict writes happen on a copy that is only committed on success.
+    # verdict writes happen on a copy that is only committed on success.  The
+    # classifier patch from (a) is scoped to (a) only, so this call actually
+    # exercises the render path.
     partial = {
         "status": "no_augmentation",
         "state": "unknown",
@@ -210,12 +215,27 @@ def test_gate_failure_is_atomic_and_wrapper_fails_open(
     def _boom_render(*_args, **_kwargs):
         raise RuntimeError("render boom")
 
-    monkeypatch.setattr(sg, "render_disclosure", _boom_render)
-    with pytest.raises(RuntimeError):
-        sg.apply_sufficiency_gate(partial, enabled=True)
+    with monkeypatch.context() as m:
+        m.setattr(sg, "render_disclosure", _boom_render)
+        with pytest.raises(RuntimeError, match="render boom"):
+            sg.apply_sufficiency_gate(partial, enabled=True)
     assert partial["context"] is None
     assert partial["trace"]["context_sha256"] is None
     assert "sufficiency" not in partial
+
+    # (b2) Missing ``trace`` (the original F2 failure mode): the gate marks
+    # the result, skips the trace update, and never partially mutates.
+    untraced = {
+        "status": "no_augmentation",
+        "state": "unknown",
+        "reason_code": "no_hit",
+        "context": None,
+        "metrics": {"latency_ms": 1.0},
+    }
+    assert sg.apply_sufficiency_gate(untraced, enabled=True) is untraced
+    assert untraced["sufficiency"]["state"] == "unknown"
+    assert untraced["context"] == untraced["sufficiency"]["disclosure_context"]
+    assert "trace" not in untraced
 
     # (c) The wrapper fails open: a gate crash inside
     # ``build_preanswer_evidence`` still returns the legacy result.  The

--- a/tests/test_sufficiency_gate.py
+++ b/tests/test_sufficiency_gate.py
@@ -126,6 +126,240 @@ def test_gate_marks_computation_sufficient_without_touching_evidence(tmp_path):
     assert result["status"] == "computed"
 
 
+def test_delivered_state_outranks_no_claim_reason_code():
+    """F1 regression: a delivered state is never overridden by a no-claim code.
+
+    The compiler's ``unknown`` is a BASE state that refusal paths carry with
+    no-claim reason codes -- those stay unmarked.  But any other delivered
+    state (e.g. ``answer_sufficient``) must outrank the reason-code tables,
+    even if a stale/future code collides with the no-claim set.
+    """
+    from hermes_lcm.sufficiency_gate import apply_sufficiency_gate
+
+    result = {
+        "status": "compiled",
+        "state": "answer_sufficient",
+        "reason_code": "unsupported_operation",  # stale/future collision
+        "context": "the taxi and the train together cost $80",
+        "trace": {},
+        "metrics": {},
+    }
+    apply_sufficiency_gate(result, enabled=True)
+    assert result["sufficiency"]["state"] == "answer_sufficient"
+    assert result["sufficiency"]["policy_action"] == "answer"
+
+    # The base-state exception still holds: unknown + no-claim code = unmarked.
+    refusal = {
+        "status": "no_augmentation",
+        "state": "unknown",
+        "reason_code": "unsupported_operation",
+        "context": None,
+        "trace": {},
+        "metrics": {},
+    }
+    apply_sufficiency_gate(refusal, enabled=True)
+    assert "sufficiency" not in refusal
+
+
+def test_gate_failure_is_atomic_and_wrapper_fails_open(
+    tmp_path, monkeypatch, caplog
+):
+    """F2 regression: gate crashes leave no partial mutation, and the
+    ``build_preanswer_evidence`` wrapper fails open to the legacy result."""
+    import pytest
+
+    import hermes_lcm.preanswer_evidence as pe
+    from hermes_lcm import sufficiency_gate as sg
+
+    # (a) Classification crash: zero mutation, zero partial marking.
+    broken = {
+        "status": "no_augmentation",
+        "state": None,
+        "reason_code": "no_hit",
+        "context": None,
+        "trace": {"context_sha256": None},
+        "metrics": {"latency_ms": 1.0},
+    }
+
+    def _boom_classify(_result):
+        raise RuntimeError("classify boom")
+
+    monkeypatch.setattr(sg, "classify_preanswer_result", _boom_classify)
+    with pytest.raises(RuntimeError):
+        sg.apply_sufficiency_gate(broken, enabled=True)
+    assert broken == {
+        "status": "no_augmentation",
+        "state": None,
+        "reason_code": "no_hit",
+        "context": None,
+        "trace": {"context_sha256": None},
+        "metrics": {"latency_ms": 1.0},
+    }
+
+    # (b) Render crash after classification: still no mutation, because the
+    # verdict writes happen on a copy that is only committed on success.
+    partial = {
+        "status": "no_augmentation",
+        "state": "unknown",
+        "reason_code": "no_hit",
+        "context": None,
+        "trace": {"context_sha256": None},
+        "metrics": {"latency_ms": 1.0},
+    }
+
+    def _boom_render(*_args, **_kwargs):
+        raise RuntimeError("render boom")
+
+    monkeypatch.setattr(sg, "render_disclosure", _boom_render)
+    with pytest.raises(RuntimeError):
+        sg.apply_sufficiency_gate(partial, enabled=True)
+    assert partial["context"] is None
+    assert partial["trace"]["context_sha256"] is None
+    assert "sufficiency" not in partial
+
+    # (c) The wrapper fails open: a gate crash inside
+    # ``build_preanswer_evidence`` still returns the legacy result.  The
+    # crash is injected through the gate module's own classification hook
+    # (module-identity-proof), and the warning is captured on the logger of
+    # the module that actually executes the wrapper.
+    engine = _engine(tmp_path)
+    taxi, train = _taxi_train(engine)
+    try:
+        legacy = _result(
+            engine,
+            "What is the total of the two costs?",
+            refs=[taxi, train],
+            enabled=True,
+        )
+
+        def _boom_apply(*_args, **_kwargs):
+            raise RuntimeError("apply boom")
+
+        # Patch AND invoke through the same module instance: the file-level
+        # import may predate harness-driven module replacement, so resolving
+        # the wrapper via ``pe`` keeps globals and patch target identical.
+        monkeypatch.setattr(pe, "apply_sufficiency_gate", _boom_apply)
+        import logging as _logging
+
+        prev_disable = _logging.root.manager.disable
+        _logging.disable(_logging.NOTSET)
+        wrapper_logger = _logging.getLogger(pe.build_preanswer_evidence.__module__)
+        prev_level = wrapper_logger.level
+        wrapper_logger.setLevel(_logging.WARNING)
+        records: list[str] = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        handler = _Capture(level=_logging.WARNING)
+        wrapper_logger.addHandler(handler)
+        try:
+            wrapped = pe.build_preanswer_evidence(
+                "What is the total of the two costs?",
+                engine=engine,
+                baseline_refs=[taxi, train],
+                enabled=True,
+                sufficiency_gate=True,
+            )
+        finally:
+            wrapper_logger.removeHandler(handler)
+            wrapper_logger.setLevel(prev_level)
+            _logging.disable(prev_disable)
+    finally:
+        engine._store.close()
+
+    assert "sufficiency" not in wrapped
+    assert _without_timing(wrapped) == _without_timing(legacy)
+    assert records and "failed open" in records[0]
+
+
+def test_gate_keeps_metrics_and_trace_digest_rederivable(tmp_path):
+    """F3 regression: metrics are never touched, so the compiler's
+    ``trace.digest_sha256`` remains re-derivable from every gated result.
+
+    The digest lives on the requirements-compiler route, so this test drives
+    ``compile_preanswer_evidence`` directly and applies the gate to its
+    finished result, mirroring the hook wiring.
+    """
+    from hermes_lcm import requirements_compiler as rc
+    from hermes_lcm import sufficiency_gate as sg
+
+    engine = _engine(tmp_path)
+    bali = _append(
+        engine, "I took a vacation to Bali this year.", observed_at=1_710_000_000
+    )
+    kyoto = _append(
+        engine, "I took a vacation to Kyoto this year.", observed_at=1_720_000_000
+    )
+    refs = [bali, kyoto]
+    try:
+        legacy = rc.compile_preanswer_evidence(
+            "How many vacations did I take this year?",
+            engine=engine,
+            baseline_refs=refs,
+            question_date="2024-12-31",
+            enabled=True,
+        )
+        gated = rc.compile_preanswer_evidence(
+            "How many vacations did I take this year?",
+            engine=engine,
+            baseline_refs=refs,
+            question_date="2024-12-31",
+            enabled=True,
+        )
+        sg.apply_sufficiency_gate(gated, enabled=True)
+    finally:
+        engine._store.close()
+
+    # Base state unknown stays annotate on this route (evidence lives in the
+    # baseline identity, not the delivered evidence list) — and annotate still
+    # renders a disclosure context, exactly where gate mutation risked the
+    # digest.
+    assert gated["state"] == "unknown"
+    assert gated["sufficiency"]["state"] == "unknown"
+    assert gated["sufficiency"]["policy_action"] == "annotate"
+    assert gated["context"] == gated["sufficiency"]["disclosure_context"]
+    # metrics are byte-identical between legacy and gated runs (timing aside)
+    assert set(gated["metrics"]) == set(legacy["metrics"])
+    for key, value in legacy["metrics"].items():
+        if key == "latency_ms":
+            continue
+        assert gated["metrics"][key] == value
+    # the gate never added a foreign metric or a mutated context metric
+    assert "sufficiency_gate_latency_ms" not in gated["metrics"]
+    assert gated["sufficiency"]["gate_latency_ms"] >= 0.0
+    # the disclosure size lives in the gate-owned section
+    assert gated["sufficiency"]["disclosure_context_chars"] == len(
+        gated["sufficiency"]["disclosure_context"]
+    )
+    # digest_sha256 remains re-derivable from the gated result
+    trace = gated["trace"]
+    assert trace["digest_sha256"]
+    material = {
+        "version": gated["version"],
+        "status": gated["status"],
+        "state": gated["state"],
+        "reason_code": gated["reason_code"],
+        "contract": {
+            "answer_kind": (gated.get("contract") or {}).get("answer_kind"),
+            "operation": (gated.get("contract") or {}).get("operation"),
+            "coverage_policy": (gated.get("contract") or {}).get("coverage_policy"),
+            "slot_count": len((gated.get("contract") or {}).get("slots") or []),
+        },
+        "baseline": gated["baseline"],
+        "closed_requirement_count": len(gated["closed_requirements"]),
+        "open_requirement_count": len(gated["open_requirements"]),
+        "novel_ref_count": len(gated["novel_exact_refs"]),
+        "finite_coverage": gated["finite_coverage"],
+        "computation_sha256": gated["computation_sha256"],
+        "retrieval_calls": gated["retrieval"]["calls"],
+        "metrics": gated["metrics"],
+        "truncated": trace["truncated"],
+    }
+    assert trace["digest_sha256"] == rc._digest(material)
+
+
 def test_open_cardinality_partial_discloses_from_stored_fields_only(tmp_path):
     engine = _engine(tmp_path)
     bali = _append(
@@ -243,4 +477,6 @@ def test_gate_never_modifies_evidence_computation_or_status(tmp_path):
         "state",
         "policy_action",
         "disclosure_context",
+        "disclosure_context_chars",
+        "gate_latency_ms",
     }

--- a/tests/test_sufficiency_hook.py
+++ b/tests/test_sufficiency_hook.py
@@ -1,0 +1,167 @@
+"""Hook-level contract tests for LCM_PREANSWER_EVIDENCE_MODE=sufficiency_v1.
+
+These reuse the packaging tests' plugin-entrypoint harness so the gate is
+exercised through the real ``pre_llm_call`` hook path, not just the module
+API.  The sufficiency mode routes through the requirements compiler and adds
+the gate verdict on top; ordinary and legacy paths stay byte-identical.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+from tests.test_packaging_install import (  # noqa: F401  (harness reuse)
+    _ensure_agent_context_engine_importable,
+    _load_plugin_entrypoint_module,
+)
+
+
+def _sufficiency_module(monkeypatch, tmp_path, name: str):
+    _ensure_agent_context_engine_importable(monkeypatch)
+    module = _load_plugin_entrypoint_module(name)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setenv("LCM_PREANSWER_EVIDENCE_ENABLED", "true")
+    monkeypatch.setenv("LCM_PREANSWER_EVIDENCE_MODE", "sufficiency_v1")
+    monkeypatch.setenv("LCM_EMBEDDINGS_ENABLED", "false")
+    return module
+
+
+def _ctx_and_hook(module):
+    hooks = {}
+
+    class _Ctx:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+        def register_hook(self, name, callback):
+            hooks.setdefault(name, []).append(callback)
+
+    ctx = _Ctx()
+    module.register(ctx)
+    ctx.engine.on_session_start("active-session", platform="cli")
+    return ctx, hooks["pre_llm_call"][0]
+
+
+def _store_fact(ctx, content, observed_at):
+    return ctx.engine._store.append(
+        "prior-session", {"role": "user", "content": content, "timestamp": observed_at}
+    )
+
+
+def _recall_hits(hits):
+    def handle(tool, args, **_kwargs):
+        assert tool == "lcm_recall"
+        return json.dumps({"hits": hits})
+
+    return handle
+
+
+def test_sufficiency_mode_answers_with_gate_verdict_on_validated_fact(
+    tmp_path, monkeypatch
+):
+    module = _sufficiency_module(monkeypatch, tmp_path, "hermes_lcm_packaging_suff_v1_ok")
+    ctx, hook = _ctx_and_hook(module)
+    fact = "You need 15 points to redeem the reward."
+    fact_id = _store_fact(ctx, fact, 100.0)
+    ctx.engine.handle_tool_call = _recall_hits(
+        [{"exact_ref": f"lcm:{fact_id}:0-{len(fact)}", "content": fact}]
+    )
+    response = hook(
+        session_id="active-session",
+        user_message="How many points do I need to redeem the reward?",
+        enabled_toolsets=["context_engine"],
+    )
+
+    assert "lcm-answer-brief" in response["context"]
+    assert "15 point" in response["context"]
+    trace = ctx.engine._last_preanswer_evidence_trace
+    assert trace["sufficiency"]["state"] == "answer_sufficient"
+    assert trace["sufficiency"]["policy_action"] == "answer"
+    assert "sufficiency-disclosure" not in response["context"]
+    ctx.engine.shutdown()
+
+
+def test_sufficiency_mode_annotates_when_no_fact_is_found(tmp_path, monkeypatch):
+    module = _sufficiency_module(
+        monkeypatch, tmp_path, "hermes_lcm_packaging_suff_v1_miss"
+    )
+    ctx, hook = _ctx_and_hook(module)
+    ctx.engine.handle_tool_call = _recall_hits([])
+    response = hook(
+        session_id="active-session",
+        user_message="How many points do I need to redeem the reward?",
+        enabled_toolsets=["context_engine"],
+    )
+
+    trace = ctx.engine._last_preanswer_evidence_trace
+    assert trace["sufficiency"]["state"] == "unknown"
+    assert trace["sufficiency"]["policy_action"] == "annotate"
+    assert "lcm-sufficiency-disclosure" in response["context"]
+    assert "state: unknown" in response["context"]
+    ctx.engine.shutdown()
+
+
+def test_sufficiency_mode_conflict_annotates_instead_of_answering(
+    tmp_path, monkeypatch
+):
+    module = _sufficiency_module(
+        monkeypatch, tmp_path, "hermes_lcm_packaging_suff_v1_conflict"
+    )
+    ctx, hook = _ctx_and_hook(module)
+    first = "You need 15 points to redeem the reward."
+    second = "You need 40 points to redeem the reward."
+    first_id = _store_fact(
+        ctx, first, datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+    )
+    second_id = _store_fact(
+        ctx, second, datetime(2024, 6, 1, tzinfo=timezone.utc).timestamp()
+    )
+    ctx.engine.handle_tool_call = _recall_hits(
+        [
+            {"exact_ref": f"lcm:{first_id}:0-{len(first)}", "content": first},
+            {"exact_ref": f"lcm:{second_id}:0-{len(second)}", "content": second},
+        ]
+    )
+    response = hook(
+        session_id="active-session",
+        user_message="How many points do I need to redeem the reward?",
+        enabled_toolsets=["context_engine"],
+    )
+
+    trace = ctx.engine._last_preanswer_evidence_trace
+    assert trace["sufficiency"]["state"] == "conflicted"
+    assert trace["sufficiency"]["policy_action"] == "annotate"
+    assert "lcm-sufficiency-disclosure" in response["context"]
+    assert "state: conflicted" in response["context"]
+    ctx.engine.shutdown()
+
+
+def test_sufficiency_mode_no_claim_paths_stay_byte_identical(tmp_path, monkeypatch):
+    module = _sufficiency_module(
+        monkeypatch, tmp_path, "hermes_lcm_packaging_suff_v1_noop"
+    )
+    ctx, hook = _ctx_and_hook(module)
+    policy = module.get_recall_policy()
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("no product retrieval is allowed")
+
+    ctx.engine.handle_tool_call = fail
+    ordinary = hook(
+        session_id="active-session",
+        user_message="Tell me about the Atlas project",
+        enabled_toolsets=["context_engine"],
+    )
+    disabled_toolset = hook(
+        session_id="active-session",
+        user_message="How long is my commute?",
+        enabled_toolsets=[],
+    )
+
+    assert ordinary == {"context": policy}
+    assert disabled_toolset == {"context": policy}
+    ctx.engine.shutdown()


### PR DESCRIPTION
## Summary

Implements the **is_sufficient gate** half of the 2026-09-03 scout synthesis decision #2 (docs/research/2026-09-03-scout-synthesis.md, Decision Question on evidence sufficiency): a single-place policy that classifies every finished preanswer-evidence result into an explicit sufficiency vocabulary and maps it to one answer-contract policy action.

- New `sufficiency_gate.py`: `answer_sufficient` / `computation_sufficient` / `finite_coverage` → **answer**; `partial` → **answer_with_disclosure** (rendered exclusively from fields already stored on the result — no provider, no fabricated content); `unknown` / `conflicted` → **annotate** instead of staying silent.
- States where the pipeline performed no evidence work (feature boundaries, unsupported questions, ordinary routes) receive **no claim at all**: unmarked stays unmarked — absent is not fact, unknown is not refuse.
- The requirements compiler's blanket `unknown` state is refined per reason code (`ambiguous_*` / `state_conflicted` → `conflicted`; grounded evidence with no delivered context → `partial`); **delivered states are never overridden**.
- The gate never calls a provider and never mutates evidence, computation, or the delivered context of sufficient results.
- Wired as `LCM_PREANSWER_EVIDENCE_MODE=sufficiency_v1` through the `pre_llm_call` hook (requirements-compiler route and legacy selective route both gate fail-open). Default-off: every other mode stays byte-identical to its previous behavior.
- Module API: `build_preanswer_evidence(sufficiency_gate=True)` for the direct path; the disclosure block is emitted as the ephemeral context only for non-sufficient states with empty context.

## Test plan

- 7 module-level tests (`tests/test_sufficiency_gate.py`): byte-identity without the flag, gate additivity on sufficient results, disclosure rendering from stored fields only, annotate-on-no-hit, no-claim paths stay unmarked, evidence/computation immutability.
- 4 hook-level tests (`tests/test_sufficiency_hook.py`) through the packaging harness: answer verdict on a validated fact, annotate on zero hits, conflicted annotation on two contradictory facts, byte-identical no-claim routing.
- Full suite in a clean checkout off `main`: **3040 passed, 1 skipped, 12 xfailed**.
- `ruff check` clean.