### PR TITLE
fix: isolate routed profile config and engine state

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -80,7 +80,20 @@ def _ensure_engine_bound_to_session(
     conversation_id: str = "",
 ) -> None:
     session_id = str(session_id or "")
-    if session_id and _engine_bound_session_id(active_engine) != session_id:
+    needs_profile_rebind = False
+    if getattr(active_engine, "_config_from_env", False):
+        try:
+            from .config import resolve_hermes_home
+
+            needs_profile_rebind = (
+                Path(resolve_hermes_home()).expanduser().resolve()
+                != Path(str(getattr(active_engine, "_hermes_home", ""))).expanduser().resolve()
+            )
+        except Exception:
+            logger.debug("LCM could not compare active profile for hook rebinding", exc_info=True)
+    if session_id and (
+        _engine_bound_session_id(active_engine) != session_id or needs_profile_rebind
+    ):
         active_engine.on_session_start(
             session_id,
             platform=platform,
@@ -362,7 +375,6 @@ def _make_command_handler(handle_lcm_command, engine, resolve_active_lcm_engine)
 
 def register(ctx):
     """Plugin entry point — register the LCM context engine and tools."""
-    from .config import LCMConfig
     from .engine import LCMEngine, resolve_active_lcm_engine
     from .schemas import (
         LCM_GREP,
@@ -382,18 +394,9 @@ def register(ctx):
         LCM_DOCTOR,
     )
 
-    config = LCMConfig.from_env()
-
-    # Resolve hermes_home for profile-scoped storage
-    hermes_home = ""
-    try:
-        from hermes_cli.config import get_hermes_home
-        hermes_home = str(get_hermes_home())
-    except Exception:
-        import os
-        hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
-
-    engine = LCMEngine(config=config, hermes_home=hermes_home)
+    # Keep the registered prototype environment-backed: each routed agent must
+    # resolve its own config and storage instead of copying this home's snapshot.
+    engine = LCMEngine()
 
     # Register as the context engine (replaces ContextCompressor)
     ctx.register_context_engine(engine)

--- a/config.py
+++ b/config.py
@@ -149,13 +149,34 @@ def _config_bool_disabled(value) -> bool:
     return False
 
 
+def resolve_hermes_home() -> Path:
+    """Resolve the active route at call time, without changing process env.
+
+    Only hosts without the context-local API use the standalone fallback. A
+    failing host resolver must not silently select a sibling/default profile.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+    except ImportError:
+        try:
+            from hermes_cli.config import get_hermes_home
+        except ImportError:
+            return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    return Path(get_hermes_home())
+
+
 def _hermes_config_path() -> Path:
-    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
-    return home / "config.yaml"
+    return resolve_hermes_home() / "config.yaml"
 
 
-def _load_hermes_config_yaml() -> dict[str, Any]:
-    cfg_path = _hermes_config_path()
+def _load_hermes_config_yaml(
+    hermes_home: str | Path | None = None,
+) -> dict[str, Any]:
+    cfg_path = (
+        Path(hermes_home).expanduser() / "config.yaml"
+        if hermes_home
+        else _hermes_config_path()
+    )
     try:
         text = cfg_path.read_text()
     except Exception:
@@ -230,8 +251,10 @@ def _hermes_compression_threshold(default: float) -> float:
     return value
 
 
-def _hermes_compression_threshold_with_source(default: float) -> tuple[float, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_compression_threshold_with_source(
+    default: float, cfg: dict[str, Any] | None = None,
+) -> tuple[float, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         lcm_section = cfg.get("lcm") or {}
         if isinstance(lcm_section, dict):
@@ -263,8 +286,10 @@ def _hermes_auxiliary_compression_timeout_ms(default: int) -> int:
     return value
 
 
-def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[int, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_auxiliary_compression_timeout_ms_with_source(
+    default: int, cfg: dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         auxiliary = cfg.get("auxiliary") or {}
         if not isinstance(auxiliary, dict):
@@ -280,8 +305,10 @@ def _hermes_auxiliary_compression_timeout_ms_with_source(default: int) -> tuple[
         return default, "default"
 
 
-def _hermes_codex_gpt55_autoraise_with_source(default: bool) -> tuple[bool, str]:
-    cfg = _load_hermes_config_yaml()
+def _hermes_codex_gpt55_autoraise_with_source(
+    default: bool, cfg: dict[str, Any] | None = None,
+) -> tuple[bool, str]:
+    cfg = cfg if cfg is not None else _load_hermes_config_yaml()
     try:
         compression = cfg.get("compression") or {}
         if not isinstance(compression, dict):
@@ -777,9 +804,14 @@ class LCMConfig:
     ignored_config_yaml_lcm_keys: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_env(cls) -> "LCMConfig":
-        """Build config from environment variables (LCM_ prefix)."""
+    def from_env(cls, hermes_home: str | Path | None = None) -> "LCMConfig":
+        """Load one profile's YAML snapshot, then apply explicit LCM_* overrides.
+
+        The host's session-start home can be supplied explicitly; otherwise use
+        the current context-local route (or the standalone/default home).
+        """
         c = cls()
+        cfg = _load_hermes_config_yaml(hermes_home)
         config_sources: dict[str, str] = {}
         config_source_warnings: list[str] = []
 
@@ -788,7 +820,7 @@ class LCMConfig:
             if warning:
                 config_source_warnings.append(warning)
 
-        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys()
+        c.ignored_config_yaml_lcm_keys = _ignored_lcm_config_yaml_keys(cfg)
 
         # Source-tracked fields (provenance recording and/or a computed default)
         # stay explicit; the uniform loop below skips them.
@@ -805,7 +837,7 @@ class LCMConfig:
             "LCM_LEAF_CHUNK_TOKENS", c.leaf_chunk_tokens
         )
         _record("leaf_chunk_tokens", source, warning)
-        context_default, context_source = _hermes_compression_threshold_with_source(c.context_threshold)
+        context_default, context_source = _hermes_compression_threshold_with_source(c.context_threshold, cfg)
         c.context_threshold, source, warning = _parse_float_env_with_source(
             "LCM_CONTEXT_THRESHOLD",
             context_default,
@@ -813,7 +845,7 @@ class LCMConfig:
         )
         _record("context_threshold", source, warning)
         c.codex_gpt55_autoraise_enabled, source = _hermes_codex_gpt55_autoraise_with_source(
-            c.codex_gpt55_autoraise_enabled
+            c.codex_gpt55_autoraise_enabled, cfg
         )
         _record("codex_gpt55_autoraise_enabled", source)
         c.summary_spend_max_calls, source, warning = _parse_int_env_with_source(
@@ -832,7 +864,7 @@ class LCMConfig:
         )
         _record("summary_spend_backoff_seconds", source, warning)
         summary_timeout_default, summary_timeout_source = _hermes_auxiliary_compression_timeout_ms_with_source(
-            c.summary_timeout_ms
+            c.summary_timeout_ms, cfg
         )
         c.summary_timeout_ms, source, warning = _parse_int_env_with_source(
             "LCM_SUMMARY_TIMEOUT_MS",

--- a/dependency-contract.json
+++ b/dependency-contract.json
@@ -64,6 +64,15 @@
         "gateway.session_context.get_session_env"
       ]
     },
+    "hermes_constants": {
+      "distribution": "hermes-agent",
+      "availability": "optional",
+      "scope": "context-local routed Hermes home resolution",
+      "version_policy": "Hermes Agent hosts exposing hermes_constants.get_hermes_home; falls back to hermes_cli.config, HERMES_HOME, or ~/.hermes",
+      "imported_api": [
+        "hermes_constants.get_hermes_home"
+      ]
+    },
     "hermes_cli": {
       "distribution": "hermes-agent",
       "availability": "optional",

--- a/engine.py
+++ b/engine.py
@@ -25,13 +25,14 @@ from .codex_routing import (
     _codex_oauth_context_cap,
     _is_codex_gpt55_route,
 )
-from .config import LCMConfig
+from .config import LCMConfig, resolve_hermes_home
 from .dag import SummaryDAG, SummaryNode
 from .diagnostics import _enforce_state_db_containment
 from .engine_registry import (
     _ACTIVE_ENGINE_REGISTRY_LOCK,
     _ACTIVE_ENGINES_BY_CONVERSATION_ID,
     _ACTIVE_ENGINES_BY_SESSION_ID,
+    _profile_registry_key,
     _remove_registry_entries_for_engine,
     resolve_active_lcm_engine,  # noqa: F401  (re-exported: hosts import it from .engine)
 )
@@ -389,7 +390,10 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
 
     def __init__(self, config: LCMConfig | None = None,
                  hermes_home: str = ""):
-        self._config = config or LCMConfig.from_env()
+        self._config_from_env = config is None
+        if self._config_from_env:
+            hermes_home = hermes_home or str(resolve_hermes_home())
+        self._config = config or LCMConfig.from_env(hermes_home)
         self._hermes_home = hermes_home
         self._assertion_extraction_metrics_lock = threading.RLock()
         self._assertion_extraction_idle = threading.Event()
@@ -433,15 +437,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._session_match_keys: list[str] = []
         self._session_ignored = False
         self._session_stateless = False
-        self._compiled_ignore_session_patterns = compile_session_patterns(
-            self._config.ignore_session_patterns
-        )
-        self._compiled_stateless_session_patterns = compile_session_patterns(
-            self._config.stateless_session_patterns
-        )
-        self._compiled_ignore_message_patterns = compile_message_patterns(
-            self._config.ignore_message_patterns
-        )
+
         self._ignored_message_count: int = 0
         # Raw messages permanently dropped because they matched
         # ignore_message_patterns. These are NOT persisted anywhere, so an
@@ -508,7 +504,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._last_compaction_duration_ms = 0.0
         # run_agent.py reads these for preflight checks
         self.protect_first_n = 3
-        self.protect_last_n = self._config.fresh_tail_count
+
         # run_agent.py reads these for context probing
         self._context_probed = False
         self._context_probe_persistable = False
@@ -517,20 +513,7 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # remain explicit.
         self.emit_automatic_compaction_status = False
         self.quiet_mode = True
-        self.summary_model = self._config.summary_model
-        self._summary_circuit_breaker = SummaryCircuitBreaker(
-            failure_threshold=self._config.summary_circuit_breaker_failure_threshold,
-            cooldown_seconds=self._config.summary_circuit_breaker_cooldown_seconds,
-        )
-        # Summary spend guard: process-local sliding window so a loop that
-        # keeps succeeding cannot burn auxiliary-model budget without bound. When
-        # tripped, escalation falls back to deterministic L3 truncation. Set
-        # summary_spend_max_calls=0 to disable.
-        self._summary_spend_guard = SummarySpendGuard(
-            max_calls=int(self._config.summary_spend_max_calls),
-            window_seconds=float(self._config.summary_spend_window_seconds),
-            backoff_seconds=float(self._config.summary_spend_backoff_seconds),
-        )
+
         self._last_overflow_recovery_failed = False
         self._last_condensation_suppressed_reason = ""
         self._last_threshold_full_sweep: dict[str, Any] = {
@@ -621,6 +604,34 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         # The scheduler associates this identity only with outstanding work, so
         # diagnostic drains do not retain every historical session key forever.
         self._rollup_maintenance_owner = object()
+        self._initialize_config_runtime()
+
+    def _initialize_config_runtime(self) -> None:
+        """Build config-derived runtime helpers at construction/profile rebind."""
+        self._compiled_ignore_session_patterns = compile_session_patterns(
+            self._config.ignore_session_patterns
+        )
+        self._compiled_stateless_session_patterns = compile_session_patterns(
+            self._config.stateless_session_patterns
+        )
+        self._compiled_ignore_message_patterns = compile_message_patterns(
+            self._config.ignore_message_patterns
+        )
+        self.protect_last_n = self._config.fresh_tail_count
+        self.summary_model = self._config.summary_model
+        self._summary_circuit_breaker = SummaryCircuitBreaker(
+            failure_threshold=self._config.summary_circuit_breaker_failure_threshold,
+            cooldown_seconds=self._config.summary_circuit_breaker_cooldown_seconds,
+        )
+        # Summary spend guard: process-local sliding window so a loop that
+        # keeps succeeding cannot burn auxiliary-model budget without bound. When
+        # tripped, escalation falls back to deterministic L3 truncation. Set
+        # summary_spend_max_calls=0 to disable.
+        self._summary_spend_guard = SummarySpendGuard(
+            max_calls=int(self._config.summary_spend_max_calls),
+            window_seconds=float(self._config.summary_spend_window_seconds),
+            backoff_seconds=float(self._config.summary_spend_backoff_seconds),
+        )
 
     def clone_for_agent(self) -> "LCMEngine":
         """Return a fresh runtime engine for one AIAgent instance.
@@ -632,14 +643,15 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         sharing one registered instance across agents can let one conversation
         rebind another conversation's raw-message ingest and lifecycle state.
 
-        The clone shares the same durable SQLite database path/configuration,
-        but gets independent session/cursor/lifecycle runtime state. Runtime
+        Environment-backed prototypes resolve the active profile afresh; explicit
+        caller-supplied configs retain their database/home. Each clone gets
+        independent session/cursor/lifecycle runtime state. Runtime
         model and context-window metadata is copied so the clone is immediately
         budget-aware even before a compatible Hermes host calls update_model().
         """
         clone = type(self)(
-            config=copy.deepcopy(self._config),
-            hermes_home=self._hermes_home,
+            config=None if self._config_from_env else copy.deepcopy(self._config),
+            hermes_home="" if self._config_from_env else self._hermes_home,
         )
         clone.model = self.model
         clone.base_url = self.base_url
@@ -829,6 +841,23 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         """
         if not hermes_home:
             return False
+        if self._config_from_env and str(self._hermes_home) != str(hermes_home):
+            # Storage helpers capture config as well as paths. Reload before
+            # binding them, even when LCM_DATABASE_PATH explicitly pins the DB.
+            config = LCMConfig.from_env(hermes_home)
+            self._close_storage()
+            self._config = config
+            self._hermes_home = hermes_home
+            self._bind_storage(self._resolve_db_path(hermes_home), hermes_home)
+            self._reset_profile_runtime_state()
+            self._initialize_config_runtime()
+            self._set_context_length(
+                self.raw_context_length or self.context_length,
+                source=self._context_length_source,
+                model=self.model,
+                provider=self.provider,
+            )
+            return True
         if self._config.database_path:
             current_home = str(self._hermes_home or "")
             current_store_home = str(getattr(getattr(self, "_store", None), "_hermes_home", "") or "")
@@ -1891,15 +1920,18 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         conversation_id = str(self._conversation_id or "")
         if not session_id:
             return
+        profile = _profile_registry_key(self._hermes_home)
+        session_key = (profile, session_id)
+        conversation_key = (profile, conversation_id)
         with _ACTIVE_ENGINE_REGISTRY_LOCK:
             _remove_registry_entries_for_engine(
                 self,
-                keep_session_id=session_id,
-                keep_conversation_id=conversation_id,
+                keep_session_id=session_key,
+                keep_conversation_id=conversation_key,
             )
-            _ACTIVE_ENGINES_BY_SESSION_ID[session_id] = self
+            _ACTIVE_ENGINES_BY_SESSION_ID[session_key] = self
             if conversation_id:
-                _ACTIVE_ENGINES_BY_CONVERSATION_ID[conversation_id] = self
+                _ACTIVE_ENGINES_BY_CONVERSATION_ID[conversation_key] = self
 
     def _unregister_active_engine_binding(self) -> None:
         with _ACTIVE_ENGINE_REGISTRY_LOCK:
@@ -2600,8 +2632,11 @@ class LCMEngine(CompactionMixin, ResetStateMixin, ReconcileMixin, AuxiliarySessi
         self._log_session_filter_diagnostics()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
-        if "hermes_home" in kwargs:
-            self._rebind_storage_for_home(str(kwargs.get("hermes_home") or ""))
+        hermes_home = str(kwargs.get("hermes_home") or "")
+        if not hermes_home and self._config_from_env:
+            hermes_home = str(resolve_hermes_home())
+        if hermes_home:
+            self._rebind_storage_for_home(hermes_home)
 
         boundary_reason = str(kwargs.get("boundary_reason") or "")
         old_session_id = str(kwargs.get("old_session_id") or "")

--- a/engine_registry.py
+++ b/engine_registry.py
@@ -13,11 +13,18 @@ from __future__ import annotations
 
 import threading
 import weakref
+from pathlib import Path
 from typing import Any
+
+from .config import resolve_hermes_home
 
 _ACTIVE_ENGINE_REGISTRY_LOCK = threading.RLock()
 _ACTIVE_ENGINES_BY_SESSION_ID = weakref.WeakValueDictionary()
 _ACTIVE_ENGINES_BY_CONVERSATION_ID = weakref.WeakValueDictionary()
+
+
+def _profile_registry_key(hermes_home: str = "") -> str:
+    return str((Path(hermes_home) if hermes_home else resolve_hermes_home()).resolve())
 
 
 def _is_usable_lcm_engine(engine: Any) -> bool:
@@ -80,8 +87,8 @@ def _engine_matches_foreground_binding(
 def _remove_registry_entries_for_engine(
     engine: Any,
     *,
-    keep_session_id: str = "",
-    keep_conversation_id: str = "",
+    keep_session_id: tuple[str, str] | None = None,
+    keep_conversation_id: tuple[str, str] | None = None,
 ) -> None:
     for registered_session_id, registered_engine in list(_ACTIVE_ENGINES_BY_SESSION_ID.items()):
         if registered_engine is engine and registered_session_id != keep_session_id:
@@ -107,17 +114,20 @@ def resolve_active_lcm_engine(
     post-turn ingest can still follow the active clone instead of rebinding the
     process-wide plugin singleton.
     """
+    profile = _profile_registry_key()
     session_id = str(session_id or "")
     conversation_id = str(conversation_id or "")
+    session_key = (profile, session_id)
+    conversation_key = (profile, conversation_id)
     with _ACTIVE_ENGINE_REGISTRY_LOCK:
         if session_id:
-            engine = _ACTIVE_ENGINES_BY_SESSION_ID.get(session_id)
+            engine = _ACTIVE_ENGINES_BY_SESSION_ID.get(session_key)
             if _engine_matches_session_binding(engine, session_id):
                 return engine
             if engine is not None:
-                _ACTIVE_ENGINES_BY_SESSION_ID.pop(session_id, None)
+                _ACTIVE_ENGINES_BY_SESSION_ID.pop(session_key, None)
         if conversation_id:
-            engine = _ACTIVE_ENGINES_BY_CONVERSATION_ID.get(conversation_id)
+            engine = _ACTIVE_ENGINES_BY_CONVERSATION_ID.get(conversation_key)
             conversation_matches = _engine_matches_conversation_binding(
                 engine,
                 conversation_id,
@@ -129,7 +139,7 @@ def resolve_active_lcm_engine(
             if conversation_matches and session_matches:
                 return engine
             if engine is not None and not conversation_matches:
-                _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_id, None)
+                _ACTIVE_ENGINES_BY_CONVERSATION_ID.pop(conversation_key, None)
         if not allow_foreground:
             return None
         # Operator commands may target the stable foreground view while a side
@@ -137,10 +147,12 @@ def resolve_active_lcm_engine(
         # this fallback or they can rebind the side-channel clone mid-turn.
         # Registry size is bounded by live AIAgent clones and values are weak.
         seen: set[int] = set()
-        for engine in (
-            list(_ACTIVE_ENGINES_BY_SESSION_ID.values())
-            + list(_ACTIVE_ENGINES_BY_CONVERSATION_ID.values())
+        for (registered_profile, _), engine in (
+            list(_ACTIVE_ENGINES_BY_SESSION_ID.items())
+            + list(_ACTIVE_ENGINES_BY_CONVERSATION_ID.items())
         ):
+            if registered_profile != profile:
+                continue
             engine_id = id(engine)
             if engine_id in seen:
                 continue

--- a/tests/test_dependency_contract.py
+++ b/tests/test_dependency_contract.py
@@ -36,7 +36,7 @@ def test_dependency_contract_validator_accepts_repository():
 
     assert result.returncode == 0, result.stderr
     assert "dependency contract valid: version 1.0.4" in result.stdout
-    assert "9 external imports declared" in result.stdout
+    assert "10 external imports declared" in result.stdout
 
 
 def test_dependency_assurance_documentation_matches_contract_version():
@@ -957,6 +957,7 @@ def test_contract_records_host_ownership_versions_and_update_owner():
         "agent",
         "fastembed",
         "gateway",
+        "hermes_constants",
         "hermes_cli",
         "huggingface_hub",
         "numpy",

--- a/tests/test_multiplex_profiles.py
+++ b/tests/test_multiplex_profiles.py
@@ -1,0 +1,365 @@
+"""Routed homes are task-local; the gateway environment stays unchanged."""
+
+from contextvars import ContextVar
+import copy
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def routed_plugin(monkeypatch, tmp_path):
+    for key in list(os.environ):
+        if key.startswith("LCM_"):
+            monkeypatch.delenv(key)
+    homes = {}
+    for name, threshold, timeout in (
+        ("default", 0.71, 11), ("alpha", 0.43, 23), ("beta", 0.62, 37),
+    ):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"compression:\n  enabled: true\n  threshold: {threshold}\n"
+            f"auxiliary:\n  compression:\n    timeout: {timeout}\n"
+        )
+        homes[name] = home
+    monkeypatch.setenv("HERMES_HOME", str(homes["default"]))
+    active_home = ContextVar("test_hermes_home", default=homes["default"])
+    constants = ModuleType("hermes_constants")
+    constants.get_hermes_home = active_home.get
+    monkeypatch.setitem(sys.modules, "hermes_constants", constants)
+    # No real host config, plugin manager, credentials, or session DB is loaded.
+    manager = SimpleNamespace(_hooks={})
+    cli = ModuleType("hermes_cli")
+    cli.__path__ = []
+    cli_config = ModuleType("hermes_cli.config")
+    cli_config.get_hermes_home = active_home.get
+    plugins = ModuleType("hermes_cli.plugins")
+    plugins.get_plugin_manager = lambda: manager
+    for name, module in (("hermes_cli", cli), ("hermes_cli.config", cli_config),
+                         ("hermes_cli.plugins", plugins)):
+        monkeypatch.setitem(sys.modules, name, module)
+
+    name = "multiplex_test_plugin"
+    root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        name, root / "__init__.py", submodule_search_locations=[str(root)]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    engines = []
+    hooks = {}
+    ctx = SimpleNamespace(
+        register_context_engine=engines.append,
+        register_hook=lambda name, handler: hooks.update({name: handler}),
+    )
+    try:
+        yield SimpleNamespace(
+            module=module, ctx=ctx, homes=homes, active_home=active_home,
+            engines=engines, hooks=hooks, manager=manager,
+        )
+    finally:
+        for engine in reversed(engines):
+            engine.shutdown()
+        for module_name in list(sys.modules):
+            if module_name.startswith(name + "."):
+                monkeypatch.delitem(sys.modules, module_name)
+
+
+def test_registered_prototype_clones_use_routed_config_and_storage(routed_plugin):
+    host = routed_plugin
+    host.module.register(host.ctx)
+    prototype = host.engines[0]
+    token = host.active_home.set(host.homes["alpha"])
+    try:
+        clone = prototype.clone_for_agent()
+        host.engines.append(clone)
+        assert clone._config.context_threshold == 0.43
+        assert clone._config.summary_timeout_ms == 23000
+        assert clone._config.config_sources["context_threshold"] == "config_yaml:compression.threshold"
+        assert clone._store.db_path == host.homes["alpha"] / "lcm.db"
+        clone.on_session_start("alpha-session", context_length=100000)
+        assert clone.context_threshold == 0.43
+        assert clone.threshold_tokens == 43000
+        assert prototype._config.context_threshold == 0.71
+        assert prototype._store.db_path == host.homes["default"] / "lcm.db"
+        assert os.environ["HERMES_HOME"] == str(host.homes["default"])
+    finally:
+        host.active_home.reset(token)
+
+
+@pytest.mark.parametrize("route_mode", ["ambient", "explicit", "empty"])
+def test_session_start_rebinds_config_and_clears_profile_state(routed_plugin, route_mode):
+    host = routed_plugin
+    host.module.register(host.ctx)
+    engine = host.engines[0].clone_for_agent()
+    host.engines.append(engine)
+    engine.on_session_start("old-session", conversation_id="old-lane", context_length=100000)
+    engine.ingest([{"role": "user", "content": "default-only record"}])
+    engine._lifecycle.record_debt("old-lane", kind="raw_backlog", size_estimate=123)
+    old_store = engine._store
+    # An explicit lifecycle home wins even if the ambient context is different;
+    # an empty host value falls back to the context-local route.
+    token = host.active_home.set(host.homes["alpha"])
+    try:
+        if route_mode == "explicit":
+            kwargs = {"hermes_home": str(host.homes["beta"])}
+            home = host.homes["beta"]
+        elif route_mode == "empty":
+            kwargs = {"hermes_home": ""}
+            home = host.homes["alpha"]
+        else:
+            kwargs = {}
+            home = host.homes["alpha"]
+        engine.on_session_start("new-session", conversation_id="new-lane", **kwargs)
+        expected_threshold = 0.62 if route_mode == "explicit" else 0.43
+        expected_timeout = 37000 if route_mode == "explicit" else 23000
+        assert engine._config.context_threshold == expected_threshold
+        assert engine._config.summary_timeout_ms == expected_timeout
+        assert engine.threshold_tokens == int(expected_threshold * 100000)
+        assert engine._store.db_path == home / "lcm.db"
+        assert engine._dag.db_path == home / "lcm.db"
+        assert engine._lifecycle.db_path == home / "lcm.db"
+        assert old_store._conn is None
+        assert engine._store.get_session_messages("old-session") == []
+        assert engine._lifecycle.get_by_conversation("old-lane") is None
+        assert engine.current_session_id == "new-session"
+        assert engine.current_conversation_id == "new-lane"
+        engine.ingest([{"role": "user", "content": "routed-only record"}])
+        assert len(engine._store.get_session_messages("new-session")) == 1
+        assert host.engines[0]._store.get_session_messages("new-session") == []
+        assert os.environ["HERMES_HOME"] == str(host.homes["default"])
+    finally:
+        host.active_home.reset(token)
+
+
+def test_interleaved_profiles_dispatch_hooks_without_sibling_state(routed_plugin):
+    host = routed_plugin
+    host.module.register(host.ctx)
+    prototype = host.engines[0]
+    resolve = sys.modules[prototype.__module__].resolve_active_lcm_engine
+    clones = {}
+    # Session/lane IDs can repeat in independently persisted profile state.
+    for name in ("alpha", "beta"):
+        token = host.active_home.set(host.homes[name])
+        try:
+            clone = prototype.clone_for_agent()
+            host.engines.append(clone)
+            clones[name] = clone
+            clone.on_session_start("same-session", conversation_id="same-lane", context_length=100000)
+            clone._lifecycle.record_debt("same-lane", kind="raw_backlog", size_estimate=123 if name == "alpha" else 456)
+        finally:
+            host.active_home.reset(token)
+
+    for name in ("alpha", "beta", "alpha", "beta"):
+        token = host.active_home.set(host.homes[name])
+        try:
+            clone = clones[name]
+            assert resolve(session_id="same-session") is clone
+            assert resolve(conversation_id="same-lane") is clone
+            assert host.hooks["pre_llm_call"](session_id="same-session") == {"context": host.module.get_recall_policy()}
+            # Exercise legacy hook lookup without a direct context_compressor.
+            host.manager._hooks["post_llm_call"][0](
+                session_id="same-session", conversation_id="same-lane",
+                conversation_history=[{"role": "user", "content": name + " private record"}],
+            )
+            assert [row["content"] for row in clone._store.get_session_messages("same-session")] == [name + " private record"]
+            state = clone._lifecycle.get_by_conversation("same-lane")
+            assert state.debt_size_estimate == (123 if name == "alpha" else 456)
+            assert clone._config.summary_timeout_ms == (23000 if name == "alpha" else 37000)
+            assert clone.threshold_tokens == (43000 if name == "alpha" else 62000)
+            assert os.environ["HERMES_HOME"] == str(host.homes["default"])
+        finally:
+            host.active_home.reset(token)
+    assert prototype._store.get_session_messages("same-session") == []
+    assert prototype._lifecycle.get_by_conversation("same-lane") is None
+    assert resolve(session_id="same-session", conversation_id="same-lane", allow_foreground=True) is None
+
+
+def test_lcm_environment_overrides_win_for_routed_yaml_and_do_not_mutate_home(
+    routed_plugin, monkeypatch
+):
+    host = routed_plugin
+    from hermes_lcm.config import LCMConfig
+
+    monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.91")
+    monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "91000")
+    before = os.environ["HERMES_HOME"]
+    config = LCMConfig.from_env(hermes_home=host.homes["alpha"])
+
+    assert config.context_threshold == 0.91
+    assert config.summary_timeout_ms == 91000
+    assert config.config_sources["context_threshold"] == "env:LCM_CONTEXT_THRESHOLD"
+    assert config.config_sources["summary_timeout_ms"] == "env:LCM_SUMMARY_TIMEOUT_MS"
+    assert os.environ["HERMES_HOME"] == before
+
+
+def test_legacy_home_resolution_falls_back_to_process_environment(monkeypatch, tmp_path):
+    from hermes_lcm.config import resolve_hermes_home
+
+    legacy_home = tmp_path / "legacy-home"
+    monkeypatch.setenv("HERMES_HOME", str(legacy_home))
+    # Force both optional context-aware host modules to be unavailable. A
+    # legacy standalone host then retains the documented environment fallback.
+    for module_name in ("hermes_constants", "hermes_cli", "hermes_cli.config"):
+        monkeypatch.setitem(sys.modules, module_name, None)
+
+    assert resolve_hermes_home() == legacy_home
+
+
+def test_legacy_post_hook_rebinds_same_session_id_across_profiles(routed_plugin):
+    host = routed_plugin
+    host.module.register(host.ctx)
+    engine = host.engines[0]
+    hook = host.manager._hooks["post_llm_call"][0]
+    expected_by_profile = {"alpha": [], "beta": []}
+    for name in ("alpha", "beta", "alpha"):
+        token = host.active_home.set(host.homes[name])
+        try:
+            hook(session_id="same-session", conversation_history=[{"role": "user", "content": name}])
+            expected_by_profile[name].append(name)
+            assert engine._store.db_path == host.homes[name] / "lcm.db"
+            assert [row["content"] for row in engine._store.get_session_messages("same-session")] == expected_by_profile[name]
+        finally:
+            host.active_home.reset(token)
+
+
+@pytest.mark.parametrize("use_yaml", [False, True])
+def test_routed_registration_and_direct_config_loading(routed_plugin, monkeypatch, use_yaml):
+    host = routed_plugin
+    config_module = importlib.import_module(host.module.__name__ + ".config")
+    if not use_yaml:
+        monkeypatch.setattr(config_module, "yaml", None)
+    # A stale legacy alias must not shadow the canonical context-local API.
+    monkeypatch.setattr(sys.modules["hermes_cli.config"], "get_hermes_home", lambda: host.homes["default"])
+    token = host.active_home.set(host.homes["beta"])
+    try:
+        config = config_module.LCMConfig.from_env()
+        assert config.context_threshold == 0.62
+        assert config.summary_timeout_ms == 37000
+        host.module.register(host.ctx)
+        engine = host.engines[0]
+        assert engine._config.context_threshold == 0.62
+        assert engine._store.db_path == host.homes["beta"] / "lcm.db"
+        assert os.environ["HERMES_HOME"] == str(host.homes["default"])
+    finally:
+        host.active_home.reset(token)
+
+
+def test_operator_overrides_survive_routed_clone_and_rebind(routed_plugin, monkeypatch, tmp_path):
+    host = routed_plugin
+    db_path = tmp_path / "operator.db"
+    monkeypatch.setenv("LCM_DATABASE_PATH", str(db_path))
+    monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.52")
+    monkeypatch.setenv("LCM_SUMMARY_TIMEOUT_MS", "19000")
+    monkeypatch.setenv("LCM_ASSERTIONS_ENABLED", "true")
+    monkeypatch.setenv("LCM_QUERY_VIEWS_ENABLED", "true")
+    host.module.register(host.ctx)
+    token = host.active_home.set(host.homes["alpha"])
+    try:
+        clone = copy.deepcopy(host.engines[0])
+        host.engines.append(clone)
+        clone.on_session_start("alpha-session", context_length=100000)
+        for name in ("alpha", "beta"):
+            clone.on_session_start(name + "-session", hermes_home=str(host.homes[name]))
+            assert clone._config.context_threshold == 0.52
+            assert clone.threshold_tokens == 52000
+            assert clone._config.summary_timeout_ms == 19000
+            assert clone._config.config_sources["context_threshold"] == "env:LCM_CONTEXT_THRESHOLD"
+            assert clone._config.config_sources["summary_timeout_ms"] == "env:LCM_SUMMARY_TIMEOUT_MS"
+            for helper in (clone._store, clone._dag, clone._lifecycle, clone._assertions, clone._query_views):
+                assert helper.db_path == db_path
+            assert clone._store._hermes_home == str(host.homes[name])
+            assert clone._store._ingest_protection_config is clone._config
+        assert host.engines[0]._hermes_home == str(host.homes["default"])
+        assert clone._config is not host.engines[0]._config
+    finally:
+        host.active_home.reset(token)
+
+
+def test_explicit_config_is_caller_owned_across_routed_clones(routed_plugin):
+    host = routed_plugin
+    config_module = importlib.import_module(host.module.__name__ + ".config")
+    engine_module = importlib.import_module(host.module.__name__ + ".engine")
+    config = config_module.LCMConfig(context_threshold=0.39, summary_timeout_ms=17000)
+    prototype = engine_module.LCMEngine(config=config, hermes_home=str(host.homes["default"]))
+    host.engines.append(prototype)
+    token = host.active_home.set(host.homes["alpha"])
+    try:
+        clone = prototype.clone_for_agent()
+        host.engines.append(clone)
+        clone.on_session_start("manual-session", hermes_home=str(host.homes["beta"]), context_length=100000)
+        assert clone._config.context_threshold == 0.39
+        assert clone._config.summary_timeout_ms == 17000
+        assert clone.threshold_tokens == 39000
+        assert clone._store.db_path == host.homes["beta"] / "lcm.db"
+        clone._config.ignore_session_patterns.append("manual-only")
+        assert "manual-only" not in prototype._config.ignore_session_patterns
+    finally:
+        host.active_home.reset(token)
+
+
+@pytest.mark.parametrize("fallback", ["legacy_api", "environment", "default_home"])
+def test_standalone_and_legacy_home_fallback(routed_plugin, monkeypatch, tmp_path, fallback):
+    host = routed_plugin
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+    if fallback != "legacy_api":
+        monkeypatch.setitem(sys.modules, "hermes_cli.config", None)
+    if fallback == "default_home":
+        monkeypatch.delenv("HERMES_HOME")
+        monkeypatch.setenv("HOME", str(tmp_path / "standalone"))
+        home = tmp_path / "standalone" / ".hermes"
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text("compression:\n  threshold: 0.47\nauxiliary:\n  compression:\n    timeout: 13\n")
+        threshold, timeout = 0.47, 13000
+    elif fallback == "legacy_api":
+        host.active_home.set(host.homes["alpha"])
+        home, threshold, timeout = host.homes["alpha"], 0.43, 23000
+    else:
+        home, threshold, timeout = host.homes["default"], 0.71, 11000
+    host.module.register(host.ctx)
+    prototype = host.engines[0]
+    clone = prototype.clone_for_agent()
+    host.engines.append(clone)
+    clone.on_session_start("fallback-session", context_length=100000)
+    assert clone._store.db_path == home / "lcm.db"
+    assert clone._config.context_threshold == threshold
+    assert clone._config.summary_timeout_ms == timeout
+    if fallback == "default_home":
+        assert "HERMES_HOME" not in os.environ
+
+
+@pytest.mark.parametrize("contents", [None, "not: [valid yaml"])
+def test_missing_or_invalid_profile_yaml_keeps_defaults(routed_plugin, contents):
+    host = routed_plugin
+    path = host.homes["default"] / "config.yaml"
+    if contents is None:
+        path.unlink()
+    else:
+        path.write_text(contents)
+    host.module.register(host.ctx)
+    engine = host.engines[0]
+    config_module = importlib.import_module(host.module.__name__ + ".config")
+    defaults = config_module.LCMConfig()
+    assert engine._config.context_threshold == defaults.context_threshold
+    assert engine._config.summary_timeout_ms == defaults.summary_timeout_ms
+    assert engine._store.db_path == host.homes["default"] / "lcm.db"
+
+
+def test_broken_context_resolver_does_not_fall_back_to_sibling(routed_plugin, monkeypatch):
+    host = routed_plugin
+
+    def broken_resolver():
+        raise RuntimeError("synthetic route failure")
+
+    monkeypatch.setattr(sys.modules["hermes_constants"], "get_hermes_home", broken_resolver)
+    with pytest.raises(RuntimeError, match="synthetic route failure"):
+        host.module.register(host.ctx)
+    assert not (host.homes["default"] / "lcm.db").exists()


### PR DESCRIPTION
## Summary
- Resolve the active Hermes home through the context-local host API instead of process-global `HERMES_HOME`.
- Reload profile configuration when an environment-backed engine is rebound, alongside its SQLite state.
- Scope active-engine registry bindings by profile home and add synthetic multiplex regression coverage.

## Why
Hermes multiplex gateways route each task through a context-local Hermes home without mutating the process-global environment. LCM previously captured YAML config and engine registry identity from the default environment, so routed profiles could inherit a sibling profile's threshold, timeout, or durable state. This extends the profile-home storage rebind precedent from #179 and adds coverage for the profile-isolation invariants discussed in #40.

## Validation
- [x] `PYTHONPATH=/opt/hermes python -m pytest tests/test_lcm_core.py tests/test_lcm_engine.py tests/test_packaging_install.py tests/test_multiplex_profiles.py tests/test_dependency_contract.py -q` -> 1204 passed.
- [x] `python scripts/validate_dependency_contract.py` -> valid, 10 external imports declared.
- [x] `ruff check .` -> all checks passed.
- [x] `python -m compileall -q .` -> passed.
- [x] `git diff --check` -> passed before commit.
- [x] Unmodified-main regression proof: copied only `tests/test_multiplex_profiles.py` into a clean baseline and ran the focused suite -> 12 failed, 6 passed; the temporary test file was removed and the baseline worktree returned clean.
- [ ] Full `pytest -q`: collection is blocked in this host because `numpy` is unavailable for `tests/test_int8_two_stage_knn.py`. A run excluding that module reached 3017 passed, 9 skipped, 12 xfailed, with six unrelated existing recall/vector-cache failures; each was reproduced on the clean baseline.

## Notes
- Tests use only temporary synthetic profile homes and SQLite databases; no production plugin checkout, live database, gateway, or service was changed.
- CI status is reported separately from local validation and was pending at submission.
- AI Assistance: The implementation, regression tests, and initial analysis were prepared with AI agents; final review, validation, commit, and submission were performed by the coordinating developer agent.

Refs #40 #179