### PR TITLE
fix: isolate LCM config across routed profiles

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -362,7 +362,7 @@ def _make_command_handler(handle_lcm_command, engine, resolve_active_lcm_engine)
 
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
-    from .config import LCMConfig
+    from .config import LCMConfig, _resolve_hermes_home
     from .engine import LCMEngine, resolve_active_lcm_engine
     from .schemas import (
         LCM_GREP,
@@ -382,16 +382,10 @@ def register(ctx):
         LCM_DOCTOR,
     )
 
-    config = LCMConfig.from_env()
+    # Resolve the context-local routed home without mutating process-global env.
+    hermes_home = str(_resolve_hermes_home())
 
-    # Resolve hermes_home for profile-scoped storage
-    hermes_home = ""
-    try:
-        from hermes_cli.config import get_hermes_home
-        hermes_home = str(get_hermes_home())
-    except Exception:
-        import os
-        hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+    config = LCMConfig.from_env(hermes_home=hermes_home or None)
 
     engine = LCMEngine(config=config, hermes_home=hermes_home)
 

--- a/config.py
+++ b/config.py
@@ -149,13 +149,38 @@ def _config_bool_disabled(value) -> bool:
     return False
 
 
-def _hermes_config_path() -> Path:
-    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
-    return home / "config.yaml"
+def _resolve_hermes_home(hermes_home: str | Path | None = None) -> Path:
+    """Resolve the active Hermes home without changing process-global state.
+
+    Routed Hermes gateways keep the active profile in a context-local core
+    override rather than mutating ``os.environ``.  The explicit argument is
+    used by engine lifecycle hooks; the core helper is the standalone fallback
+    for callers that do not have a home argument.
+    """
+    if hermes_home:
+        return Path(hermes_home).expanduser()
+
+    for module_name in ("hermes_constants", "hermes_cli.config"):
+        try:
+            module = __import__(module_name, fromlist=["get_hermes_home"])
+            resolver = getattr(module, "get_hermes_home", None)
+            if callable(resolver):
+                resolved_home = resolver()
+                return Path(str(resolved_home)).expanduser()
+        except Exception:
+            continue
+
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
 
 
-def _load_hermes_config_yaml() -> dict[str, Any]:
-    cfg_path = _hermes_config_path()
+def _hermes_config_path(hermes_home: str | Path | None = None) -> Path:
+    return _resolve_hermes_home(hermes_home) / "config.yaml"
+
+
+def _load_hermes_config_yaml(
+    hermes_home: str | Path | None = None,
+) -> dict[str, Any]:
+    cfg_path = _hermes_config_path(hermes_home)
     try:
         text = cfg_path.read_text()
     except Exception:
@@ -202,8 +227,12 @@ def _load_hermes_config_yaml() -> dict[str, Any]:
 _SUPPORTED_LCM_CONFIG_YAML_KEYS = {"context_threshold"}
 
 
-def _ignored_lcm_config_yaml_keys(cfg: dict[str, Any] | None = None) -> list[str]:
-    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
+def _ignored_lcm_config_yaml_keys(
+    cfg: dict[str, Any] | None = None,
+    *,
+    hermes_home: str | Path | None = None,
+) -> list[str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml(hermes_home)
     lcm_section = cfg.get("lcm") if isinstance(cfg, dict) else None
     if not isinstance(lcm_section, dict):
         return []
@@ -214,7 +243,11 @@ def _ignored_lcm_config_yaml_keys(cfg: dict[str, Any] | None = None) -> list[str
     )
 
 
-def _hermes_compression_threshold(default: float) -> float:
+def _hermes_compression_threshold(
+    default: float,
+    *,
+    hermes_home: str | Path | None = None,
+) -> float:
     """Read lcm.context_threshold or Hermes compression.threshold from config.yaml.
 
     Priority when no ``LCM_CONTEXT_THRESHOLD`` env var is set:
@@ -226,12 +259,19 @@ def _hermes_compression_threshold(default: float) -> float:
     operators tune LCM compaction independently of the Hermes compression setting.
     Disabled Hermes compression should not leak its threshold into LCM.
     """
-    value, _source = _hermes_compression_threshold_with_source(default)
+    value, _source = _hermes_compression_threshold_with_source(
+        default,
+        hermes_home=hermes_home,
+    )
     return value
 
 
-def _hermes_compression_threshold_with_source(default: float) -> tuple[float, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_compression_threshold_with_source(
+    default: float,
+    *,
+    hermes_home: str | Path | None = None,
+) -> tuple[float, str]:
+    cfg = _load_hermes_config_yaml(hermes_home)
     try:
         lcm_section = cfg.get("lcm") or {}
         if isinstance(lcm_section, dict):
@@ -251,7 +291,11 @@ def _hermes_compression_threshold_with_source(default: float) -> tuple[float, st
     return default, "default"
 
 
-def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
+def _hermes_auxiliary_compression_timeout_ms(
+    default: int,
+    *,
+    hermes_home: str | Path | None = None,
+) -> int:
     """Read Hermes auxiliary.compression.timeout when no LCM override is present.
 
     Hermes uses seconds for the auxiliary compression timeout, while LCM stores
@@ -259,12 +303,19 @@ def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
     calls from timing out earlier than the host compression route unless
     ``LCM_SUMMARY_TIMEOUT_MS`` is explicitly configured.
     """
-    value, _source = _hermes_auxiliary_compression_timeout_ms_with_source(default)
+    value, _source = _hermes_auxiliary_compression_timeout_ms_with_source(
+        default,
+        hermes_home=hermes_home,
+    )
     return value
 
 
-def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[int, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_auxiliary_compression_timeout_ms_with_source(
+    default: int,
+    *,
+    hermes_home: str | Path | None = None,
+) -> tuple[int, str]:
+    cfg = _load_hermes_config_yaml(hermes_home)
     try:
         auxiliary = cfg.get("auxiliary") or {}
         if not isinstance(auxiliary, dict):
@@ -280,8 +331,12 @@ def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[
         return default, "default"
 
 
-def _hermes_codex_gpt55_autoraise_with_source(default: bool) -> tuple[bool, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_codex_gpt55_autoraise_with_source(
+    default: bool,
+    *,
+    hermes_home: str | Path | None = None,
+) -> tuple[bool, str]:
+    cfg = _load_hermes_config_yaml(hermes_home)
     try:
         compression = cfg.get("compression") or {}
         if not isinstance(compression, dict):
@@ -775,11 +830,22 @@ class LCMConfig:
     config_sources: dict[str, str] = field(default_factory=dict)
     config_source_warnings: list[str] = field(default_factory=list)
     ignored_config_yaml_lcm_keys: list[str] = field(default_factory=list)
+    config_hermes_home: str = ""
 
     @classmethod
-    def from_env(cls) -> "LCMConfig":
-        """Build config from environment variables (LCM_ prefix)."""
+    def from_env(
+        cls,
+        *,
+        hermes_home: str | Path | None = None,
+    ) -> "LCMConfig":
+        """Build config from environment variables and one Hermes profile.
+
+        ``hermes_home`` is intentionally an argument instead of a temporary
+        ``HERMES_HOME`` environment mutation so concurrent routed profiles
+        cannot observe each other's configuration.
+        """
         c = cls()
+        c.config_hermes_home = str(_resolve_hermes_home(hermes_home))
         config_sources: dict[str, str] = {}
         config_source_warnings: list[str] = []
 
@@ -788,7 +854,9 @@ class LCMConfig:
             if warning:
                 config_source_warnings.append(warning)
 
-        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys()
+        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys(
+            hermes_home=hermes_home
+        )
 
         # Source-tracked fields (provenance recording and/or a computed default)
         # stay explicit; the uniform loop below skips them.
@@ -805,7 +873,10 @@ class LCMConfig:
             "LCM_LEAF_CHUNK_TOKENS", c.leaf_chunk_tokens
         )
         _record("leaf_chunk_tokens", source, warning)
-        context_default, context_source = _hermes_compression_threshold_with_source(c.context_threshold)
+        context_default, context_source = _hermes_compression_threshold_with_source(
+            c.context_threshold,
+            hermes_home=hermes_home,
+        )
         c.context_threshold, source, warning = _parse_float_env_with_source(
             "LCM_CONTEXT_THRESHOLD",
             context_default,
@@ -813,7 +884,8 @@ class LCMConfig:
         )
         _record("context_threshold", source, warning)
         c.codex_gpt55_autoraise_enabled, source = _hermes_codex_gpt55_autoraise_with_source(
-            c.codex_gpt55_autoraise_enabled
+            c.codex_gpt55_autoraise_enabled,
+            hermes_home=hermes_home,
         )
         _record("codex_gpt55_autoraise_enabled", source)
         c.summary_spend_max_calls, source, warning = _parse_int_env_with_source(
@@ -832,7 +904,8 @@ class LCMConfig:
         )
         _record("summary_spend_backoff_seconds", source, warning)
         summary_timeout_default, summary_timeout_source = _hermes_auxiliary_compression_timeout_ms_with_source(
-            c.summary_timeout_ms
+            c.summary_timeout_ms,
+            hermes_home=hermes_home,
         )
         c.summary_timeout_ms, source, warning = _parse_int_env_with_source(
             "LCM_SUMMARY_TIMEOUT_MS",

--- a/engine.py
+++ b/engine.py
@@ -25,7 +25,7 @@ from .codex_routing import (
     _codex_oauth_context_cap,
     _is_codex_gpt55_route,
 )
-from .config import LCMConfig
+from .config import LCMConfig, _resolve_hermes_home
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
 from .engine_registry import (
@@ -389,8 +389,22 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def __init__(self, config: LCMConfig | None = None,
                  hermes_home: str = ""):
-        self._config = config or LCMConfig.from_env()
-        self._hermes_home = hermes_home
+        effective_home = str(hermes_home or "")
+        config_home = str(getattr(config, "config_hermes_home", "") or "")
+        if not effective_home and (
+            config is None or getattr(config, "config_sources", None)
+        ):
+            effective_home = config_home or str(_resolve_hermes_home())
+        if config is None:
+            self._config = LCMConfig.from_env(hermes_home=effective_home or None)
+        elif config_home and config_home != effective_home:
+            self._config = LCMConfig.from_env(hermes_home=effective_home)
+        else:
+            self._config = config
+        self._hermes_home = effective_home
+        self._config_hermes_home = str(
+            getattr(self._config, "config_hermes_home", "") or effective_home
+        )
         self._assertion_extraction_metrics_lock = threading.RLock()
         self._assertion_extraction_idle = threading.Event()
         self._assertion_extraction_idle.set()
@@ -406,8 +420,8 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._assertion_extraction_last_error = ""
         self._assertion_extraction_last_model = ""
 
-        db_path = self._resolve_db_path(hermes_home)
-        self._bind_storage(db_path, hermes_home)
+        db_path = self._resolve_db_path(effective_home)
+        self._bind_storage(db_path, effective_home)
 
         self._session_id: str = ""
         self._session_platform: str = ""
@@ -852,6 +866,68 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._bind_storage(db_path, hermes_home)
         self._reset_profile_runtime_state()
         logger.info("LCM rebound storage for Hermes home %s", hermes_home)
+        return True
+
+    def _refresh_profile_config(self, hermes_home: str = "") -> bool:
+        """Reload profile-derived config for a routed Hermes home.
+
+        ``LCMConfig`` instances created manually are intentionally left alone:
+        callers that pass a config object have already supplied the operator's
+        explicit runtime policy.  Configs built by ``from_env`` retain their
+        process-global ``LCM_*`` overrides while rereading only the selected
+        profile's YAML through an explicit path argument.
+        """
+        if (
+            not hermes_home
+            or not getattr(self._config, "config_sources", None)
+            or str(self._config_hermes_home or "") == str(hermes_home)
+        ):
+            return False
+
+        self._config = LCMConfig.from_env(hermes_home=hermes_home)
+        self._config_hermes_home = str(hermes_home)
+        self._compiled_ignore_session_patterns = compile_session_patterns(
+            self._config.ignore_session_patterns
+        )
+        self._compiled_stateless_session_patterns = compile_session_patterns(
+            self._config.stateless_session_patterns
+        )
+        self._compiled_ignore_message_patterns = compile_message_patterns(
+            self._config.ignore_message_patterns
+        )
+        self.protect_last_n = self._config.fresh_tail_count
+        self.summary_model = self._config.summary_model
+        with self._summary_circuit_breaker._lock:
+            self._summary_circuit_breaker.failure_threshold = int(
+                self._config.summary_circuit_breaker_failure_threshold
+            )
+            self._summary_circuit_breaker.cooldown_seconds = int(
+                self._config.summary_circuit_breaker_cooldown_seconds
+            )
+        with self._summary_spend_guard._lock:
+            self._summary_spend_guard.max_calls = int(self._config.summary_spend_max_calls)
+            self._summary_spend_guard.window_seconds = float(
+                self._config.summary_spend_window_seconds
+            )
+            self._summary_spend_guard.backoff_seconds = float(
+                self._config.summary_spend_backoff_seconds
+            )
+        store = getattr(self, "_store", None)
+        if store is not None:
+            store._ingest_protection_config = self._config
+        if self.raw_context_length:
+            self._set_context_length(
+                self.raw_context_length,
+                source=self._context_length_source or "profile_config_refresh",
+                model=self.model,
+                provider=self.provider,
+            )
+        else:
+            self.context_threshold, self._context_threshold_source, self._context_threshold_autoraised = (
+                self._runtime_context_threshold(model=self.model, provider=self.provider)
+            )
+            self.threshold_percent = self.context_threshold
+        logger.info("LCM refreshed profile config for Hermes home %s", hermes_home)
         return True
 
     def _runtime_context_threshold(
@@ -2600,8 +2676,12 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._log_session_filter_diagnostics()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
-        if "hermes_home" in kwargs:
-            self._rebind_storage_for_home(str(kwargs.get("hermes_home") or ""))
+        hermes_home = str(kwargs.get("hermes_home") or "")
+        if not hermes_home and getattr(self._config, "config_sources", None):
+            hermes_home = str(_resolve_hermes_home())
+        if hermes_home:
+            self._refresh_profile_config(hermes_home)
+            self._rebind_storage_for_home(hermes_home)
 
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")

--- a/tests/test_profile_isolation.py
+++ b/tests/test_profile_isolation.py
@@ -1,0 +1,284 @@
+"""Regression tests for routed Hermes profile isolation."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import threading
+from contextvars import ContextVar
+from types import ModuleType
+from pathlib import Path
+
+from hermes_lcm.config import LCMConfig
+from hermes_lcm.engine import LCMEngine
+
+
+def _write_profile_config(home: Path, *, threshold: float, timeout: float) -> None:
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "\n".join(
+            [
+                "compression:",
+                "  enabled: true",
+                f"  threshold: {threshold}",
+                "auxiliary:",
+                "  compression:",
+                f"    timeout: {timeout}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_plugin_module(name: str):
+    repo_root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        name,
+        str(repo_root / "__init__.py"),
+        submodule_search_locations=[str(repo_root)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_from_env_accepts_routed_home_without_mutating_process_environment(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(default_home, threshold=0.11, timeout=11)
+    _write_profile_config(profile_a, threshold=0.23, timeout=23)
+    _write_profile_config(profile_b, threshold=0.79, timeout=79)
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+    monkeypatch.delenv("LCM_SUMMARY_TIMEOUT_MS", raising=False)
+    monkeypatch.delenv("LCM_DATABASE_PATH", raising=False)
+    before = os.environ["HERMES_HOME"]
+
+    config_a = LCMConfig.from_env(hermes_home=str(profile_a))
+    config_b = LCMConfig.from_env(hermes_home=str(profile_b))
+
+    assert config_a.context_threshold == 0.23
+    assert config_b.context_threshold == 0.79
+    assert config_a.summary_timeout_ms == 23_000
+    assert config_b.summary_timeout_ms == 79_000
+    assert os.environ["HERMES_HOME"] == before
+
+    monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "1234")
+    monkeypatch.setenv("LCM_DATABASE_PATH", str(tmp_path / "shared.db"))
+    override_a = LCMConfig.from_env(hermes_home=str(profile_a))
+    override_b = LCMConfig.from_env(hermes_home=str(profile_b))
+    assert override_a.summary_timeout_ms == 1234
+    assert override_b.summary_timeout_ms == 1234
+    assert override_a.database_path == override_b.database_path == str(tmp_path / "shared.db")
+
+
+def test_context_local_home_is_used_when_host_omits_lifecycle_home(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(default_home, threshold=0.13, timeout=13)
+    _write_profile_config(profile_a, threshold=0.29, timeout=29)
+    _write_profile_config(profile_b, threshold=0.83, timeout=83)
+
+    active_home = ContextVar("active_home", default=str(default_home))
+    core = ModuleType("hermes_constants")
+    setattr(core, "get_hermes_home", lambda: active_home.get())
+    monkeypatch.setitem(sys.modules, "hermes_constants", core)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+    monkeypatch.setenv("LCM_SUMMARY_SPEND_MAX_CALLS", "4")
+    monkeypatch.setenv("LCM_SUMMARY_SPEND_WINDOW_SECONDS", "10")
+    monkeypatch.setenv("LCM_SUMMARY_SPEND_BACKOFF_SECONDS", "20")
+    monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "2")
+    monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS", "30")
+
+    engine = LCMEngine(
+        config=LCMConfig.from_env(hermes_home=str(profile_a)),
+        hermes_home=str(profile_a),
+    )
+    spend_guard = engine._summary_spend_guard
+    circuit_breaker = engine._summary_circuit_breaker
+    assert spend_guard.try_record_call(now=1.0) is True
+    circuit_breaker.record_failure("test-model", now=1.0)
+    try:
+        monkeypatch.setenv("LCM_SUMMARY_SPEND_MAX_CALLS", "9")
+        monkeypatch.setenv("LCM_SUMMARY_SPEND_WINDOW_SECONDS", "90")
+        monkeypatch.setenv("LCM_SUMMARY_SPEND_BACKOFF_SECONDS", "180")
+        monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "5")
+        monkeypatch.setenv("LCM_SUMMARY_CIRCUIT_BREAKER_COOLDOWN_SECONDS", "300")
+        token = active_home.set(str(profile_b))
+        try:
+            engine.on_session_start("session-b")
+        finally:
+            active_home.reset(token)
+        assert engine._config.context_threshold == 0.83
+        assert engine._config.summary_timeout_ms == 83_000
+        assert engine._store.db_path == profile_b / "lcm.db"
+        assert spend_guard.max_calls == 9
+        assert spend_guard.window_seconds == 90.0
+        assert spend_guard.backoff_seconds == 180.0
+        assert circuit_breaker.failure_threshold == 5
+        assert circuit_breaker.cooldown_seconds == 300
+        assert os.environ["HERMES_HOME"] == str(default_home)
+
+        token = active_home.set(str(profile_a))
+        try:
+            engine.on_session_start("session-a")
+        finally:
+            active_home.reset(token)
+        assert engine._config.context_threshold == 0.29
+        assert engine._store.db_path == profile_a / "lcm.db"
+        assert engine._summary_spend_guard is spend_guard
+        assert spend_guard._calls == [1.0]
+        assert engine._summary_circuit_breaker is circuit_breaker
+        assert circuit_breaker._failures["test-model"] == 1
+    finally:
+        engine.shutdown()
+
+
+def test_plugin_registration_uses_context_local_home(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(default_home, threshold=0.17, timeout=17)
+    _write_profile_config(profile_b, threshold=0.77, timeout=77)
+
+    active_home = ContextVar("active_home", default=str(default_home))
+    core = ModuleType("hermes_constants")
+    setattr(core, "get_hermes_home", lambda: active_home.get())
+    monkeypatch.setitem(sys.modules, "hermes_constants", core)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+    class Context:
+        engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    token = active_home.set(str(profile_b))
+    ctx = Context()
+    try:
+        _load_plugin_module("hermes_lcm_profile_registration").register(ctx)
+    finally:
+        active_home.reset(token)
+    engine = ctx.engine
+    assert engine is not None
+    try:
+        assert engine._config.context_threshold == 0.77
+        assert engine._config.summary_timeout_ms == 77_000
+        assert engine._store.db_path == profile_b / "lcm.db"
+    finally:
+        engine.shutdown()
+
+
+def test_constructor_reconciles_config_home_with_storage_home(tmp_path, monkeypatch):
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(profile_a, threshold=0.27, timeout=27)
+    _write_profile_config(profile_b, threshold=0.73, timeout=73)
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+
+    config_a = LCMConfig.from_env(hermes_home=str(profile_a))
+    engine = LCMEngine(config=config_a, hermes_home=str(profile_b))
+    try:
+        assert engine._config.context_threshold == 0.73
+        assert engine._config.summary_timeout_ms == 73_000
+        assert engine._config.config_hermes_home == str(profile_b)
+        assert engine._store.db_path == profile_b / "lcm.db"
+    finally:
+        engine.shutdown()
+
+
+def test_distinct_context_local_profiles_can_rebind_concurrently(tmp_path, monkeypatch):
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(profile_a, threshold=0.37, timeout=37)
+    _write_profile_config(profile_b, threshold=0.71, timeout=71)
+
+    active_home = ContextVar("active_home", default="")
+    core = ModuleType("hermes_constants")
+    setattr(core, "get_hermes_home", lambda: active_home.get())
+    monkeypatch.setitem(sys.modules, "hermes_constants", core)
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+    prototype = LCMEngine(
+        config=LCMConfig.from_env(hermes_home=str(profile_a)),
+        hermes_home=str(profile_a),
+    )
+    clone_a = prototype.clone_for_agent()
+    clone_b = prototype.clone_for_agent()
+    barrier = threading.Barrier(2)
+    seen: dict[str, tuple[float, Path]] = {}
+
+    def bind(name: str, engine: LCMEngine, home: Path) -> None:
+        token = active_home.set(str(home))
+        try:
+            barrier.wait(timeout=5)
+            engine.on_session_start(name)
+            seen[name] = (engine._config.context_threshold, engine._store.db_path)
+        finally:
+            active_home.reset(token)
+
+    threads = [
+        threading.Thread(target=bind, args=("session-a", clone_a, profile_a)),
+        threading.Thread(target=bind, args=("session-b", clone_b, profile_b)),
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+        assert all(not thread.is_alive() for thread in threads)
+        assert seen == {
+            "session-a": (0.37, profile_a / "lcm.db"),
+            "session-b": (0.71, profile_b / "lcm.db"),
+        }
+    finally:
+        clone_a.shutdown()
+        clone_b.shutdown()
+        prototype.shutdown()
+
+
+def test_cloned_engine_rebinds_profile_config_storage_and_override_precedence(
+    tmp_path, monkeypatch
+):
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    _write_profile_config(profile_a, threshold=0.31, timeout=31)
+    _write_profile_config(profile_b, threshold=0.67, timeout=67)
+
+    monkeypatch.delenv("LCM_CONTEXT_THRESHOLD", raising=False)
+    prototype = LCMEngine(
+        config=LCMConfig.from_env(hermes_home=str(profile_a)),
+        hermes_home=str(profile_a),
+    )
+    clone_a = prototype.clone_for_agent()
+    clone_b = prototype.clone_for_agent()
+    try:
+        clone_a.on_session_start("session-a", hermes_home=str(profile_a))
+        clone_b.on_session_start("session-b", hermes_home=str(profile_b))
+
+        assert clone_a._config.context_threshold == 0.31
+        assert clone_b._config.context_threshold == 0.67
+        assert clone_a._config.summary_timeout_ms == 31_000
+        assert clone_b._config.summary_timeout_ms == 67_000
+        assert clone_a._store.db_path == profile_a / "lcm.db"
+        assert clone_b._store.db_path == profile_b / "lcm.db"
+        assert clone_a._store._hermes_home == str(profile_a)
+        assert clone_b._store._hermes_home == str(profile_b)
+        assert clone_a._config is not clone_b._config
+
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.91")
+        clone_b.on_session_start("session-a-override", hermes_home=str(profile_a))
+        clone_b.on_session_start("session-b-override", hermes_home=str(profile_b))
+        assert clone_b._config.context_threshold == 0.91
+        assert clone_b._config.config_sources["context_threshold"] == "env:LCM_CONTEXT_THRESHOLD"
+        assert clone_a._config.context_threshold == 0.31
+    finally:
+        clone_a.shutdown()
+        clone_b.shutdown()
+        prototype.shutdown()


### PR DESCRIPTION
## Summary
- Resolve Hermes home through the routed context-local core API instead of process-global `HERMES_HOME` state.
- Thread the selected home through LCM YAML config loading and plugin registration.
- Reload profile-derived config and rebind profile-scoped storage when a cached engine starts a session for another routed home, while preserving explicit/manual config and env override precedence.
- Preserve circuit-breaker/spend-guard state while updating their limits for the active profile.

## Why
A multiplex gateway can keep multiple cached agents for different Hermes profiles in one process. The LCM plugin previously read `config.yaml` from the process-global environment during registration and cloned the resulting config, so later profile sessions could use the first profile's threshold and database. This change keeps profile selection explicit/context-local and rebinds both effective configuration and storage per engine lifecycle.

## Validation
- [x] Focused validation: `HERMES_HOME=/tmp/hermes-lcm-suite-home PYTHONPATH=/tmp/hermes-lcm-agent-stub:. /tmp/hermes-lcm-venv/bin/python -m pytest -q tests/test_profile_isolation.py` -> 6 passed
- [x] Relevant validation: `HERMES_HOME=/tmp/hermes-lcm-suite-home PYTHONPATH=/tmp/hermes-lcm-agent-stub:. /tmp/hermes-lcm-venv/bin/python -m pytest -q tests/test_profile_isolation.py tests/test_lcm_engine.py tests/test_lcm_core.py` -> 1075 passed
- [x] Full validation: `HERMES_HOME=/tmp/hermes-lcm-suite-home PYTHONPATH=/tmp/hermes-lcm-agent-stub:. /tmp/hermes-lcm-venv/bin/python -m pytest tests/ -q` -> 3035 passed, 1 skipped, 12 xfailed
- [x] `ruff check .`
- [x] `scripts/validate_dependency_contract.py`
- [x] `python -m compileall -q .`
- [x] `python -m py_compile scripts/import_lossless_claw.py`
- [x] `bash -n scripts/install.sh scripts/update.sh`
- [x] `git diff --check`

## Notes
- Regression fixtures use isolated synthetic profile homes and SQLite databases; no live profile state is accessed or modified.
- The change does not mutate `os.environ["HERMES_HOME"]` and retains explicit `LCM_*` environment overrides.
- CI checks are expected to run on this pull request; no CI result is being pre-claimed here.

Refs #
